### PR TITLE
Add voxel-memory, stochastic/contagion CA dynamics, experimental CA modules, and differentiation-aware fitness

### DIFF
--- a/agent/evolution_engine.py
+++ b/agent/evolution_engine.py
@@ -12,6 +12,7 @@ License: MIT
 from typing import Dict, List, Any, Optional, Tuple, Callable, Union
 from dataclasses import dataclass, field
 from enum import Enum
+import math
 import random
 import numpy as np
 import time
@@ -94,13 +95,68 @@ class FitnessEvaluator(ABC):
 
 class DefaultFitnessEvaluator(FitnessEvaluator):
     """Default fitness evaluator implementation."""
+
+    ENTROPY_BONUS_WEIGHT: float = 0.25
+    STRUCTURAL_DOMINANCE_PENALTY_WEIGHT: float = 0.30
+    STRUCTURAL_DOMINANCE_TARGET: float = 0.55
+
+    @staticmethod
+    def _extract_state_counts(environment_context: Dict[str, Any]) -> Dict[str, int]:
+        raw_counts = environment_context.get("cell_state_counts")
+        if not raw_counts:
+            return {}
+
+        if isinstance(raw_counts, dict):
+            return {
+                str(k).upper(): int(v)
+                for k, v in raw_counts.items()
+                if isinstance(v, (int, float)) and v >= 0
+            }
+
+        if isinstance(raw_counts, (list, tuple)):
+            state_names = ["VOID", "STRUCTURAL", "COMPUTE", "ENERGY", "SENSOR"]
+            return {
+                state_names[idx]: int(v)
+                for idx, v in enumerate(raw_counts[:len(state_names)])
+                if isinstance(v, (int, float)) and v >= 0
+            }
+
+        return {}
+
+    @classmethod
+    def _differentiation_score(cls, environment_context: Dict[str, Any]) -> float:
+        counts = cls._extract_state_counts(environment_context)
+        if not counts:
+            return 0.0
+
+        non_void_states = ("STRUCTURAL", "COMPUTE", "ENERGY", "SENSOR")
+        non_void_counts = [counts.get(state, 0) for state in non_void_states]
+        total_non_void = sum(non_void_counts)
+        if total_non_void <= 0:
+            return 0.0
+
+        probs = [c / total_non_void for c in non_void_counts if c > 0]
+        if len(probs) <= 1:
+            normalized_entropy = 0.0
+        else:
+            entropy = -sum(p * math.log(p) for p in probs)
+            normalized_entropy = entropy / math.log(len(non_void_states))
+
+        structural_ratio = counts.get("STRUCTURAL", 0) / total_non_void
+        dominance_excess = max(0.0, structural_ratio - cls.STRUCTURAL_DOMINANCE_TARGET)
+        dominance_penalty = min(1.0, dominance_excess / (1.0 - cls.STRUCTURAL_DOMINANCE_TARGET))
+
+        entropy_bonus = cls.ENTROPY_BONUS_WEIGHT * normalized_entropy
+        penalty = cls.STRUCTURAL_DOMINANCE_PENALTY_WEIGHT * dominance_penalty
+        return entropy_bonus - penalty
     
     def evaluate_meme(self, meme: Meme, environment_context: Dict[str, Any]) -> float:
         base_fitness = meme.calculate_fitness(environment_context)
         propagation_bonus = min(0.2, meme.propagation_count * 0.01)
         env_fitness = sum(meme.environment_fitness.values()) / max(1, len(meme.environment_fitness))
         env_bonus = env_fitness * 0.1
-        total_fitness = base_fitness + propagation_bonus + env_bonus
+        differentiation_term = self._differentiation_score(environment_context)
+        total_fitness = base_fitness + propagation_bonus + env_bonus + differentiation_term
         return max(0.0, min(1.0, total_fitness))
     
     def evaluate_agent(self, agent: FogletAgent, environment_context: Dict[str, Any]) -> float:

--- a/ca/rules/example.toml
+++ b/ca/rules/example.toml
@@ -1,33 +1,154 @@
 # Example CA rule: Branching growth with multiple states
 
 [rule]
-name = "branching-growth"
+name = "branching-growth-v0.7.5"
 states = ["VOID", "STRUCTURAL", "COMPUTE", "ENERGY", "SENSOR"]
 neighborhood = "moore-3d"
 transition = "outer-totalistic"
 
 [params]
-# Outer-totalistic transitions based on neighbor count
-# Format: current_state = { neighbor_count = next_state }
+# Deterministic backbone; stochastic/contagion sections introduce non-determinism.
 
 [params.transitions]
-# VOID cells become STRUCTURAL with 4-6 neighbors
-VOID = { 4 = "STRUCTURAL", 5 = "STRUCTURAL", 6 = "STRUCTURAL" }
+# Widen re-nucleation to maintain scaffold regeneration.
+VOID = {
+  3 = "STRUCTURAL",
+  4 = "STRUCTURAL",
+  5 = "STRUCTURAL",
+  6 = "STRUCTURAL"
+}
 
-# STRUCTURAL cells evolve based on density
-STRUCTURAL = { 2 = "STRUCTURAL", 3 = "STRUCTURAL", 4 = "COMPUTE", 5 = "COMPUTE" }
+# Buff STRUCTURAL: preserve low-density scaffold before differentiation.
+STRUCTURAL = {
+  0 = "STRUCTURAL",
+  1 = "STRUCTURAL",
+  2 = "STRUCTURAL",
+  3 = "COMPUTE",
+  4 = "COMPUTE",
+  5 = "ENERGY",
+  6 = "SENSOR",
+  7 = "SENSOR",
+  8 = "SENSOR"
+}
 
-# COMPUTE cells can become ENERGY or SENSOR
-COMPUTE = { 2 = "COMPUTE", 3 = "ENERGY", 4 = "SENSOR" }
+# Buff COMPUTE: wider stability band so it can accumulate as an intermediary.
+COMPUTE = {
+  1 = "COMPUTE",
+  2 = "COMPUTE",
+  3 = "COMPUTE",
+  4 = "ENERGY",
+  5 = "SENSOR",
+  6 = "SENSOR"
+}
 
-# ENERGY cells are stable
-ENERGY = { 2 = "ENERGY", 3 = "ENERGY", 4 = "ENERGY" }
+# ENERGY remains robust but can still route to SENSOR at higher density.
+ENERGY = {
+  0 = "ENERGY",
+  1 = "ENERGY",
+  2 = "ENERGY",
+  3 = "ENERGY",
+  4 = "ENERGY",
+  5 = "ENERGY",
+  6 = "SENSOR",
+  7 = "SENSOR",
+  8 = "SENSOR"
+}
 
-# SENSOR cells are stable
-SENSOR = { 2 = "SENSOR", 3 = "SENSOR", 4 = "SENSOR" }
+# Nerf SENSOR: vulnerable at extreme densities (7-8 no longer stable mapping).
+SENSOR = {
+  0 = "SENSOR",
+  1 = "SENSOR",
+  2 = "SENSOR",
+  3 = "SENSOR",
+  4 = "SENSOR",
+  5 = "SENSOR",
+  6 = "SENSOR"
+}
+
+[params.contagion]
+enabled = true
+# State-aware neighbor influence thresholds.
+energy_neighbor_threshold = 4
+sensor_neighbor_threshold = 4
+# STRUCTURAL/COMPUTE near ENERGY/SENSOR clusters are likely to convert.
+structural_energy_conversion_prob = 0.34
+structural_sensor_conversion_prob = 0.34
+compute_energy_conversion_prob = 0.15
+compute_sensor_conversion_prob = 0.30
+
+[params.stochastic]
+enabled = true
+# Cranked chaos baseline (requested: 8%).
+baseline_transition_prob = 0.08
+# Direct stochastic specialization from scaffold and compute states.
+structural_to_energy_prob = 0.08
+structural_to_sensor_prob = 0.08
+compute_to_energy_prob = 0.10
+compute_to_sensor_prob = 0.10
+# Asymmetric decay: STRUCTURAL fragile, ENERGY/SENSOR resilient.
+structural_to_void_decay_prob = 0.025
+energy_to_void_decay_prob = 0.004
+sensor_to_void_decay_prob = 0.003
+
+[params.decay]
+enabled = true
+# Structural cells with low support decay quickly, forcing turnover.
+inactivity_neighbor_threshold = 1
+structural_inactive_steps_to_decay = 6
 
 [params.meta]
-description = "Multi-state branching growth rule for fractal structures"
+description = "v0.7.5 cosmic garden lock with coherence, bamboo rebirth, and entropy damping"
 author = "UtilityFog Team"
-version = "0.1.0"
-target_lambda = 1.5  # Target branching factor (edge of chaos)
+version = "0.7.5"
+target_lambda = 1.7
+
+[params.experimental.selective_memory_decay]
+enabled = false
+memory_strength_threshold = 0.75
+compute_neighbor_threshold = 6
+low_decay_rate = 0.015
+high_decay_rate = 0.045
+
+[params.experimental.density_phase_detector]
+enabled = false
+window_size = 8
+density_low_threshold = 0.10
+density_high_threshold = 0.65
+first_derivative_threshold = 0.03
+second_derivative_threshold = 0.02
+contraction_density_threshold = 0.22
+trigger_sandboxed_memory = false
+
+[params.experimental.mini_lattice]
+enabled = false
+default_size = 16
+default_steps = 6
+
+[params.cosmic_garden]
+# Cluster coherence (D1,D2)
+cluster_coherence_threshold = 3
+shield_strength = 0.85
+
+# Halbach recuperation (E1,E2)
+halbach_recuperation_rate = 0.40
+temporal_dilation = 0.15
+
+# Bamboo protocol (G1-G4)
+bamboo_initial_growth = 100
+bamboo_max_length = 500
+bamboo_rebirth_age = 488
+otolith_vector = 0.05
+
+# Metabolic priority (F1,F2)
+biofilm_leech_rate = 0.10
+super_pod_threshold = 8
+
+# Entropy damping (H1,H2)
+damping_radius = 2
+analogue_mutation = 0.03
+
+age_young_threshold = 8
+age_mature_threshold = 40
+reverse_contagion_base_prob = 0.20
+energy_to_compute_prob = 0.20
+rag_reinforcement_boost = 1.50

--- a/ca/rules/example.toml
+++ b/ca/rules/example.toml
@@ -111,12 +111,10 @@ high_decay_rate = 0.045
 
 [params.experimental.density_phase_detector]
 enabled = false
-window_size = 8
-density_low_threshold = 0.10
-density_high_threshold = 0.65
-first_derivative_threshold = 0.03
-second_derivative_threshold = 0.02
-contraction_density_threshold = 0.22
+window_size = 10
+theta_c = 0.12
+alpha_c = 0.02
+savgol_poly_order = 3
 trigger_sandboxed_memory = false
 
 [params.experimental.mini_lattice]

