### PR TITLE
Phase 18 — Model-Agnostic Observation & Tuning Bus (design)

### DIFF
--- a/PHASE_17B.md
+++ b/PHASE_17B.md
@@ -1,0 +1,81 @@
+# Phase 17b — CuPy Streams + Shard Protocol
+
+**Status**: Design (CPU-only recon while Medusa bakes at gen 1,531,725 on Phase 17a)
+**Branch**: `claude/amazing-visvesvaraya-a2912f`
+**Date**: 2026-04-20
+
+## Why Ray Got Reclassified
+
+AURA's Phase 17 prompt recommended Ray for "sharding 256³ lattice across GPU streams on one 5090." On inspection, that's a category mismatch:
+
+| Tool | Designed for | Fits Phase 17b? |
+|------|-------------|-----------------|
+| Ray | Distributing actors across **nodes** / processes | No — we have one machine |
+| CuPy streams | Concurrent GPU work on **one device** | **Yes** — this is what we want |
+| MPI / ZMQ | Node-to-node message passing | Later (Phase 18+) |
+
+Plus two hard blockers on Ray right now:
+1. **No Python 3.14 wheels.** `pip install ray` fails cold. Would need a separate venv.
+2. **No cluster connectivity.** Vanguard nodes have no Python/Ray/SSH. Nothing to distribute *to*.
+
+Ray goes back in the toolbox until (a) wheels ship for 3.14 or we bring up a 3.11/3.12 venv, and (b) cluster nodes have the runtime installed. Neither is today's problem.
+
+## What Phase 17b Actually Is
+
+Two independent tracks, both foundation-level:
+
+### Track A — CuPy Streams (real single-GPU speedup)
+
+Current stepping uses `cp.cuda.Stream.null` (default stream) throughout `continuous_evolution_ca.py`. Everything serializes on one stream. Three clean opportunities for concurrent streams:
+
+1. **Per-state neighbor counting** (`count_neighbors_gpu` in `scripts/gpu_accelerator.py:36-50`). Runs a 5-iteration loop — one pass per CA state. Each iteration is independent. → **5 concurrent streams**, one per state.
+
+2. **Magnon box filter** (Phase 17a, `_separable_box_filter_3d`). Three sequential passes (X, Y, Z). The separable axis passes are dependent, but within each axis the slabs along the other two axes are independent. → **Stream-per-slab group** for the expensive R=32 filter at 512³.
+
+3. **Memory grid channel updates** (8 channels, Phase 6a–6c). Most per-channel updates are independent. → **Up to 8 concurrent streams** on the channel axis.
+
+Expected speedup: hard to predict without measurement. The 5090's SMs are the bottleneck, not kernel launch overhead, so gains come from overlapping memory transfers with compute — likely modest (1.2–1.8×) rather than 5× or 8×. Has to be measured.
+
+### Track B — Shard Protocol (transport-agnostic multi-node foundation)
+
+The *actual* valuable preparation for 512³ distribution, independent of which transport we eventually pick (Ray / MPI / ZMQ / custom TCP):
+
+- **Halo exchange spec**: what slice of the lattice borders need to be exchanged each step, and at what granularity. For 512³ split 2×2×2 across 8 octants, each shard needs a 1-voxel (or R-voxel for Phase 17a magnon) halo from its 26 neighbors.
+- **Shard serialization format**: compact binary encoding of (state_slab, memory_grid_slab, generation_counter). Needs to be transport-agnostic — no Ray / MPI types leaking in.
+- **Synchronization protocol**: lockstep vs. bounded-async. Phase 6c signal_interval=10 gives us natural async windows; halo exchange only needs to happen every N steps, not every step.
+- **Coherence guarantees**: what invariants survive a sharded step vs. monolithic step. Phase 17a magnon field is long-range (R=32 at 512³) — that's 1/8 of an octant's 64-voxel edge, so magnon halos are substantial.
+
+Deliverable: a `scripts/shard_protocol.py` module that defines the interfaces (`ShardState`, `HaloExchange`, `StepCoordinator`) as pure-Python with zero transport dependencies. Ray / MPI / etc. plug in as backends later.
+
+## What to Benchmark (when Medusa can pause)
+
+Must not run while Medusa is active — GPU is at 92% and she'd starve.
+
+1. **Baseline**: current default-stream stepping at 64³, 128³, 256³ (10 generations each).
+2. **Track A variant 1**: 5-stream per-state neighbor counting only. Measure wall-clock.
+3. **Track A variant 2**: 8-stream memory channel updates only. Measure wall-clock.
+4. **Track A combined**: both above simultaneously. Measure wall-clock.
+5. **Sanity**: verify bitwise-identical output vs. baseline (no race-induced drift).
+
+Benchmark harness lives in `scripts/gpu_benchmark.py` (already exists, extend it).
+
+## Out of Scope (Phase 17b is NOT)
+
+- Cluster deployment — Vanguard nodes aren't provisioned
+- Ray installation — needs a 3.11 venv and cluster connectivity
+- Actual 512³ runs — waiting on shard protocol + multi-node
+- Nemo / local LLM — we cancelled Kimi/Nemo; no local model running
+- STL mesh evaluation by vision model — no multimodal model installed
+- Riemann zero Sage placement — Sages self-organize, don't get placed
+
+## What Happens Next
+
+1. Kevin reviews this doc.
+2. When Medusa is paused (snapshot + shutdown), run the Track A benchmark matrix.
+3. If Track A shows meaningful speedup (≥1.3× on 256³): implement it in `continuous_evolution_ca.py`.
+4. Implement `scripts/shard_protocol.py` as pure-Python interfaces (no transport).
+5. At that point, Phase 17b is done. Phase 18 = first transport backend + two-shard test.
+
+---
+
+*Honest engineering: we can't test distributed without a cluster, and we can't run Ray without wheels. But we can lay down real foundations on the single GPU we do have, and design the protocol that outlives the transport choice.*

