### PR TITLE
ci: seed software-garden workflows (8 stubs)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,10 @@
+name: codeql
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow codeql running."

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,10 @@
+name: container
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow container running."

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,10 @@
+name: docs-deploy
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow docs-deploy running."

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -1,0 +1,10 @@
+name: nightly-bench
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow nightly-bench running."

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,10 @@
+name: pypi-publish
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow pypi-publish running."

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,10 @@
+name: release-smoke
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow release-smoke running."

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,10 @@
+name: sbom
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow sbom running."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,10 @@
+name: scorecard
+on:
+  workflow_dispatch: {}
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "Stub workflow scorecard running."


### PR DESCRIPTION
This PR adds 8 stub GitHub Actions workflows to seed the software-garden CI/CD infrastructure:

- codeql.yml - Code quality analysis stub
- container.yml - Container operations stub  
- docs-deploy.yml - Documentation deployment stub
- nightly-bench.yml - Nightly benchmarking stub
- pypi-publish.yml - PyPI publishing stub
- release-smoke.yml - Release smoke testing stub
- sbom.yml - Software Bill of Materials stub
- scorecard.yml - Security scorecard stub

Each workflow is a minimal workflow_dispatch stub that prints its name when triggered manually.