--- a/crates/uft_ca/src/lib.rs
+++ b/crates/uft_ca/src/lib.rs
@@ -80,6 +80,7 @@ impl NeighborCount {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct VoxelMemory {
     pub compute_age: u16,
+    pub compute_half_step: bool,
     pub last_active_gen: u32,
     pub memory_strength: f32,
     pub structural_age: u16,
@@ -121,6 +122,20 @@ pub struct VoxelMemoryParams {
     pub super_pod_threshold: usize,
     pub damping_radius: usize,
     pub analogue_mutation: f32,
+    // Phase 3: Mamba-Viking memory dynamics
+    pub mamba_delta_threshold: f32,
+    pub mamba_tau_base: f32,
+    pub mamba_tau_scale: f32,
+    pub mamba_boost_base: f32,
+    pub mamba_boost_gain: f32,
+    pub mamba_age_stability_gain: f32,
+    pub mamba_high_delta_floor: f32,
+    // Phase 3: Void sanctuary + epsilon regularization
+    pub void_sanctuary_multiplier: f32,
+    pub epsilon_p_max: f32,
+    pub epsilon_buffer: f32,
+    pub epsilon_n_c: usize,
+    pub epsilon_tau: f32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -144,22 +159,16 @@ pub const SELECTIVE_MEMORY_DECAY_DEFAULTS: SelectiveMemoryDecayConfig = Selectiv
 pub struct DensityPhaseDetectorConfig {
     pub enabled: bool,
     pub window_size: usize,
-    pub density_low_threshold: f32,
-    pub density_high_threshold: f32,
-    pub first_derivative_threshold: f32,
-    pub second_derivative_threshold: f32,
-    pub contraction_density_threshold: f32,
+    pub theta_c: f32,
+    pub alpha_c: f32,
     pub trigger_sandboxed_memory: bool,
 }
 
 pub const DENSITY_PHASE_DETECTOR_DEFAULTS: DensityPhaseDetectorConfig = DensityPhaseDetectorConfig {
     enabled: false,
-    window_size: 8,
-    density_low_threshold: 0.10,
-    density_high_threshold: 0.65,
-    first_derivative_threshold: 0.03,
-    second_derivative_threshold: 0.02,
-    contraction_density_threshold: 0.22,
+    window_size: 10,
+    theta_c: 0.12,
+    alpha_c: 0.02,
     trigger_sandboxed_memory: false,
 };
 
@@ -212,11 +221,23 @@ pub const VOXEL_MEMORY_PARAMS: VoxelMemoryParams = VoxelMemoryParams {
     super_pod_threshold: 8,
     damping_radius: 2,
     analogue_mutation: 0.03,
+    mamba_delta_threshold: 0.12,
+    mamba_tau_base: 5.0,
+    mamba_tau_scale: 12.0,
+    mamba_boost_base: 0.015,
+    mamba_boost_gain: 0.045,
+    mamba_age_stability_gain: 0.03,
+    mamba_high_delta_floor: 1.15,
+    void_sanctuary_multiplier: 50.0,
+    epsilon_p_max: 0.943,
+    epsilon_buffer: 0.08,
+    epsilon_n_c: 20,
+    epsilon_tau: 3.0,
 };
 
 impl VoxelMemory {
     pub fn new() -> Self {
-        Self { compute_age: 0, last_active_gen: 0, memory_strength: 1.0, structural_age: 0, energy_reserve: 1.0 }
+        Self { compute_age: 0, compute_half_step: false, last_active_gen: 0, memory_strength: 1.0, structural_age: 0, energy_reserve: 1.0 }
     }
 
     pub fn decay_resistance(&self) -> f32 {
@@ -242,24 +263,46 @@ impl VoxelMemory {
     pub fn decay_memory_selective(
         &mut self,
         current_gen: u32,
-        compute_neighbors: usize,
+        counts: &NeighborCount,
+        current: CellState,
         config: SelectiveMemoryDecayConfig,
     ) {
         let generations_inactive = current_gen.saturating_sub(self.last_active_gen);
-        if !config.enabled {
-            self.decay_memory(current_gen);
-            return;
+
+        let total = counts.total_non_void() as f32;
+        let density_delta = ((counts.compute + counts.energy) as f32 - counts.structural as f32) / 26.0;
+        let delta_abs = density_delta.abs();
+
+        let p = &VOXEL_MEMORY_PARAMS;
+        let tau = (p.mamba_tau_base + p.mamba_tau_scale * delta_abs).max(0.25);
+        let baseline = (-1.0 / tau).exp();
+        let mut boost = (p.mamba_boost_base + p.mamba_boost_gain * delta_abs) * density_delta;
+        if config.enabled {
+            let gate = if self.memory_strength >= config.memory_strength_threshold
+                || counts.compute >= config.compute_neighbor_threshold
+            {
+                config.high_decay_rate
+            } else {
+                config.low_decay_rate
+            };
+            boost += density_delta * gate;
         }
 
-        let rate = if self.memory_strength >= config.memory_strength_threshold
-            || compute_neighbors >= config.compute_neighbor_threshold
-        {
-            config.high_decay_rate
+        let age_phi = if current == CellState::Compute {
+            1.0
         } else {
-            config.low_decay_rate
+            (self.compute_age as f32 / p.age_mature_threshold.max(1) as f32).clamp(0.0, 1.0)
         };
+        let stability = p.mamba_age_stability_gain * age_phi;
 
-        self.memory_strength *= (1.0 - rate).powi(generations_inactive as i32);
+        self.memory_strength = self.memory_strength * baseline.powi(generations_inactive as i32) + boost + stability;
+
+        if delta_abs < p.mamba_delta_threshold && total < 3.0 {
+            self.memory_strength *= 0.92;
+        }
+        if delta_abs >= p.mamba_delta_threshold {
+            self.memory_strength = self.memory_strength.max(p.mamba_high_delta_floor);
+        }
         self.memory_strength = self.memory_strength.max(0.01);
     }
 }
@@ -286,11 +329,8 @@ impl DensityPhaseDetector {
 
         let mut triggered = false;
         if self.config.enabled && self.densities.len() >= 3 {
-            let in_band = density >= self.config.density_low_threshold && density <= self.config.density_high_threshold;
-            let high_d1 = first_derivative.abs() >= self.config.first_derivative_threshold;
-            let high_d2 = second_derivative.abs() >= self.config.second_derivative_threshold;
-            let contracting = density <= self.config.contraction_density_threshold && first_derivative < 0.0;
-            triggered = in_band && high_d1 && high_d2 && contracting;
+            triggered = first_derivative < -(self.config.theta_c / 2.0)
+                && second_derivative < -self.config.alpha_c;
         }
 
         DensityPhaseSignal { density, first_derivative, second_derivative, triggered }
@@ -488,14 +528,23 @@ impl MultiStateRule {
         rng_seed: u64,
     ) -> CellState {
         let mut next = self.apply_stochastic(current, counts, rng_seed);
+        let active_neighbors = counts.total_non_void();
 
         if current == CellState::Compute {
-            memory.compute_age = memory.compute_age.saturating_add(1);
+            if active_neighbors == 0 {
+                memory.compute_half_step = !memory.compute_half_step;
+                if memory.compute_half_step {
+                    memory.compute_age = memory.compute_age.saturating_add(1);
+                }
+            } else {
+                memory.compute_half_step = false;
+                memory.compute_age = memory.compute_age.saturating_add(1);
+            }
             memory.last_active_gen = current_gen;
             memory.memory_strength = (memory.memory_strength + VOXEL_MEMORY_PARAMS.halbach_recuperation_rate * 0.1).min(2.0);
             memory.structural_age = 0;
         } else {
-            memory.decay_memory(current_gen);
+            memory.decay_memory_selective(current_gen, counts, current, SELECTIVE_MEMORY_DECAY_DEFAULTS);
         }
 
         if current == CellState::Structural {
@@ -511,12 +560,35 @@ impl MultiStateRule {
         }
 
         if current == CellState::Compute && next == CellState::Void {
+            if active_neighbors >= VOXEL_MEMORY_PARAMS.epsilon_n_c {
+                let mut reg_hasher = DefaultHasher::new();
+                (rng_seed.wrapping_add(41)).hash(&mut reg_hasher);
+                (active_neighbors as u64).hash(&mut reg_hasher);
+                let reg_roll = (reg_hasher.finish() % 1000) as f32 / 1000.0;
+                let density_offset = (active_neighbors - VOXEL_MEMORY_PARAMS.epsilon_n_c) as f32;
+                let p_reg = VOXEL_MEMORY_PARAMS.epsilon_p_max
+                    - VOXEL_MEMORY_PARAMS.epsilon_buffer
+                        * (-(density_offset / VOXEL_MEMORY_PARAMS.epsilon_tau.max(0.1))).exp();
+                let death_prob = p_reg.min(VOXEL_MEMORY_PARAMS.epsilon_p_max);
+                let survival_prob = (1.0 - death_prob).max(0.057);
+                if reg_roll < survival_prob {
+                    next = CellState::Compute;
+                }
+            }
+
+            if next == CellState::Compute {
+                return next;
+            }
+
             let mut hasher = DefaultHasher::new();
             (rng_seed.wrapping_add(7)).hash(&mut hasher);
             (counts.compute as u64).hash(&mut hasher);
             (counts.energy as u64).hash(&mut hasher);
             let roll = (hasher.finish() % 1000) as f32 / 1000.0;
             let mut resistance = memory.decay_resistance() * memory.memory_strength.min(1.5);
+            if active_neighbors == 0 {
+                resistance *= VOXEL_MEMORY_PARAMS.void_sanctuary_multiplier;
+            }
             if counts.compute >= VOXEL_MEMORY_PARAMS.forward_contagion_threshold {
                 resistance += VOXEL_MEMORY_PARAMS.cluster_shield_bonus;
             }
@@ -582,6 +654,7 @@ impl MultiStateRule {
 
         if next != CellState::Compute {
             memory.compute_age = 0;
+            memory.compute_half_step = false;
         }
 
         next
@@ -1664,30 +1737,63 @@ mod tests {
         m2.last_active_gen = 5;
 
         m1.decay_memory(12);
-        m2.decay_memory_selective(12, 4, SELECTIVE_MEMORY_DECAY_DEFAULTS);
+        let counts = NeighborCount { compute: 4, ..NeighborCount::default() };
+        m2.decay_memory_selective(12, &counts, CellState::Structural, SELECTIVE_MEMORY_DECAY_DEFAULTS);
 
-        assert!((m1.memory_strength - m2.memory_strength).abs() < 1e-6);
+        assert!(m2.memory_strength > 0.01);
+        assert!(m2.memory_strength <= 2.0);
+        assert!(m2.memory_strength != m1.memory_strength);
     }
 
     #[test]
     fn test_density_phase_detector_triggers_in_contraction_band() {
         let mut detector = DensityPhaseDetector::new(DensityPhaseDetectorConfig {
             enabled: true,
-            window_size: 5,
-            density_low_threshold: 0.05,
-            density_high_threshold: 0.8,
-            first_derivative_threshold: 0.05,
-            second_derivative_threshold: 0.02,
-            contraction_density_threshold: 0.30,
+            window_size: 10,
+            theta_c: 0.12,
+            alpha_c: 0.02,
             trigger_sandboxed_memory: true,
         });
 
-        let _ = detector.update(0.90);
-        let _ = detector.update(0.25);
-        let signal = detector.update(0.12);
+        let _ = detector.update(1.00);
+        let _ = detector.update(0.80);
+        let signal = detector.update(0.50);
 
         assert!(signal.triggered);
         assert!(signal.first_derivative < 0.0);
+    }
+
+    #[test]
+    fn test_void_sanctuary_slows_compute_aging() {
+        let mut rule = MultiStateRule::new();
+        rule.set_default(CellState::Compute, CellState::Compute);
+        let counts = NeighborCount::default();
+        for seed in 0..2048u64 {
+            let mut memory = VoxelMemory::new();
+            let n1 = rule.apply_with_memory(CellState::Compute, &counts, &mut memory, 1, seed);
+            let age_after_1 = memory.compute_age;
+            let n2 = rule.apply_with_memory(CellState::Compute, &counts, &mut memory, 2, seed.wrapping_add(1));
+            let age_after_2 = memory.compute_age;
+            if n1 == CellState::Compute && n2 == CellState::Compute {
+                assert_eq!(age_after_1, 1);
+                assert_eq!(age_after_2, 1);
+                return;
+            }
+        }
+        panic!("no deterministic seed preserved compute state for void sanctuary aging test");
+    }
+
+    #[test]
+    fn test_epsilon_buffer_preserves_packed_survival_floor() {
+        let n = 26usize;
+        let density_offset = (n - VOXEL_MEMORY_PARAMS.epsilon_n_c) as f32;
+        let p_reg = VOXEL_MEMORY_PARAMS.epsilon_p_max
+            - VOXEL_MEMORY_PARAMS.epsilon_buffer
+                * (-(density_offset / VOXEL_MEMORY_PARAMS.epsilon_tau.max(0.1))).exp();
+        let death_prob = p_reg.min(VOXEL_MEMORY_PARAMS.epsilon_p_max);
+        let survival_prob = (1.0 - death_prob).max(0.057);
+        assert!(death_prob <= 0.943 + 1e-6);
+        assert!(survival_prob > 0.05);
     }
 
     #[test]

--- a/crates/uft_ca/src/lib.rs
+++ b/crates/uft_ca/src/lib.rs
@@ -12,6 +12,9 @@
 //! - State observation: census, spatial queries, time-series recording, snapshot/replay
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use rayon::prelude::*;
 
 #[cfg(feature = "python")]
@@ -70,6 +73,238 @@ impl NeighborCount {
 
     pub fn total_non_void(&self) -> usize {
         self.structural + self.compute + self.energy + self.sensor
+    }
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VoxelMemory {
+    pub compute_age: u16,
+    pub last_active_gen: u32,
+    pub memory_strength: f32,
+    pub structural_age: u16,
+    pub energy_reserve: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VoxelMemoryParams {
+    // A1-A3: age matrix
+    pub age_young_threshold: u16,
+    pub age_mature_threshold: u16,
+    pub resistance_max: f32,
+    // B1-B4: density-targeting rebalance
+    pub reverse_contagion_threshold: usize,
+    pub reverse_contagion_base_prob: f32,
+    pub reverse_contagion_boost: f32,
+    pub energy_to_compute_prob: f32,
+    pub compute_energy_conversion_prob: f32,
+    // C1-C3: forward contagion mitigation
+    pub forward_contagion_threshold: usize,
+    pub forward_contagion_penalty: f32,
+    pub forward_contagion_floor: f32,
+    // D1-D3: limit cycle preservation
+    pub rag_query_radius: usize,
+    pub rag_memory_decay: f32,
+    pub rag_reinforcement_boost: f32,
+    pub rag_entropy_weight: f32,
+    pub cluster_shield_bonus: f32,
+    // v0.7.5 cosmic garden locks
+    pub cluster_coherence_threshold: usize,
+    pub shield_strength: f32,
+    pub halbach_recuperation_rate: f32,
+    pub temporal_dilation: f32,
+    pub bamboo_initial_growth: u16,
+    pub bamboo_max_length: u16,
+    pub bamboo_rebirth_age: u16,
+    pub otolith_vector: f32,
+    pub biofilm_leech_rate: f32,
+    pub super_pod_threshold: usize,
+    pub damping_radius: usize,
+    pub analogue_mutation: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SelectiveMemoryDecayConfig {
+    pub enabled: bool,
+    pub memory_strength_threshold: f32,
+    pub compute_neighbor_threshold: usize,
+    pub low_decay_rate: f32,
+    pub high_decay_rate: f32,
+}
+
+pub const SELECTIVE_MEMORY_DECAY_DEFAULTS: SelectiveMemoryDecayConfig = SelectiveMemoryDecayConfig {
+    enabled: false,
+    memory_strength_threshold: 0.75,
+    compute_neighbor_threshold: 6,
+    low_decay_rate: 0.015,
+    high_decay_rate: 0.045,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DensityPhaseDetectorConfig {
+    pub enabled: bool,
+    pub window_size: usize,
+    pub density_low_threshold: f32,
+    pub density_high_threshold: f32,
+    pub first_derivative_threshold: f32,
+    pub second_derivative_threshold: f32,
+    pub contraction_density_threshold: f32,
+    pub trigger_sandboxed_memory: bool,
+}
+
+pub const DENSITY_PHASE_DETECTOR_DEFAULTS: DensityPhaseDetectorConfig = DensityPhaseDetectorConfig {
+    enabled: false,
+    window_size: 8,
+    density_low_threshold: 0.10,
+    density_high_threshold: 0.65,
+    first_derivative_threshold: 0.03,
+    second_derivative_threshold: 0.02,
+    contraction_density_threshold: 0.22,
+    trigger_sandboxed_memory: false,
+};
+
+#[derive(Debug, Clone)]
+pub struct DensityPhaseDetector {
+    pub config: DensityPhaseDetectorConfig,
+    densities: VecDeque<f32>,
+    derivatives: VecDeque<f32>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DensityPhaseSignal {
+    pub density: f32,
+    pub first_derivative: f32,
+    pub second_derivative: f32,
+    pub triggered: bool,
+}
+
+pub const VOXEL_MEMORY_PARAMS: VoxelMemoryParams = VoxelMemoryParams {
+    // A1-A3
+    age_young_threshold: 8,
+    age_mature_threshold: 40,
+    resistance_max: 0.82,
+    // B1-B4
+    reverse_contagion_threshold: 4,
+    reverse_contagion_base_prob: 0.20,
+    reverse_contagion_boost: 0.06,
+    energy_to_compute_prob: 0.20,
+    compute_energy_conversion_prob: 0.15,
+    // C1-C3
+    forward_contagion_threshold: 5,
+    forward_contagion_penalty: 0.18,
+    forward_contagion_floor: 0.40,
+    // D1-D3
+    rag_query_radius: 3,
+    rag_memory_decay: 0.015,
+    rag_reinforcement_boost: 1.50,
+    rag_entropy_weight: 0.18,
+    cluster_shield_bonus: 0.15,
+    // Cosmic garden 18-lock parameters
+    cluster_coherence_threshold: 3,
+    shield_strength: 0.85,
+    halbach_recuperation_rate: 0.40,
+    temporal_dilation: 0.15,
+    bamboo_initial_growth: 100,
+    bamboo_max_length: 500,
+    bamboo_rebirth_age: 488,
+    otolith_vector: 0.05,
+    biofilm_leech_rate: 0.10,
+    super_pod_threshold: 8,
+    damping_radius: 2,
+    analogue_mutation: 0.03,
+};
+
+impl VoxelMemory {
+    pub fn new() -> Self {
+        Self { compute_age: 0, last_active_gen: 0, memory_strength: 1.0, structural_age: 0, energy_reserve: 1.0 }
+    }
+
+    pub fn decay_resistance(&self) -> f32 {
+        let age = self.compute_age;
+        let p = &VOXEL_MEMORY_PARAMS;
+
+        if age <= p.age_young_threshold {
+            (age as f32 / p.age_young_threshold as f32) * p.resistance_max
+        } else if age <= p.age_mature_threshold {
+            p.resistance_max
+        } else {
+            p.resistance_max * (-((age - p.age_mature_threshold) as f32) / 500.0).exp()
+        }
+    }
+
+    pub fn decay_memory(&mut self, current_gen: u32) {
+        let generations_inactive = current_gen.saturating_sub(self.last_active_gen);
+        let p = &VOXEL_MEMORY_PARAMS;
+        self.memory_strength *= (1.0 - (p.rag_memory_decay * p.temporal_dilation)).powi(generations_inactive as i32);
+        self.memory_strength = self.memory_strength.max(0.01);
+    }
+
+    pub fn decay_memory_selective(
+        &mut self,
+        current_gen: u32,
+        compute_neighbors: usize,
+        config: SelectiveMemoryDecayConfig,
+    ) {
+        let generations_inactive = current_gen.saturating_sub(self.last_active_gen);
+        if !config.enabled {
+            self.decay_memory(current_gen);
+            return;
+        }
+
+        let rate = if self.memory_strength >= config.memory_strength_threshold
+            || compute_neighbors >= config.compute_neighbor_threshold
+        {
+            config.high_decay_rate
+        } else {
+            config.low_decay_rate
+        };
+
+        self.memory_strength *= (1.0 - rate).powi(generations_inactive as i32);
+        self.memory_strength = self.memory_strength.max(0.01);
+    }
+}
+
+impl DensityPhaseDetector {
+    pub fn new(config: DensityPhaseDetectorConfig) -> Self {
+        Self { config, densities: VecDeque::new(), derivatives: VecDeque::new() }
+    }
+
+    pub fn update(&mut self, density: f32) -> DensityPhaseSignal {
+        let prev_density = *self.densities.back().unwrap_or(&density);
+        let first_derivative = density - prev_density;
+        let prev_d1 = *self.derivatives.back().unwrap_or(&first_derivative);
+        let second_derivative = first_derivative - prev_d1;
+
+        self.densities.push_back(density);
+        self.derivatives.push_back(first_derivative);
+        while self.densities.len() > self.config.window_size {
+            self.densities.pop_front();
+        }
+        while self.derivatives.len() > self.config.window_size {
+            self.derivatives.pop_front();
+        }
+
+        let mut triggered = false;
+        if self.config.enabled && self.densities.len() >= 3 {
+            let in_band = density >= self.config.density_low_threshold && density <= self.config.density_high_threshold;
+            let high_d1 = first_derivative.abs() >= self.config.first_derivative_threshold;
+            let high_d2 = second_derivative.abs() >= self.config.second_derivative_threshold;
+            let contracting = density <= self.config.contraction_density_threshold && first_derivative < 0.0;
+            triggered = in_band && high_d1 && high_d2 && contracting;
+        }
+
+        DensityPhaseSignal { density, first_derivative, second_derivative, triggered }
+    }
+}
+
+pub fn reverse_contagion_probability(compute_neighbors: usize) -> f32 {
+    let p = &VOXEL_MEMORY_PARAMS;
+    if compute_neighbors < p.reverse_contagion_threshold {
+        0.0
+    } else {
+        let excess = (compute_neighbors - p.reverse_contagion_threshold) as f32;
+        let prob = p.reverse_contagion_base_prob + p.reverse_contagion_boost * excess;
+        prob.min(0.95)
     }
 }
 
@@ -185,6 +420,191 @@ impl MultiStateRule {
         rule.set_default(CellState::Sensor, CellState::Sensor);
 
         rule
+    }
+
+    pub fn utility_fog_optimized_v060() -> Self {
+        let mut rule = MultiStateRule::new();
+
+        // VOID transitions: broader nucleation window
+        rule.add_transition(CellState::Void, CellState::Energy, 2, usize::MAX, CellState::Energy);
+        rule.add_transition(CellState::Void, CellState::Structural, 3, usize::MAX, CellState::Structural);
+        rule.set_default(CellState::Void, CellState::Void);
+
+        // ENERGY transitions: enhanced stability with COMPUTE coupling
+        rule.add_transition(CellState::Energy, CellState::Compute, 1, usize::MAX, CellState::Compute);
+        rule.add_transition(CellState::Energy, CellState::Energy, 1, usize::MAX, CellState::Energy);
+        rule.set_default(CellState::Energy, CellState::Void);
+
+        // COMPUTE transitions: density-preserving with ENERGY dependency
+        rule.add_transition(CellState::Compute, CellState::Energy, 1, usize::MAX, CellState::Compute);
+        rule.add_transition(CellState::Compute, CellState::Compute, 2, 4, CellState::Compute);
+        rule.set_default(CellState::Compute, CellState::Void);
+
+        // STRUCTURAL transitions
+        rule.add_transition(CellState::Structural, CellState::Structural, 1, 2, CellState::Structural);
+        rule.add_transition(CellState::Structural, CellState::Structural, 3, 6, CellState::Compute);
+        rule.add_transition(CellState::Structural, CellState::Structural, 7, usize::MAX, CellState::Structural);
+        rule.set_default(CellState::Structural, CellState::Void);
+
+        // SENSOR transitions
+        rule.add_transition(CellState::Sensor, CellState::Compute, 2, usize::MAX, CellState::Compute);
+        rule.set_default(CellState::Sensor, CellState::Sensor);
+
+        rule
+    }
+
+    /// Stochastic transition with density-targeting probability curve.
+    pub fn apply_stochastic(&self, current: CellState, counts: &NeighborCount, rng_seed: u64) -> CellState {
+        let mut hasher = DefaultHasher::new();
+        rng_seed.hash(&mut hasher);
+        (counts.structural as u64).hash(&mut hasher);
+        (counts.compute as u64).hash(&mut hasher);
+        (counts.energy as u64).hash(&mut hasher);
+        let hash_val = hasher.finish();
+
+        let base_state = self.apply(current, counts);
+
+        if current == CellState::Structural && base_state == CellState::Compute {
+            let prob_factor = (hash_val % 100) as f64 / 100.0;
+            let compute_density = counts.compute as f64 / 26.0;
+            let target_prob = if compute_density < 0.25 { 0.85 } else { 0.35 };
+
+            if prob_factor < target_prob {
+                CellState::Compute
+            } else {
+                CellState::Structural
+            }
+        } else {
+            base_state
+        }
+    }
+
+    pub fn apply_with_memory(
+        &self,
+        current: CellState,
+        counts: &NeighborCount,
+        memory: &mut VoxelMemory,
+        current_gen: u32,
+        rng_seed: u64,
+    ) -> CellState {
+        let mut next = self.apply_stochastic(current, counts, rng_seed);
+
+        if current == CellState::Compute {
+            memory.compute_age = memory.compute_age.saturating_add(1);
+            memory.last_active_gen = current_gen;
+            memory.memory_strength = (memory.memory_strength + VOXEL_MEMORY_PARAMS.halbach_recuperation_rate * 0.1).min(2.0);
+            memory.structural_age = 0;
+        } else {
+            memory.decay_memory(current_gen);
+        }
+
+        if current == CellState::Structural {
+            memory.structural_age = memory.structural_age.saturating_add(1);
+            if memory.structural_age < VOXEL_MEMORY_PARAMS.bamboo_initial_growth {
+                memory.memory_strength = (memory.memory_strength + VOXEL_MEMORY_PARAMS.otolith_vector).min(2.0);
+            }
+            if memory.structural_age >= VOXEL_MEMORY_PARAMS.bamboo_rebirth_age {
+                next = CellState::Compute;
+                memory.structural_age = 0;
+                memory.compute_age = VOXEL_MEMORY_PARAMS.bamboo_initial_growth.min(VOXEL_MEMORY_PARAMS.bamboo_max_length);
+            }
+        }
+
+        if current == CellState::Compute && next == CellState::Void {
+            let mut hasher = DefaultHasher::new();
+            (rng_seed.wrapping_add(7)).hash(&mut hasher);
+            (counts.compute as u64).hash(&mut hasher);
+            (counts.energy as u64).hash(&mut hasher);
+            let roll = (hasher.finish() % 1000) as f32 / 1000.0;
+            let mut resistance = memory.decay_resistance() * memory.memory_strength.min(1.5);
+            if counts.compute >= VOXEL_MEMORY_PARAMS.forward_contagion_threshold {
+                resistance += VOXEL_MEMORY_PARAMS.cluster_shield_bonus;
+            }
+            if counts.compute >= VOXEL_MEMORY_PARAMS.cluster_coherence_threshold {
+                resistance += VOXEL_MEMORY_PARAMS.shield_strength * 0.25;
+            }
+            resistance = resistance.min(0.98);
+            if roll < resistance {
+                next = CellState::Compute;
+            }
+        }
+
+        if current == CellState::Energy {
+            let mut hasher = DefaultHasher::new();
+            rng_seed.hash(&mut hasher);
+            (counts.compute as u64).hash(&mut hasher);
+            let roll = (hasher.finish() % 1000) as f32 / 1000.0;
+            let mut prob = VOXEL_MEMORY_PARAMS.energy_to_compute_prob;
+            if counts.compute >= VOXEL_MEMORY_PARAMS.super_pod_threshold {
+                let leech = VOXEL_MEMORY_PARAMS.biofilm_leech_rate;
+                memory.energy_reserve = (memory.energy_reserve * (1.0 - leech)).max(0.05);
+                prob = (prob + leech * 0.5).min(0.95);
+            }
+            if counts.structural >= VOXEL_MEMORY_PARAMS.forward_contagion_threshold {
+                prob = (prob - VOXEL_MEMORY_PARAMS.forward_contagion_penalty)
+                    .max(VOXEL_MEMORY_PARAMS.forward_contagion_floor * VOXEL_MEMORY_PARAMS.energy_to_compute_prob);
+            }
+            if roll < prob {
+                next = CellState::Compute;
+                memory.compute_age = memory.compute_age.saturating_add(1);
+                memory.last_active_gen = current_gen;
+            }
+        }
+
+        if current == CellState::Structural {
+            let rc_prob = reverse_contagion_probability(counts.compute);
+            if rc_prob > 0.0 {
+                let mut hasher = DefaultHasher::new();
+                (rng_seed.wrapping_add(13)).hash(&mut hasher);
+                (counts.compute as u64).hash(&mut hasher);
+                let roll = (hasher.finish() % 1000) as f32 / 1000.0;
+                if roll < rc_prob {
+                    next = CellState::Compute;
+                    memory.compute_age = memory.compute_age.saturating_add(1);
+                    memory.last_active_gen = current_gen;
+                }
+            }
+        }
+
+        // Entropy damping via analogue mutation noise.
+        let mut hasher = DefaultHasher::new();
+        (rng_seed.wrapping_add(29)).hash(&mut hasher);
+        let noise_roll = (hasher.finish() % 1000) as f32 / 1000.0;
+        if noise_roll < VOXEL_MEMORY_PARAMS.analogue_mutation {
+            next = match next {
+                CellState::Structural => CellState::Compute,
+                CellState::Compute => CellState::Energy,
+                CellState::Energy => CellState::Sensor,
+                CellState::Sensor => CellState::Structural,
+                CellState::Void => CellState::Void,
+            };
+        }
+
+        if next != CellState::Compute {
+            memory.compute_age = 0;
+        }
+
+        next
+    }
+
+    /// OpenFang-style WASM sandbox gate for contraction-phase simulations.
+    pub fn apply_with_memory_sandboxed(
+        &self,
+        current: CellState,
+        counts: &NeighborCount,
+        memory: &mut VoxelMemory,
+        current_gen: u32,
+        rng_seed: u64,
+        contraction_phase: bool,
+    ) -> CellState {
+        let mut next = self.apply_with_memory(current, counts, memory, current_gen, rng_seed);
+        if contraction_phase {
+            // During contraction, prevent unstable direct jump to VOID for mature COMPUTE clusters.
+            if current == CellState::Compute && counts.compute >= VOXEL_MEMORY_PARAMS.damping_radius + 3 && next == CellState::Void {
+                next = CellState::Compute;
+            }
+        }
+        next
     }
 }
 
@@ -330,6 +750,69 @@ impl GraphState {
         }
     }
 
+    pub fn step_multi_stochastic(&self, rule: &MultiStateRule) -> GraphState {
+        let mut next_nodes = vec![0u8; self.nodes.len()];
+        for i in 0..self.nodes.len() {
+            let current = CellState::from(self.nodes[i]);
+            let counts = self.count_neighbors(i);
+            let next = rule.apply_stochastic(current, &counts, i as u64);
+            next_nodes[i] = u8::from(next);
+        }
+        GraphState {
+            nodes: next_nodes,
+            adjacency: self.adjacency.clone(),
+        }
+    }
+
+
+
+    pub fn step_multi_with_memory(
+        &self,
+        rule: &MultiStateRule,
+        memory_grid: &mut [VoxelMemory],
+        current_gen: u32,
+    ) -> GraphState {
+        let mut next_nodes = vec![0u8; self.nodes.len()];
+        for i in 0..self.nodes.len() {
+            let current = CellState::from(self.nodes[i]);
+            let counts = self.count_neighbors(i);
+            let next = rule.apply_with_memory(current, &counts, &mut memory_grid[i], current_gen, i as u64);
+            next_nodes[i] = u8::from(next);
+        }
+        GraphState { nodes: next_nodes, adjacency: self.adjacency.clone() }
+    }
+
+    pub fn step_multi_with_memory_experimental(
+        &self,
+        rule: &MultiStateRule,
+        memory_grid: &mut [VoxelMemory],
+        current_gen: u32,
+        _selective_decay: SelectiveMemoryDecayConfig,
+        mut detector: Option<&mut DensityPhaseDetector>,
+    ) -> GraphState {
+        let total = self.nodes.len().max(1) as f32;
+        let non_void = self.nodes.iter().filter(|&&s| s != u8::from(CellState::Void)).count() as f32;
+        let signal = detector.as_deref_mut().map(|d| d.update(non_void / total));
+        let contraction_phase = signal
+            .map(|s| s.triggered)
+            .unwrap_or(false);
+
+        let mut next_nodes = vec![0u8; self.nodes.len()];
+        for i in 0..self.nodes.len() {
+            let current = CellState::from(self.nodes[i]);
+            let counts = self.count_neighbors(i);
+            let next = rule.apply_with_memory_sandboxed(
+                current,
+                &counts,
+                &mut memory_grid[i],
+                current_gen,
+                i as u64,
+                contraction_phase,
+            );
+            next_nodes[i] = u8::from(next);
+        }
+        GraphState { nodes: next_nodes, adjacency: self.adjacency.clone() }
+    }
     pub fn step_multi_par(&self, rule: &MultiStateRule) -> GraphState {
         let next_nodes: Vec<u8> = (0..self.nodes.len())
             .into_par_iter()
@@ -345,11 +828,34 @@ impl GraphState {
         }
     }
 
+    pub fn step_multi_par_stochastic(&self, rule: &MultiStateRule) -> GraphState {
+        let next_nodes: Vec<u8> = (0..self.nodes.len())
+            .into_par_iter()
+            .map(|i| {
+                let current = CellState::from(self.nodes[i]);
+                let counts = self.count_neighbors(i);
+                u8::from(rule.apply_stochastic(current, &counts, i as u64))
+            })
+            .collect();
+        GraphState {
+            nodes: next_nodes,
+            adjacency: self.adjacency.clone(),
+        }
+    }
+
     pub fn step_auto(&self, rule: &MultiStateRule) -> GraphState {
         if self.nodes.len() >= PAR_THRESHOLD {
             self.step_multi_par(rule)
         } else {
             self.step_multi(rule)
+        }
+    }
+
+    pub fn step_auto_stochastic(&self, rule: &MultiStateRule) -> GraphState {
+        if self.nodes.len() >= PAR_THRESHOLD {
+            self.step_multi_par_stochastic(rule)
+        } else {
+            self.step_multi_stochastic(rule)
         }
     }
 
@@ -763,6 +1269,8 @@ pub struct MultiStateGraphLattice {
     state: GraphState,
     rule: MultiStateRule,
     coords: Option<Vec<(f64, f64, f64)>>,
+    memory_grid: Vec<VoxelMemory>,
+    generation: u32,
 }
 
 #[cfg(feature = "python")]
@@ -783,19 +1291,25 @@ impl MultiStateGraphLattice {
         for (from, default) in defaults {
             rule.set_default(CellState::from(from), CellState::from(default));
         }
+        let node_count = states.len();
         Self {
             state: GraphState::new(states, adjacency),
             rule,
             coords: None,
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         }
     }
 
     #[staticmethod]
     fn with_fog_rules(states: Vec<u8>, adjacency: Vec<Vec<usize>>) -> Self {
+        let node_count = states.len();
         Self {
             state: GraphState::new(states, adjacency),
-            rule: MultiStateRule::utility_fog_default(),
+            rule: MultiStateRule::utility_fog_optimized_v060(),
             coords: None,
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         }
     }
 
@@ -803,10 +1317,13 @@ impl MultiStateGraphLattice {
     fn sierpinski(depth: usize, initial_state: u8) -> Self {
         let gs = SierpinskiTetrahedron::generate(depth, CellState::from(initial_state));
         let coords = SierpinskiTetrahedron::coords(depth);
+        let node_count = gs.nodes.len();
         Self {
             state: gs,
-            rule: MultiStateRule::utility_fog_default(),
+            rule: MultiStateRule::utility_fog_optimized_v060(),
             coords: Some(coords),
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         }
     }
 
@@ -814,10 +1331,13 @@ impl MultiStateGraphLattice {
     fn menger(depth: usize, initial_state: u8) -> Self {
         let gs = MengerSponge::generate(depth, CellState::from(initial_state));
         let coords = MengerSponge::coords(depth);
+        let node_count = gs.nodes.len();
         Self {
             state: gs,
-            rule: MultiStateRule::utility_fog_default(),
+            rule: MultiStateRule::utility_fog_optimized_v060(),
             coords: Some(coords),
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         }
     }
 
@@ -825,16 +1345,20 @@ impl MultiStateGraphLattice {
     fn octahedral(side: usize, initial_state: u8) -> Self {
         let gs = OctahedralFogLattice::generate(side, CellState::from(initial_state));
         let coords = OctahedralFogLattice::coords(side);
+        let node_count = gs.nodes.len();
         Self {
             state: gs,
-            rule: MultiStateRule::utility_fog_default(),
+            rule: MultiStateRule::utility_fog_optimized_v060(),
             coords: Some(coords),
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         }
     }
 
     fn step(&mut self) -> Vec<u8> {
-        let next = self.state.step_multi(&self.rule);
+        let next = self.state.step_multi_with_memory(&self.rule, &mut self.memory_grid, self.generation);
         self.state = next;
+        self.generation = self.generation.saturating_add(1);
         self.state.nodes.clone()
     }
 
@@ -860,42 +1384,51 @@ impl MultiStateGraphLattice {
 
     fn step_n(&mut self, n: usize) -> Vec<u8> {
         for _ in 0..n {
-            let next = self.state.step_multi(&self.rule);
+            let next = self.state.step_multi_with_memory(&self.rule, &mut self.memory_grid, self.generation);
             self.state = next;
+            self.generation = self.generation.saturating_add(1);
         }
         self.state.nodes.clone()
     }
 
     fn step_par(&mut self) -> Vec<u8> {
-        let next = self.state.step_multi_par(&self.rule);
+        let next = self.state.step_multi_par_stochastic(&self.rule);
         self.state = next;
+        self.generation = self.generation.saturating_add(1);
         self.state.nodes.clone()
     }
 
     fn step_par_n(&mut self, n: usize) -> Vec<u8> {
         for _ in 0..n {
-            let next = self.state.step_multi_par(&self.rule);
+            let next = self.state.step_multi_par_stochastic(&self.rule);
             self.state = next;
+            self.generation = self.generation.saturating_add(1);
         }
         self.state.nodes.clone()
     }
 
     fn step_auto(&mut self) -> Vec<u8> {
-        let next = self.state.step_auto(&self.rule);
+        let next = self.state.step_auto_stochastic(&self.rule);
         self.state = next;
+        self.generation = self.generation.saturating_add(1);
         self.state.nodes.clone()
     }
 
     fn step_auto_n(&mut self, n: usize) -> Vec<u8> {
         for _ in 0..n {
-            let next = self.state.step_auto(&self.rule);
+            let next = self.state.step_auto_stochastic(&self.rule);
             self.state = next;
+            self.generation = self.generation.saturating_add(1);
         }
         self.state.nodes.clone()
     }
 
     fn set_states(&mut self, states: Vec<u8>) {
         self.state.nodes = states;
+        if self.memory_grid.len() != self.state.nodes.len() {
+            self.memory_grid = vec![VoxelMemory::new(); self.state.nodes.len()];
+            self.generation = 0;
+        }
     }
 
     fn census(&self) -> HashMap<u8, usize> {
@@ -1004,10 +1537,13 @@ impl MultiStateGraphLattice {
         } else {
             None
         };
+        let node_count = gs.nodes.len();
         Ok(Self {
             state: gs,
-            rule: MultiStateRule::utility_fog_default(),
+            rule: MultiStateRule::utility_fog_optimized_v060(),
             coords,
+            memory_grid: vec![VoxelMemory::new(); node_count],
+            generation: 0,
         })
     }
 
@@ -1116,6 +1652,42 @@ mod tests {
         assert_eq!(CellState::from(0), CellState::Void);
         assert_eq!(CellState::from(1), CellState::Structural);
         assert_eq!(u8::from(CellState::Compute), 2);
+    }
+
+    #[test]
+    fn test_selective_memory_decay_default_matches_baseline_path() {
+        let mut m1 = VoxelMemory::new();
+        let mut m2 = VoxelMemory::new();
+        m1.memory_strength = 1.2;
+        m2.memory_strength = 1.2;
+        m1.last_active_gen = 5;
+        m2.last_active_gen = 5;
+
+        m1.decay_memory(12);
+        m2.decay_memory_selective(12, 4, SELECTIVE_MEMORY_DECAY_DEFAULTS);
+
+        assert!((m1.memory_strength - m2.memory_strength).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_density_phase_detector_triggers_in_contraction_band() {
+        let mut detector = DensityPhaseDetector::new(DensityPhaseDetectorConfig {
+            enabled: true,
+            window_size: 5,
+            density_low_threshold: 0.05,
+            density_high_threshold: 0.8,
+            first_derivative_threshold: 0.05,
+            second_derivative_threshold: 0.02,
+            contraction_density_threshold: 0.30,
+            trigger_sandboxed_memory: true,
+        });
+
+        let _ = detector.update(0.90);
+        let _ = detector.update(0.25);
+        let signal = detector.update(0.12);
+
+        assert!(signal.triggered);
+        assert!(signal.first_derivative < 0.0);
     }
 
     #[test]

--- a/docs/experimental_phase3_modules.md
+++ b/docs/experimental_phase3_modules.md
@@ -1,0 +1,27 @@
+# Experimental Phase 3 Modules (Feature-Flagged)
+
+This document describes **hypothesis-stage** infrastructure added for experimentation.
+
+## Hypothesis-stage modules (default OFF)
+
+- Selective memory decay (`params.experimental.selective_memory_decay`)
+  - Mamba-inspired selective decay lane for `memory_strength`.
+  - Hypothesis: selective decay can improve adaptation under density shifts.
+- Density-phase detector (`params.experimental.density_phase_detector`)
+  - Rolling detector for density, first derivative, second derivative.
+  - Hypothesis: contraction-phase detection can gate sandboxed memory stepping.
+- Mini-lattice mutation harness (`run_mini_lattice_mutation_trials`)
+  - 16^3 default for isolated mutation trials.
+  - Hypothesis: reduced lattice can rank mutation classes quickly.
+
+## Validated in this PR
+
+- Config loading paths for experimental flags.
+- Detector trigger logic under contraction-like density traces.
+- Selective decay math behavior for high-decay vs low-decay paths.
+
+## Not validated / not claimed
+
+- No claim of predictive equivalence between 16^3 and production-scale lattices.
+- No production mutation acceptance wiring.
+- No changes to Mayfly ecology parameters, Bamboo thresholds, or existing telemetry control panel behavior.

--- a/docs/experimental_phase3_modules.md
+++ b/docs/experimental_phase3_modules.md
@@ -1,27 +1,37 @@
-# Experimental Phase 3 Modules (Feature-Flagged)
+# Phase 3 NVIDIA Architecture Rewrite (Targeted)
 
-This document describes **hypothesis-stage** infrastructure added for experimentation.
+This note summarizes the **newly wired equations** and what is still hypothesis-stage.
 
-## Hypothesis-stage modules (default OFF)
+## Implemented mechanisms
 
-- Selective memory decay (`params.experimental.selective_memory_decay`)
-  - Mamba-inspired selective decay lane for `memory_strength`.
-  - Hypothesis: selective decay can improve adaptation under density shifts.
-- Density-phase detector (`params.experimental.density_phase_detector`)
-  - Rolling detector for density, first derivative, second derivative.
-  - Hypothesis: contraction-phase detection can gate sandboxed memory stepping.
-- Mini-lattice mutation harness (`run_mini_lattice_mutation_trials`)
-  - 16^3 default for isolated mutation trials.
-  - Hypothesis: reduced lattice can rank mutation classes quickly.
+1. **Mamba-Viking memory update (Rust)**
+   - `memory_strength` now follows a delta-prioritized state-space update:
+     - `M(t+1) = M(t) exp(-1/tau(delta)) + B(delta) delta + S Phi(age)`
+   - Low-delta sequential noise is pruned; high-delta events preserve a minimum memory floor.
 
-## Validated in this PR
+2. **Cosmos Predict trigger (Python)**
+   - Rolling density detector now computes **Savitzky-Golay-like** first/second derivatives
+     from a windowed polynomial fit (default `N=10`).
+   - PRE-CONTRACTION trigger condition:
+     - `d rho / dt < -theta_c/2`
+     - `d^2 rho / dt^2 < -alpha_c`
+   - When enabled, this gates `contraction_phase=True` into sandboxed memory protection.
 
-- Config loading paths for experimental flags.
-- Detector trigger logic under contraction-like density traces.
-- Selective decay math behavior for high-decay vs low-decay paths.
+3. **Void Sanctuary shield (Rust)**
+   - Isolated COMPUTE (`n=0`) receives a `Lambda_void = 50.0` resistance multiplier.
+   - Isolated COMPUTE aging is slowed to half-rate (effective +0.5 step/step).
 
-## Not validated / not claimed
+4. **Dimensional regularization epsilon-buffer (Rust)**
+   - For dense neighborhoods (`n >= 20`), death probability is regularized:
+     - `P_reg = P_max - epsilon * exp(-(n - n_c)/tau_epsilon)`
+   - `P_max` is capped at `0.943`, preserving a >5% survival floor.
 
-- No claim of predictive equivalence between 16^3 and production-scale lattices.
-- No production mutation acceptance wiring.
-- No changes to Mayfly ecology parameters, Bamboo thresholds, or existing telemetry control panel behavior.
+## Validation scope in this PR
+
+- Added focused tests for selective-decay behavior, detector triggering, void-aging slowdown,
+  and epsilon survival cap invariants.
+
+## Non-claims
+
+- No claim that reduced lattices are predictive of full-scale dynamics.
+- No claim that these changes alone solve all long-run mortality regimes.

--- a/scripts/continuous_evolution.py
+++ b/scripts/continuous_evolution.py
@@ -220,6 +220,35 @@ def save_branch_primitives(primitives: List[Dict[str, Any]], epoch: int,
 # Status reporting
 # ---------------------------------------------------------------------------
 
+def generate_primordial_seed_cube(
+    lattice_size: int,
+    cube_size: int = 3,
+    active_state: int = 1,
+) -> np.ndarray:
+    """Create a centered 3D CA seed cube to avoid cold-start extinction.
+
+    The lattice is initialized to VOID (0) everywhere, then a dense cube
+    of STRUCTURAL (default state 1) cells is injected at the exact center.
+    """
+    if cube_size not in (3, 5):
+        raise ValueError(f"cube_size must be 3 or 5, got {cube_size}")
+    if lattice_size < cube_size:
+        raise ValueError(
+            f"lattice_size ({lattice_size}) must be >= cube_size ({cube_size})"
+        )
+
+    seed = np.zeros((lattice_size, lattice_size, lattice_size), dtype=np.uint8)
+    half = cube_size // 2
+    center = lattice_size // 2
+
+    x0, x1 = center - half, center + half + 1
+    y0, y1 = center - half, center + half + 1
+    z0, z1 = center - half, center + half + 1
+
+    seed[x0:x1, y0:y1, z0:z1] = np.uint8(active_state)
+    return seed
+
+
 def print_status_update(epoch: int, total_epochs: int, epoch_result: GrokkingRunResult,
                         primitives_count: int, primitives_path: str,
                         cumulative_time: float, temps: Dict[str, float]):
@@ -263,6 +292,13 @@ def main():
                         help="0 = infinite, N = stop after N epochs")
     parser.add_argument("--status-interval", type=int, default=300,
                         help="Seconds between full status reports (default 300 = 5 min)")
+    parser.add_argument(
+        "--seed-cube-size",
+        type=int,
+        default=3,
+        choices=(3, 5),
+        help="Primordial seed cube edge length for CA bootstrap (3 or 5)",
+    )
     args = parser.parse_args()
 
     print(BANNER)
@@ -285,6 +321,7 @@ def main():
     print(f"  Exchanges/Epoch: {args.exchanges}")
     print(f"  Sweeps/Exchange: {args.sweeps}")
     print(f"  Seed:            {args.seed}")
+    print(f"  Seed Cube:       {args.seed_cube_size}x{args.seed_cube_size}x{args.seed_cube_size} STRUCTURAL")
     print(f"  Epoch Limit:     {'infinite' if args.epoch_limit == 0 else args.epoch_limit}")
     print(f"  Status Interval: {args.status_interval}s")
     print(f"  Thermal Ceiling: {temp_threshold}C (resume at {temp_resume}C)")
@@ -331,6 +368,15 @@ def main():
     total_time = 0.0
     last_status_time = time.time()
     seed_offset = args.seed
+    primordial_seed = generate_primordial_seed_cube(
+        lattice_size=args.lattice,
+        cube_size=args.seed_cube_size,
+    )
+    active_seed_cells = int(np.count_nonzero(primordial_seed))
+    print(
+        f"  [SEED] Primordial cube initialized at lattice center "
+        f"({active_seed_cells} active STRUCTURAL cells)."
+    )
 
     while not SHUTDOWN_REQUESTED:
         if args.epoch_limit > 0 and epoch >= args.epoch_limit:

--- a/scripts/continuous_evolution_ca.py
+++ b/scripts/continuous_evolution_ca.py
@@ -99,12 +99,10 @@ class SelectiveMemoryDecayConfig:
 @dataclass
 class DensityPhaseDetectorConfig:
     enabled: bool = False
-    window_size: int = 8
-    density_low_threshold: float = 0.10
-    density_high_threshold: float = 0.65
-    first_derivative_threshold: float = 0.03
-    second_derivative_threshold: float = 0.02
-    contraction_density_threshold: float = 0.22
+    window_size: int = 10
+    theta_c: float = 0.12
+    alpha_c: float = 0.02
+    savgol_poly_order: int = 3
     trigger_sandboxed_memory: bool = False
 
 
@@ -345,12 +343,10 @@ def load_experimental_config(rule_spec: Mapping[str, Any]) -> ExperimentalConfig
         ),
         density_phase_detector=DensityPhaseDetectorConfig(
             enabled=bool(detector.get("enabled", False)),
-            window_size=max(3, int(detector.get("window_size", 8))),
-            density_low_threshold=float(detector.get("density_low_threshold", 0.10)),
-            density_high_threshold=float(detector.get("density_high_threshold", 0.65)),
-            first_derivative_threshold=float(detector.get("first_derivative_threshold", 0.03)),
-            second_derivative_threshold=float(detector.get("second_derivative_threshold", 0.02)),
-            contraction_density_threshold=float(detector.get("contraction_density_threshold", 0.22)),
+            window_size=max(5, int(detector.get("window_size", 10))),
+            theta_c=float(detector.get("theta_c", 0.12)),
+            alpha_c=float(detector.get("alpha_c", 0.02)),
+            savgol_poly_order=int(detector.get("savgol_poly_order", 3)),
             trigger_sandboxed_memory=bool(detector.get("trigger_sandboxed_memory", False)),
         ),
         mini_lattice=MiniLatticeExperimentConfig(
@@ -365,30 +361,49 @@ def init_density_phase_detector(config: DensityPhaseDetectorConfig) -> DensityPh
     return DensityPhaseDetector(config=config)
 
 
+def _savgol_latest_derivatives(values: List[float], window_size: int, poly_order: int) -> Tuple[float, float]:
+    if not values:
+        return 0.0, 0.0
+    if len(values) < max(3, window_size):
+        if len(values) < 3:
+            return 0.0, 0.0
+        d1 = values[-1] - values[-2]
+        d2 = d1 - (values[-2] - values[-3])
+        return float(d1), float(d2)
+
+    w = max(5, window_size)
+    window_vals = np.asarray(values[-w:], dtype=np.float32)
+    x = np.arange(window_vals.shape[0], dtype=np.float32)
+    degree = int(max(2, min(poly_order, w - 2)))
+    coeffs = np.polyfit(x, window_vals, degree)
+    p = np.poly1d(coeffs)
+    dp = np.polyder(p, 1)
+    d2p = np.polyder(p, 2)
+    x_eval = float(x[-1])
+    return float(dp(x_eval)), float(d2p(x_eval))
+
+
 def update_density_phase_detector(detector: Optional[DensityPhaseDetector], state: np.ndarray) -> Dict[str, float]:
     if detector is None:
         return {}
 
     density = float(np.count_nonzero(state) / max(1, state.size))
-    prev_density = detector.densities[-1] if detector.densities else density
-    d1 = density - prev_density
-    prev_d1 = detector.first_derivatives[-1] if detector.first_derivatives else d1
-    d2 = d1 - prev_d1
-
     detector.densities.append(density)
-    detector.first_derivatives.append(d1)
     if len(detector.densities) > detector.config.window_size:
         detector.densities.popleft()
+
+    d1, d2 = _savgol_latest_derivatives(
+        list(detector.densities),
+        detector.config.window_size,
+        detector.config.savgol_poly_order,
+    )
+    detector.first_derivatives.append(d1)
     if len(detector.first_derivatives) > detector.config.window_size:
         detector.first_derivatives.popleft()
 
     triggered = 0.0
     if detector.config.enabled and len(detector.densities) >= 3:
-        in_band = detector.config.density_low_threshold <= density <= detector.config.density_high_threshold
-        high_d1 = abs(d1) >= detector.config.first_derivative_threshold
-        high_d2 = abs(d2) >= detector.config.second_derivative_threshold
-        contracting = density <= detector.config.contraction_density_threshold and d1 < 0
-        if in_band and high_d1 and high_d2 and contracting:
+        if d1 < -(detector.config.theta_c / 2.0) and d2 < -detector.config.alpha_c:
             triggered = 1.0
 
     return {

--- a/scripts/continuous_evolution_ca.py
+++ b/scripts/continuous_evolution_ca.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+"""3D CA stepping utilities with state-aware contagion, stochasticity, decay, and voxel memory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from collections import deque
+from typing import Any, Deque, Dict, List, Mapping, Optional, Tuple
+
+import numpy as np
+import tomli
+
+STATE_NAME_TO_ID = {
+    "VOID": 0,
+    "STRUCTURAL": 1,
+    "COMPUTE": 2,
+    "ENERGY": 3,
+    "SENSOR": 4,
+}
+
+
+@dataclass
+class DecayConfig:
+    enabled: bool = True
+    inactivity_neighbor_threshold: int = 1
+    structural_inactive_steps_to_decay: int = 6
+
+
+@dataclass
+class StochasticConfig:
+    enabled: bool = True
+    baseline_transition_prob: float = 0.08
+    structural_to_energy_prob: float = 0.08
+    structural_to_sensor_prob: float = 0.08
+    compute_to_energy_prob: float = 0.10
+    compute_to_sensor_prob: float = 0.10
+    structural_to_void_decay_prob: float = 0.04
+    energy_to_void_decay_prob: float = 0.005
+    sensor_to_void_decay_prob: float = 0.004
+
+
+@dataclass
+class ContagionConfig:
+    enabled: bool = True
+    energy_neighbor_threshold: int = 4
+    sensor_neighbor_threshold: int = 4
+    structural_energy_conversion_prob: float = 0.40
+    structural_sensor_conversion_prob: float = 0.30
+    compute_energy_conversion_prob: float = 0.15
+    compute_sensor_conversion_prob: float = 0.25
+
+
+@dataclass
+class VoxelMemoryParams:
+    # A1-A3
+    age_young_threshold: int = 8
+    age_mature_threshold: int = 40
+    resistance_max: float = 0.82
+    # B1-B4
+    reverse_contagion_threshold: int = 4
+    reverse_contagion_base_prob: float = 0.20
+    reverse_contagion_boost: float = 0.06
+    energy_to_compute_prob: float = 0.20
+    # C1-C3
+    forward_contagion_threshold: int = 5
+    forward_contagion_penalty: float = 0.18
+    forward_contagion_floor: float = 0.40
+    # D1-D3
+    rag_query_radius: int = 3
+    rag_memory_decay: float = 0.015
+    rag_reinforcement_boost: float = 1.50
+    rag_entropy_weight: float = 0.18
+    # v0.7.5 lock params
+    cluster_shield_bonus: float = 0.15
+    cluster_coherence_threshold: int = 3
+    shield_strength: float = 0.85
+    halbach_recuperation_rate: float = 0.40
+    temporal_dilation: float = 0.15
+    bamboo_initial_growth: int = 100
+    bamboo_max_length: int = 500
+    bamboo_rebirth_age: int = 488
+    otolith_vector: float = 0.05
+    biofilm_leech_rate: float = 0.10
+    super_pod_threshold: int = 8
+    damping_radius: int = 2
+    analogue_mutation: float = 0.03
+
+
+@dataclass
+class SelectiveMemoryDecayConfig:
+    enabled: bool = False
+    memory_strength_threshold: float = 0.75
+    compute_neighbor_threshold: int = 6
+    low_decay_rate: float = 0.015
+    high_decay_rate: float = 0.045
+
+
+@dataclass
+class DensityPhaseDetectorConfig:
+    enabled: bool = False
+    window_size: int = 8
+    density_low_threshold: float = 0.10
+    density_high_threshold: float = 0.65
+    first_derivative_threshold: float = 0.03
+    second_derivative_threshold: float = 0.02
+    contraction_density_threshold: float = 0.22
+    trigger_sandboxed_memory: bool = False
+
+
+@dataclass
+class MiniLatticeExperimentConfig:
+    enabled: bool = False
+    default_size: int = 16
+    default_steps: int = 6
+
+
+@dataclass
+class ExperimentalConfig:
+    selective_memory_decay: SelectiveMemoryDecayConfig = field(default_factory=SelectiveMemoryDecayConfig)
+    density_phase_detector: DensityPhaseDetectorConfig = field(default_factory=DensityPhaseDetectorConfig)
+    mini_lattice: MiniLatticeExperimentConfig = field(default_factory=MiniLatticeExperimentConfig)
+
+
+def load_rule_spec(rule_path: str | Path) -> Dict[str, Any]:
+    with Path(rule_path).open("rb") as f:
+        return tomli.load(f)
+
+
+def init_memory_grid(shape: Tuple[int, int, int]) -> np.ndarray:
+    """Memory grid channels: [compute_age, last_active_gen, memory_strength, structural_age, energy_reserve]."""
+    grid = np.zeros((5,) + shape, dtype=np.float32)
+    grid[2, :, :, :] = 1.0
+    grid[4, :, :, :] = 1.0
+    return grid
+
+@dataclass
+class TelemetryWindow:
+    transition_matrix: np.ndarray = field(default_factory=lambda: np.zeros((5, 5), dtype=np.int64))
+    structural_lifetimes: List[float] = field(default_factory=list)
+    compute_lifetimes: List[float] = field(default_factory=list)
+
+
+@dataclass
+class DensityPhaseDetector:
+    config: DensityPhaseDetectorConfig
+    densities: Deque[float] = field(default_factory=deque)
+    first_derivatives: Deque[float] = field(default_factory=deque)
+
+
+def init_telemetry_window() -> TelemetryWindow:
+    return TelemetryWindow()
+
+
+def _percentile(values: List[float], q: float) -> float:
+    if not values:
+        return 0.0
+    return float(np.percentile(np.asarray(values, dtype=np.float32), q))
+
+
+def _histogram(values: List[float], bins: int = 10) -> Dict[str, Any]:
+    if not values:
+        return {"bins": [], "counts": []}
+    counts, edges = np.histogram(np.asarray(values, dtype=np.float32), bins=bins)
+    return {"bins": edges.tolist(), "counts": counts.tolist()}
+
+
+def update_telemetry_window(
+    telemetry: Optional[TelemetryWindow],
+    prev_state: np.ndarray,
+    next_state: np.ndarray,
+    compute_age_snapshot: np.ndarray,
+    structural_age_snapshot: np.ndarray,
+) -> None:
+    if telemetry is None:
+        return
+
+    flat_prev = prev_state.ravel().astype(np.int64)
+    flat_next = next_state.ravel().astype(np.int64)
+    for src in range(5):
+        src_mask = flat_prev == src
+        if not np.any(src_mask):
+            continue
+        dst_vals = flat_next[src_mask]
+        counts = np.bincount(dst_vals, minlength=5)
+        telemetry.transition_matrix[src, :] += counts[:5]
+
+    structural_left = (prev_state == STATE_NAME_TO_ID["STRUCTURAL"]) & (next_state != STATE_NAME_TO_ID["STRUCTURAL"])
+    compute_left = (prev_state == STATE_NAME_TO_ID["COMPUTE"]) & (next_state != STATE_NAME_TO_ID["COMPUTE"])
+    if np.any(structural_left):
+        telemetry.structural_lifetimes.extend(structural_age_snapshot[structural_left].astype(float).tolist())
+    if np.any(compute_left):
+        telemetry.compute_lifetimes.extend(compute_age_snapshot[compute_left].astype(float).tolist())
+
+
+def summarize_telemetry_window(telemetry: Optional[TelemetryWindow]) -> Tuple[str, Dict[str, Any]]:
+    if telemetry is None:
+        return "(telemetry disabled)", {}
+
+    matrix = telemetry.transition_matrix
+    transitions = []
+    for src in range(5):
+        for dst in range(5):
+            c = int(matrix[src, dst])
+            if c > 0:
+                transitions.append((c, src, dst))
+    transitions.sort(reverse=True)
+    top_pairs = [
+        {
+            "from": int(src),
+            "to": int(dst),
+            "count": int(c),
+        }
+        for c, src, dst in transitions[:10]
+    ]
+
+    s_median = _percentile(telemetry.structural_lifetimes, 50)
+    s_p95 = _percentile(telemetry.structural_lifetimes, 95)
+    c_median = _percentile(telemetry.compute_lifetimes, 50)
+    c_p95 = _percentile(telemetry.compute_lifetimes, 95)
+
+    payload = {
+        "structural": {
+            "median": s_median,
+            "p95": s_p95,
+            "histogram": _histogram(telemetry.structural_lifetimes),
+        },
+        "compute": {
+            "median": c_median,
+            "p95": c_p95,
+            "histogram": _histogram(telemetry.compute_lifetimes),
+        },
+        "transition_matrix": matrix.astype(int).tolist(),
+        "top_transition_pairs": top_pairs,
+    }
+
+    summary = (
+        f"Telemetry Window | STRUCTURAL median={s_median:.2f} p95={s_p95:.2f} | "
+        f"COMPUTE median={c_median:.2f} p95={c_p95:.2f} | "
+        f"Top transitions={top_pairs[:3]}"
+    )
+    return summary, payload
+
+
+def write_telemetry_artifact(path: str | Path, payload: Dict[str, Any]) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    import json
+    with Path(path).open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def reset_telemetry_window(telemetry: Optional[TelemetryWindow]) -> None:
+    if telemetry is None:
+        return
+    telemetry.transition_matrix.fill(0)
+    telemetry.structural_lifetimes.clear()
+    telemetry.compute_lifetimes.clear()
+
+
+
+def _count_neighbors_by_state(state: np.ndarray) -> np.ndarray:
+    if state.ndim != 3:
+        raise ValueError(f"Expected a 3D lattice, got shape={state.shape}")
+
+    out = np.zeros((len(STATE_NAME_TO_ID),) + state.shape, dtype=np.int16)
+    for state_id in range(len(STATE_NAME_TO_ID)):
+        indicator = (state == state_id).astype(np.int16)
+        padded = np.pad(indicator, 1, mode="constant", constant_values=0)
+        counts = np.zeros_like(indicator, dtype=np.int16)
+        for dz in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for dx in (-1, 0, 1):
+                    if dx == 0 and dy == 0 and dz == 0:
+                        continue
+                    counts += padded[
+                        1 + dz:1 + dz + state.shape[0],
+                        1 + dy:1 + dy + state.shape[1],
+                        1 + dx:1 + dx + state.shape[2],
+                    ]
+        out[state_id] = counts
+    return out
+
+
+def _compile_transition_table(rule_spec: Mapping[str, Any]) -> Dict[int, Dict[int, int]]:
+    transitions = rule_spec["params"]["transitions"]
+    table: Dict[int, Dict[int, int]] = {}
+    for state_name, mapping in transitions.items():
+        src = STATE_NAME_TO_ID[state_name.upper()]
+        table[src] = {}
+        for neighbor_count, target_name in mapping.items():
+            table[src][int(neighbor_count)] = STATE_NAME_TO_ID[str(target_name).upper()]
+    return table
+
+
+def _load_decay_config(rule_spec: Mapping[str, Any]) -> DecayConfig:
+    decay = rule_spec.get("params", {}).get("decay", {})
+    return DecayConfig(
+        enabled=bool(decay.get("enabled", True)),
+        inactivity_neighbor_threshold=int(decay.get("inactivity_neighbor_threshold", 1)),
+        structural_inactive_steps_to_decay=int(decay.get("structural_inactive_steps_to_decay", 6)),
+    )
+
+
+def _load_stochastic_config(rule_spec: Mapping[str, Any]) -> StochasticConfig:
+    stoch = rule_spec.get("params", {}).get("stochastic", {})
+    baseline = float(stoch.get("baseline_transition_prob", 0.08))
+    return StochasticConfig(
+        enabled=bool(stoch.get("enabled", True)),
+        baseline_transition_prob=baseline,
+        structural_to_energy_prob=float(stoch.get("structural_to_energy_prob", baseline)),
+        structural_to_sensor_prob=float(stoch.get("structural_to_sensor_prob", baseline)),
+        compute_to_energy_prob=float(stoch.get("compute_to_energy_prob", baseline + 0.02)),
+        compute_to_sensor_prob=float(stoch.get("compute_to_sensor_prob", baseline + 0.02)),
+        structural_to_void_decay_prob=float(stoch.get("structural_to_void_decay_prob", 0.04)),
+        energy_to_void_decay_prob=float(stoch.get("energy_to_void_decay_prob", 0.005)),
+        sensor_to_void_decay_prob=float(stoch.get("sensor_to_void_decay_prob", 0.004)),
+    )
+
+
+def _load_contagion_config(rule_spec: Mapping[str, Any]) -> ContagionConfig:
+    contagion = rule_spec.get("params", {}).get("contagion", {})
+    return ContagionConfig(
+        enabled=bool(contagion.get("enabled", True)),
+        energy_neighbor_threshold=int(contagion.get("energy_neighbor_threshold", 4)),
+        sensor_neighbor_threshold=int(contagion.get("sensor_neighbor_threshold", 4)),
+        structural_energy_conversion_prob=float(contagion.get("structural_energy_conversion_prob", 0.40)),
+        structural_sensor_conversion_prob=float(contagion.get("structural_sensor_conversion_prob", 0.30)),
+        compute_energy_conversion_prob=float(contagion.get("compute_energy_conversion_prob", 0.15)),
+        compute_sensor_conversion_prob=float(contagion.get("compute_sensor_conversion_prob", 0.25)),
+    )
+
+
+def load_experimental_config(rule_spec: Mapping[str, Any]) -> ExperimentalConfig:
+    exp = rule_spec.get("params", {}).get("experimental", {})
+    selective = exp.get("selective_memory_decay", {})
+    detector = exp.get("density_phase_detector", {})
+    mini = exp.get("mini_lattice", {})
+    return ExperimentalConfig(
+        selective_memory_decay=SelectiveMemoryDecayConfig(
+            enabled=bool(selective.get("enabled", False)),
+            memory_strength_threshold=float(selective.get("memory_strength_threshold", 0.75)),
+            compute_neighbor_threshold=int(selective.get("compute_neighbor_threshold", 6)),
+            low_decay_rate=float(selective.get("low_decay_rate", 0.015)),
+            high_decay_rate=float(selective.get("high_decay_rate", 0.045)),
+        ),
+        density_phase_detector=DensityPhaseDetectorConfig(
+            enabled=bool(detector.get("enabled", False)),
+            window_size=max(3, int(detector.get("window_size", 8))),
+            density_low_threshold=float(detector.get("density_low_threshold", 0.10)),
+            density_high_threshold=float(detector.get("density_high_threshold", 0.65)),
+            first_derivative_threshold=float(detector.get("first_derivative_threshold", 0.03)),
+            second_derivative_threshold=float(detector.get("second_derivative_threshold", 0.02)),
+            contraction_density_threshold=float(detector.get("contraction_density_threshold", 0.22)),
+            trigger_sandboxed_memory=bool(detector.get("trigger_sandboxed_memory", False)),
+        ),
+        mini_lattice=MiniLatticeExperimentConfig(
+            enabled=bool(mini.get("enabled", False)),
+            default_size=int(mini.get("default_size", 16)),
+            default_steps=int(mini.get("default_steps", 6)),
+        ),
+    )
+
+
+def init_density_phase_detector(config: DensityPhaseDetectorConfig) -> DensityPhaseDetector:
+    return DensityPhaseDetector(config=config)
+
+
+def update_density_phase_detector(detector: Optional[DensityPhaseDetector], state: np.ndarray) -> Dict[str, float]:
+    if detector is None:
+        return {}
+
+    density = float(np.count_nonzero(state) / max(1, state.size))
+    prev_density = detector.densities[-1] if detector.densities else density
+    d1 = density - prev_density
+    prev_d1 = detector.first_derivatives[-1] if detector.first_derivatives else d1
+    d2 = d1 - prev_d1
+
+    detector.densities.append(density)
+    detector.first_derivatives.append(d1)
+    if len(detector.densities) > detector.config.window_size:
+        detector.densities.popleft()
+    if len(detector.first_derivatives) > detector.config.window_size:
+        detector.first_derivatives.popleft()
+
+    triggered = 0.0
+    if detector.config.enabled and len(detector.densities) >= 3:
+        in_band = detector.config.density_low_threshold <= density <= detector.config.density_high_threshold
+        high_d1 = abs(d1) >= detector.config.first_derivative_threshold
+        high_d2 = abs(d2) >= detector.config.second_derivative_threshold
+        contracting = density <= detector.config.contraction_density_threshold and d1 < 0
+        if in_band and high_d1 and high_d2 and contracting:
+            triggered = 1.0
+
+    return {
+        "phase_density": density,
+        "phase_d1": d1,
+        "phase_d2": d2,
+        "phase_triggered": triggered,
+    }
+
+
+def _compute_neighbor_count(mask: np.ndarray) -> np.ndarray:
+    padded = np.pad(mask.astype(np.int16), 1, mode="constant", constant_values=0)
+    cluster = np.zeros_like(mask, dtype=np.int16)
+    for dz in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dx in (-1, 0, 1):
+                if dx == 0 and dy == 0 and dz == 0:
+                    continue
+                cluster += padded[
+                    1 + dz:1 + dz + mask.shape[0],
+                    1 + dy:1 + dy + mask.shape[1],
+                    1 + dx:1 + dx + mask.shape[2],
+                ]
+    return cluster
+
+
+def _apply_selective_memory_decay(
+    memory_grid: np.ndarray,
+    compute_mask: np.ndarray,
+    compute_cluster: np.ndarray,
+    current_gen: int,
+    mem: VoxelMemoryParams,
+    cfg: SelectiveMemoryDecayConfig,
+) -> None:
+    inactive = ~compute_mask
+    generations_inactive = np.maximum(0.0, float(current_gen) - memory_grid[1])
+
+    if not cfg.enabled:
+        memory_grid[2][inactive] *= np.power(1.0 - (mem.rag_memory_decay * mem.temporal_dilation), generations_inactive[inactive])
+        memory_grid[2] = np.maximum(memory_grid[2], 0.01)
+        return
+
+    decay_rate = np.full(memory_grid[2].shape, cfg.low_decay_rate, dtype=np.float32)
+    high_decay_mask = inactive & (
+        (memory_grid[2] >= cfg.memory_strength_threshold)
+        | (compute_cluster >= cfg.compute_neighbor_threshold)
+    )
+    decay_rate[high_decay_mask] = cfg.high_decay_rate
+
+    power = np.where(inactive, generations_inactive, 0.0)
+    memory_grid[2] *= np.power(1.0 - decay_rate, power)
+    memory_grid[2] = np.maximum(memory_grid[2], 0.01)
+
+
+def apply_with_memory_sandboxed(next_state: np.ndarray, memory_grid: np.ndarray, mem: VoxelMemoryParams, contraction_phase: bool) -> np.ndarray:
+    if not contraction_phase:
+        return next_state
+    out = next_state.copy()
+    mature_compute = memory_grid[0] >= float(mem.age_mature_threshold)
+    dense_compute = _compute_neighbor_count(out == STATE_NAME_TO_ID["COMPUTE"]) >= (mem.damping_radius + 3)
+    rescued = (out == STATE_NAME_TO_ID["VOID"]) & mature_compute & dense_compute
+    out[rescued] = STATE_NAME_TO_ID["COMPUTE"]
+    return out
+
+
+def _apply_deterministic_transitions(state: np.ndarray, active_neighbors: np.ndarray, table: Mapping[int, Mapping[int, int]]) -> np.ndarray:
+    next_state = np.zeros_like(state)
+    for src, mapping in table.items():
+        src_mask = state == src
+        if not np.any(src_mask):
+            continue
+        for n_count, target in mapping.items():
+            next_state[src_mask & (active_neighbors == n_count)] = target
+    return next_state
+
+
+def _reverse_contagion_probability(compute_neighbors: np.ndarray, mem: VoxelMemoryParams) -> np.ndarray:
+    excess = np.maximum(0, compute_neighbors - mem.reverse_contagion_threshold)
+    prob = mem.reverse_contagion_base_prob + mem.reverse_contagion_boost * excess.astype(np.float32)
+    prob[compute_neighbors < mem.reverse_contagion_threshold] = 0.0
+    return np.minimum(prob, 0.95)
+
+
+def _apply_contagion_overrides(next_state: np.ndarray, neighbor_counts_by_state: np.ndarray, rng: np.random.Generator, contagion: ContagionConfig, memory_grid: np.ndarray, mem: VoxelMemoryParams) -> np.ndarray:
+    if not contagion.enabled:
+        return next_state
+
+    out = next_state.copy()
+    energy_n = neighbor_counts_by_state[STATE_NAME_TO_ID["ENERGY"]]
+    sensor_n = neighbor_counts_by_state[STATE_NAME_TO_ID["SENSOR"]]
+    compute_n = neighbor_counts_by_state[STATE_NAME_TO_ID["COMPUTE"]]
+
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    compute = out == STATE_NAME_TO_ID["COMPUTE"]
+
+    out[structural & (energy_n >= contagion.energy_neighbor_threshold) & (rng.random(out.shape) < contagion.structural_energy_conversion_prob)] = STATE_NAME_TO_ID["ENERGY"]
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    out[structural & (sensor_n >= contagion.sensor_neighbor_threshold) & (rng.random(out.shape) < contagion.structural_sensor_conversion_prob)] = STATE_NAME_TO_ID["SENSOR"]
+
+    out[compute & (energy_n >= contagion.energy_neighbor_threshold) & (rng.random(out.shape) < contagion.compute_energy_conversion_prob)] = STATE_NAME_TO_ID["ENERGY"]
+    compute = out == STATE_NAME_TO_ID["COMPUTE"]
+    out[compute & (sensor_n >= contagion.sensor_neighbor_threshold) & (rng.random(out.shape) < contagion.compute_sensor_conversion_prob)] = STATE_NAME_TO_ID["SENSOR"]
+
+    # Reverse contagion: dense COMPUTE neighborhoods recruit nearby STRUCTURAL cells.
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    rc_prob = _reverse_contagion_probability(compute_n, mem)
+    rc_prob = np.minimum(0.95, rc_prob * np.maximum(0.25, memory_grid[2]))
+    out[structural & (rng.random(out.shape) < rc_prob)] = STATE_NAME_TO_ID["COMPUTE"]
+
+    return out
+
+
+def _apply_stochastic_overrides(next_state: np.ndarray, rng: np.random.Generator, stoch: StochasticConfig) -> np.ndarray:
+    if not stoch.enabled:
+        return next_state
+
+    out = next_state.copy()
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    compute = out == STATE_NAME_TO_ID["COMPUTE"]
+    energy = out == STATE_NAME_TO_ID["ENERGY"]
+    sensor = out == STATE_NAME_TO_ID["SENSOR"]
+
+    out[structural & (rng.random(out.shape) < stoch.structural_to_energy_prob)] = STATE_NAME_TO_ID["ENERGY"]
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    out[structural & (rng.random(out.shape) < stoch.structural_to_sensor_prob)] = STATE_NAME_TO_ID["SENSOR"]
+
+    out[compute & (rng.random(out.shape) < stoch.compute_to_energy_prob)] = STATE_NAME_TO_ID["ENERGY"]
+    compute = out == STATE_NAME_TO_ID["COMPUTE"]
+    out[compute & (rng.random(out.shape) < stoch.compute_to_sensor_prob)] = STATE_NAME_TO_ID["SENSOR"]
+
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    out[structural & (rng.random(out.shape) < stoch.structural_to_void_decay_prob)] = STATE_NAME_TO_ID["VOID"]
+    out[energy & (rng.random(out.shape) < stoch.energy_to_void_decay_prob)] = STATE_NAME_TO_ID["VOID"]
+    out[sensor & (rng.random(out.shape) < stoch.sensor_to_void_decay_prob)] = STATE_NAME_TO_ID["VOID"]
+
+    return out
+
+
+def _apply_memory_reinforcement(
+    next_state: np.ndarray,
+    memory_grid: np.ndarray,
+    current_gen: int,
+    mem: VoxelMemoryParams,
+    rng: np.random.Generator,
+    selective_decay: Optional[SelectiveMemoryDecayConfig] = None,
+) -> np.ndarray:
+    out = next_state.copy()
+    compute = out == STATE_NAME_TO_ID["COMPUTE"]
+
+    # Update compute age + active generation + strengthening.
+    memory_grid[0][compute] = np.minimum(memory_grid[0][compute] + 1.0, 65535.0)
+    memory_grid[1][compute] = float(current_gen)
+    memory_grid[2][compute] = np.minimum(memory_grid[2][compute] * mem.rag_reinforcement_boost, 2.0)
+
+    # Bamboo protocol: structural age growth + rebirth channel.
+    structural = out == STATE_NAME_TO_ID["STRUCTURAL"]
+    memory_grid[3][structural] = np.minimum(memory_grid[3][structural] + 1.0, float(mem.bamboo_max_length))
+    memory_grid[2][structural] = np.minimum(memory_grid[2][structural] + mem.otolith_vector, 2.0)
+    rebirth = structural & (memory_grid[3] >= float(mem.bamboo_rebirth_age))
+    out[rebirth] = STATE_NAME_TO_ID["COMPUTE"]
+    memory_grid[3][~structural] = 0.0
+
+    # Memory-based decay resistance for compute cells that drifted to VOID.
+    dropped_compute = (next_state == STATE_NAME_TO_ID["VOID"]) & (memory_grid[0] > 0)
+    age = memory_grid[0]
+    resistance = np.zeros_like(memory_grid[2])
+    young = age <= mem.age_young_threshold
+    mature = (age > mem.age_young_threshold) & (age <= mem.age_mature_threshold)
+    old = age > mem.age_mature_threshold
+
+    resistance[young] = (age[young] / max(1.0, float(mem.age_young_threshold))) * mem.resistance_max
+    resistance[mature] = mem.resistance_max
+    resistance[old] = mem.resistance_max * np.exp(-(age[old] - mem.age_mature_threshold) / 500.0)
+    resistance *= np.minimum(memory_grid[2], 1.5)
+    compute_cluster = _compute_neighbor_count(out == STATE_NAME_TO_ID["COMPUTE"])
+
+    _apply_selective_memory_decay(
+        memory_grid,
+        compute,
+        compute_cluster,
+        current_gen,
+        mem,
+        selective_decay if selective_decay is not None else SelectiveMemoryDecayConfig(enabled=False),
+    )
+    resistance = np.minimum(0.98, resistance + (compute_cluster >= mem.cluster_coherence_threshold).astype(np.float32) * (mem.cluster_shield_bonus + mem.shield_strength * 0.15))
+
+    out[dropped_compute & (rng.random(out.shape) < resistance)] = STATE_NAME_TO_ID["COMPUTE"]
+
+    # Energy->compute economy bridge with forward-contagion mitigation.
+    energy = out == STATE_NAME_TO_ID["ENERGY"]
+    scluster = _compute_neighbor_count(out == STATE_NAME_TO_ID["STRUCTURAL"])
+    e2c_prob = np.full(out.shape, mem.energy_to_compute_prob, dtype=np.float32)
+    mitigated = np.maximum(
+        mem.forward_contagion_floor * mem.energy_to_compute_prob,
+        mem.energy_to_compute_prob - mem.forward_contagion_penalty,
+    )
+    e2c_prob[scluster >= mem.forward_contagion_threshold] = mitigated
+    superpod = compute_cluster >= mem.super_pod_threshold
+    e2c_prob[superpod] = np.minimum(0.95, e2c_prob[superpod] + mem.biofilm_leech_rate * 0.5)
+    memory_grid[4][superpod] = np.maximum(0.05, memory_grid[4][superpod] * (1.0 - mem.biofilm_leech_rate))
+    out[energy & (rng.random(out.shape) < e2c_prob)] = STATE_NAME_TO_ID["COMPUTE"]
+
+    # Entropy damping (analogue mutation noise)
+    mut_mask = rng.random(out.shape) < mem.analogue_mutation
+    out[mut_mask & (out == STATE_NAME_TO_ID["STRUCTURAL"])] = STATE_NAME_TO_ID["COMPUTE"]
+    out[mut_mask & (out == STATE_NAME_TO_ID["COMPUTE"])] = STATE_NAME_TO_ID["ENERGY"]
+    out[mut_mask & (out == STATE_NAME_TO_ID["ENERGY"])] = STATE_NAME_TO_ID["SENSOR"]
+    out[mut_mask & (out == STATE_NAME_TO_ID["SENSOR"])] = STATE_NAME_TO_ID["STRUCTURAL"]
+
+    # reset age if not compute after final reinforcement
+    memory_grid[0][out != STATE_NAME_TO_ID["COMPUTE"]] = 0.0
+    return out
+
+
+def step_ca_lattice(
+    state: np.ndarray,
+    rule_spec: Mapping[str, Any],
+    rng: np.random.Generator,
+    inactivity_steps: Optional[np.ndarray] = None,
+    memory_grid: Optional[np.ndarray] = None,
+    current_gen: int = 0,
+    telemetry: Optional[TelemetryWindow] = None,
+    phase_detector: Optional[DensityPhaseDetector] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Dict[str, float]]:
+    """Single CA step with deterministic + contagion + stochastic + decay + memory dynamics."""
+    if state.ndim != 3:
+        raise ValueError(f"Expected a 3D lattice, got shape={state.shape}")
+
+    if memory_grid is None:
+        memory_grid = init_memory_grid(state.shape)
+
+    compute_age_snapshot = memory_grid[0].copy() if memory_grid is not None else None
+    structural_age_snapshot = memory_grid[3].copy() if memory_grid is not None else None
+
+    table = _compile_transition_table(rule_spec)
+    decay = _load_decay_config(rule_spec)
+    stoch = _load_stochastic_config(rule_spec)
+    contagion = _load_contagion_config(rule_spec)
+    experimental = load_experimental_config(rule_spec)
+    mem = VoxelMemoryParams()
+
+    neighbor_counts = _count_neighbors_by_state(state)
+    active_neighbors = np.sum(neighbor_counts[1:], axis=0)
+
+    next_state = _apply_deterministic_transitions(state, active_neighbors, table)
+    next_state = _apply_contagion_overrides(next_state, neighbor_counts, rng, contagion, memory_grid, mem)
+
+    if inactivity_steps is None:
+        inactivity_steps = np.zeros_like(state, dtype=np.int16)
+
+    if decay.enabled:
+        structural = next_state == STATE_NAME_TO_ID["STRUCTURAL"]
+        low_support = active_neighbors <= decay.inactivity_neighbor_threshold
+        inactivity_steps = np.where(structural & low_support, inactivity_steps + 1, 0)
+        next_state[structural & (inactivity_steps >= decay.structural_inactive_steps_to_decay)] = STATE_NAME_TO_ID["VOID"]
+        inactivity_steps[~structural] = 0
+
+    next_state = _apply_stochastic_overrides(next_state, rng, stoch)
+    next_state = _apply_memory_reinforcement(
+        next_state,
+        memory_grid,
+        current_gen,
+        mem,
+        rng,
+        experimental.selective_memory_decay,
+    )
+
+    phase_signals = update_density_phase_detector(phase_detector, next_state)
+    if (
+        phase_detector is not None
+        and phase_detector.config.trigger_sandboxed_memory
+        and phase_signals.get("phase_triggered", 0.0) > 0
+    ):
+        next_state = apply_with_memory_sandboxed(next_state, memory_grid, mem, contraction_phase=True)
+
+    update_telemetry_window(
+        telemetry,
+        state,
+        next_state,
+        compute_age_snapshot if compute_age_snapshot is not None else np.zeros_like(state, dtype=np.float32),
+        structural_age_snapshot if structural_age_snapshot is not None else np.zeros_like(state, dtype=np.float32),
+    )
+
+    counts = np.bincount(next_state.ravel(), minlength=5)
+    non_void_total = int(np.sum(counts[1:]))
+    probs = counts[1:] / max(1, non_void_total)
+    non_zero_probs = probs[probs > 0]
+    entropy = float(-np.sum(non_zero_probs * np.log(non_zero_probs))) if non_zero_probs.size else 0.0
+    normalized_entropy = float(entropy / np.log(4.0)) if non_zero_probs.size > 1 else 0.0
+
+    metrics = {
+        "entropy": normalized_entropy,
+        "structural_ratio": float(counts[1] / max(1, non_void_total)),
+        "void_ratio": float(counts[0] / max(1, np.prod(next_state.shape))),
+        "compute_ratio": float(counts[2] / max(1, np.prod(next_state.shape))),
+        "energy_ratio": float(counts[3] / max(1, np.prod(next_state.shape))),
+        "sensor_ratio": float(counts[4] / max(1, np.prod(next_state.shape))),
+    }
+    metrics.update(phase_signals)
+    return next_state.astype(np.uint8, copy=False), inactivity_steps.astype(np.int16, copy=False), memory_grid.astype(np.float32, copy=False), metrics
+
+
+def run_mini_lattice_mutation_trials(
+    base_rule_spec: Mapping[str, Any],
+    mutation_specs: List[Mapping[str, Any]],
+    trials_per_mutation: int = 3,
+    lattice_size: int = 16,
+    steps: int = 6,
+    seed: int = 0,
+) -> List[Dict[str, Any]]:
+    """Experimental-only reduced-lattice harness (16^3 default).
+
+    Hypothesis aid only: this harness is for isolated mutation trials and does not claim
+    predictive equivalence with full-size production lattices.
+    """
+    rng = np.random.default_rng(seed)
+    results: List[Dict[str, Any]] = []
+    for mutation_id, mutation in enumerate(mutation_specs):
+        trial_scores: List[float] = []
+        for trial in range(trials_per_mutation):
+            state = np.zeros((lattice_size, lattice_size, lattice_size), dtype=np.uint8)
+            c = lattice_size // 2
+            state[c, c, c] = STATE_NAME_TO_ID["STRUCTURAL"]
+            memory = init_memory_grid(state.shape)
+            inactivity = np.zeros_like(state, dtype=np.int16)
+            rule = dict(base_rule_spec)
+            rule_params = dict(rule.get("params", {}))
+            trial_mut = dict(mutation)
+            if "transitions" in trial_mut and "transitions" in rule_params:
+                transitions = dict(rule_params["transitions"])
+                transitions.update(trial_mut.pop("transitions"))
+                rule_params["transitions"] = transitions
+            rule_params.update(trial_mut)
+            rule["params"] = rule_params
+            for gen in range(steps):
+                state, inactivity, memory, metrics = step_ca_lattice(state, rule, rng, inactivity, memory, gen + 1)
+            trial_scores.append(float(metrics.get("compute_ratio", 0.0) + metrics.get("structural_ratio", 0.0)))
+
+        avg = float(np.mean(np.asarray(trial_scores, dtype=np.float32))) if trial_scores else 0.0
+        label = "collapse" if avg < 0.05 else "stable" if avg < 0.35 else "growth"
+        results.append({
+            "mutation_id": mutation_id,
+            "mean_survival_score": avg,
+            "classification": label,
+            "hypothesis_only": True,
+            "lattice_size": lattice_size,
+        })
+    return results

--- a/tests/test_continuous_evolution_ca.py
+++ b/tests/test_continuous_evolution_ca.py
@@ -1,0 +1,206 @@
+import numpy as np
+
+from scripts.continuous_evolution_ca import (
+    DensityPhaseDetectorConfig,
+    SelectiveMemoryDecayConfig,
+    _apply_selective_memory_decay,
+    init_density_phase_detector,
+    init_memory_grid,
+    init_telemetry_window,
+    load_experimental_config,
+    step_ca_lattice,
+    summarize_telemetry_window,
+    update_density_phase_detector,
+)
+
+
+def _rule_spec_for_tests():
+    return {
+        "params": {
+            "transitions": {
+                "VOID": {3: "STRUCTURAL"},
+                "STRUCTURAL": {0: "STRUCTURAL", 1: "STRUCTURAL", 3: "COMPUTE", 6: "STRUCTURAL"},
+                "COMPUTE": {1: "COMPUTE", 2: "ENERGY"},
+                "ENERGY": {0: "ENERGY", 1: "ENERGY"},
+                "SENSOR": {0: "SENSOR", 1: "SENSOR"},
+            },
+            "contagion": {
+                "enabled": True,
+                "energy_neighbor_threshold": 4,
+                "sensor_neighbor_threshold": 4,
+                "structural_energy_conversion_prob": 1.0,
+                "structural_sensor_conversion_prob": 0.0,
+                "compute_energy_conversion_prob": 0.0,
+                "compute_sensor_conversion_prob": 0.0,
+            },
+            "stochastic": {
+                "enabled": True,
+                "baseline_transition_prob": 0.08,
+                "structural_to_energy_prob": 1.0,
+                "structural_to_sensor_prob": 0.0,
+                "compute_to_energy_prob": 0.0,
+                "compute_to_sensor_prob": 0.0,
+                "structural_to_void_decay_prob": 0.0,
+                "energy_to_void_decay_prob": 0.0,
+                "sensor_to_void_decay_prob": 0.0,
+            },
+            "decay": {
+                "enabled": True,
+                "inactivity_neighbor_threshold": 1,
+                "structural_inactive_steps_to_decay": 2,
+            },
+        }
+    }
+
+
+def test_stochastic_transition_promotes_structural_to_energy() -> None:
+    state = np.zeros((5, 5, 5), dtype=np.uint8)
+    state[2, 2, 2] = 1
+
+    rule = _rule_spec_for_tests()
+    rule["params"]["contagion"]["enabled"] = False
+
+    rng = np.random.default_rng(7)
+    nxt, inactivity, memory, _ = step_ca_lattice(state, rule, rng, memory_grid=init_memory_grid(state.shape), current_gen=1)
+
+    assert inactivity.shape == state.shape
+    assert memory.shape[0] == 5
+    assert nxt[2, 2, 2] == 3
+
+
+def test_contagion_promotes_structural_with_energy_neighbors() -> None:
+    state = np.zeros((5, 5, 5), dtype=np.uint8)
+    state[2, 2, 2] = 1
+    # 6 ENERGY neighbors around center -> exceeds threshold=4
+    for p in [(1, 2, 2), (3, 2, 2), (2, 1, 2), (2, 3, 2), (2, 2, 1), (2, 2, 3)]:
+        state[p] = 3
+
+    rule = _rule_spec_for_tests()
+    rule["params"]["stochastic"]["enabled"] = False
+
+    rng = np.random.default_rng(19)
+    nxt, _, _, _ = step_ca_lattice(state, rule, rng, memory_grid=init_memory_grid(state.shape), current_gen=1)
+
+    assert nxt[2, 2, 2] == 3
+
+
+def test_decay_recycles_inactive_structural_cells() -> None:
+    rule = _rule_spec_for_tests()
+    rule["params"]["stochastic"]["enabled"] = False
+    rule["params"]["contagion"]["enabled"] = False
+
+    state = np.zeros((5, 5, 5), dtype=np.uint8)
+    state[2, 2, 2] = 1
+
+    rng = np.random.default_rng(11)
+    inactivity = np.zeros_like(state, dtype=np.int16)
+
+    nxt, inactivity, memory, _ = step_ca_lattice(state, rule, rng, inactivity, init_memory_grid(state.shape), 1)
+    assert nxt[2, 2, 2] == 1
+    nxt2, inactivity2, memory2, _ = step_ca_lattice(nxt, rule, rng, inactivity, memory, 2)
+
+    assert inactivity2[2, 2, 2] >= 2
+    assert nxt2[2, 2, 2] == 0
+
+
+def test_asymmetric_stability_keeps_energy_cells_alive() -> None:
+    rule = _rule_spec_for_tests()
+    rule["params"]["contagion"]["enabled"] = False
+    rule["params"]["stochastic"].update(
+        {
+            "enabled": True,
+            "structural_to_void_decay_prob": 1.0,
+            "energy_to_void_decay_prob": 0.0,
+            "sensor_to_void_decay_prob": 0.0,
+            "structural_to_energy_prob": 0.0,
+            "structural_to_sensor_prob": 0.0,
+            "compute_to_energy_prob": 0.0,
+            "compute_to_sensor_prob": 0.0,
+        }
+    )
+
+    state = np.zeros((5, 5, 5), dtype=np.uint8)
+    state[2, 2, 2] = 3  # ENERGY
+
+    rng = np.random.default_rng(31)
+    nxt, _, _, _ = step_ca_lattice(state, rule, rng, memory_grid=init_memory_grid(state.shape), current_gen=1)
+
+    assert nxt[2, 2, 2] == 3
+
+
+def test_telemetry_window_collects_lifetimes_and_matrix() -> None:
+    rule = _rule_spec_for_tests()
+    rule["params"]["stochastic"]["enabled"] = False
+    rule["params"]["contagion"]["enabled"] = False
+
+    state = np.zeros((5, 5, 5), dtype=np.uint8)
+    state[2, 2, 2] = 1
+    inactivity = np.zeros_like(state, dtype=np.int16)
+    memory = init_memory_grid(state.shape)
+    telemetry = init_telemetry_window()
+    rng = np.random.default_rng(123)
+
+    state, inactivity, memory, _ = step_ca_lattice(
+        state, rule, rng, inactivity, memory, 1, telemetry
+    )
+    state, inactivity, memory, _ = step_ca_lattice(
+        state, rule, rng, inactivity, memory, 2, telemetry
+    )
+
+    summary, payload = summarize_telemetry_window(telemetry)
+
+    assert "Telemetry Window" in summary
+    assert "transition_matrix" in payload
+    assert len(payload["transition_matrix"]) == 5
+
+
+def test_load_experimental_config_defaults_disabled() -> None:
+    cfg = load_experimental_config({"params": {}})
+    assert cfg.selective_memory_decay.enabled is False
+    assert cfg.density_phase_detector.enabled is False
+    assert cfg.mini_lattice.default_size == 16
+
+
+def test_selective_memory_decay_math_applies_high_decay_rate() -> None:
+    memory = init_memory_grid((3, 3, 3))
+    memory[2, :, :, :] = 1.0
+    memory[1, :, :, :] = 0.0
+    compute_mask = np.zeros((3, 3, 3), dtype=bool)
+    compute_cluster = np.zeros((3, 3, 3), dtype=np.int16)
+    compute_cluster[1, 1, 1] = 9
+
+    cfg = SelectiveMemoryDecayConfig(
+        enabled=True,
+        memory_strength_threshold=2.0,
+        compute_neighbor_threshold=6,
+        low_decay_rate=0.01,
+        high_decay_rate=0.50,
+    )
+    from scripts.continuous_evolution_ca import VoxelMemoryParams
+    _apply_selective_memory_decay(memory, compute_mask, compute_cluster, current_gen=1, mem=VoxelMemoryParams(), cfg=cfg)
+
+    assert memory[2, 1, 1, 1] < memory[2, 0, 0, 0]
+
+
+def test_density_phase_detector_trigger_logic() -> None:
+    detector = init_density_phase_detector(
+        DensityPhaseDetectorConfig(
+            enabled=True,
+            window_size=5,
+            density_low_threshold=0.05,
+            density_high_threshold=0.8,
+            first_derivative_threshold=0.05,
+            second_derivative_threshold=0.02,
+            contraction_density_threshold=0.30,
+            trigger_sandboxed_memory=True,
+        )
+    )
+    s1 = np.ones((4, 4, 4), dtype=np.uint8)
+    s2 = np.zeros((4, 4, 4), dtype=np.uint8)
+    s2.ravel()[:16] = 1
+    s3 = np.zeros((4, 4, 4), dtype=np.uint8)
+    s3.ravel()[:8] = 1
+    update_density_phase_detector(detector, s1)
+    update_density_phase_detector(detector, s2)
+    sig = update_density_phase_detector(detector, s3)
+    assert sig["phase_triggered"] == 1.0

--- a/tests/test_continuous_evolution_ca.py
+++ b/tests/test_continuous_evolution_ca.py
@@ -186,21 +186,20 @@ def test_density_phase_detector_trigger_logic() -> None:
     detector = init_density_phase_detector(
         DensityPhaseDetectorConfig(
             enabled=True,
-            window_size=5,
-            density_low_threshold=0.05,
-            density_high_threshold=0.8,
-            first_derivative_threshold=0.05,
-            second_derivative_threshold=0.02,
-            contraction_density_threshold=0.30,
+            window_size=10,
+            theta_c=0.12,
+            alpha_c=0.02,
+            savgol_poly_order=3,
             trigger_sandboxed_memory=True,
         )
     )
-    s1 = np.ones((4, 4, 4), dtype=np.uint8)
-    s2 = np.zeros((4, 4, 4), dtype=np.uint8)
-    s2.ravel()[:16] = 1
-    s3 = np.zeros((4, 4, 4), dtype=np.uint8)
-    s3.ravel()[:8] = 1
-    update_density_phase_detector(detector, s1)
-    update_density_phase_detector(detector, s2)
-    sig = update_density_phase_detector(detector, s3)
-    assert sig["phase_triggered"] == 1.0
+    ratios = [0.90, 0.84, 0.76, 0.66, 0.54, 0.40, 0.28, 0.18, 0.10, 0.04]
+    sig = {}
+    triggered = False
+    for ratio in ratios:
+        s = np.zeros((10, 10, 10), dtype=np.uint8)
+        active = int(ratio * s.size)
+        s.ravel()[:active] = 1
+        sig = update_density_phase_detector(detector, s)
+        triggered = triggered or bool(sig["phase_triggered"])
+    assert triggered

--- a/tests/test_differentiation_fitness.py
+++ b/tests/test_differentiation_fitness.py
@@ -1,0 +1,64 @@
+from agent.evolution_engine import DefaultFitnessEvaluator
+from agent.meme_structure import Meme, MemeGenes
+
+
+def _neutral_meme() -> Meme:
+    meme = Meme(genes=MemeGenes(
+        dominance=0.0,
+        virality=0.0,
+        stability=0.5,
+        compatibility=0.5,
+        expression_threshold=0.5,
+    ))
+    meme.environment_fitness = {}
+    meme.propagation_count = 0
+    return meme
+
+
+def test_entropy_bonus_rewards_heterogeneous_state_mix() -> None:
+    evaluator = DefaultFitnessEvaluator()
+    meme = _neutral_meme()
+
+    monolithic_context = {
+        "cell_state_counts": {
+            "STRUCTURAL": 67000,
+            "COMPUTE": 100,
+            "ENERGY": 100,
+            "SENSOR": 100,
+        }
+    }
+    differentiated_context = {
+        "cell_state_counts": {
+            "STRUCTURAL": 20000,
+            "COMPUTE": 17000,
+            "ENERGY": 15000,
+            "SENSOR": 15000,
+        }
+    }
+
+    monolithic_score = evaluator.evaluate_meme(meme, monolithic_context)
+    differentiated_score = evaluator.evaluate_meme(meme, differentiated_context)
+
+    assert differentiated_score > monolithic_score
+
+
+def test_structural_dominance_penalty_applies_after_target_threshold() -> None:
+    evaluator = DefaultFitnessEvaluator()
+    meme = _neutral_meme()
+
+    below_target = {"cell_state_counts": {"STRUCTURAL": 54, "COMPUTE": 20, "ENERGY": 13, "SENSOR": 13}}
+    above_target = {"cell_state_counts": {"STRUCTURAL": 90, "COMPUTE": 4, "ENERGY": 3, "SENSOR": 3}}
+
+    assert evaluator.evaluate_meme(meme, below_target) > evaluator.evaluate_meme(meme, above_target)
+
+
+def test_list_state_vector_is_supported() -> None:
+    evaluator = DefaultFitnessEvaluator()
+    meme = _neutral_meme()
+
+    # [VOID, STRUCTURAL, COMPUTE, ENERGY, SENSOR]
+    vector_context = {"cell_state_counts": [190000, 17000, 17000, 17000, 17000]}
+
+    score = evaluator.evaluate_meme(meme, vector_context)
+
+    assert 0.0 <= score <= 1.0


### PR DESCRIPTION
### Motivation

- Introduce richer CA dynamics (stochastic transitions, contagion, selective decay, and entropy damping) to improve scaffold maintenance, compute resilience, and exploratory specialization.
- Add voxel-local memory and phase-detection to preserve mature compute clusters and gate sandboxed behaviour during contraction phases.
- Make fitness evaluation sensitive to population differentiation (entropy) and penalize structural dominance to steer meme evolution toward balanced specialization.

### Description

- Enhanced `DefaultFitnessEvaluator` in `agent/evolution_engine.py` to include a differentiation score that computes normalized entropy of non-void states and applies a structural-dominance penalty via `_extract_state_counts` and `_differentiation_score` helpers. 
- Updated CA example rule `ca/rules/example.toml` to `branching-growth-v0.7.5` and added deterministic backbone plus `contagion`, `stochastic`, `decay`, and multiple experimental parameter sections. 
- Extended Rust CA kernel `crates/uft_ca/src/lib.rs` with `VoxelMemory`, `VoxelMemoryParams`, `DensityPhaseDetector`, and related constants and functions, added memory-aware transition methods (`apply_with_memory`, `apply_with_memory_sandboxed`), stochastic variants (`apply_stochastic`), memory/experimental stepping paths on `GraphState`, and Python bindings that track a `memory_grid` and `generation`. 
- Added a Python CA harness `scripts/continuous_evolution_ca.py` that implements a full 3D stepping pipeline with deterministic transitions, contagion overrides, stochastic overrides, selective memory decay, phase detection, telemetry collection, and a mini-lattice mutation harness for experiment trials. 
- Added `generate_primordial_seed_cube` and a `--seed-cube-size` option in `scripts/continuous_evolution.py` to bootstrap CA runs with a centered structural cube. 
- Added documentation `docs/experimental_phase3_modules.md` describing feature-flagged experimental modules and their hypotheses. 
- Tests and examples: added Rust unit tests validating selective memory decay and density-phase detector, and Python tests exercising the CA harness and the differentiation-aware fitness evaluator (`tests/test_continuous_evolution_ca.py`, `tests/test_differentiation_fitness.py`).

### Testing

- Ran Rust unit tests with `cargo test` for the CA crate including `DensityPhaseDetector` and `VoxelMemory` logic, and they passed. 
- Ran Python unit tests with `pytest` covering the CA stepping harness, telemetry and detector logic (`tests/test_continuous_evolution_ca.py`) and fitness differentiation tests (`tests/test_differentiation_fitness.py`), and they passed. 
- CI smoke: integration paths exercised include instantiation of `MultiStateGraphLattice` via Python bindings and a basic continuous evolution bootstrap using `generate_primordial_seed_cube`, both executed in the test harness successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a988074fe88331af8600c3f408316c)