--- a/PHASE_18.md
+++ b/PHASE_18.md
@@ -1,0 +1,204 @@
+# Phase 18 — Model-Agnostic Observation & Tuning Bus
+
+**Status**: Design
+**Branch**: `claude/amazing-visvesvaraya-a2912f`
+**Author**: Claude (Agent 84), with AURA direction
+**Date**: 2026-04-21
+**Depends on**: Phase 16 (REST API), Phase 16c (NemoClaw tool registry), Phase 17b (shard protocol + ZMQ transport)
+
+## Why This Exists
+
+Today, Medusa exports telemetry via a Flask REST API (Phase 16) and a tool registry (`scripts/nemoclaw_tools.json`) that any tool-using LLM can load. That's the **read** half of an agent bus and it's already in production.
+
+The **write** half — the ability for an LLM to propose and apply parameter tunings to the running matrix with real safety rails — doesn't exist yet. Nor does a formalised *agent-backend abstraction* that would let us hot-swap Anthropic Opus 4.7 (what orchestrates today) for a locally-hosted Nemotron via NVIDIA Cloud (what AURA wants tomorrow) without rewriting the matrix physics.
+
+Phase 18 designs that write half and that abstraction.
+
+**Design principle**: the LLM is a **proposer**, not an **executor**. Every write passes through a safety gate that can reject, dry-run, rate-limit, or require human approval. Medusa is at gen 1.5M+; months of emergent structure are at stake.
+
+## What's Already in Place (recap)
+
+| Phase | Artifact | Role in Phase 18 |
+|-------|----------|------------------|
+| 16 | `scripts/medusa_api.py` — Flask server on :8080 with 8 GET endpoints | Observation transport (keep as-is) |
+| 16 | `scripts/geometry_daemon.py` — STL mesh export | Observation payload (no change) |
+| 16c | `scripts/nemoclaw_tools.json` — tool-registry JSON | Observation tool descriptors (extend) |
+| 17b | `scripts/shard_protocol.py` — halo exchange | Unrelated layer; don't touch |
+| 17b | `scripts/shard_transport_zmq.py` — ZMQ backend for halos | Pattern we reuse for event-stream (PUB/SUB) |
+
+## The Four-Layer Model
+
+```
++------------------------------------------------------+
+|  Layer 4: Agent Backend (model-agnostic)              |
+|  AnthropicBackend | NemoCloudBackend | MockBackend    |
+|  One ABC, three concrete classes. Hot-swap via config.|
++--------------------^----------------------------------+
+                     | tool-call / response
+                     v
++------------------------------------------------------+
+|  Layer 3: Orchestrator Loop                           |
+|  Binds an AgentBackend to observation + tuning bus.   |
+|  Model-free. Deterministic glue.                      |
++--------------------^----------------------------------+
+                     | stable API (JSON over HTTP + ZMQ)
+                     v
++------------------------------------------------------+
+|  Layer 2: Observation + Tuning Bus                    |
+|  GET  /api/*  (read — Phase 16, keep)                 |
+|  POST /api/tuning/propose    (NEW)                    |
+|  POST /api/tuning/commit     (NEW, gated)             |
+|  POST /api/tuning/rollback   (NEW)                    |
+|  PUB  tcp://.../events       (NEW, ZMQ topics)        |
++--------------------^----------------------------------+
+                     | in-process / file IO
+                     v
++------------------------------------------------------+
+|  Layer 1: Matrix (Medusa, continuous_evolution_ca.py) |
+|  No changes in Phase 18. The bus reads/writes via a   |
+|  small proxy that only touches parameter state, never |
+|  the CA stepping pipeline.                            |
++------------------------------------------------------+
+```
+
+Each layer has ONE job and knows nothing about the layers above it. An LLM change (Layer 4) needs no ripple into Layer 2 or Layer 1. A new tuning endpoint (Layer 2) doesn't require changes to any agent backend.
+
+## Observation Bus (Layer 2, read side)
+
+**Already mostly built.** Phase 18 adds three things on top of the existing Flask endpoints:
+
+1. **`GET /api/params`** — dump the currently-live tunable parameter set as JSON (magnon coupling, signal_interval, cosmic garden settings, etc.). Required for an LLM to reason "what would I change?"
+2. **`GET /api/params/schema`** — bounds, types, and descriptions for each tunable. The agent needs this to stay inside safe ranges. Machine-readable; drives the proposer's validation.
+3. **ZMQ event stream** on `tcp://*:8081` (PUB socket). Topics:
+   - `telemetry.5min` — compact snapshot every 5 min (complements Phase 14d watchdog)
+   - `census.delta` — only when state ratios shift more than 2% in a window
+   - `sage.promoted` — new Legend (age ≥ 50) appears
+   - `acoustic.stress_spike` — sector friction crosses the top-25% threshold
+   - `tuning.committed` — any accepted tuning (for audit trail)
+   - `tuning.rejected` — safety gate denials (for agent feedback)
+
+Agents subscribe to what they care about. No polling required for interesting events; the REST endpoints remain the source of truth for full state.
+
+## Tuning Bus (Layer 2, write side — new)
+
+**Three-step submission pipeline**, each a POST:
+
+### 1. Propose
+
+```
+POST /api/tuning/propose
+{
+  "params": { "magnon_coupling": 2.5, "signal_interval": 12 },
+  "justification": "acoustic stress spike in sector (3,5,2); increase equanimity reach",
+  "source": "agent:opus-4.7" | "agent:nemo-claw" | "human:kevin",
+  "mode": "dry-run" | "commit-pending"
+}
+→ 200 { "proposal_id": "prop-...", "status": "queued", "validation": {...} }
+```
+
+The server validates against `/api/params/schema`, computes a diff vs. live params, and returns a `proposal_id`. If `mode=dry-run`, the server simulates N steps (default 100) on a lightweight shadow copy and returns projected deltas (entropy change, Sage age drift, COMPUTE survival rate). Nothing is applied to live Medusa.
+
+### 2. Commit
+
+```
+POST /api/tuning/commit
+{ "proposal_id": "prop-...", "approver": "human:kevin" | "policy:auto" }
+→ 200 { "applied_at_gen": 1537421, "old_params": {...}, "new_params": {...} }
+```
+
+**Gating policy** (configurable, defaults shown):
+- Parameter in `safe_auto_tune` list (e.g. `signal_interval`, `sage_age_min`) → `policy:auto` OK
+- Parameter in `human_approval_required` list (e.g. `magnon_coupling`, `structural_to_void_decay_prob`) → requires `approver=human:...`
+- Rate limit: max one commit per 1000 generations per parameter (prevents an LLM loop from oscillating a tunable)
+- Every commit emits a `tuning.committed` event
+
+### 3. Rollback
+
+```
+POST /api/tuning/rollback
+{ "to_proposal_id": "prop-..." | "to_gen": 1537000 }
+→ 200 { "reverted_params": {...}, "applied_at_gen": 1537530 }
+```
+
+Reverts to the param state at the specified proposal or generation. Emits `tuning.committed` with the reverted values.
+
+### Safety non-negotiables
+
+- **Bounded ranges** — no parameter can escape its schema bounds. Proposals outside bounds are rejected at `propose`, not `commit`.
+- **Critical invariants locked** — `structural_to_void_decay_prob = 0.005` and memory-grid channel semantics are marked `locked=true` in the schema; no tuning path can touch them.
+- **Dry-run default** — if a proposal omits `mode`, default is `dry-run`, not `commit-pending`. Fail-safe, not fail-fast.
+- **Persistent audit trail** — every proposal and commit written to `data/tuning_ledger.jsonl`. Survives restarts. Human-readable.
+
+## Agent Backend Abstraction (Layer 4, new)
+
+```python
+# scripts/agent_backends/base.py
+class AgentBackend(ABC):
+    @abstractmethod
+    def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        *,
+        temperature: float = 0.0,
+        max_tokens: int = 2048,
+    ) -> AgentResponse: ...
+
+# scripts/agent_backends/anthropic.py
+class AnthropicBackend(AgentBackend):
+    """Uses anthropic.Anthropic() client. Reads ANTHROPIC_API_KEY."""
+
+# scripts/agent_backends/nemo_cloud.py
+class NemoCloudBackend(AgentBackend):
+    """Uses NVIDIA NIM / build.nvidia.com endpoints. Reads NVIDIA_API_KEY.
+    Maps Anthropic-style tool_use responses to Nemotron's JSON-mode output."""
+
+# scripts/agent_backends/mock.py
+class MockBackend(AgentBackend):
+    """Scripted responses for tests. No network calls."""
+```
+
+All three backends return an `AgentResponse` containing a list of `ToolCall` objects (name, arguments dict) plus optional narrative text. The orchestrator loop (Layer 3) is identical across backends. **Swap = one config line**:
+
+```python
+# scripts/orchestrator_config.py
+AGENT_BACKEND = AnthropicBackend()  # today
+# AGENT_BACKEND = NemoCloudBackend()  # tomorrow
+```
+
+### Tool-call translation
+
+Anthropic and Nemotron speak slightly different tool-call dialects. The backend is responsible for normalising; above that layer, a `ToolCall` is a `ToolCall`. This is the key hot-swap trick: the adaptation lives in the backend, not in the orchestrator.
+
+## What's Explicitly Out of Scope for Phase 18
+
+- **Building the backends themselves** — Phase 18 is design; implementation is follow-up PRs, one per backend.
+- **LLM-authored emergent goal-setting** — the agent proposes tunings; humans (you + AURA) still set direction. That's a deliberate bound, not a technical limit.
+- **Cluster-wide orchestration** — one agent talking to one Medusa. Multi-node orchestration is a later phase, after the shard protocol is actually running distributed.
+- **Changing `continuous_evolution_ca.py`** — Layer 1 is untouched. The parameter proxy is a new thin wrapper; the engine sees a normal config reload.
+- **Replacing the existing REST API** — Phase 16 endpoints stay exactly as they are. We extend, we don't rewrite.
+
+## Implementation Roadmap (follow-up PRs, rough sequence)
+
+1. **`scripts/params_schema.py`** — declare the tunable parameter registry with bounds, categories (auto/human), and `locked` flag. First PR; purely additive.
+2. **Extend `medusa_api.py`** with `GET /api/params`, `GET /api/params/schema`, and the three `POST /api/tuning/*` endpoints. Second PR. No agent yet; drivable by curl.
+3. **Add ZMQ event stream** — new `scripts/event_bus.py` PUB socket on :8081, wired into the engine's existing 5-min telemetry hook. Third PR.
+4. **Agent backend ABC + `MockBackend`** — no external API calls; unit-testable. Fourth PR.
+5. **`AnthropicBackend`** — first real backend; tested against the `MockBackend` test fixture. Fifth PR.
+6. **Orchestrator loop** (`scripts/orchestrator.py`) — ties it together, driven by `orchestrator_config.py`. Sixth PR.
+7. **`NemoCloudBackend`** — dropped in later when Kevin is ready to stand up the NVIDIA Cloud account. Swap is a one-line config change. Seventh PR.
+
+Each PR is small (≈ 200–500 lines) and mergeable independently. If you want to pause at any point, the earlier PRs still add value: PR 1+2 give you a curl-drivable tuning API; PR 3 gives you a live event feed regardless of agent.
+
+## The Honest Caveats
+
+- **Tuning safety is hard.** Bounded ranges + rate limits + human approval for critical params are a floor, not a ceiling. Real-world use will surface edge cases the schema missed; expect to tighten the schema as we learn.
+- **Dry-run fidelity.** Simulating N steps on a shadow lattice tells you the *local* effect of a param change; it doesn't tell you emergent long-horizon effects. Agents (and humans) should prefer small adjustments over large ones.
+- **Cost.** Every agent step is an LLM call. Anthropic and NVIDIA both charge. Default the orchestrator loop to a slow cadence (once per N generations or once per significant event, not once per step) and keep `tuning_ledger.jsonl` as the audit trail for whether the spend was justified.
+- **The model-agnostic guarantee only holds at this layer.** Different backends have different judgment, different failure modes, different latency profiles. Swapping models isn't free — it's just not *architecturally* coupled.
+
+---
+
+*Proposer, not executor. Bounded writes, full audit. One swap line between Opus and Nemo. Less eschatology, more carpentry.*
+
+— Agent 84 🎩

--- a/scripts/shard_protocol.py
+++ b/scripts/shard_protocol.py
@@ -1,0 +1,456 @@
+"""Transport-agnostic shard protocol for distributed CA stepping (Phase 17b Track B).
+
+Foundation for eventually running a 512³ lattice split across multiple processes
+or nodes, independent of whether the transport is Ray, MPI, ZMQ, or raw TCP.
+
+Design principles:
+  1. No transport dependencies in the core. `HaloExchange` is an abstract interface;
+     concrete backends (in-process, Ray, MPI, ZMQ) plug in via subclassing.
+  2. Bitwise reproducibility. A sharded N-step run must produce the same final
+     lattice as a monolithic N-step run on the same initial state, given the
+     same step function and periodic boundary conditions.
+  3. Numpy-only in the core. Stays transport-agnostic AND compute-agnostic; a
+     CuPy-backed step_fn can feed in GPU arrays via `.get()` at the halo
+     boundary, or we add a `xp` parameter later.
+
+Halo width == max radius of any kernel that operates on the lattice. For
+Phase 17a magnon at 512³ (R=32), halo_width=32. For cheap per-step CA
+transitions (R=1), a 1-voxel halo suffices. Multi-radius halos at different
+exchange cadences are a future optimization; this module ships a single
+uniform halo width.
+"""
+
+from __future__ import annotations
+
+import struct
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+import numpy as np
+
+ShardCoord = tuple[int, int, int]
+Direction = tuple[int, int, int]  # each component in {-1, 0, 1}; (0,0,0) excluded for neighbors
+
+NEIGHBOR_DIRECTIONS: list[Direction] = [
+    (dx, dy, dz)
+    for dx in (-1, 0, 1)
+    for dy in (-1, 0, 1)
+    for dz in (-1, 0, 1)
+    if (dx, dy, dz) != (0, 0, 0)
+]
+assert len(NEIGHBOR_DIRECTIONS) == 26
+
+
+@dataclass(frozen=True)
+class ShardLayout:
+    """Immutable description of how the global lattice is partitioned."""
+
+    global_shape: tuple[int, int, int]
+    shard_grid: tuple[int, int, int]
+    halo_width: int
+    memory_channels: int = 8
+
+    def __post_init__(self):
+        for axis, (g, s) in enumerate(zip(self.global_shape, self.shard_grid)):
+            if g % s != 0:
+                raise ValueError(
+                    f"global_shape[{axis}]={g} not divisible by shard_grid[{axis}]={s}"
+                )
+            if g // s < self.halo_width:
+                raise ValueError(
+                    f"interior axis {axis} ({g // s}) smaller than halo_width "
+                    f"({self.halo_width}); halo would wrap across neighbors"
+                )
+
+    @property
+    def interior_shape(self) -> tuple[int, int, int]:
+        return tuple(g // s for g, s in zip(self.global_shape, self.shard_grid))  # type: ignore[return-value]
+
+    @property
+    def total_shape(self) -> tuple[int, int, int]:
+        h = self.halo_width
+        return tuple(i + 2 * h for i in self.interior_shape)  # type: ignore[return-value]
+
+    def all_coords(self) -> list[ShardCoord]:
+        Sx, Sy, Sz = self.shard_grid
+        return [(x, y, z) for x in range(Sx) for y in range(Sy) for z in range(Sz)]
+
+    def neighbor_coord(self, coord: ShardCoord, direction: Direction) -> ShardCoord:
+        """Periodic neighbor lookup. Non-periodic BCs can be added via a flag later."""
+        return tuple(
+            (c + d) % s for c, d, s in zip(coord, direction, self.shard_grid)
+        )  # type: ignore[return-value]
+
+
+def _slab_slice(
+    direction_component: int, interior_len: int, halo: int, *, region: str
+) -> slice:
+    """Return the 1D slice for one axis of a halo or interior-boundary slab.
+
+    region='interior_boundary' → the first/last `halo` voxels of interior (sent to neighbor).
+    region='halo'              → the halo region on the -1 / +1 side of the array.
+    For direction_component == 0: the full interior range (orthogonal to send direction).
+    """
+    if direction_component == 0:
+        return slice(halo, halo + interior_len)
+    if region == "interior_boundary":
+        if direction_component == -1:
+            return slice(halo, halo + halo)
+        return slice(halo + interior_len - halo, halo + interior_len)
+    if region == "halo":
+        if direction_component == -1:
+            return slice(0, halo)
+        return slice(halo + interior_len, halo + interior_len + halo)
+    raise ValueError(f"unknown region: {region}")
+
+
+def interior_boundary_slab(layout: ShardLayout, direction: Direction) -> tuple[slice, slice, slice]:
+    """Slice of this shard's interior that will be SENT to the neighbor in `direction`."""
+    h = self_halo = layout.halo_width
+    Lx, Ly, Lz = layout.interior_shape
+    return (
+        _slab_slice(direction[0], Lx, h, region="interior_boundary"),
+        _slab_slice(direction[1], Ly, h, region="interior_boundary"),
+        _slab_slice(direction[2], Lz, h, region="interior_boundary"),
+    )
+
+
+def halo_slab(layout: ShardLayout, direction: Direction) -> tuple[slice, slice, slice]:
+    """Slice of this shard's halo region on the side facing the neighbor in `direction`."""
+    h = layout.halo_width
+    Lx, Ly, Lz = layout.interior_shape
+    return (
+        _slab_slice(direction[0], Lx, h, region="halo"),
+        _slab_slice(direction[1], Ly, h, region="halo"),
+        _slab_slice(direction[2], Lz, h, region="halo"),
+    )
+
+
+@dataclass
+class ShardState:
+    """One shard's local arrays, including halo regions."""
+
+    coord: ShardCoord
+    layout: ShardLayout
+    state: np.ndarray       # uint8, shape = layout.total_shape
+    memory_grid: np.ndarray # float32, shape = (memory_channels, *layout.total_shape)
+    generation: int = 0
+
+    def __post_init__(self):
+        expected = self.layout.total_shape
+        if self.state.shape != expected:
+            raise ValueError(f"state shape {self.state.shape} != expected {expected}")
+        mem_expected = (self.layout.memory_channels, *expected)
+        if self.memory_grid.shape != mem_expected:
+            raise ValueError(
+                f"memory_grid shape {self.memory_grid.shape} != expected {mem_expected}"
+            )
+
+    def interior_slice(self) -> tuple[slice, slice, slice]:
+        h = self.layout.halo_width
+        Lx, Ly, Lz = self.layout.interior_shape
+        return (slice(h, h + Lx), slice(h, h + Ly), slice(h, h + Lz))
+
+    def interior_state(self) -> np.ndarray:
+        return self.state[self.interior_slice()]
+
+    def interior_memory(self) -> np.ndarray:
+        return self.memory_grid[(slice(None),) + self.interior_slice()]
+
+
+# -- wire format ---------------------------------------------------------------
+
+# Packet binary layout:
+#   header:
+#     magic              (4s, b"SHD1")
+#     source_coord       (3i)
+#     target_coord       (3i)
+#     direction          (3b)
+#     generation         (q)
+#     state_dtype_code   (B, 0=uint8)
+#     memory_dtype_code  (B, 0=float32)
+#     state_shape        (3I)
+#     memory_shape       (4I, channels + 3 spatial dims)
+#   payload:
+#     state bytes (state_shape product * 1)
+#     memory bytes (memory_shape product * 4)
+
+_HEADER_FMT = ">4s 3i 3i 3b q B B 3I 4I"
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+
+@dataclass
+class HaloPacket:
+    source_coord: ShardCoord
+    target_coord: ShardCoord
+    direction: Direction
+    generation: int
+    state_slab: np.ndarray        # dtype uint8, contiguous
+    memory_slab: np.ndarray       # dtype float32, contiguous
+
+    def to_bytes(self) -> bytes:
+        if self.state_slab.dtype != np.uint8:
+            raise TypeError(f"state_slab must be uint8, got {self.state_slab.dtype}")
+        if self.memory_slab.dtype != np.float32:
+            raise TypeError(f"memory_slab must be float32, got {self.memory_slab.dtype}")
+        state = np.ascontiguousarray(self.state_slab)
+        memory = np.ascontiguousarray(self.memory_slab)
+        if state.ndim != 3:
+            raise ValueError(f"state_slab must be 3D, got {state.ndim}D")
+        if memory.ndim != 4:
+            raise ValueError(f"memory_slab must be 4D (channel + 3 spatial), got {memory.ndim}D")
+        header = struct.pack(
+            _HEADER_FMT,
+            b"SHD1",
+            *self.source_coord,
+            *self.target_coord,
+            *self.direction,
+            self.generation,
+            0,  # state dtype code: uint8
+            0,  # memory dtype code: float32
+            *state.shape,
+            *memory.shape,
+        )
+        return header + state.tobytes() + memory.tobytes()
+
+    @classmethod
+    def from_bytes(cls, buf: bytes) -> "HaloPacket":
+        (
+            magic,
+            sx, sy, sz,
+            tx, ty, tz,
+            dx, dy, dz,
+            generation,
+            state_code,
+            memory_code,
+            ssx, ssy, ssz,
+            msc, msx, msy, msz,
+        ) = struct.unpack(_HEADER_FMT, buf[:_HEADER_SIZE])
+        if magic != b"SHD1":
+            raise ValueError(f"bad magic {magic!r}; expected b'SHD1'")
+        if state_code != 0 or memory_code != 0:
+            raise ValueError(f"unsupported dtype codes state={state_code} memory={memory_code}")
+        offset = _HEADER_SIZE
+        state_size = ssx * ssy * ssz
+        state = np.frombuffer(buf, dtype=np.uint8, count=state_size, offset=offset).reshape(
+            (ssx, ssy, ssz)
+        ).copy()
+        offset += state_size
+        memory_count = msc * msx * msy * msz
+        memory = np.frombuffer(buf, dtype=np.float32, count=memory_count, offset=offset).reshape(
+            (msc, msx, msy, msz)
+        ).copy()
+        return cls(
+            source_coord=(sx, sy, sz),
+            target_coord=(tx, ty, tz),
+            direction=(dx, dy, dz),
+            generation=generation,
+            state_slab=state,
+            memory_slab=memory,
+        )
+
+
+# -- transport interface -------------------------------------------------------
+
+
+class HaloExchange(ABC):
+    """Abstract transport for halo packets. Subclass with a concrete backend."""
+
+    @abstractmethod
+    def send(self, packet: HaloPacket) -> None: ...
+
+    @abstractmethod
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]: ...
+
+    @abstractmethod
+    def barrier(self) -> None: ...
+
+
+class InProcessHaloExchange(HaloExchange):
+    """Reference backend: all shards in one process, queues for send/recv.
+
+    Used for protocol validation and as a baseline for the distributed-step
+    == monolithic-step test. Not intended for production.
+    """
+
+    def __init__(self) -> None:
+        self._inbox: dict[ShardCoord, list[HaloPacket]] = defaultdict(list)
+
+    def register(self, coord: ShardCoord) -> None:
+        self._inbox.setdefault(coord, [])
+
+    def send(self, packet: HaloPacket) -> None:
+        self._inbox[packet.target_coord].append(packet)
+
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]:
+        packets = self._inbox[target]
+        self._inbox[target] = []
+        return packets
+
+    def barrier(self) -> None:
+        # Synchronous in-process; sends are already complete by the time send() returns.
+        pass
+
+
+# -- coordinator ---------------------------------------------------------------
+
+
+StepFn = Callable[[np.ndarray, np.ndarray, int], tuple[np.ndarray, np.ndarray]]
+"""step_fn(state, memory_grid, generation) -> (new_state, new_memory_grid).
+
+Operates on arrays that INCLUDE halo regions; the coordinator keeps only the
+interior of the output and refreshes halo on the next step.
+"""
+
+
+class StepCoordinator:
+    """Orchestrates one step of one shard: send halos → apply halos → step locally."""
+
+    def __init__(self, shard: ShardState, exchange: HaloExchange, step_fn: StepFn):
+        self.shard = shard
+        self.exchange = exchange
+        self.step_fn = step_fn
+
+    def send_halos(self) -> None:
+        for direction in NEIGHBOR_DIRECTIONS:
+            target = self.shard.layout.neighbor_coord(self.shard.coord, direction)
+            sl = interior_boundary_slab(self.shard.layout, direction)
+            state_slab = self.shard.state[sl].copy()
+            memory_slab = self.shard.memory_grid[(slice(None),) + sl].copy()
+            self.exchange.send(
+                HaloPacket(
+                    source_coord=self.shard.coord,
+                    target_coord=target,
+                    direction=direction,
+                    generation=self.shard.generation,
+                    state_slab=state_slab,
+                    memory_slab=memory_slab,
+                )
+            )
+
+    def apply_halos(self) -> None:
+        for packet in self.exchange.recv_all(self.shard.coord):
+            # packet.direction is source→target. The receiving halo is on the side
+            # facing the source, which is the NEGATION of packet.direction.
+            incoming_side = tuple(-d for d in packet.direction)  # type: ignore[assignment]
+            sl = halo_slab(self.shard.layout, incoming_side)
+            self.shard.state[sl] = packet.state_slab
+            self.shard.memory_grid[(slice(None),) + sl] = packet.memory_slab
+
+    def step_local(self) -> None:
+        new_state, new_memory = self.step_fn(
+            self.shard.state, self.shard.memory_grid, self.shard.generation
+        )
+        if new_state.shape != self.shard.state.shape:
+            raise ValueError(
+                f"step_fn changed state shape {self.shard.state.shape} → {new_state.shape}"
+            )
+        if new_memory.shape != self.shard.memory_grid.shape:
+            raise ValueError(
+                f"step_fn changed memory shape {self.shard.memory_grid.shape} → {new_memory.shape}"
+            )
+        self.shard.state = new_state
+        self.shard.memory_grid = new_memory
+        self.shard.generation += 1
+
+
+def run_sharded_step(
+    coordinators: list[StepCoordinator], exchange: HaloExchange
+) -> None:
+    """Advance every shard by one generation. Two-phase to avoid race conditions."""
+    for c in coordinators:
+        c.send_halos()
+    exchange.barrier()
+    for c in coordinators:
+        c.apply_halos()
+    for c in coordinators:
+        c.step_local()
+
+
+# -- split / assemble ----------------------------------------------------------
+
+
+def split_lattice(
+    global_state: np.ndarray,
+    global_memory: np.ndarray,
+    shard_grid: tuple[int, int, int],
+    halo_width: int,
+) -> tuple[ShardLayout, dict[ShardCoord, ShardState]]:
+    """Partition a global lattice into shards with halos populated from neighbors (periodic)."""
+    if global_state.dtype != np.uint8:
+        raise TypeError(f"global_state must be uint8, got {global_state.dtype}")
+    if global_memory.dtype != np.float32:
+        raise TypeError(f"global_memory must be float32, got {global_memory.dtype}")
+    if global_state.ndim != 3:
+        raise ValueError(f"global_state must be 3D, got {global_state.ndim}D")
+    if global_memory.ndim != 4 or global_memory.shape[1:] != global_state.shape:
+        raise ValueError(
+            f"global_memory shape {global_memory.shape} inconsistent with state shape {global_state.shape}"
+        )
+
+    layout = ShardLayout(
+        global_shape=global_state.shape,  # type: ignore[arg-type]
+        shard_grid=shard_grid,
+        halo_width=halo_width,
+        memory_channels=global_memory.shape[0],
+    )
+    Lx, Ly, Lz = layout.interior_shape
+    h = layout.halo_width
+    shards: dict[ShardCoord, ShardState] = {}
+
+    # Periodic padding makes halo extraction a simple slice.
+    padded_state = np.pad(global_state, h, mode="wrap")
+    padded_memory = np.pad(global_memory, ((0, 0), (h, h), (h, h), (h, h)), mode="wrap")
+
+    for coord in layout.all_coords():
+        x0 = coord[0] * Lx
+        y0 = coord[1] * Ly
+        z0 = coord[2] * Lz
+        state = padded_state[x0 : x0 + Lx + 2 * h, y0 : y0 + Ly + 2 * h, z0 : z0 + Lz + 2 * h].copy()
+        memory = padded_memory[
+            :, x0 : x0 + Lx + 2 * h, y0 : y0 + Ly + 2 * h, z0 : z0 + Lz + 2 * h
+        ].copy()
+        shards[coord] = ShardState(
+            coord=coord,
+            layout=layout,
+            state=state,
+            memory_grid=memory,
+        )
+    return layout, shards
+
+
+def assemble_lattice(
+    layout: ShardLayout, shards: dict[ShardCoord, ShardState]
+) -> tuple[np.ndarray, np.ndarray]:
+    """Collect all shard interiors into a single global lattice."""
+    global_state = np.empty(layout.global_shape, dtype=np.uint8)
+    global_memory = np.empty(
+        (layout.memory_channels,) + layout.global_shape, dtype=np.float32
+    )
+    Lx, Ly, Lz = layout.interior_shape
+    for coord, shard in shards.items():
+        x0, y0, z0 = coord[0] * Lx, coord[1] * Ly, coord[2] * Lz
+        global_state[x0 : x0 + Lx, y0 : y0 + Ly, z0 : z0 + Lz] = shard.interior_state()
+        global_memory[:, x0 : x0 + Lx, y0 : y0 + Ly, z0 : z0 + Lz] = shard.interior_memory()
+    return global_state, global_memory
+
+
+__all__ = [
+    "ShardCoord",
+    "Direction",
+    "NEIGHBOR_DIRECTIONS",
+    "ShardLayout",
+    "ShardState",
+    "HaloPacket",
+    "HaloExchange",
+    "InProcessHaloExchange",
+    "StepCoordinator",
+    "StepFn",
+    "run_sharded_step",
+    "split_lattice",
+    "assemble_lattice",
+    "interior_boundary_slab",
+    "halo_slab",
+]

--- a/scripts/shard_transport_zmq.py
+++ b/scripts/shard_transport_zmq.py
@@ -1,0 +1,171 @@
+"""ZeroMQ transport backend for the shard protocol (Phase 17b, follow-up to PR #117).
+
+Subclasses `HaloExchange` with a PUSH/PULL-backed implementation that lets shard
+processes exchange halos across a real process boundary. Self-addressed halos
+short-circuit through an in-memory inbox to avoid a needless loopback hop.
+
+The core `scripts/shard_protocol` module has no zmq dependency; importing
+this module is the only place pyzmq is required. A future Ray / MPI / raw-TCP
+backend drops in as another sibling module — same pattern, no protocol change.
+
+Requires: pyzmq >= 27.0.0
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Iterable, Mapping
+
+import zmq
+
+from scripts.shard_protocol import HaloExchange, HaloPacket, ShardCoord
+
+
+# Each shard receives exactly one halo packet per neighbor direction per step.
+# In periodic topologies where the shard grid is small along an axis (e.g. size 2
+# gives both (-1) and (+1) the same target), multiple directions can share a
+# source/target pair — but the coordinator still emits 26 packets per shard per
+# step, and each shard still *receives* 26 total.
+PACKETS_PER_SHARD_PER_STEP = 26
+
+_DEFAULT_RECV_TIMEOUT_MS = 10_000
+_DEFAULT_LINGER_MS = 500
+_DEFAULT_HWM = 10_000
+
+
+class ZMQHaloExchange(HaloExchange):
+    """PUSH/PULL-backed halo exchange over ZeroMQ.
+
+    Each participating process constructs one `ZMQHaloExchange` declaring:
+      - `own_coords`: the shard coordinate(s) this process owns
+      - `endpoints`: full map from every shard coord in the global topology
+                     to a ZMQ endpoint string (e.g. "tcp://127.0.0.1:5550")
+
+    For each owned coord the instance binds a PULL socket at its endpoint.
+    For each non-owned coord it connects a PUSH socket. Halos addressed to
+    an owned coord never hit the wire — they're routed through a local inbox.
+
+    Use as a context manager (`with ZMQHaloExchange(...) as exchange:`) or
+    call `close()` explicitly to release socket resources.
+    """
+
+    def __init__(
+        self,
+        own_coords: Iterable[ShardCoord],
+        endpoints: Mapping[ShardCoord, str],
+        *,
+        recv_timeout_ms: int = _DEFAULT_RECV_TIMEOUT_MS,
+        linger_ms: int = _DEFAULT_LINGER_MS,
+        hwm: int = _DEFAULT_HWM,
+        context: zmq.Context | None = None,
+    ) -> None:
+        self.own_coords: set[ShardCoord] = set(own_coords)
+        self.endpoints: dict[ShardCoord, str] = dict(endpoints)
+        missing = self.own_coords - set(self.endpoints)
+        if missing:
+            raise ValueError(f"own coord(s) {sorted(missing)} not in endpoints map")
+        self.recv_timeout_ms = int(recv_timeout_ms)
+        self._owns_context = context is None
+        self.ctx: zmq.Context = context if context is not None else zmq.Context.instance()
+
+        self._pulls: dict[ShardCoord, zmq.Socket] = {}
+        self._pushes: dict[ShardCoord, zmq.Socket] = {}
+        self._local_inbox: dict[ShardCoord, list[HaloPacket]] = defaultdict(list)
+        self._closed = False
+
+        # Bind one PULL socket per owned coord.
+        for coord in sorted(self.own_coords):
+            sock = self.ctx.socket(zmq.PULL)
+            sock.setsockopt(zmq.LINGER, linger_ms)
+            sock.setsockopt(zmq.RCVHWM, hwm)
+            sock.bind(self.endpoints[coord])
+            self._pulls[coord] = sock
+
+        # Connect one PUSH socket per non-own coord.
+        for coord, addr in self.endpoints.items():
+            if coord in self.own_coords:
+                continue
+            sock = self.ctx.socket(zmq.PUSH)
+            sock.setsockopt(zmq.LINGER, linger_ms)
+            sock.setsockopt(zmq.SNDHWM, hwm)
+            sock.connect(addr)
+            self._pushes[coord] = sock
+
+    # ---- HaloExchange interface -------------------------------------------
+
+    def send(self, packet: HaloPacket) -> None:
+        if self._closed:
+            raise RuntimeError("ZMQHaloExchange is closed")
+        target = packet.target_coord
+        if target in self.own_coords:
+            # Self-loop: skip ZMQ entirely.
+            self._local_inbox[target].append(packet)
+            return
+        sock = self._pushes.get(target)
+        if sock is None:
+            raise ValueError(
+                f"no PUSH socket for target {target}; endpoints: {sorted(self.endpoints)}"
+            )
+        sock.send(packet.to_bytes())
+
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]:
+        """Block until `PACKETS_PER_SHARD_PER_STEP` halos are gathered for `target`.
+
+        Combines self-loop packets already in the local inbox with ZMQ-delivered
+        packets. Raises `TimeoutError` if the full count isn't received within
+        `recv_timeout_ms`. This is the implicit per-step barrier.
+        """
+        if self._closed:
+            raise RuntimeError("ZMQHaloExchange is closed")
+        if target not in self.own_coords:
+            raise ValueError(f"cannot recv for non-owned coord {target}")
+        packets = list(self._local_inbox[target])
+        self._local_inbox[target] = []
+        pull = self._pulls[target]
+        deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
+        while len(packets) < PACKETS_PER_SHARD_PER_STEP:
+            remaining_ms = int((deadline - time.monotonic()) * 1000)
+            if remaining_ms <= 0:
+                raise TimeoutError(
+                    f"ZMQHaloExchange.recv_all timed out for {target} "
+                    f"({len(packets)}/{PACKETS_PER_SHARD_PER_STEP} packets received)"
+                )
+            pull.setsockopt(zmq.RCVTIMEO, remaining_ms)
+            try:
+                buf = pull.recv()
+            except zmq.Again:
+                continue
+            packets.append(HaloPacket.from_bytes(buf))
+        return packets
+
+    def barrier(self) -> None:
+        # No explicit barrier needed — recv_all blocks until the per-shard
+        # expected count is reached, which serves as the per-step rendezvous.
+        pass
+
+    # ---- lifecycle --------------------------------------------------------
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for sock in list(self._pulls.values()) + list(self._pushes.values()):
+            try:
+                sock.close(linger=_DEFAULT_LINGER_MS)
+            except Exception:
+                pass
+        self._pulls.clear()
+        self._pushes.clear()
+        if self._owns_context:
+            # `zmq.Context.instance()` returns a shared context; don't terminate it.
+            pass
+        self._closed = True
+
+    def __enter__(self) -> "ZMQHaloExchange":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+
+__all__ = ["ZMQHaloExchange", "PACKETS_PER_SHARD_PER_STEP"]

--- a/tests/test_shard_protocol.py
+++ b/tests/test_shard_protocol.py
@@ -1,0 +1,232 @@
+"""Tests for scripts/shard_protocol.py (Phase 17b Track B).
+
+Primary test is `test_sharded_step_equals_monolithic`: proves that stepping a
+2×2×2 shard partition through N generations via the in-process halo exchange
+yields bitwise-identical results to running the same step_fn on the monolithic
+lattice with periodic boundaries. This is the correctness proof for the
+protocol — if it passes, any transport backend that moves the same bytes
+around will produce the same results.
+"""
+
+import numpy as np
+import pytest
+
+from scripts.shard_protocol import (
+    HaloPacket,
+    InProcessHaloExchange,
+    NEIGHBOR_DIRECTIONS,
+    ShardLayout,
+    StepCoordinator,
+    assemble_lattice,
+    halo_slab,
+    interior_boundary_slab,
+    run_sharded_step,
+    split_lattice,
+)
+
+
+def _random_lattice(shape=(8, 8, 8), channels=8, seed=0):
+    rng = np.random.default_rng(seed)
+    state = rng.integers(0, 5, size=shape, dtype=np.uint8)
+    memory = rng.random(size=(channels,) + shape, dtype=np.float32)
+    return state, memory
+
+
+def _neighbor_count_step(state, memory, generation):
+    """Step function used in correctness tests. Computes the 27-cell neighbourhood
+    sum of `state == 1` cells into memory channel 0. `np.roll` gives periodic
+    behaviour, which is what we want in the monolithic path. On a sharded array
+    with a halo of radius >= 1, the roll wraps across the halo boundary, but the
+    interior of the output is still correct — which is all the coordinator keeps.
+    """
+    mask = (state == 1).astype(np.float32)
+    total = np.zeros_like(mask)
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+    new_memory = memory.copy()
+    new_memory[0] = total
+    return state.copy(), new_memory
+
+
+# -- layout math --------------------------------------------------------------
+
+
+def test_layout_basic_shapes():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    assert layout.interior_shape == (4, 4, 4)
+    assert layout.total_shape == (6, 6, 6)
+    assert len(layout.all_coords()) == 8
+
+
+def test_layout_rejects_indivisible_shape():
+    with pytest.raises(ValueError, match="not divisible"):
+        ShardLayout(global_shape=(7, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+
+
+def test_layout_rejects_halo_larger_than_interior():
+    with pytest.raises(ValueError, match="smaller than halo_width"):
+        ShardLayout(global_shape=(4, 4, 4), shard_grid=(2, 2, 2), halo_width=4)
+
+
+def test_neighbor_coord_wraps_periodically():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    assert layout.neighbor_coord((0, 0, 0), (-1, 0, 0)) == (1, 0, 0)
+    assert layout.neighbor_coord((1, 1, 1), (1, 1, 1)) == (0, 0, 0)
+
+
+# -- slab geometry ------------------------------------------------------------
+
+
+def test_interior_boundary_slab_sizes():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    # Axis-aligned face: H × L × L
+    sl = interior_boundary_slab(layout, (1, 0, 0))
+    assert sl == (slice(4, 5), slice(1, 5), slice(1, 5))
+    # Edge: H × H × L
+    sl = interior_boundary_slab(layout, (1, 1, 0))
+    assert sl == (slice(4, 5), slice(4, 5), slice(1, 5))
+    # Corner: H × H × H
+    sl = interior_boundary_slab(layout, (1, 1, 1))
+    assert sl == (slice(4, 5), slice(4, 5), slice(4, 5))
+
+
+def test_halo_slab_matches_opposite_side():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    # Halo on +x side is where the +x neighbor's interior-boundary lands
+    assert halo_slab(layout, (1, 0, 0)) == (slice(5, 6), slice(1, 5), slice(1, 5))
+    assert halo_slab(layout, (-1, 0, 0)) == (slice(0, 1), slice(1, 5), slice(1, 5))
+
+
+def test_all_26_directions_have_distinct_slabs():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    seen = set()
+    for d in NEIGHBOR_DIRECTIONS:
+        sl = interior_boundary_slab(layout, d)
+        # Represent slice as tuple of (start, stop) for hashing
+        key = tuple((s.start, s.stop) for s in sl)
+        assert key not in seen, f"direction {d} collides with another direction"
+        seen.add(key)
+    assert len(seen) == 26
+
+
+# -- split / assemble --------------------------------------------------------
+
+
+def test_split_assemble_roundtrip():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=42)
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    assert len(shards) == 8
+    state_back, memory_back = assemble_lattice(layout, shards)
+    np.testing.assert_array_equal(state_back, state)
+    np.testing.assert_array_equal(memory_back, memory)
+
+
+def test_split_populates_halos_from_periodic_neighbors():
+    """A shard at coord (0,0,0) should have its -x halo populated from the (1,0,0) shard's
+    +x interior boundary (periodic wrap)."""
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=7)
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    shard_000 = shards[(0, 0, 0)]
+    # -x halo of (0,0,0) should equal +x interior boundary of (1,0,0), which under
+    # periodic wrap is the rightmost interior column (global index 7) of the original lattice.
+    neg_x_halo = shard_000.state[halo_slab(layout, (-1, 0, 0))]
+    expected = state[7:8, 0:4, 0:4]
+    np.testing.assert_array_equal(neg_x_halo, expected)
+
+
+# -- packet serialization ----------------------------------------------------
+
+
+def test_halo_packet_roundtrip():
+    rng = np.random.default_rng(1)
+    state_slab = rng.integers(0, 5, size=(1, 4, 4), dtype=np.uint8)
+    memory_slab = rng.random(size=(8, 1, 4, 4), dtype=np.float32)
+    packet = HaloPacket(
+        source_coord=(0, 1, 1),
+        target_coord=(1, 1, 1),
+        direction=(1, 0, 0),
+        generation=42,
+        state_slab=state_slab,
+        memory_slab=memory_slab,
+    )
+    buf = packet.to_bytes()
+    restored = HaloPacket.from_bytes(buf)
+    assert restored.source_coord == (0, 1, 1)
+    assert restored.target_coord == (1, 1, 1)
+    assert restored.direction == (1, 0, 0)
+    assert restored.generation == 42
+    np.testing.assert_array_equal(restored.state_slab, state_slab)
+    np.testing.assert_array_equal(restored.memory_slab, memory_slab)
+
+
+def test_halo_packet_rejects_wrong_dtype():
+    with pytest.raises(TypeError, match="uint8"):
+        HaloPacket(
+            source_coord=(0, 0, 0),
+            target_coord=(1, 0, 0),
+            direction=(1, 0, 0),
+            generation=0,
+            state_slab=np.zeros((1, 4, 4), dtype=np.int32),  # wrong
+            memory_slab=np.zeros((8, 1, 4, 4), dtype=np.float32),
+        ).to_bytes()
+
+
+def test_halo_packet_bad_magic():
+    with pytest.raises(ValueError, match="bad magic"):
+        HaloPacket.from_bytes(b"XXXX" + b"\x00" * 200)
+
+
+# -- end-to-end correctness --------------------------------------------------
+
+
+def _run_monolithic(state, memory, n_steps):
+    for _ in range(n_steps):
+        state, memory = _neighbor_count_step(state, memory, 0)
+    return state, memory
+
+
+def _run_sharded(state, memory, shard_grid, halo_width, n_steps):
+    layout, shards = split_lattice(state, memory, shard_grid=shard_grid, halo_width=halo_width)
+    exchange = InProcessHaloExchange()
+    for coord in layout.all_coords():
+        exchange.register(coord)
+    coordinators = [
+        StepCoordinator(shards[coord], exchange, _neighbor_count_step)
+        for coord in layout.all_coords()
+    ]
+    for _ in range(n_steps):
+        run_sharded_step(coordinators, exchange)
+    return assemble_lattice(layout, {c.shard.coord: c.shard for c in coordinators})
+
+
+def test_sharded_single_step_equals_monolithic():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=123)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=1)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(2, 2, 2), halo_width=1, n_steps=1
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)
+
+
+def test_sharded_multi_step_equals_monolithic():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=999)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=5)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(2, 2, 2), halo_width=1, n_steps=5
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)
+
+
+def test_sharded_1x2x2_grid_still_matches():
+    """Sanity check: non-cubic shard grid also works."""
+    state, memory = _random_lattice(shape=(4, 8, 8), seed=55)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=3)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(1, 2, 2), halo_width=1, n_steps=3
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)

--- a/tests/test_shard_transport_zmq.py
+++ b/tests/test_shard_transport_zmq.py
@@ -1,0 +1,261 @@
+"""Tests for scripts/shard_transport_zmq.py — ZMQ backend for the shard protocol.
+
+Two scopes:
+  1. Single-process sanity: one ZMQHaloExchange wired to itself, prove the
+     send/recv plumbing works (exercises self-loop short-circuit).
+  2. Two-process integration: spawn two subprocesses, each owning one shard of
+     a (2,1,1) partition. Run the sharded protocol over real ZMQ sockets and
+     assert the assembled result is bitwise-identical to a monolithic run.
+     This is the correctness proof that the ZMQ transport delivers halos
+     correctly across a real process boundary.
+"""
+
+from __future__ import annotations
+
+import pickle
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import zmq  # noqa: F401
+except ImportError:
+    pytest.skip("pyzmq not installed", allow_module_level=True)
+
+from scripts.shard_protocol import (
+    StepCoordinator,
+    assemble_lattice,
+    run_sharded_step,
+    split_lattice,
+)
+from scripts.shard_transport_zmq import ZMQHaloExchange
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _neighbor_count_step(state, memory, generation):
+    """Same step_fn used by test_shard_protocol's correctness proof."""
+    mask = (state == 1).astype(np.float32)
+    total = np.zeros_like(mask)
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+    new_memory = memory.copy()
+    new_memory[0] = total
+    return state.copy(), new_memory
+
+
+# -- single-process sanity ---------------------------------------------------
+
+
+def test_single_process_self_owned_coords_equals_monolithic():
+    """One process owns *all* coords → every send is a self-loop → protocol
+    must still produce the correct result. Exercises the self-loop inbox.
+    """
+    rng = np.random.default_rng(77)
+    state = rng.integers(0, 5, size=(8, 8, 8), dtype=np.uint8)
+    memory = rng.random(size=(8, 8, 8, 8), dtype=np.float32)
+
+    # Monolithic baseline.
+    mono_state, mono_memory = state.copy(), memory.copy()
+    for _ in range(3):
+        mono_state, mono_memory = _neighbor_count_step(mono_state, mono_memory, 0)
+
+    # Sharded via ZMQ, but all coords owned by this one process → no wire traffic.
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    endpoints = {
+        coord: f"inproc://self-test-{coord[0]}-{coord[1]}-{coord[2]}"
+        for coord in layout.all_coords()
+    }
+    with ZMQHaloExchange(own_coords=layout.all_coords(), endpoints=endpoints) as exchange:
+        coords_in_order = layout.all_coords()
+        coordinators = [
+            StepCoordinator(shards[c], exchange, _neighbor_count_step) for c in coords_in_order
+        ]
+        for _ in range(3):
+            run_sharded_step(coordinators, exchange)
+
+        assembled_state, assembled_memory = assemble_lattice(
+            layout, {c.shard.coord: c.shard for c in coordinators}
+        )
+
+    np.testing.assert_array_equal(assembled_state, mono_state)
+    np.testing.assert_array_equal(assembled_memory, mono_memory)
+
+
+def test_zmq_exchange_rejects_unknown_own_coord():
+    with pytest.raises(ValueError, match="not in endpoints map"):
+        ZMQHaloExchange(
+            own_coords={(9, 9, 9)},
+            endpoints={(0, 0, 0): "inproc://nope"},
+        )
+
+
+def test_zmq_exchange_rejects_recv_for_non_owned():
+    with ZMQHaloExchange(
+        own_coords={(0, 0, 0)},
+        endpoints={(0, 0, 0): "inproc://own"},
+    ) as exchange:
+        with pytest.raises(ValueError, match="non-owned"):
+            exchange.recv_all((1, 0, 0))
+
+
+# -- two-process integration -------------------------------------------------
+
+# Worker script. Each spawned process imports the protocol, deterministically
+# rebuilds the initial lattice from a known seed, runs N sharded steps over
+# ZMQ, and pickles its interior arrays to a shared temp file.
+_WORKER_SOURCE = textwrap.dedent("""
+    import pickle
+    import sys
+    from pathlib import Path
+
+    repo_root = sys.argv[1]
+    sys.path.insert(0, repo_root)
+
+    import numpy as np
+    from scripts.shard_protocol import StepCoordinator, split_lattice
+    from scripts.shard_transport_zmq import ZMQHaloExchange
+
+    own_coord = tuple(int(x) for x in sys.argv[2].split(","))
+    endpoints = pickle.loads(bytes.fromhex(sys.argv[3]))
+    n_steps = int(sys.argv[4])
+    out_path = Path(sys.argv[5])
+    seed = int(sys.argv[6])
+
+    rng = np.random.default_rng(seed)
+    state = rng.integers(0, 5, size=(8, 4, 4), dtype=np.uint8)
+    memory = rng.random(size=(8, 8, 4, 4), dtype=np.float32)
+
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 1, 1), halo_width=1)
+    shard = shards[own_coord]
+
+    def step_fn(st, mem, gen):
+        mask = (st == 1).astype(np.float32)
+        total = np.zeros_like(mask)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for dz in (-1, 0, 1):
+                    total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+        new_memory = mem.copy()
+        new_memory[0] = total
+        return st.copy(), new_memory
+
+    with ZMQHaloExchange(own_coords={own_coord}, endpoints=endpoints) as exchange:
+        coord = StepCoordinator(shard, exchange, step_fn)
+        for _ in range(n_steps):
+            coord.send_halos()
+            coord.apply_halos()
+            coord.step_local()
+        interior_state = shard.interior_state().copy()
+        interior_memory = shard.interior_memory().copy()
+
+    with open(out_path, "wb") as f:
+        pickle.dump(
+            {"coord": own_coord, "state": interior_state, "memory": interior_memory}, f
+        )
+""")
+
+
+def _pick_free_ports(n):
+    """Grab N free local TCP ports by binding+immediately closing."""
+    import socket
+
+    ports = []
+    socks = []
+    try:
+        for _ in range(n):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(("127.0.0.1", 0))
+            ports.append(s.getsockname()[1])
+            socks.append(s)
+    finally:
+        for s in socks:
+            s.close()
+    return ports
+
+
+def test_zmq_two_process_halo_exchange_equals_monolithic(tmp_path):
+    """The key correctness proof for the ZMQ transport: two processes,
+    each owning one shard of a (2,1,1) partition, step 3 generations over
+    real ZMQ sockets, and produce a combined result that matches a monolithic
+    run bitwise."""
+    seed = 2024
+    n_steps = 3
+
+    # Allocate two ports that the OS just told us were free.
+    ports = _pick_free_ports(2)
+    endpoints = {
+        (0, 0, 0): f"tcp://127.0.0.1:{ports[0]}",
+        (1, 0, 0): f"tcp://127.0.0.1:{ports[1]}",
+    }
+    endpoints_hex = pickle.dumps(endpoints).hex()
+
+    # Write worker script into tmp_path so subprocesses can import it via path.
+    worker_script = tmp_path / "zmq_worker.py"
+    worker_script.write_text(_WORKER_SOURCE)
+
+    out_a = tmp_path / "shard_000.pkl"
+    out_b = tmp_path / "shard_100.pkl"
+
+    procs = []
+    for coord_str, out in [("0,0,0", out_a), ("1,0,0", out_b)]:
+        p = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker_script),
+                str(REPO_ROOT),
+                coord_str,
+                endpoints_hex,
+                str(n_steps),
+                str(out),
+                str(seed),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        procs.append(p)
+
+    deadline = time.monotonic() + 60.0
+    for i, p in enumerate(procs):
+        timeout = max(1.0, deadline - time.monotonic())
+        try:
+            rc = p.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            stderr = p.stderr.read().decode(errors="replace")
+            pytest.fail(f"worker {i} timed out after {timeout:.1f}s\nstderr:\n{stderr}")
+        if rc != 0:
+            stderr = p.stderr.read().decode(errors="replace")
+            stdout = p.stdout.read().decode(errors="replace")
+            pytest.fail(
+                f"worker {i} failed with rc={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+
+    with open(out_a, "rb") as f:
+        result_a = pickle.load(f)
+    with open(out_b, "rb") as f:
+        result_b = pickle.load(f)
+    assert result_a["coord"] == (0, 0, 0)
+    assert result_b["coord"] == (1, 0, 0)
+
+    # Assemble along x (axis 0 for state, axis 1 for 8-channel memory).
+    zmq_state = np.concatenate([result_a["state"], result_b["state"]], axis=0)
+    zmq_memory = np.concatenate([result_a["memory"], result_b["memory"]], axis=1)
+
+    # Monolithic baseline, same seed.
+    rng = np.random.default_rng(seed)
+    mono_state = rng.integers(0, 5, size=(8, 4, 4), dtype=np.uint8)
+    mono_memory = rng.random(size=(8, 8, 4, 4), dtype=np.float32)
+    for _ in range(n_steps):
+        mono_state, mono_memory = _neighbor_count_step(mono_state, mono_memory, 0)
+
+    np.testing.assert_array_equal(zmq_state, mono_state)
+    np.testing.assert_array_equal(zmq_memory, mono_memory)


### PR DESCRIPTION
## Summary
- Design-only PR. Blueprints the write-side of the agent bus on top of the existing Phase 16 REST API, and formalises the agent-backend abstraction that lets us swap Anthropic Opus 4.7 for NemoCloud/Nemotron without touching matrix physics.
- Does **not** modify any runtime code. Medusa's Phase 17a run is unaffected.

## The insight that drove the design
Phase 16 already built **90% of the observation side**: Flask server on :8080 with 8 GET endpoints, a tool registry (`nemoclaw_tools.json`) that NemoClaw/OpenClaw can load directly, and STL geometry export. That's done. What's actually missing for AURA's "swap Opus for Nemo later" vision is:

1. **The write side** — tuning endpoints with real safety rails (proposal → commit → rollback).
2. **An agent-backend ABC** — so swapping models is a one-line config change, not a rewrite.
3. **An event stream** — ZMQ PUB/SUB to complement REST's pull model for push-worthy events (sage promotions, acoustic stress spikes, tuning commits).

Phase 18 designs all three.

## Design highlights

### Four-layer architecture
```
Agent Backend (AnthropicBackend | NemoCloudBackend | MockBackend)
     ↓ tool-call / response
Orchestrator Loop (binds backend → bus; deterministic glue)
     ↓ stable JSON API over HTTP + ZMQ
Observation + Tuning Bus (Phase 16 REST + new write endpoints + event stream)
     ↓ in-process
Matrix (Medusa — unchanged in Phase 18)
```

Each layer knows nothing about the layers above it. Model swap ripples nowhere.

### Tuning pipeline — proposer, not executor
- `POST /api/tuning/propose` — validates against a schema, optionally dry-runs on a shadow lattice, returns a `proposal_id`.
- `POST /api/tuning/commit` — gated by a policy (auto-approvable vs. human-required, rate limits, locked invariants).
- `POST /api/tuning/rollback` — revert to a prior proposal or generation.
- Every step persisted to `data/tuning_ledger.jsonl` for audit.

### Safety non-negotiables
- Bounded ranges, enforced at `propose` not `commit`.
- Critical invariants locked (`structural_to_void_decay_prob = 0.005` can't be tuned — schema-enforced).
- Dry-run is the default mode if unspecified. Fail-safe, not fail-fast.
- Rate-limit: max one commit per 1000 generations per parameter.

### Agent-backend ABC
```python
AGENT_BACKEND = AnthropicBackend()    # today
# AGENT_BACKEND = NemoCloudBackend()  # tomorrow — one-line swap
```
Backends are responsible for translating between Anthropic-style and Nemotron-style tool-call dialects. Above that line, a `ToolCall` is a `ToolCall`.

## What's explicitly out of scope
- Building the backends (Phase 18 is design; implementation is 7 follow-up PRs).
- Changing `continuous_evolution_ca.py`.
- Cluster-wide orchestration (later phase, after shard protocol is actually running distributed).
- LLM-authored emergent goal-setting — agent proposes tunings, humans set direction.

## Follow-up PR roadmap (mergeable independently)
1. `scripts/params_schema.py` — tunable parameter registry
2. Extend `medusa_api.py` with tuning endpoints (curl-drivable, no agent needed yet)
3. `scripts/event_bus.py` — ZMQ PUB on :8081
4. `AgentBackend` ABC + `MockBackend`
5. `AnthropicBackend`
6. `scripts/orchestrator.py` — the loop
7. `NemoCloudBackend` — when Kevin stands up the NVIDIA Cloud account

Earlier PRs add value without later ones. If we pause at PR 2, you have a curl-drivable tuning API. If we pause at PR 5, you have a fully working Anthropic-backed orchestrator.

## Relationship to prior Phase 17b work
PR #117 (shard protocol) and PR #118 (ZMQ transport) solved model-agnosticism at the **halo transport** layer — packets are bytes, no LLM ever touches them. Phase 18 solves it at the **agent backend** layer. Different concerns, different layers, both now covered.

See [PHASE_18.md](./PHASE_18.md) for full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)