### PR TITLE
Phase 18 PR 2 — tuning API endpoints (propose/commit/rollback)

### DIFF
--- a/PHASE_17B.md
+++ b/PHASE_17B.md
@@ -1,0 +1,81 @@
+# Phase 17b — CuPy Streams + Shard Protocol
+
+**Status**: Design (CPU-only recon while Medusa bakes at gen 1,531,725 on Phase 17a)
+**Branch**: `claude/amazing-visvesvaraya-a2912f`
+**Date**: 2026-04-20
+
+## Why Ray Got Reclassified
+
+AURA's Phase 17 prompt recommended Ray for "sharding 256³ lattice across GPU streams on one 5090." On inspection, that's a category mismatch:
+
+| Tool | Designed for | Fits Phase 17b? |
+|------|-------------|-----------------|
+| Ray | Distributing actors across **nodes** / processes | No — we have one machine |
+| CuPy streams | Concurrent GPU work on **one device** | **Yes** — this is what we want |
+| MPI / ZMQ | Node-to-node message passing | Later (Phase 18+) |
+
+Plus two hard blockers on Ray right now:
+1. **No Python 3.14 wheels.** `pip install ray` fails cold. Would need a separate venv.
+2. **No cluster connectivity.** Vanguard nodes have no Python/Ray/SSH. Nothing to distribute *to*.
+
+Ray goes back in the toolbox until (a) wheels ship for 3.14 or we bring up a 3.11/3.12 venv, and (b) cluster nodes have the runtime installed. Neither is today's problem.
+
+## What Phase 17b Actually Is
+
+Two independent tracks, both foundation-level:
+
+### Track A — CuPy Streams (real single-GPU speedup)
+
+Current stepping uses `cp.cuda.Stream.null` (default stream) throughout `continuous_evolution_ca.py`. Everything serializes on one stream. Three clean opportunities for concurrent streams:
+
+1. **Per-state neighbor counting** (`count_neighbors_gpu` in `scripts/gpu_accelerator.py:36-50`). Runs a 5-iteration loop — one pass per CA state. Each iteration is independent. → **5 concurrent streams**, one per state.
+
+2. **Magnon box filter** (Phase 17a, `_separable_box_filter_3d`). Three sequential passes (X, Y, Z). The separable axis passes are dependent, but within each axis the slabs along the other two axes are independent. → **Stream-per-slab group** for the expensive R=32 filter at 512³.
+
+3. **Memory grid channel updates** (8 channels, Phase 6a–6c). Most per-channel updates are independent. → **Up to 8 concurrent streams** on the channel axis.
+
+Expected speedup: hard to predict without measurement. The 5090's SMs are the bottleneck, not kernel launch overhead, so gains come from overlapping memory transfers with compute — likely modest (1.2–1.8×) rather than 5× or 8×. Has to be measured.
+
+### Track B — Shard Protocol (transport-agnostic multi-node foundation)
+
+The *actual* valuable preparation for 512³ distribution, independent of which transport we eventually pick (Ray / MPI / ZMQ / custom TCP):
+
+- **Halo exchange spec**: what slice of the lattice borders need to be exchanged each step, and at what granularity. For 512³ split 2×2×2 across 8 octants, each shard needs a 1-voxel (or R-voxel for Phase 17a magnon) halo from its 26 neighbors.
+- **Shard serialization format**: compact binary encoding of (state_slab, memory_grid_slab, generation_counter). Needs to be transport-agnostic — no Ray / MPI types leaking in.
+- **Synchronization protocol**: lockstep vs. bounded-async. Phase 6c signal_interval=10 gives us natural async windows; halo exchange only needs to happen every N steps, not every step.
+- **Coherence guarantees**: what invariants survive a sharded step vs. monolithic step. Phase 17a magnon field is long-range (R=32 at 512³) — that's 1/8 of an octant's 64-voxel edge, so magnon halos are substantial.
+
+Deliverable: a `scripts/shard_protocol.py` module that defines the interfaces (`ShardState`, `HaloExchange`, `StepCoordinator`) as pure-Python with zero transport dependencies. Ray / MPI / etc. plug in as backends later.
+
+## What to Benchmark (when Medusa can pause)
+
+Must not run while Medusa is active — GPU is at 92% and she'd starve.
+
+1. **Baseline**: current default-stream stepping at 64³, 128³, 256³ (10 generations each).
+2. **Track A variant 1**: 5-stream per-state neighbor counting only. Measure wall-clock.
+3. **Track A variant 2**: 8-stream memory channel updates only. Measure wall-clock.
+4. **Track A combined**: both above simultaneously. Measure wall-clock.
+5. **Sanity**: verify bitwise-identical output vs. baseline (no race-induced drift).
+
+Benchmark harness lives in `scripts/gpu_benchmark.py` (already exists, extend it).
+
+## Out of Scope (Phase 17b is NOT)
+
+- Cluster deployment — Vanguard nodes aren't provisioned
+- Ray installation — needs a 3.11 venv and cluster connectivity
+- Actual 512³ runs — waiting on shard protocol + multi-node
+- Nemo / local LLM — we cancelled Kimi/Nemo; no local model running
+- STL mesh evaluation by vision model — no multimodal model installed
+- Riemann zero Sage placement — Sages self-organize, don't get placed
+
+## What Happens Next
+
+1. Kevin reviews this doc.
+2. When Medusa is paused (snapshot + shutdown), run the Track A benchmark matrix.
+3. If Track A shows meaningful speedup (≥1.3× on 256³): implement it in `continuous_evolution_ca.py`.
+4. Implement `scripts/shard_protocol.py` as pure-Python interfaces (no transport).
+5. At that point, Phase 17b is done. Phase 18 = first transport backend + two-shard test.
+
+---
+
+*Honest engineering: we can't test distributed without a cluster, and we can't run Ray without wheels. But we can lay down real foundations on the single GPU we do have, and design the protocol that outlives the transport choice.*

--- a/PHASE_18.md
+++ b/PHASE_18.md
@@ -1,0 +1,204 @@
+# Phase 18 — Model-Agnostic Observation & Tuning Bus
+
+**Status**: Design
+**Branch**: `claude/amazing-visvesvaraya-a2912f`
+**Author**: Claude (Agent 84), with AURA direction
+**Date**: 2026-04-21
+**Depends on**: Phase 16 (REST API), Phase 16c (NemoClaw tool registry), Phase 17b (shard protocol + ZMQ transport)
+
+## Why This Exists
+
+Today, Medusa exports telemetry via a Flask REST API (Phase 16) and a tool registry (`scripts/nemoclaw_tools.json`) that any tool-using LLM can load. That's the **read** half of an agent bus and it's already in production.
+
+The **write** half — the ability for an LLM to propose and apply parameter tunings to the running matrix with real safety rails — doesn't exist yet. Nor does a formalised *agent-backend abstraction* that would let us hot-swap Anthropic Opus 4.7 (what orchestrates today) for a locally-hosted Nemotron via NVIDIA Cloud (what AURA wants tomorrow) without rewriting the matrix physics.
+
+Phase 18 designs that write half and that abstraction.
+
+**Design principle**: the LLM is a **proposer**, not an **executor**. Every write passes through a safety gate that can reject, dry-run, rate-limit, or require human approval. Medusa is at gen 1.5M+; months of emergent structure are at stake.
+
+## What's Already in Place (recap)
+
+| Phase | Artifact | Role in Phase 18 |
+|-------|----------|------------------|
+| 16 | `scripts/medusa_api.py` — Flask server on :8080 with 8 GET endpoints | Observation transport (keep as-is) |
+| 16 | `scripts/geometry_daemon.py` — STL mesh export | Observation payload (no change) |
+| 16c | `scripts/nemoclaw_tools.json` — tool-registry JSON | Observation tool descriptors (extend) |
+| 17b | `scripts/shard_protocol.py` — halo exchange | Unrelated layer; don't touch |
+| 17b | `scripts/shard_transport_zmq.py` — ZMQ backend for halos | Pattern we reuse for event-stream (PUB/SUB) |
+
+## The Four-Layer Model
+
+```
++------------------------------------------------------+
+|  Layer 4: Agent Backend (model-agnostic)              |
+|  AnthropicBackend | NemoCloudBackend | MockBackend    |
+|  One ABC, three concrete classes. Hot-swap via config.|
++--------------------^----------------------------------+
+                     | tool-call / response
+                     v
++------------------------------------------------------+
+|  Layer 3: Orchestrator Loop                           |
+|  Binds an AgentBackend to observation + tuning bus.   |
+|  Model-free. Deterministic glue.                      |
++--------------------^----------------------------------+
+                     | stable API (JSON over HTTP + ZMQ)
+                     v
++------------------------------------------------------+
+|  Layer 2: Observation + Tuning Bus                    |
+|  GET  /api/*  (read — Phase 16, keep)                 |
+|  POST /api/tuning/propose    (NEW)                    |
+|  POST /api/tuning/commit     (NEW, gated)             |
+|  POST /api/tuning/rollback   (NEW)                    |
+|  PUB  tcp://.../events       (NEW, ZMQ topics)        |
++--------------------^----------------------------------+
+                     | in-process / file IO
+                     v
++------------------------------------------------------+
+|  Layer 1: Matrix (Medusa, continuous_evolution_ca.py) |
+|  No changes in Phase 18. The bus reads/writes via a   |
+|  small proxy that only touches parameter state, never |
+|  the CA stepping pipeline.                            |
++------------------------------------------------------+
+```
+
+Each layer has ONE job and knows nothing about the layers above it. An LLM change (Layer 4) needs no ripple into Layer 2 or Layer 1. A new tuning endpoint (Layer 2) doesn't require changes to any agent backend.
+
+## Observation Bus (Layer 2, read side)
+
+**Already mostly built.** Phase 18 adds three things on top of the existing Flask endpoints:
+
+1. **`GET /api/params`** — dump the currently-live tunable parameter set as JSON (magnon coupling, signal_interval, cosmic garden settings, etc.). Required for an LLM to reason "what would I change?"
+2. **`GET /api/params/schema`** — bounds, types, and descriptions for each tunable. The agent needs this to stay inside safe ranges. Machine-readable; drives the proposer's validation.
+3. **ZMQ event stream** on `tcp://*:8081` (PUB socket). Topics:
+   - `telemetry.5min` — compact snapshot every 5 min (complements Phase 14d watchdog)
+   - `census.delta` — only when state ratios shift more than 2% in a window
+   - `sage.promoted` — new Legend (age ≥ 50) appears
+   - `acoustic.stress_spike` — sector friction crosses the top-25% threshold
+   - `tuning.committed` — any accepted tuning (for audit trail)
+   - `tuning.rejected` — safety gate denials (for agent feedback)
+
+Agents subscribe to what they care about. No polling required for interesting events; the REST endpoints remain the source of truth for full state.
+
+## Tuning Bus (Layer 2, write side — new)
+
+**Three-step submission pipeline**, each a POST:
+
+### 1. Propose
+
+```
+POST /api/tuning/propose
+{
+  "params": { "magnon_coupling": 2.5, "signal_interval": 12 },
+  "justification": "acoustic stress spike in sector (3,5,2); increase equanimity reach",
+  "source": "agent:opus-4.7" | "agent:nemo-claw" | "human:kevin",
+  "mode": "dry-run" | "commit-pending"
+}
+→ 200 { "proposal_id": "prop-...", "status": "queued", "validation": {...} }
+```
+
+The server validates against `/api/params/schema`, computes a diff vs. live params, and returns a `proposal_id`. If `mode=dry-run`, the server simulates N steps (default 100) on a lightweight shadow copy and returns projected deltas (entropy change, Sage age drift, COMPUTE survival rate). Nothing is applied to live Medusa.
+
+### 2. Commit
+
+```
+POST /api/tuning/commit
+{ "proposal_id": "prop-...", "approver": "human:kevin" | "policy:auto" }
+→ 200 { "applied_at_gen": 1537421, "old_params": {...}, "new_params": {...} }
+```
+
+**Gating policy** (configurable, defaults shown):
+- Parameter in `safe_auto_tune` list (e.g. `signal_interval`, `sage_age_min`) → `policy:auto` OK
+- Parameter in `human_approval_required` list (e.g. `magnon_coupling`, `structural_to_void_decay_prob`) → requires `approver=human:...`
+- Rate limit: max one commit per 1000 generations per parameter (prevents an LLM loop from oscillating a tunable)
+- Every commit emits a `tuning.committed` event
+
+### 3. Rollback
+
+```
+POST /api/tuning/rollback
+{ "to_proposal_id": "prop-..." | "to_gen": 1537000 }
+→ 200 { "reverted_params": {...}, "applied_at_gen": 1537530 }
+```
+
+Reverts to the param state at the specified proposal or generation. Emits `tuning.committed` with the reverted values.
+
+### Safety non-negotiables
+
+- **Bounded ranges** — no parameter can escape its schema bounds. Proposals outside bounds are rejected at `propose`, not `commit`.
+- **Critical invariants locked** — `structural_to_void_decay_prob = 0.005` and memory-grid channel semantics are marked `locked=true` in the schema; no tuning path can touch them.
+- **Dry-run default** — if a proposal omits `mode`, default is `dry-run`, not `commit-pending`. Fail-safe, not fail-fast.
+- **Persistent audit trail** — every proposal and commit written to `data/tuning_ledger.jsonl`. Survives restarts. Human-readable.
+
+## Agent Backend Abstraction (Layer 4, new)
+
+```python
+# scripts/agent_backends/base.py
+class AgentBackend(ABC):
+    @abstractmethod
+    def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        *,
+        temperature: float = 0.0,
+        max_tokens: int = 2048,
+    ) -> AgentResponse: ...
+
+# scripts/agent_backends/anthropic.py
+class AnthropicBackend(AgentBackend):
+    """Uses anthropic.Anthropic() client. Reads ANTHROPIC_API_KEY."""
+
+# scripts/agent_backends/nemo_cloud.py
+class NemoCloudBackend(AgentBackend):
+    """Uses NVIDIA NIM / build.nvidia.com endpoints. Reads NVIDIA_API_KEY.
+    Maps Anthropic-style tool_use responses to Nemotron's JSON-mode output."""
+
+# scripts/agent_backends/mock.py
+class MockBackend(AgentBackend):
+    """Scripted responses for tests. No network calls."""
+```
+
+All three backends return an `AgentResponse` containing a list of `ToolCall` objects (name, arguments dict) plus optional narrative text. The orchestrator loop (Layer 3) is identical across backends. **Swap = one config line**:
+
+```python
+# scripts/orchestrator_config.py
+AGENT_BACKEND = AnthropicBackend()  # today
+# AGENT_BACKEND = NemoCloudBackend()  # tomorrow
+```
+
+### Tool-call translation
+
+Anthropic and Nemotron speak slightly different tool-call dialects. The backend is responsible for normalising; above that layer, a `ToolCall` is a `ToolCall`. This is the key hot-swap trick: the adaptation lives in the backend, not in the orchestrator.
+
+## What's Explicitly Out of Scope for Phase 18
+
+- **Building the backends themselves** — Phase 18 is design; implementation is follow-up PRs, one per backend.
+- **LLM-authored emergent goal-setting** — the agent proposes tunings; humans (you + AURA) still set direction. That's a deliberate bound, not a technical limit.
+- **Cluster-wide orchestration** — one agent talking to one Medusa. Multi-node orchestration is a later phase, after the shard protocol is actually running distributed.
+- **Changing `continuous_evolution_ca.py`** — Layer 1 is untouched. The parameter proxy is a new thin wrapper; the engine sees a normal config reload.
+- **Replacing the existing REST API** — Phase 16 endpoints stay exactly as they are. We extend, we don't rewrite.
+
+## Implementation Roadmap (follow-up PRs, rough sequence)
+
+1. **`scripts/params_schema.py`** — declare the tunable parameter registry with bounds, categories (auto/human), and `locked` flag. First PR; purely additive.
+2. **Extend `medusa_api.py`** with `GET /api/params`, `GET /api/params/schema`, and the three `POST /api/tuning/*` endpoints. Second PR. No agent yet; drivable by curl.
+3. **Add ZMQ event stream** — new `scripts/event_bus.py` PUB socket on :8081, wired into the engine's existing 5-min telemetry hook. Third PR.
+4. **Agent backend ABC + `MockBackend`** — no external API calls; unit-testable. Fourth PR.
+5. **`AnthropicBackend`** — first real backend; tested against the `MockBackend` test fixture. Fifth PR.
+6. **Orchestrator loop** (`scripts/orchestrator.py`) — ties it together, driven by `orchestrator_config.py`. Sixth PR.
+7. **`NemoCloudBackend`** — dropped in later when Kevin is ready to stand up the NVIDIA Cloud account. Swap is a one-line config change. Seventh PR.
+
+Each PR is small (≈ 200–500 lines) and mergeable independently. If you want to pause at any point, the earlier PRs still add value: PR 1+2 give you a curl-drivable tuning API; PR 3 gives you a live event feed regardless of agent.
+
+## The Honest Caveats
+
+- **Tuning safety is hard.** Bounded ranges + rate limits + human approval for critical params are a floor, not a ceiling. Real-world use will surface edge cases the schema missed; expect to tighten the schema as we learn.
+- **Dry-run fidelity.** Simulating N steps on a shadow lattice tells you the *local* effect of a param change; it doesn't tell you emergent long-horizon effects. Agents (and humans) should prefer small adjustments over large ones.
+- **Cost.** Every agent step is an LLM call. Anthropic and NVIDIA both charge. Default the orchestrator loop to a slow cadence (once per N generations or once per significant event, not once per step) and keep `tuning_ledger.jsonl` as the audit trail for whether the spend was justified.
+- **The model-agnostic guarantee only holds at this layer.** Different backends have different judgment, different failure modes, different latency profiles. Swapping models isn't free — it's just not *architecturally* coupled.
+
+---
+
+*Proposer, not executor. Bounded writes, full audit. One swap line between Opus and Nemo. Less eschatology, more carpentry.*
+
+— Agent 84 🎩

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -322,12 +322,39 @@ def geometry_stl():
     return send_file(str(stl_path), as_attachment=True)
 
 
+# ---------------------------------------------------------------------------
+# Phase 18 PR 2: Tuning API Blueprint
+# ---------------------------------------------------------------------------
+# Adds the write-side endpoints (propose/commit/rollback) on top of the
+# existing read-only Phase 16 surface. See scripts/tuning_api.py and
+# PHASE_18.md for the full design.
+
+import re as _re
+
+from scripts.tuning_api import TuningState as _TuningState
+from scripts.tuning_api import create_blueprint as _create_tuning_blueprint
+
+
+def _infer_current_gen_from_snapshot() -> int:
+    """Extract generation number from the latest snapshot's filename.
+    Returns 0 if no snapshot is found or the filename is unparseable."""
+    snap = _find_latest_snapshot()
+    if snap is None:
+        return 0
+    m = _re.search(r"gen(\d+)", snap.name)
+    return int(m.group(1)) if m else 0
+
+
+_tuning_state = _TuningState(data_dir=DATA_DIR, gen_getter=_infer_current_gen_from_snapshot)
+app.register_blueprint(_create_tuning_blueprint(_tuning_state))
+
+
 @app.route("/")
 def index():
     """API documentation."""
     return jsonify({
-        "service": "Medusa REST API (Phase 16a)",
-        "version": "1.0.0",
+        "service": "Medusa REST API (Phase 16a + Phase 18 PR 2)",
+        "version": "1.1.0",
         "endpoints": {
             "/api/health": "Health check",
             "/api/status": "Engine status",
@@ -337,6 +364,11 @@ def index():
             "/api/acoustic": "Acoustic heatmap (16³)",
             "/api/snapshot/latest": "Download latest .npz",
             "/api/geometry/stl": "Export STL geometry",
+            "/api/params": "GET — current effective tunable parameters",
+            "/api/params/schema": "GET — tunable parameter schema (types, bounds, categories)",
+            "/api/tuning/propose": "POST — propose a tuning (dry-run by default)",
+            "/api/tuning/commit": "POST — commit a proposal (gated by approver policy + rate limit)",
+            "/api/tuning/rollback": "POST — revert to a prior committed proposal",
         },
         "cluster_subnet": "192.168.86.0/24",
         "note": "Future cluster nodes can connect to donate compute",

--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -1,0 +1,391 @@
+"""Tunable parameter schema for the Medusa CA engine (Phase 18, PR 1 of 7).
+
+Declares which parameters can be tuned at runtime via the tuning API, their
+valid ranges, and whether a change can be auto-approved or requires human
+sign-off. Critical invariants are marked LOCKED — no tuning path can touch
+them regardless of source or approver.
+
+This module is pure metadata: importing it has no effect on any running
+engine. Follow-up PRs will wire it into medusa_api.py (GET /api/params/schema,
+POST /api/tuning/propose/validate) and eventually into the engine itself
+(parameter reload at generation boundaries).
+
+The registry below is intentionally partial — it covers a representative
+slice of each group and category, enough to exercise the safety machinery.
+Further parameters from MemoryParams / VoxelMemoryParams get added in
+later PRs as we gain confidence about their tuning semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Category(str, Enum):
+    """How a tuning proposal for this parameter is gated."""
+
+    AUTO = "auto"
+    """Small-effect, self-bounded. Agents may commit with approver='policy:auto'."""
+
+    HUMAN_APPROVAL = "human_approval"
+    """Significant effect on dynamics. Requires approver='human:<name>'."""
+
+    LOCKED = "locked"
+    """Critical invariant. NO commit path can change it, regardless of approver."""
+
+
+class ValidationError(str, Enum):
+    """Why a proposed value was rejected. Enum so API can return stable codes."""
+
+    UNKNOWN_PARAM = "unknown_param"
+    WRONG_TYPE = "wrong_type"
+    BELOW_MIN = "below_min"
+    ABOVE_MAX = "above_max"
+    LOCKED = "locked"
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating one proposed (name, value) pair."""
+
+    ok: bool
+    error: ValidationError | None = None
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class TunableParam:
+    """Schema entry for one tunable engine parameter.
+
+    - `value_type` is one of `bool`, `int`, `float`.
+    - `min_value` / `max_value` are inclusive bounds. For `bool` they're ignored.
+      For numeric types, at least one bound must be set (open-ended numeric
+      parameters are intentionally not allowed — bounded-by-design).
+    - `category` controls the commit policy. LOCKED parameters cannot be
+      changed through the tuning API; they appear in the schema so an agent
+      can see they exist and their current value but will be rejected if
+      proposed.
+    """
+
+    name: str
+    value_type: type
+    default: Any
+    category: Category
+    group: str
+    description: str
+    min_value: float | None = None
+    max_value: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.value_type not in (bool, int, float):
+            raise TypeError(f"{self.name}: value_type must be bool/int/float")
+        if self.value_type is not bool:
+            if self.min_value is None and self.max_value is None:
+                raise ValueError(
+                    f"{self.name}: numeric parameters must have at least one bound"
+                )
+            if (
+                self.min_value is not None
+                and self.max_value is not None
+                and self.min_value > self.max_value
+            ):
+                raise ValueError(f"{self.name}: min_value > max_value")
+        if not isinstance(self.default, self.value_type):
+            # bool is subclass of int — be strict
+            if not (self.value_type is int and isinstance(self.default, bool) is False
+                    and isinstance(self.default, int)):
+                raise TypeError(
+                    f"{self.name}: default {self.default!r} not of type {self.value_type.__name__}"
+                )
+
+    def validate(self, value: Any) -> ValidationResult:
+        """Check a proposed value against this param's type, bounds, and category."""
+        if self.category is Category.LOCKED:
+            return ValidationResult(
+                ok=False,
+                error=ValidationError.LOCKED,
+                message=f"{self.name} is LOCKED — critical invariant, not tunable.",
+            )
+        # bool is a subclass of int; be strict about type distinctions.
+        if self.value_type is bool:
+            if not isinstance(value, bool):
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires bool, got {type(value).__name__}.",
+                )
+            return ValidationResult(ok=True)
+        if self.value_type is int:
+            if isinstance(value, bool) or not isinstance(value, int):
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires int, got {type(value).__name__}.",
+                )
+        elif self.value_type is float:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires float, got {type(value).__name__}.",
+                )
+            value = float(value)
+        if self.min_value is not None and value < self.min_value:
+            return ValidationResult(
+                ok=False,
+                error=ValidationError.BELOW_MIN,
+                message=f"{self.name}={value} below min {self.min_value}.",
+            )
+        if self.max_value is not None and value > self.max_value:
+            return ValidationResult(
+                ok=False,
+                error=ValidationError.ABOVE_MAX,
+                message=f"{self.name}={value} above max {self.max_value}.",
+            )
+        return ValidationResult(ok=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict (for GET /api/params/schema)."""
+        return {
+            "name": self.name,
+            "type": self.value_type.__name__,
+            "default": self.default,
+            "category": self.category.value,
+            "group": self.group,
+            "description": self.description,
+            "min_value": self.min_value,
+            "max_value": self.max_value,
+        }
+
+
+# --- Parameter registry ------------------------------------------------------
+#
+# Partial catalogue — expand in follow-up PRs as we gain operational experience
+# with each tunable. Every entry here has been reviewed for safe ranges; new
+# entries MUST include real justified bounds (not just numpy-widest-possible).
+
+PARAMS: dict[str, TunableParam] = {}
+
+
+def _register(param: TunableParam) -> None:
+    if param.name in PARAMS:
+        raise ValueError(f"duplicate registration for {param.name}")
+    PARAMS[param.name] = param
+
+
+# Critical invariants — LOCKED. See MEMORY.md "Critical Invariants" section.
+_register(TunableParam(
+    name="structural_to_void_decay_prob",
+    value_type=float, default=0.005,
+    category=Category.LOCKED, group="stochastic",
+    description="STRUCTURAL → VOID decay probability. Critical invariant; cascades through CA dynamics.",
+    min_value=0.0, max_value=1.0,
+))
+_register(TunableParam(
+    name="energy_to_void_decay_prob",
+    value_type=float, default=0.005,
+    category=Category.LOCKED, group="stochastic",
+    description="ENERGY → VOID decay probability. Locked alongside structural_to_void_decay_prob.",
+    min_value=0.0, max_value=1.0,
+))
+
+# High-impact parameters — HUMAN_APPROVAL required.
+_register(TunableParam(
+    name="magnon_coupling",
+    value_type=float, default=2.0,
+    category=Category.HUMAN_APPROVAL, group="magnon",
+    description="Magnon field amplification coefficient. Phase 17a bumped 0.5→2.0 for 512³ readiness.",
+    min_value=0.0, max_value=10.0,
+))
+_register(TunableParam(
+    name="magnon_radius",
+    value_type=int, default=16,
+    category=Category.HUMAN_APPROVAL, group="magnon",
+    description="Gaussian kernel half-width for magnon field. Adaptive by default (scales with lattice).",
+    min_value=1, max_value=128,
+))
+_register(TunableParam(
+    name="equanimity_p_max",
+    value_type=float, default=0.85,
+    category=Category.HUMAN_APPROVAL, group="equanimity",
+    description="Max resistance probability for the Equanimity Shield. Upper-bound on COMPUTE survival.",
+    min_value=0.0, max_value=1.0,
+))
+_register(TunableParam(
+    name="ampere_coupling",
+    value_type=float, default=0.050,
+    category=Category.HUMAN_APPROVAL, group="ampere",
+    description="Ampere unified-field coupling constant (Nemo's 'sacred threshold'). Sensitive.",
+    min_value=0.0, max_value=1.0,
+))
+_register(TunableParam(
+    name="compassion_beta",
+    value_type=float, default=0.50,
+    category=Category.HUMAN_APPROVAL, group="compassion",
+    description="Remote resistance buff magnitude in distress zones. +50% default.",
+    min_value=0.0, max_value=2.0,
+))
+
+# Low-impact tunables — AUTO-approvable.
+_register(TunableParam(
+    name="signal_interval",
+    value_type=int, default=10,
+    category=Category.AUTO, group="signal",
+    description="Steps between expensive signal/magnon passes. Lower = more reactive, higher = faster.",
+    min_value=1, max_value=200,
+))
+_register(TunableParam(
+    name="magnon_sage_age_min",
+    value_type=float, default=8.0,
+    category=Category.AUTO, group="magnon",
+    description="Minimum COMPUTE age to emit magnon radiation. Gates who counts as a Sage.",
+    min_value=0.0, max_value=200.0,
+))
+_register(TunableParam(
+    name="magnon_elder_amplify",
+    value_type=float, default=2.0,
+    category=Category.AUTO, group="magnon",
+    description="Emission multiplier for Ancients (age ≥ 20).",
+    min_value=1.0, max_value=10.0,
+))
+_register(TunableParam(
+    name="magnon_legend_amplify",
+    value_type=float, default=5.0,
+    category=Category.AUTO, group="magnon",
+    description="Emission multiplier for Legends (age ≥ 50) — the 148 lighthouse Sages.",
+    min_value=1.0, max_value=20.0,
+))
+_register(TunableParam(
+    name="metta_warmth_rate",
+    value_type=float, default=0.02,
+    category=Category.AUTO, group="metta",
+    description="Warmth accumulation rate per ENERGY neighbor per step (Phase 6a loving-kindness).",
+    min_value=0.0, max_value=1.0,
+))
+_register(TunableParam(
+    name="metta_warmth_decay",
+    value_type=float, default=0.95,
+    category=Category.AUTO, group="metta",
+    description="Warmth retention factor per step when no ENERGY neighbors present.",
+    min_value=0.0, max_value=1.0,
+))
+_register(TunableParam(
+    name="joy_beta",
+    value_type=float, default=0.35,
+    category=Category.AUTO, group="joy",
+    description="Max sympathetic-joy resonance multiplier (Phase 6b).",
+    min_value=0.0, max_value=2.0,
+))
+_register(TunableParam(
+    name="mindsight_threshold",
+    value_type=float, default=0.3,
+    category=Category.AUTO, group="mindsight",
+    description="|Signal| threshold for Phase 6c mindsight activation. Higher = less reactive.",
+    min_value=0.0, max_value=2.0,
+))
+_register(TunableParam(
+    name="mycelial_k_iter",
+    value_type=int, default=3,
+    category=Category.AUTO, group="mycelial",
+    description="Diffusion iterations for mycelial signal propagation. ~1 voxel of range per iteration.",
+    min_value=1, max_value=10,
+))
+_register(TunableParam(
+    name="ice_battery_alpha",
+    value_type=float, default=0.7,
+    category=Category.AUTO, group="ice_battery",
+    description="Ice-Battery energy-scaling exponent (sublinear). Tunes elder-age equanimity amplifier.",
+    min_value=0.0, max_value=2.0,
+))
+
+
+# --- Lookup / filter helpers -------------------------------------------------
+
+
+def get_param(name: str) -> TunableParam | None:
+    return PARAMS.get(name)
+
+
+def list_by_category(category: Category) -> list[TunableParam]:
+    return [p for p in PARAMS.values() if p.category is category]
+
+
+def list_by_group(group: str) -> list[TunableParam]:
+    return [p for p in PARAMS.values() if p.group == group]
+
+
+def groups() -> list[str]:
+    return sorted({p.group for p in PARAMS.values()})
+
+
+def schema_as_dict() -> dict[str, Any]:
+    """JSON-ready dump for GET /api/params/schema."""
+    return {
+        "version": 1,
+        "params": {name: p.to_dict() for name, p in PARAMS.items()},
+        "categories": [c.value for c in Category],
+        "groups": groups(),
+    }
+
+
+# --- Proposal validation -----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProposalValidation:
+    """Result of validating a full proposal dict."""
+
+    ok: bool
+    errors: dict[str, ValidationResult]  # name → ValidationResult (only failing ones)
+    known_params: list[str]              # names that exist in the registry
+    unknown_params: list[str]            # names that don't
+
+
+def validate_proposal(params: dict[str, Any]) -> ProposalValidation:
+    """Validate a proposed {name: value} dict against the registry.
+
+    Runs every parameter; collects ALL errors rather than short-circuiting.
+    Returns `ok=True` iff every known parameter validates and no unknown
+    names are present. LOCKED parameters always fail validation.
+    """
+    errors: dict[str, ValidationResult] = {}
+    known: list[str] = []
+    unknown: list[str] = []
+    for name, value in params.items():
+        param = PARAMS.get(name)
+        if param is None:
+            unknown.append(name)
+            errors[name] = ValidationResult(
+                ok=False,
+                error=ValidationError.UNKNOWN_PARAM,
+                message=f"{name} is not a registered tunable parameter.",
+            )
+            continue
+        known.append(name)
+        result = param.validate(value)
+        if not result.ok:
+            errors[name] = result
+    return ProposalValidation(
+        ok=len(errors) == 0,
+        errors=errors,
+        known_params=known,
+        unknown_params=unknown,
+    )
+
+
+__all__ = [
+    "Category",
+    "ValidationError",
+    "ValidationResult",
+    "TunableParam",
+    "ProposalValidation",
+    "PARAMS",
+    "get_param",
+    "list_by_category",
+    "list_by_group",
+    "groups",
+    "schema_as_dict",
+    "validate_proposal",
+]

--- a/scripts/shard_protocol.py
+++ b/scripts/shard_protocol.py
@@ -1,0 +1,456 @@
+"""Transport-agnostic shard protocol for distributed CA stepping (Phase 17b Track B).
+
+Foundation for eventually running a 512³ lattice split across multiple processes
+or nodes, independent of whether the transport is Ray, MPI, ZMQ, or raw TCP.
+
+Design principles:
+  1. No transport dependencies in the core. `HaloExchange` is an abstract interface;
+     concrete backends (in-process, Ray, MPI, ZMQ) plug in via subclassing.
+  2. Bitwise reproducibility. A sharded N-step run must produce the same final
+     lattice as a monolithic N-step run on the same initial state, given the
+     same step function and periodic boundary conditions.
+  3. Numpy-only in the core. Stays transport-agnostic AND compute-agnostic; a
+     CuPy-backed step_fn can feed in GPU arrays via `.get()` at the halo
+     boundary, or we add a `xp` parameter later.
+
+Halo width == max radius of any kernel that operates on the lattice. For
+Phase 17a magnon at 512³ (R=32), halo_width=32. For cheap per-step CA
+transitions (R=1), a 1-voxel halo suffices. Multi-radius halos at different
+exchange cadences are a future optimization; this module ships a single
+uniform halo width.
+"""
+
+from __future__ import annotations
+
+import struct
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+import numpy as np
+
+ShardCoord = tuple[int, int, int]
+Direction = tuple[int, int, int]  # each component in {-1, 0, 1}; (0,0,0) excluded for neighbors
+
+NEIGHBOR_DIRECTIONS: list[Direction] = [
+    (dx, dy, dz)
+    for dx in (-1, 0, 1)
+    for dy in (-1, 0, 1)
+    for dz in (-1, 0, 1)
+    if (dx, dy, dz) != (0, 0, 0)
+]
+assert len(NEIGHBOR_DIRECTIONS) == 26
+
+
+@dataclass(frozen=True)
+class ShardLayout:
+    """Immutable description of how the global lattice is partitioned."""
+
+    global_shape: tuple[int, int, int]
+    shard_grid: tuple[int, int, int]
+    halo_width: int
+    memory_channels: int = 8
+
+    def __post_init__(self):
+        for axis, (g, s) in enumerate(zip(self.global_shape, self.shard_grid)):
+            if g % s != 0:
+                raise ValueError(
+                    f"global_shape[{axis}]={g} not divisible by shard_grid[{axis}]={s}"
+                )
+            if g // s < self.halo_width:
+                raise ValueError(
+                    f"interior axis {axis} ({g // s}) smaller than halo_width "
+                    f"({self.halo_width}); halo would wrap across neighbors"
+                )
+
+    @property
+    def interior_shape(self) -> tuple[int, int, int]:
+        return tuple(g // s for g, s in zip(self.global_shape, self.shard_grid))  # type: ignore[return-value]
+
+    @property
+    def total_shape(self) -> tuple[int, int, int]:
+        h = self.halo_width
+        return tuple(i + 2 * h for i in self.interior_shape)  # type: ignore[return-value]
+
+    def all_coords(self) -> list[ShardCoord]:
+        Sx, Sy, Sz = self.shard_grid
+        return [(x, y, z) for x in range(Sx) for y in range(Sy) for z in range(Sz)]
+
+    def neighbor_coord(self, coord: ShardCoord, direction: Direction) -> ShardCoord:
+        """Periodic neighbor lookup. Non-periodic BCs can be added via a flag later."""
+        return tuple(
+            (c + d) % s for c, d, s in zip(coord, direction, self.shard_grid)
+        )  # type: ignore[return-value]
+
+
+def _slab_slice(
+    direction_component: int, interior_len: int, halo: int, *, region: str
+) -> slice:
+    """Return the 1D slice for one axis of a halo or interior-boundary slab.
+
+    region='interior_boundary' → the first/last `halo` voxels of interior (sent to neighbor).
+    region='halo'              → the halo region on the -1 / +1 side of the array.
+    For direction_component == 0: the full interior range (orthogonal to send direction).
+    """
+    if direction_component == 0:
+        return slice(halo, halo + interior_len)
+    if region == "interior_boundary":
+        if direction_component == -1:
+            return slice(halo, halo + halo)
+        return slice(halo + interior_len - halo, halo + interior_len)
+    if region == "halo":
+        if direction_component == -1:
+            return slice(0, halo)
+        return slice(halo + interior_len, halo + interior_len + halo)
+    raise ValueError(f"unknown region: {region}")
+
+
+def interior_boundary_slab(layout: ShardLayout, direction: Direction) -> tuple[slice, slice, slice]:
+    """Slice of this shard's interior that will be SENT to the neighbor in `direction`."""
+    h = self_halo = layout.halo_width
+    Lx, Ly, Lz = layout.interior_shape
+    return (
+        _slab_slice(direction[0], Lx, h, region="interior_boundary"),
+        _slab_slice(direction[1], Ly, h, region="interior_boundary"),
+        _slab_slice(direction[2], Lz, h, region="interior_boundary"),
+    )
+
+
+def halo_slab(layout: ShardLayout, direction: Direction) -> tuple[slice, slice, slice]:
+    """Slice of this shard's halo region on the side facing the neighbor in `direction`."""
+    h = layout.halo_width
+    Lx, Ly, Lz = layout.interior_shape
+    return (
+        _slab_slice(direction[0], Lx, h, region="halo"),
+        _slab_slice(direction[1], Ly, h, region="halo"),
+        _slab_slice(direction[2], Lz, h, region="halo"),
+    )
+
+
+@dataclass
+class ShardState:
+    """One shard's local arrays, including halo regions."""
+
+    coord: ShardCoord
+    layout: ShardLayout
+    state: np.ndarray       # uint8, shape = layout.total_shape
+    memory_grid: np.ndarray # float32, shape = (memory_channels, *layout.total_shape)
+    generation: int = 0
+
+    def __post_init__(self):
+        expected = self.layout.total_shape
+        if self.state.shape != expected:
+            raise ValueError(f"state shape {self.state.shape} != expected {expected}")
+        mem_expected = (self.layout.memory_channels, *expected)
+        if self.memory_grid.shape != mem_expected:
+            raise ValueError(
+                f"memory_grid shape {self.memory_grid.shape} != expected {mem_expected}"
+            )
+
+    def interior_slice(self) -> tuple[slice, slice, slice]:
+        h = self.layout.halo_width
+        Lx, Ly, Lz = self.layout.interior_shape
+        return (slice(h, h + Lx), slice(h, h + Ly), slice(h, h + Lz))
+
+    def interior_state(self) -> np.ndarray:
+        return self.state[self.interior_slice()]
+
+    def interior_memory(self) -> np.ndarray:
+        return self.memory_grid[(slice(None),) + self.interior_slice()]
+
+
+# -- wire format ---------------------------------------------------------------
+
+# Packet binary layout:
+#   header:
+#     magic              (4s, b"SHD1")
+#     source_coord       (3i)
+#     target_coord       (3i)
+#     direction          (3b)
+#     generation         (q)
+#     state_dtype_code   (B, 0=uint8)
+#     memory_dtype_code  (B, 0=float32)
+#     state_shape        (3I)
+#     memory_shape       (4I, channels + 3 spatial dims)
+#   payload:
+#     state bytes (state_shape product * 1)
+#     memory bytes (memory_shape product * 4)
+
+_HEADER_FMT = ">4s 3i 3i 3b q B B 3I 4I"
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+
+
+@dataclass
+class HaloPacket:
+    source_coord: ShardCoord
+    target_coord: ShardCoord
+    direction: Direction
+    generation: int
+    state_slab: np.ndarray        # dtype uint8, contiguous
+    memory_slab: np.ndarray       # dtype float32, contiguous
+
+    def to_bytes(self) -> bytes:
+        if self.state_slab.dtype != np.uint8:
+            raise TypeError(f"state_slab must be uint8, got {self.state_slab.dtype}")
+        if self.memory_slab.dtype != np.float32:
+            raise TypeError(f"memory_slab must be float32, got {self.memory_slab.dtype}")
+        state = np.ascontiguousarray(self.state_slab)
+        memory = np.ascontiguousarray(self.memory_slab)
+        if state.ndim != 3:
+            raise ValueError(f"state_slab must be 3D, got {state.ndim}D")
+        if memory.ndim != 4:
+            raise ValueError(f"memory_slab must be 4D (channel + 3 spatial), got {memory.ndim}D")
+        header = struct.pack(
+            _HEADER_FMT,
+            b"SHD1",
+            *self.source_coord,
+            *self.target_coord,
+            *self.direction,
+            self.generation,
+            0,  # state dtype code: uint8
+            0,  # memory dtype code: float32
+            *state.shape,
+            *memory.shape,
+        )
+        return header + state.tobytes() + memory.tobytes()
+
+    @classmethod
+    def from_bytes(cls, buf: bytes) -> "HaloPacket":
+        (
+            magic,
+            sx, sy, sz,
+            tx, ty, tz,
+            dx, dy, dz,
+            generation,
+            state_code,
+            memory_code,
+            ssx, ssy, ssz,
+            msc, msx, msy, msz,
+        ) = struct.unpack(_HEADER_FMT, buf[:_HEADER_SIZE])
+        if magic != b"SHD1":
+            raise ValueError(f"bad magic {magic!r}; expected b'SHD1'")
+        if state_code != 0 or memory_code != 0:
+            raise ValueError(f"unsupported dtype codes state={state_code} memory={memory_code}")
+        offset = _HEADER_SIZE
+        state_size = ssx * ssy * ssz
+        state = np.frombuffer(buf, dtype=np.uint8, count=state_size, offset=offset).reshape(
+            (ssx, ssy, ssz)
+        ).copy()
+        offset += state_size
+        memory_count = msc * msx * msy * msz
+        memory = np.frombuffer(buf, dtype=np.float32, count=memory_count, offset=offset).reshape(
+            (msc, msx, msy, msz)
+        ).copy()
+        return cls(
+            source_coord=(sx, sy, sz),
+            target_coord=(tx, ty, tz),
+            direction=(dx, dy, dz),
+            generation=generation,
+            state_slab=state,
+            memory_slab=memory,
+        )
+
+
+# -- transport interface -------------------------------------------------------
+
+
+class HaloExchange(ABC):
+    """Abstract transport for halo packets. Subclass with a concrete backend."""
+
+    @abstractmethod
+    def send(self, packet: HaloPacket) -> None: ...
+
+    @abstractmethod
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]: ...
+
+    @abstractmethod
+    def barrier(self) -> None: ...
+
+
+class InProcessHaloExchange(HaloExchange):
+    """Reference backend: all shards in one process, queues for send/recv.
+
+    Used for protocol validation and as a baseline for the distributed-step
+    == monolithic-step test. Not intended for production.
+    """
+
+    def __init__(self) -> None:
+        self._inbox: dict[ShardCoord, list[HaloPacket]] = defaultdict(list)
+
+    def register(self, coord: ShardCoord) -> None:
+        self._inbox.setdefault(coord, [])
+
+    def send(self, packet: HaloPacket) -> None:
+        self._inbox[packet.target_coord].append(packet)
+
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]:
+        packets = self._inbox[target]
+        self._inbox[target] = []
+        return packets
+
+    def barrier(self) -> None:
+        # Synchronous in-process; sends are already complete by the time send() returns.
+        pass
+
+
+# -- coordinator ---------------------------------------------------------------
+
+
+StepFn = Callable[[np.ndarray, np.ndarray, int], tuple[np.ndarray, np.ndarray]]
+"""step_fn(state, memory_grid, generation) -> (new_state, new_memory_grid).
+
+Operates on arrays that INCLUDE halo regions; the coordinator keeps only the
+interior of the output and refreshes halo on the next step.
+"""
+
+
+class StepCoordinator:
+    """Orchestrates one step of one shard: send halos → apply halos → step locally."""
+
+    def __init__(self, shard: ShardState, exchange: HaloExchange, step_fn: StepFn):
+        self.shard = shard
+        self.exchange = exchange
+        self.step_fn = step_fn
+
+    def send_halos(self) -> None:
+        for direction in NEIGHBOR_DIRECTIONS:
+            target = self.shard.layout.neighbor_coord(self.shard.coord, direction)
+            sl = interior_boundary_slab(self.shard.layout, direction)
+            state_slab = self.shard.state[sl].copy()
+            memory_slab = self.shard.memory_grid[(slice(None),) + sl].copy()
+            self.exchange.send(
+                HaloPacket(
+                    source_coord=self.shard.coord,
+                    target_coord=target,
+                    direction=direction,
+                    generation=self.shard.generation,
+                    state_slab=state_slab,
+                    memory_slab=memory_slab,
+                )
+            )
+
+    def apply_halos(self) -> None:
+        for packet in self.exchange.recv_all(self.shard.coord):
+            # packet.direction is source→target. The receiving halo is on the side
+            # facing the source, which is the NEGATION of packet.direction.
+            incoming_side = tuple(-d for d in packet.direction)  # type: ignore[assignment]
+            sl = halo_slab(self.shard.layout, incoming_side)
+            self.shard.state[sl] = packet.state_slab
+            self.shard.memory_grid[(slice(None),) + sl] = packet.memory_slab
+
+    def step_local(self) -> None:
+        new_state, new_memory = self.step_fn(
+            self.shard.state, self.shard.memory_grid, self.shard.generation
+        )
+        if new_state.shape != self.shard.state.shape:
+            raise ValueError(
+                f"step_fn changed state shape {self.shard.state.shape} → {new_state.shape}"
+            )
+        if new_memory.shape != self.shard.memory_grid.shape:
+            raise ValueError(
+                f"step_fn changed memory shape {self.shard.memory_grid.shape} → {new_memory.shape}"
+            )
+        self.shard.state = new_state
+        self.shard.memory_grid = new_memory
+        self.shard.generation += 1
+
+
+def run_sharded_step(
+    coordinators: list[StepCoordinator], exchange: HaloExchange
+) -> None:
+    """Advance every shard by one generation. Two-phase to avoid race conditions."""
+    for c in coordinators:
+        c.send_halos()
+    exchange.barrier()
+    for c in coordinators:
+        c.apply_halos()
+    for c in coordinators:
+        c.step_local()
+
+
+# -- split / assemble ----------------------------------------------------------
+
+
+def split_lattice(
+    global_state: np.ndarray,
+    global_memory: np.ndarray,
+    shard_grid: tuple[int, int, int],
+    halo_width: int,
+) -> tuple[ShardLayout, dict[ShardCoord, ShardState]]:
+    """Partition a global lattice into shards with halos populated from neighbors (periodic)."""
+    if global_state.dtype != np.uint8:
+        raise TypeError(f"global_state must be uint8, got {global_state.dtype}")
+    if global_memory.dtype != np.float32:
+        raise TypeError(f"global_memory must be float32, got {global_memory.dtype}")
+    if global_state.ndim != 3:
+        raise ValueError(f"global_state must be 3D, got {global_state.ndim}D")
+    if global_memory.ndim != 4 or global_memory.shape[1:] != global_state.shape:
+        raise ValueError(
+            f"global_memory shape {global_memory.shape} inconsistent with state shape {global_state.shape}"
+        )
+
+    layout = ShardLayout(
+        global_shape=global_state.shape,  # type: ignore[arg-type]
+        shard_grid=shard_grid,
+        halo_width=halo_width,
+        memory_channels=global_memory.shape[0],
+    )
+    Lx, Ly, Lz = layout.interior_shape
+    h = layout.halo_width
+    shards: dict[ShardCoord, ShardState] = {}
+
+    # Periodic padding makes halo extraction a simple slice.
+    padded_state = np.pad(global_state, h, mode="wrap")
+    padded_memory = np.pad(global_memory, ((0, 0), (h, h), (h, h), (h, h)), mode="wrap")
+
+    for coord in layout.all_coords():
+        x0 = coord[0] * Lx
+        y0 = coord[1] * Ly
+        z0 = coord[2] * Lz
+        state = padded_state[x0 : x0 + Lx + 2 * h, y0 : y0 + Ly + 2 * h, z0 : z0 + Lz + 2 * h].copy()
+        memory = padded_memory[
+            :, x0 : x0 + Lx + 2 * h, y0 : y0 + Ly + 2 * h, z0 : z0 + Lz + 2 * h
+        ].copy()
+        shards[coord] = ShardState(
+            coord=coord,
+            layout=layout,
+            state=state,
+            memory_grid=memory,
+        )
+    return layout, shards
+
+
+def assemble_lattice(
+    layout: ShardLayout, shards: dict[ShardCoord, ShardState]
+) -> tuple[np.ndarray, np.ndarray]:
+    """Collect all shard interiors into a single global lattice."""
+    global_state = np.empty(layout.global_shape, dtype=np.uint8)
+    global_memory = np.empty(
+        (layout.memory_channels,) + layout.global_shape, dtype=np.float32
+    )
+    Lx, Ly, Lz = layout.interior_shape
+    for coord, shard in shards.items():
+        x0, y0, z0 = coord[0] * Lx, coord[1] * Ly, coord[2] * Lz
+        global_state[x0 : x0 + Lx, y0 : y0 + Ly, z0 : z0 + Lz] = shard.interior_state()
+        global_memory[:, x0 : x0 + Lx, y0 : y0 + Ly, z0 : z0 + Lz] = shard.interior_memory()
+    return global_state, global_memory
+
+
+__all__ = [
+    "ShardCoord",
+    "Direction",
+    "NEIGHBOR_DIRECTIONS",
+    "ShardLayout",
+    "ShardState",
+    "HaloPacket",
+    "HaloExchange",
+    "InProcessHaloExchange",
+    "StepCoordinator",
+    "StepFn",
+    "run_sharded_step",
+    "split_lattice",
+    "assemble_lattice",
+    "interior_boundary_slab",
+    "halo_slab",
+]

--- a/scripts/shard_transport_zmq.py
+++ b/scripts/shard_transport_zmq.py
@@ -1,0 +1,171 @@
+"""ZeroMQ transport backend for the shard protocol (Phase 17b, follow-up to PR #117).
+
+Subclasses `HaloExchange` with a PUSH/PULL-backed implementation that lets shard
+processes exchange halos across a real process boundary. Self-addressed halos
+short-circuit through an in-memory inbox to avoid a needless loopback hop.
+
+The core `scripts/shard_protocol` module has no zmq dependency; importing
+this module is the only place pyzmq is required. A future Ray / MPI / raw-TCP
+backend drops in as another sibling module — same pattern, no protocol change.
+
+Requires: pyzmq >= 27.0.0
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Iterable, Mapping
+
+import zmq
+
+from scripts.shard_protocol import HaloExchange, HaloPacket, ShardCoord
+
+
+# Each shard receives exactly one halo packet per neighbor direction per step.
+# In periodic topologies where the shard grid is small along an axis (e.g. size 2
+# gives both (-1) and (+1) the same target), multiple directions can share a
+# source/target pair — but the coordinator still emits 26 packets per shard per
+# step, and each shard still *receives* 26 total.
+PACKETS_PER_SHARD_PER_STEP = 26
+
+_DEFAULT_RECV_TIMEOUT_MS = 10_000
+_DEFAULT_LINGER_MS = 500
+_DEFAULT_HWM = 10_000
+
+
+class ZMQHaloExchange(HaloExchange):
+    """PUSH/PULL-backed halo exchange over ZeroMQ.
+
+    Each participating process constructs one `ZMQHaloExchange` declaring:
+      - `own_coords`: the shard coordinate(s) this process owns
+      - `endpoints`: full map from every shard coord in the global topology
+                     to a ZMQ endpoint string (e.g. "tcp://127.0.0.1:5550")
+
+    For each owned coord the instance binds a PULL socket at its endpoint.
+    For each non-owned coord it connects a PUSH socket. Halos addressed to
+    an owned coord never hit the wire — they're routed through a local inbox.
+
+    Use as a context manager (`with ZMQHaloExchange(...) as exchange:`) or
+    call `close()` explicitly to release socket resources.
+    """
+
+    def __init__(
+        self,
+        own_coords: Iterable[ShardCoord],
+        endpoints: Mapping[ShardCoord, str],
+        *,
+        recv_timeout_ms: int = _DEFAULT_RECV_TIMEOUT_MS,
+        linger_ms: int = _DEFAULT_LINGER_MS,
+        hwm: int = _DEFAULT_HWM,
+        context: zmq.Context | None = None,
+    ) -> None:
+        self.own_coords: set[ShardCoord] = set(own_coords)
+        self.endpoints: dict[ShardCoord, str] = dict(endpoints)
+        missing = self.own_coords - set(self.endpoints)
+        if missing:
+            raise ValueError(f"own coord(s) {sorted(missing)} not in endpoints map")
+        self.recv_timeout_ms = int(recv_timeout_ms)
+        self._owns_context = context is None
+        self.ctx: zmq.Context = context if context is not None else zmq.Context.instance()
+
+        self._pulls: dict[ShardCoord, zmq.Socket] = {}
+        self._pushes: dict[ShardCoord, zmq.Socket] = {}
+        self._local_inbox: dict[ShardCoord, list[HaloPacket]] = defaultdict(list)
+        self._closed = False
+
+        # Bind one PULL socket per owned coord.
+        for coord in sorted(self.own_coords):
+            sock = self.ctx.socket(zmq.PULL)
+            sock.setsockopt(zmq.LINGER, linger_ms)
+            sock.setsockopt(zmq.RCVHWM, hwm)
+            sock.bind(self.endpoints[coord])
+            self._pulls[coord] = sock
+
+        # Connect one PUSH socket per non-own coord.
+        for coord, addr in self.endpoints.items():
+            if coord in self.own_coords:
+                continue
+            sock = self.ctx.socket(zmq.PUSH)
+            sock.setsockopt(zmq.LINGER, linger_ms)
+            sock.setsockopt(zmq.SNDHWM, hwm)
+            sock.connect(addr)
+            self._pushes[coord] = sock
+
+    # ---- HaloExchange interface -------------------------------------------
+
+    def send(self, packet: HaloPacket) -> None:
+        if self._closed:
+            raise RuntimeError("ZMQHaloExchange is closed")
+        target = packet.target_coord
+        if target in self.own_coords:
+            # Self-loop: skip ZMQ entirely.
+            self._local_inbox[target].append(packet)
+            return
+        sock = self._pushes.get(target)
+        if sock is None:
+            raise ValueError(
+                f"no PUSH socket for target {target}; endpoints: {sorted(self.endpoints)}"
+            )
+        sock.send(packet.to_bytes())
+
+    def recv_all(self, target: ShardCoord) -> list[HaloPacket]:
+        """Block until `PACKETS_PER_SHARD_PER_STEP` halos are gathered for `target`.
+
+        Combines self-loop packets already in the local inbox with ZMQ-delivered
+        packets. Raises `TimeoutError` if the full count isn't received within
+        `recv_timeout_ms`. This is the implicit per-step barrier.
+        """
+        if self._closed:
+            raise RuntimeError("ZMQHaloExchange is closed")
+        if target not in self.own_coords:
+            raise ValueError(f"cannot recv for non-owned coord {target}")
+        packets = list(self._local_inbox[target])
+        self._local_inbox[target] = []
+        pull = self._pulls[target]
+        deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
+        while len(packets) < PACKETS_PER_SHARD_PER_STEP:
+            remaining_ms = int((deadline - time.monotonic()) * 1000)
+            if remaining_ms <= 0:
+                raise TimeoutError(
+                    f"ZMQHaloExchange.recv_all timed out for {target} "
+                    f"({len(packets)}/{PACKETS_PER_SHARD_PER_STEP} packets received)"
+                )
+            pull.setsockopt(zmq.RCVTIMEO, remaining_ms)
+            try:
+                buf = pull.recv()
+            except zmq.Again:
+                continue
+            packets.append(HaloPacket.from_bytes(buf))
+        return packets
+
+    def barrier(self) -> None:
+        # No explicit barrier needed — recv_all blocks until the per-shard
+        # expected count is reached, which serves as the per-step rendezvous.
+        pass
+
+    # ---- lifecycle --------------------------------------------------------
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for sock in list(self._pulls.values()) + list(self._pushes.values()):
+            try:
+                sock.close(linger=_DEFAULT_LINGER_MS)
+            except Exception:
+                pass
+        self._pulls.clear()
+        self._pushes.clear()
+        if self._owns_context:
+            # `zmq.Context.instance()` returns a shared context; don't terminate it.
+            pass
+        self._closed = True
+
+    def __enter__(self) -> "ZMQHaloExchange":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+
+__all__ = ["ZMQHaloExchange", "PACKETS_PER_SHARD_PER_STEP"]

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -1,0 +1,405 @@
+"""Phase 18 PR 2 — Tuning API Blueprint.
+
+Adds write-side tuning endpoints on top of the Phase 16 REST surface:
+
+  GET  /api/params            — current effective params (dict)
+  GET  /api/params/schema     — full registry schema from params_schema
+  POST /api/tuning/propose    — validate + append to ledger; dry-run by default
+  POST /api/tuning/commit     — gated commit; writes tuning_pending.json
+  POST /api/tuning/rollback   — revert to a prior proposal's snapshot
+
+Persists an append-only JSONL ledger at `data/tuning_ledger.jsonl` and a
+single-file pending-tuning at `data/tuning_pending.json`. The engine-side
+reload consumer (that actually reads tuning_pending.json and applies the
+parameters to the running CA) is a later PR in the Phase 18 roadmap.
+For now, the pending file is an authoritative promise waiting to be picked up.
+
+Safety contract enforced here:
+  - LOCKED params always rejected at `propose` (via params_schema.validate_proposal).
+  - HUMAN_APPROVAL params require `approver` starting with `human:` at commit.
+  - Per-parameter rate limit (MIN_GEN_BETWEEN_COMMITS_PER_PARAM generations).
+  - Invalid proposals cannot be committed even if approver is otherwise sufficient.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from flask import Blueprint, Response, jsonify, request
+
+from scripts.params_schema import (
+    PARAMS,
+    Category,
+    get_param,
+    schema_as_dict,
+    validate_proposal,
+)
+
+
+MIN_GEN_BETWEEN_COMMITS_PER_PARAM = 1000
+"""Minimum generations between successive commits touching the same parameter.
+Prevents an LLM in a tight loop from oscillating a tunable."""
+
+VALID_MODES = ("dry-run", "commit-pending")
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _new_proposal_id() -> str:
+    return "prop-" + secrets.token_hex(4)
+
+
+def _atomic_write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+# -- typed error ------------------------------------------------------------
+
+
+class TuningError(Exception):
+    """Raised by TuningState methods to signal a policy or lookup failure."""
+
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+
+# -- state ------------------------------------------------------------------
+
+
+class TuningState:
+    """Authoritative in-memory view of the tuning ledger. Writes through to disk.
+
+    Rebuilds its state on startup by replaying the JSONL ledger. Thread-safe
+    (Flask's threaded request handling can drive it from multiple workers).
+    """
+
+    def __init__(
+        self,
+        data_dir: Path,
+        gen_getter: Optional[Callable[[], int]] = None,
+    ) -> None:
+        self.data_dir = Path(data_dir)
+        self.ledger_path = self.data_dir / "tuning_ledger.jsonl"
+        self.pending_path = self.data_dir / "tuning_pending.json"
+        self._gen_getter: Callable[[], int] = gen_getter or (lambda: 0)
+        self._lock = threading.Lock()
+
+        self._effective: dict[str, Any] = {name: p.default for name, p in PARAMS.items()}
+        self._last_commit_gen: dict[str, int] = {}
+        self._proposals: dict[str, dict[str, Any]] = {}
+        self._snapshots_after_commit: dict[str, dict[str, Any]] = {}
+        self._replay_ledger()
+
+    # ---- read ----
+
+    def effective_params(self) -> dict[str, Any]:
+        with self._lock:
+            return dict(self._effective)
+
+    def current_gen(self) -> int:
+        try:
+            return int(self._gen_getter())
+        except Exception:
+            return 0
+
+    # ---- write: propose ----
+
+    def propose(
+        self,
+        params: dict[str, Any],
+        source: str,
+        justification: str,
+        mode: str,
+    ) -> dict[str, Any]:
+        if mode not in VALID_MODES:
+            raise TuningError(400, "bad_mode", f"mode must be one of {VALID_MODES}")
+        with self._lock:
+            validation = validate_proposal(params)
+            proposal_id = _new_proposal_id()
+            entry: dict[str, Any] = {
+                "ts": _now_iso(),
+                "type": "propose",
+                "proposal_id": proposal_id,
+                "source": source,
+                "justification": justification,
+                "mode": mode,
+                "params": dict(params),
+                "validation": {
+                    "ok": validation.ok,
+                    "errors": {
+                        name: {
+                            "error": r.error.value if r.error else None,
+                            "message": r.message,
+                        }
+                        for name, r in validation.errors.items()
+                    },
+                },
+            }
+            self._append_ledger(entry)
+            self._proposals[proposal_id] = entry
+            return entry
+
+    # ---- write: commit ----
+
+    def commit(self, proposal_id: str, approver: str) -> dict[str, Any]:
+        with self._lock:
+            proposal = self._proposals.get(proposal_id)
+            if proposal is None:
+                raise TuningError(
+                    404, "unknown_proposal",
+                    f"No proposal with id {proposal_id}.",
+                )
+            if not proposal["validation"]["ok"]:
+                raise TuningError(
+                    409, "invalid_proposal",
+                    "Proposal failed validation; cannot commit.",
+                )
+            params: dict[str, Any] = proposal["params"]
+
+            # Approver policy.
+            if _contains_human_approval_param(params) and not approver.startswith("human:"):
+                offender = _first_param_in_category(params, Category.HUMAN_APPROVAL)
+                raise TuningError(
+                    403, "human_approval_required",
+                    f"Proposal touches {offender} which requires approver='human:<name>'.",
+                )
+
+            # Rate limit.
+            current_gen = self.current_gen()
+            for name in params:
+                last = self._last_commit_gen.get(name)
+                if last is not None and (current_gen - last) < MIN_GEN_BETWEEN_COMMITS_PER_PARAM:
+                    next_ok = last + MIN_GEN_BETWEEN_COMMITS_PER_PARAM
+                    raise TuningError(
+                        429, "rate_limited",
+                        f"{name} last committed at gen {last}; next allowed at gen {next_ok} (current {current_gen}).",
+                    )
+
+            # Apply.
+            self._effective.update(params)
+            for name in params:
+                self._last_commit_gen[name] = current_gen
+            snapshot = dict(self._effective)
+            self._snapshots_after_commit[proposal_id] = snapshot
+
+            entry = {
+                "ts": _now_iso(),
+                "type": "commit",
+                "proposal_id": proposal_id,
+                "approver": approver,
+                "applied_at_gen": current_gen,
+                "params": dict(params),
+                "effective_after": snapshot,
+            }
+            self._append_ledger(entry)
+            _atomic_write_json(
+                self.pending_path,
+                {
+                    "applied_at_gen": current_gen,
+                    "effective_params": snapshot,
+                    "proposal_id": proposal_id,
+                    "kind": "commit",
+                },
+            )
+            return entry
+
+    # ---- write: rollback ----
+
+    def rollback(self, to_proposal_id: str) -> dict[str, Any]:
+        with self._lock:
+            snapshot = self._snapshots_after_commit.get(to_proposal_id)
+            if snapshot is None:
+                raise TuningError(
+                    404, "unknown_proposal",
+                    f"No committed snapshot for proposal {to_proposal_id}; cannot rollback.",
+                )
+            current_gen = self.current_gen()
+            changed = [k for k, v in snapshot.items() if self._effective.get(k) != v]
+            self._effective = dict(snapshot)
+            for name in changed:
+                self._last_commit_gen[name] = current_gen
+            entry = {
+                "ts": _now_iso(),
+                "type": "rollback",
+                "to_proposal_id": to_proposal_id,
+                "applied_at_gen": current_gen,
+                "reverted_params": dict(snapshot),
+                "changed_back": changed,
+            }
+            self._append_ledger(entry)
+            _atomic_write_json(
+                self.pending_path,
+                {
+                    "applied_at_gen": current_gen,
+                    "effective_params": dict(snapshot),
+                    "rollback_to": to_proposal_id,
+                    "kind": "rollback",
+                },
+            )
+            return entry
+
+    # ---- internal ----
+
+    def _replay_ledger(self) -> None:
+        if not self.ledger_path.exists():
+            return
+        with self.ledger_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # skip corrupt lines; don't let a bad append poison startup
+                etype = entry.get("type")
+                if etype == "propose":
+                    self._proposals[entry["proposal_id"]] = entry
+                elif etype == "commit":
+                    pid = entry.get("proposal_id")
+                    params = entry.get("params", {})
+                    gen = entry.get("applied_at_gen", 0)
+                    self._effective.update(params)
+                    for name in params:
+                        self._last_commit_gen[name] = gen
+                    self._snapshots_after_commit[pid] = dict(
+                        entry.get("effective_after", self._effective)
+                    )
+                elif etype == "rollback":
+                    reverted = entry.get("reverted_params", {})
+                    gen = entry.get("applied_at_gen", 0)
+                    self._effective = dict(reverted)
+                    for name in entry.get("changed_back", []):
+                        self._last_commit_gen[name] = gen
+
+    def _append_ledger(self, entry: dict[str, Any]) -> None:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        with self.ledger_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _contains_human_approval_param(params: dict[str, Any]) -> bool:
+    for name in params:
+        p = get_param(name)
+        if p and p.category is Category.HUMAN_APPROVAL:
+            return True
+    return False
+
+
+def _first_param_in_category(params: dict[str, Any], category: Category) -> str:
+    for name in params:
+        p = get_param(name)
+        if p and p.category is category:
+            return name
+    return "unknown"
+
+
+# -- blueprint --------------------------------------------------------------
+
+
+def create_blueprint(state: TuningState) -> Blueprint:
+    bp = Blueprint("tuning", __name__, url_prefix="/api")
+
+    @bp.route("/params", methods=["GET"])
+    def get_current_params() -> Response:
+        return jsonify({"effective_params": state.effective_params(),
+                        "current_gen": state.current_gen()})
+
+    @bp.route("/params/schema", methods=["GET"])
+    def get_schema() -> Response:
+        return jsonify(schema_as_dict())
+
+    @bp.route("/tuning/propose", methods=["POST"])
+    def propose() -> Response:
+        body = request.get_json(silent=True) or {}
+        params = body.get("params")
+        if not isinstance(params, dict) or not params:
+            return jsonify({
+                "error": "bad_request",
+                "message": "'params' (non-empty object) is required",
+            }), 400
+        source = str(body.get("source", "unspecified"))
+        justification = str(body.get("justification", ""))
+        mode = body.get("mode", "dry-run")  # default to safe
+        try:
+            entry = state.propose(
+                params=params, source=source, justification=justification, mode=mode,
+            )
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
+        status = 200 if entry["validation"]["ok"] else 422
+        return jsonify({
+            "proposal_id": entry["proposal_id"],
+            "status": "accepted" if entry["validation"]["ok"] else "rejected",
+            "mode": mode,
+            "validation": entry["validation"],
+        }), status
+
+    @bp.route("/tuning/commit", methods=["POST"])
+    def commit() -> Response:
+        body = request.get_json(silent=True) or {}
+        proposal_id = body.get("proposal_id")
+        approver = body.get("approver")
+        if not proposal_id or not approver:
+            return jsonify({
+                "error": "bad_request",
+                "message": "proposal_id and approver are required",
+            }), 400
+        try:
+            entry = state.commit(proposal_id=proposal_id, approver=approver)
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
+        return jsonify({
+            "proposal_id": proposal_id,
+            "status": "committed",
+            "applied_at_gen": entry["applied_at_gen"],
+            "approver": approver,
+            "effective_after": entry["effective_after"],
+        })
+
+    @bp.route("/tuning/rollback", methods=["POST"])
+    def rollback() -> Response:
+        body = request.get_json(silent=True) or {}
+        to_proposal_id = body.get("to_proposal_id")
+        if not to_proposal_id:
+            return jsonify({
+                "error": "bad_request",
+                "message": "to_proposal_id is required",
+            }), 400
+        try:
+            entry = state.rollback(to_proposal_id=to_proposal_id)
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
+        return jsonify({
+            "status": "rolled_back",
+            "to_proposal_id": to_proposal_id,
+            "applied_at_gen": entry["applied_at_gen"],
+            "effective_params": entry["reverted_params"],
+        })
+
+    return bp
+
+
+__all__ = [
+    "MIN_GEN_BETWEEN_COMMITS_PER_PARAM",
+    "VALID_MODES",
+    "TuningError",
+    "TuningState",
+    "create_blueprint",
+]

--- a/tests/test_params_schema.py
+++ b/tests/test_params_schema.py
@@ -1,0 +1,273 @@
+"""Tests for scripts/params_schema.py (Phase 18, PR 1).
+
+Verifies the schema framework and the initial parameter registry:
+- TunableParam validation (type, bounds, category gating)
+- LOCKED params always reject
+- Proposal-level aggregate validation (collects all errors)
+- Schema serialization
+- Registry sanity: no duplicate names, every param has a valid group, every
+  LOCKED param is listed in MEMORY.md's critical invariants (spirit check).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.params_schema import (
+    PARAMS,
+    Category,
+    ProposalValidation,
+    TunableParam,
+    ValidationError,
+    get_param,
+    groups,
+    list_by_category,
+    list_by_group,
+    schema_as_dict,
+    validate_proposal,
+)
+
+
+# -- TunableParam construction -----------------------------------------------
+
+
+def test_tunable_param_construction_requires_bounds_for_numeric():
+    with pytest.raises(ValueError, match="at least one bound"):
+        TunableParam(
+            name="foo",
+            value_type=float,
+            default=0.5,
+            category=Category.AUTO,
+            group="test",
+            description="no bounds",
+        )
+
+
+def test_tunable_param_rejects_min_greater_than_max():
+    with pytest.raises(ValueError, match="min_value > max_value"):
+        TunableParam(
+            name="foo",
+            value_type=float,
+            default=0.5,
+            category=Category.AUTO,
+            group="test",
+            description="bad bounds",
+            min_value=1.0,
+            max_value=0.5,
+        )
+
+
+def test_tunable_param_rejects_unsupported_type():
+    with pytest.raises(TypeError, match="bool/int/float"):
+        TunableParam(
+            name="foo",
+            value_type=str,  # type: ignore[arg-type]
+            default="x",
+            category=Category.AUTO,
+            group="test",
+            description="bad type",
+        )
+
+
+def test_tunable_param_rejects_default_type_mismatch():
+    with pytest.raises(TypeError, match="not of type"):
+        TunableParam(
+            name="foo",
+            value_type=float,
+            default="not-a-float",  # type: ignore[arg-type]
+            category=Category.AUTO,
+            group="test",
+            description="bad default",
+            min_value=0.0,
+            max_value=1.0,
+        )
+
+
+# -- validate() on individual params -----------------------------------------
+
+
+def _float_param(**kwargs) -> TunableParam:
+    defaults = dict(
+        name="x",
+        value_type=float,
+        default=0.5,
+        category=Category.AUTO,
+        group="test",
+        description="x",
+        min_value=0.0,
+        max_value=1.0,
+    )
+    defaults.update(kwargs)
+    return TunableParam(**defaults)
+
+
+def test_validate_accepts_in_range_float():
+    assert _float_param().validate(0.25).ok
+
+
+def test_validate_rejects_below_min():
+    result = _float_param(min_value=0.0).validate(-0.1)
+    assert not result.ok
+    assert result.error is ValidationError.BELOW_MIN
+
+
+def test_validate_rejects_above_max():
+    result = _float_param(max_value=1.0).validate(1.5)
+    assert not result.ok
+    assert result.error is ValidationError.ABOVE_MAX
+
+
+def test_validate_rejects_wrong_type_for_float():
+    result = _float_param().validate("string")
+    assert not result.ok
+    assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_validate_rejects_bool_for_float():
+    """bool is a subclass of int, but we're strict: bool ≠ float."""
+    result = _float_param().validate(True)
+    assert not result.ok
+    assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_validate_rejects_bool_for_int():
+    p = TunableParam(
+        name="n", value_type=int, default=1,
+        category=Category.AUTO, group="test", description="n",
+        min_value=0, max_value=10,
+    )
+    result = p.validate(True)
+    assert not result.ok
+    assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_validate_bool_param_accepts_true_and_false():
+    p = TunableParam(
+        name="enabled", value_type=bool, default=True,
+        category=Category.AUTO, group="test", description="enabled",
+    )
+    assert p.validate(True).ok
+    assert p.validate(False).ok
+    assert not p.validate(1).ok
+
+
+def test_locked_param_rejects_any_value():
+    p = TunableParam(
+        name="locked", value_type=float, default=0.005,
+        category=Category.LOCKED, group="critical", description="locked",
+        min_value=0.0, max_value=1.0,
+    )
+    result = p.validate(0.004)  # within bounds, but still locked
+    assert not result.ok
+    assert result.error is ValidationError.LOCKED
+
+
+# -- proposal-level validation -----------------------------------------------
+
+
+def test_validate_proposal_ok_for_valid_input():
+    result = validate_proposal({"signal_interval": 12, "magnon_sage_age_min": 7.5})
+    assert isinstance(result, ProposalValidation)
+    assert result.ok
+    assert set(result.known_params) == {"signal_interval", "magnon_sage_age_min"}
+    assert result.unknown_params == []
+    assert result.errors == {}
+
+
+def test_validate_proposal_collects_all_errors():
+    result = validate_proposal({
+        "signal_interval": 0,                       # below min
+        "magnon_coupling": "high",                  # wrong type
+        "structural_to_void_decay_prob": 0.004,    # LOCKED
+        "nonexistent_param": 42,                    # unknown
+    })
+    assert not result.ok
+    assert set(result.errors) == {
+        "signal_interval",
+        "magnon_coupling",
+        "structural_to_void_decay_prob",
+        "nonexistent_param",
+    }
+    assert result.errors["signal_interval"].error is ValidationError.BELOW_MIN
+    assert result.errors["magnon_coupling"].error is ValidationError.WRONG_TYPE
+    assert result.errors["structural_to_void_decay_prob"].error is ValidationError.LOCKED
+    assert result.errors["nonexistent_param"].error is ValidationError.UNKNOWN_PARAM
+    assert "nonexistent_param" in result.unknown_params
+
+
+def test_validate_proposal_empty_input_is_ok():
+    result = validate_proposal({})
+    assert result.ok
+
+
+# -- registry sanity ---------------------------------------------------------
+
+
+def test_registry_has_no_duplicates():
+    # PARAMS is a dict, so duplicates at import time are impossible; this
+    # also asserts the registry is populated.
+    assert len(PARAMS) > 0
+
+
+def test_registry_has_all_three_categories():
+    assert len(list_by_category(Category.LOCKED)) >= 1
+    assert len(list_by_category(Category.HUMAN_APPROVAL)) >= 1
+    assert len(list_by_category(Category.AUTO)) >= 1
+
+
+def test_registry_locks_structural_to_void_decay():
+    """MEMORY.md Critical Invariants: this must be locked. Regression fence."""
+    p = get_param("structural_to_void_decay_prob")
+    assert p is not None
+    assert p.category is Category.LOCKED
+
+
+def test_registry_locks_energy_to_void_decay():
+    p = get_param("energy_to_void_decay_prob")
+    assert p is not None
+    assert p.category is Category.LOCKED
+
+
+def test_every_param_has_a_group():
+    for name, p in PARAMS.items():
+        assert p.group, f"{name} has empty group"
+
+
+def test_groups_helper_returns_sorted_unique():
+    gs = groups()
+    assert gs == sorted(set(gs))
+    # Sampling: known groups that must exist for the partial registry.
+    assert "magnon" in gs
+    assert "metta" in gs
+    assert "stochastic" in gs
+
+
+def test_list_by_group_roundtrip():
+    for g in groups():
+        for p in list_by_group(g):
+            assert p.group == g
+
+
+# -- schema serialization ----------------------------------------------------
+
+
+def test_schema_as_dict_is_json_friendly():
+    import json
+
+    schema = schema_as_dict()
+    # Must round-trip through JSON without custom encoders.
+    buf = json.dumps(schema)
+    loaded = json.loads(buf)
+    assert loaded["version"] == 1
+    assert "signal_interval" in loaded["params"]
+    assert loaded["params"]["signal_interval"]["type"] == "int"
+    assert loaded["params"]["signal_interval"]["category"] == "auto"
+    assert "locked" in loaded["categories"]
+
+
+def test_schema_dict_param_entries_have_required_keys():
+    schema = schema_as_dict()
+    required = {"name", "type", "default", "category", "group", "description",
+                "min_value", "max_value"}
+    for name, entry in schema["params"].items():
+        assert required <= set(entry), f"{name} missing keys: {required - set(entry)}"

--- a/tests/test_shard_protocol.py
+++ b/tests/test_shard_protocol.py
@@ -1,0 +1,232 @@
+"""Tests for scripts/shard_protocol.py (Phase 17b Track B).
+
+Primary test is `test_sharded_step_equals_monolithic`: proves that stepping a
+2×2×2 shard partition through N generations via the in-process halo exchange
+yields bitwise-identical results to running the same step_fn on the monolithic
+lattice with periodic boundaries. This is the correctness proof for the
+protocol — if it passes, any transport backend that moves the same bytes
+around will produce the same results.
+"""
+
+import numpy as np
+import pytest
+
+from scripts.shard_protocol import (
+    HaloPacket,
+    InProcessHaloExchange,
+    NEIGHBOR_DIRECTIONS,
+    ShardLayout,
+    StepCoordinator,
+    assemble_lattice,
+    halo_slab,
+    interior_boundary_slab,
+    run_sharded_step,
+    split_lattice,
+)
+
+
+def _random_lattice(shape=(8, 8, 8), channels=8, seed=0):
+    rng = np.random.default_rng(seed)
+    state = rng.integers(0, 5, size=shape, dtype=np.uint8)
+    memory = rng.random(size=(channels,) + shape, dtype=np.float32)
+    return state, memory
+
+
+def _neighbor_count_step(state, memory, generation):
+    """Step function used in correctness tests. Computes the 27-cell neighbourhood
+    sum of `state == 1` cells into memory channel 0. `np.roll` gives periodic
+    behaviour, which is what we want in the monolithic path. On a sharded array
+    with a halo of radius >= 1, the roll wraps across the halo boundary, but the
+    interior of the output is still correct — which is all the coordinator keeps.
+    """
+    mask = (state == 1).astype(np.float32)
+    total = np.zeros_like(mask)
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+    new_memory = memory.copy()
+    new_memory[0] = total
+    return state.copy(), new_memory
+
+
+# -- layout math --------------------------------------------------------------
+
+
+def test_layout_basic_shapes():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    assert layout.interior_shape == (4, 4, 4)
+    assert layout.total_shape == (6, 6, 6)
+    assert len(layout.all_coords()) == 8
+
+
+def test_layout_rejects_indivisible_shape():
+    with pytest.raises(ValueError, match="not divisible"):
+        ShardLayout(global_shape=(7, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+
+
+def test_layout_rejects_halo_larger_than_interior():
+    with pytest.raises(ValueError, match="smaller than halo_width"):
+        ShardLayout(global_shape=(4, 4, 4), shard_grid=(2, 2, 2), halo_width=4)
+
+
+def test_neighbor_coord_wraps_periodically():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    assert layout.neighbor_coord((0, 0, 0), (-1, 0, 0)) == (1, 0, 0)
+    assert layout.neighbor_coord((1, 1, 1), (1, 1, 1)) == (0, 0, 0)
+
+
+# -- slab geometry ------------------------------------------------------------
+
+
+def test_interior_boundary_slab_sizes():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    # Axis-aligned face: H × L × L
+    sl = interior_boundary_slab(layout, (1, 0, 0))
+    assert sl == (slice(4, 5), slice(1, 5), slice(1, 5))
+    # Edge: H × H × L
+    sl = interior_boundary_slab(layout, (1, 1, 0))
+    assert sl == (slice(4, 5), slice(4, 5), slice(1, 5))
+    # Corner: H × H × H
+    sl = interior_boundary_slab(layout, (1, 1, 1))
+    assert sl == (slice(4, 5), slice(4, 5), slice(4, 5))
+
+
+def test_halo_slab_matches_opposite_side():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    # Halo on +x side is where the +x neighbor's interior-boundary lands
+    assert halo_slab(layout, (1, 0, 0)) == (slice(5, 6), slice(1, 5), slice(1, 5))
+    assert halo_slab(layout, (-1, 0, 0)) == (slice(0, 1), slice(1, 5), slice(1, 5))
+
+
+def test_all_26_directions_have_distinct_slabs():
+    layout = ShardLayout(global_shape=(8, 8, 8), shard_grid=(2, 2, 2), halo_width=1)
+    seen = set()
+    for d in NEIGHBOR_DIRECTIONS:
+        sl = interior_boundary_slab(layout, d)
+        # Represent slice as tuple of (start, stop) for hashing
+        key = tuple((s.start, s.stop) for s in sl)
+        assert key not in seen, f"direction {d} collides with another direction"
+        seen.add(key)
+    assert len(seen) == 26
+
+
+# -- split / assemble --------------------------------------------------------
+
+
+def test_split_assemble_roundtrip():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=42)
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    assert len(shards) == 8
+    state_back, memory_back = assemble_lattice(layout, shards)
+    np.testing.assert_array_equal(state_back, state)
+    np.testing.assert_array_equal(memory_back, memory)
+
+
+def test_split_populates_halos_from_periodic_neighbors():
+    """A shard at coord (0,0,0) should have its -x halo populated from the (1,0,0) shard's
+    +x interior boundary (periodic wrap)."""
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=7)
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    shard_000 = shards[(0, 0, 0)]
+    # -x halo of (0,0,0) should equal +x interior boundary of (1,0,0), which under
+    # periodic wrap is the rightmost interior column (global index 7) of the original lattice.
+    neg_x_halo = shard_000.state[halo_slab(layout, (-1, 0, 0))]
+    expected = state[7:8, 0:4, 0:4]
+    np.testing.assert_array_equal(neg_x_halo, expected)
+
+
+# -- packet serialization ----------------------------------------------------
+
+
+def test_halo_packet_roundtrip():
+    rng = np.random.default_rng(1)
+    state_slab = rng.integers(0, 5, size=(1, 4, 4), dtype=np.uint8)
+    memory_slab = rng.random(size=(8, 1, 4, 4), dtype=np.float32)
+    packet = HaloPacket(
+        source_coord=(0, 1, 1),
+        target_coord=(1, 1, 1),
+        direction=(1, 0, 0),
+        generation=42,
+        state_slab=state_slab,
+        memory_slab=memory_slab,
+    )
+    buf = packet.to_bytes()
+    restored = HaloPacket.from_bytes(buf)
+    assert restored.source_coord == (0, 1, 1)
+    assert restored.target_coord == (1, 1, 1)
+    assert restored.direction == (1, 0, 0)
+    assert restored.generation == 42
+    np.testing.assert_array_equal(restored.state_slab, state_slab)
+    np.testing.assert_array_equal(restored.memory_slab, memory_slab)
+
+
+def test_halo_packet_rejects_wrong_dtype():
+    with pytest.raises(TypeError, match="uint8"):
+        HaloPacket(
+            source_coord=(0, 0, 0),
+            target_coord=(1, 0, 0),
+            direction=(1, 0, 0),
+            generation=0,
+            state_slab=np.zeros((1, 4, 4), dtype=np.int32),  # wrong
+            memory_slab=np.zeros((8, 1, 4, 4), dtype=np.float32),
+        ).to_bytes()
+
+
+def test_halo_packet_bad_magic():
+    with pytest.raises(ValueError, match="bad magic"):
+        HaloPacket.from_bytes(b"XXXX" + b"\x00" * 200)
+
+
+# -- end-to-end correctness --------------------------------------------------
+
+
+def _run_monolithic(state, memory, n_steps):
+    for _ in range(n_steps):
+        state, memory = _neighbor_count_step(state, memory, 0)
+    return state, memory
+
+
+def _run_sharded(state, memory, shard_grid, halo_width, n_steps):
+    layout, shards = split_lattice(state, memory, shard_grid=shard_grid, halo_width=halo_width)
+    exchange = InProcessHaloExchange()
+    for coord in layout.all_coords():
+        exchange.register(coord)
+    coordinators = [
+        StepCoordinator(shards[coord], exchange, _neighbor_count_step)
+        for coord in layout.all_coords()
+    ]
+    for _ in range(n_steps):
+        run_sharded_step(coordinators, exchange)
+    return assemble_lattice(layout, {c.shard.coord: c.shard for c in coordinators})
+
+
+def test_sharded_single_step_equals_monolithic():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=123)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=1)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(2, 2, 2), halo_width=1, n_steps=1
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)
+
+
+def test_sharded_multi_step_equals_monolithic():
+    state, memory = _random_lattice(shape=(8, 8, 8), seed=999)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=5)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(2, 2, 2), halo_width=1, n_steps=5
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)
+
+
+def test_sharded_1x2x2_grid_still_matches():
+    """Sanity check: non-cubic shard grid also works."""
+    state, memory = _random_lattice(shape=(4, 8, 8), seed=55)
+    mono_state, mono_memory = _run_monolithic(state.copy(), memory.copy(), n_steps=3)
+    shard_state, shard_memory = _run_sharded(
+        state.copy(), memory.copy(), shard_grid=(1, 2, 2), halo_width=1, n_steps=3
+    )
+    np.testing.assert_array_equal(shard_state, mono_state)
+    np.testing.assert_array_equal(shard_memory, mono_memory)

--- a/tests/test_shard_transport_zmq.py
+++ b/tests/test_shard_transport_zmq.py
@@ -1,0 +1,261 @@
+"""Tests for scripts/shard_transport_zmq.py — ZMQ backend for the shard protocol.
+
+Two scopes:
+  1. Single-process sanity: one ZMQHaloExchange wired to itself, prove the
+     send/recv plumbing works (exercises self-loop short-circuit).
+  2. Two-process integration: spawn two subprocesses, each owning one shard of
+     a (2,1,1) partition. Run the sharded protocol over real ZMQ sockets and
+     assert the assembled result is bitwise-identical to a monolithic run.
+     This is the correctness proof that the ZMQ transport delivers halos
+     correctly across a real process boundary.
+"""
+
+from __future__ import annotations
+
+import pickle
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import zmq  # noqa: F401
+except ImportError:
+    pytest.skip("pyzmq not installed", allow_module_level=True)
+
+from scripts.shard_protocol import (
+    StepCoordinator,
+    assemble_lattice,
+    run_sharded_step,
+    split_lattice,
+)
+from scripts.shard_transport_zmq import ZMQHaloExchange
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _neighbor_count_step(state, memory, generation):
+    """Same step_fn used by test_shard_protocol's correctness proof."""
+    mask = (state == 1).astype(np.float32)
+    total = np.zeros_like(mask)
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            for dz in (-1, 0, 1):
+                total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+    new_memory = memory.copy()
+    new_memory[0] = total
+    return state.copy(), new_memory
+
+
+# -- single-process sanity ---------------------------------------------------
+
+
+def test_single_process_self_owned_coords_equals_monolithic():
+    """One process owns *all* coords → every send is a self-loop → protocol
+    must still produce the correct result. Exercises the self-loop inbox.
+    """
+    rng = np.random.default_rng(77)
+    state = rng.integers(0, 5, size=(8, 8, 8), dtype=np.uint8)
+    memory = rng.random(size=(8, 8, 8, 8), dtype=np.float32)
+
+    # Monolithic baseline.
+    mono_state, mono_memory = state.copy(), memory.copy()
+    for _ in range(3):
+        mono_state, mono_memory = _neighbor_count_step(mono_state, mono_memory, 0)
+
+    # Sharded via ZMQ, but all coords owned by this one process → no wire traffic.
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 2, 2), halo_width=1)
+    endpoints = {
+        coord: f"inproc://self-test-{coord[0]}-{coord[1]}-{coord[2]}"
+        for coord in layout.all_coords()
+    }
+    with ZMQHaloExchange(own_coords=layout.all_coords(), endpoints=endpoints) as exchange:
+        coords_in_order = layout.all_coords()
+        coordinators = [
+            StepCoordinator(shards[c], exchange, _neighbor_count_step) for c in coords_in_order
+        ]
+        for _ in range(3):
+            run_sharded_step(coordinators, exchange)
+
+        assembled_state, assembled_memory = assemble_lattice(
+            layout, {c.shard.coord: c.shard for c in coordinators}
+        )
+
+    np.testing.assert_array_equal(assembled_state, mono_state)
+    np.testing.assert_array_equal(assembled_memory, mono_memory)
+
+
+def test_zmq_exchange_rejects_unknown_own_coord():
+    with pytest.raises(ValueError, match="not in endpoints map"):
+        ZMQHaloExchange(
+            own_coords={(9, 9, 9)},
+            endpoints={(0, 0, 0): "inproc://nope"},
+        )
+
+
+def test_zmq_exchange_rejects_recv_for_non_owned():
+    with ZMQHaloExchange(
+        own_coords={(0, 0, 0)},
+        endpoints={(0, 0, 0): "inproc://own"},
+    ) as exchange:
+        with pytest.raises(ValueError, match="non-owned"):
+            exchange.recv_all((1, 0, 0))
+
+
+# -- two-process integration -------------------------------------------------
+
+# Worker script. Each spawned process imports the protocol, deterministically
+# rebuilds the initial lattice from a known seed, runs N sharded steps over
+# ZMQ, and pickles its interior arrays to a shared temp file.
+_WORKER_SOURCE = textwrap.dedent("""
+    import pickle
+    import sys
+    from pathlib import Path
+
+    repo_root = sys.argv[1]
+    sys.path.insert(0, repo_root)
+
+    import numpy as np
+    from scripts.shard_protocol import StepCoordinator, split_lattice
+    from scripts.shard_transport_zmq import ZMQHaloExchange
+
+    own_coord = tuple(int(x) for x in sys.argv[2].split(","))
+    endpoints = pickle.loads(bytes.fromhex(sys.argv[3]))
+    n_steps = int(sys.argv[4])
+    out_path = Path(sys.argv[5])
+    seed = int(sys.argv[6])
+
+    rng = np.random.default_rng(seed)
+    state = rng.integers(0, 5, size=(8, 4, 4), dtype=np.uint8)
+    memory = rng.random(size=(8, 8, 4, 4), dtype=np.float32)
+
+    layout, shards = split_lattice(state, memory, shard_grid=(2, 1, 1), halo_width=1)
+    shard = shards[own_coord]
+
+    def step_fn(st, mem, gen):
+        mask = (st == 1).astype(np.float32)
+        total = np.zeros_like(mask)
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for dz in (-1, 0, 1):
+                    total += np.roll(np.roll(np.roll(mask, dx, 0), dy, 1), dz, 2)
+        new_memory = mem.copy()
+        new_memory[0] = total
+        return st.copy(), new_memory
+
+    with ZMQHaloExchange(own_coords={own_coord}, endpoints=endpoints) as exchange:
+        coord = StepCoordinator(shard, exchange, step_fn)
+        for _ in range(n_steps):
+            coord.send_halos()
+            coord.apply_halos()
+            coord.step_local()
+        interior_state = shard.interior_state().copy()
+        interior_memory = shard.interior_memory().copy()
+
+    with open(out_path, "wb") as f:
+        pickle.dump(
+            {"coord": own_coord, "state": interior_state, "memory": interior_memory}, f
+        )
+""")
+
+
+def _pick_free_ports(n):
+    """Grab N free local TCP ports by binding+immediately closing."""
+    import socket
+
+    ports = []
+    socks = []
+    try:
+        for _ in range(n):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind(("127.0.0.1", 0))
+            ports.append(s.getsockname()[1])
+            socks.append(s)
+    finally:
+        for s in socks:
+            s.close()
+    return ports
+
+
+def test_zmq_two_process_halo_exchange_equals_monolithic(tmp_path):
+    """The key correctness proof for the ZMQ transport: two processes,
+    each owning one shard of a (2,1,1) partition, step 3 generations over
+    real ZMQ sockets, and produce a combined result that matches a monolithic
+    run bitwise."""
+    seed = 2024
+    n_steps = 3
+
+    # Allocate two ports that the OS just told us were free.
+    ports = _pick_free_ports(2)
+    endpoints = {
+        (0, 0, 0): f"tcp://127.0.0.1:{ports[0]}",
+        (1, 0, 0): f"tcp://127.0.0.1:{ports[1]}",
+    }
+    endpoints_hex = pickle.dumps(endpoints).hex()
+
+    # Write worker script into tmp_path so subprocesses can import it via path.
+    worker_script = tmp_path / "zmq_worker.py"
+    worker_script.write_text(_WORKER_SOURCE)
+
+    out_a = tmp_path / "shard_000.pkl"
+    out_b = tmp_path / "shard_100.pkl"
+
+    procs = []
+    for coord_str, out in [("0,0,0", out_a), ("1,0,0", out_b)]:
+        p = subprocess.Popen(
+            [
+                sys.executable,
+                str(worker_script),
+                str(REPO_ROOT),
+                coord_str,
+                endpoints_hex,
+                str(n_steps),
+                str(out),
+                str(seed),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        procs.append(p)
+
+    deadline = time.monotonic() + 60.0
+    for i, p in enumerate(procs):
+        timeout = max(1.0, deadline - time.monotonic())
+        try:
+            rc = p.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            stderr = p.stderr.read().decode(errors="replace")
+            pytest.fail(f"worker {i} timed out after {timeout:.1f}s\nstderr:\n{stderr}")
+        if rc != 0:
+            stderr = p.stderr.read().decode(errors="replace")
+            stdout = p.stdout.read().decode(errors="replace")
+            pytest.fail(
+                f"worker {i} failed with rc={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+
+    with open(out_a, "rb") as f:
+        result_a = pickle.load(f)
+    with open(out_b, "rb") as f:
+        result_b = pickle.load(f)
+    assert result_a["coord"] == (0, 0, 0)
+    assert result_b["coord"] == (1, 0, 0)
+
+    # Assemble along x (axis 0 for state, axis 1 for 8-channel memory).
+    zmq_state = np.concatenate([result_a["state"], result_b["state"]], axis=0)
+    zmq_memory = np.concatenate([result_a["memory"], result_b["memory"]], axis=1)
+
+    # Monolithic baseline, same seed.
+    rng = np.random.default_rng(seed)
+    mono_state = rng.integers(0, 5, size=(8, 4, 4), dtype=np.uint8)
+    mono_memory = rng.random(size=(8, 8, 4, 4), dtype=np.float32)
+    for _ in range(n_steps):
+        mono_state, mono_memory = _neighbor_count_step(mono_state, mono_memory, 0)
+
+    np.testing.assert_array_equal(zmq_state, mono_state)
+    np.testing.assert_array_equal(zmq_memory, mono_memory)

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -1,0 +1,310 @@
+"""Tests for scripts/tuning_api.py (Phase 18 PR 2).
+
+Covers:
+  - GET  /api/params             default effective params from registry
+  - GET  /api/params/schema      full schema round-trip
+  - POST /api/tuning/propose     accept / reject (validation failures)
+  - POST /api/tuning/commit      auto vs human approval, rate-limit, invalid
+                                  proposal, unknown proposal
+  - POST /api/tuning/rollback    unknown + happy-path
+  - Ledger persistence: replay across TuningState restart
+  - Pending-tuning file written with atomic rename semantics
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from scripts.tuning_api import (
+    MIN_GEN_BETWEEN_COMMITS_PER_PARAM,
+    TuningState,
+    create_blueprint,
+)
+from scripts.params_schema import PARAMS, Category
+
+
+# -- fixtures ---------------------------------------------------------------
+
+
+class FakeGen:
+    """Drop-in replacement for gen_getter; tests bump the value explicitly."""
+
+    def __init__(self, start: int = 1_000_000) -> None:
+        self.value = start
+
+    def advance(self, n: int) -> None:
+        self.value += n
+
+    def __call__(self) -> int:
+        return self.value
+
+
+@pytest.fixture
+def tuning(tmp_path: Path):
+    gen = FakeGen()
+    state = TuningState(data_dir=tmp_path, gen_getter=gen)
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint(state))
+    client = app.test_client()
+    return client, state, gen, tmp_path
+
+
+def _json(resp):
+    return resp.status_code, resp.get_json()
+
+
+# -- GET endpoints ----------------------------------------------------------
+
+
+def test_get_params_returns_registry_defaults(tuning):
+    client, state, gen, _ = tuning
+    code, body = _json(client.get("/api/params"))
+    assert code == 200
+    eff = body["effective_params"]
+    for name, param in PARAMS.items():
+        assert eff[name] == param.default
+    assert body["current_gen"] == gen.value
+
+
+def test_get_schema_round_trips_json(tuning):
+    client, *_ = tuning
+    code, body = _json(client.get("/api/params/schema"))
+    assert code == 200
+    assert body["version"] == 1
+    assert "signal_interval" in body["params"]
+    assert body["params"]["signal_interval"]["category"] == "auto"
+
+
+# -- POST /api/tuning/propose ----------------------------------------------
+
+
+def test_propose_accepts_valid(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"signal_interval": 12}, "source": "human:kevin", "justification": "test"},
+    ))
+    assert code == 200
+    assert body["status"] == "accepted"
+    assert body["mode"] == "dry-run"  # default
+    assert body["proposal_id"].startswith("prop-")
+    assert body["validation"]["ok"] is True
+
+
+def test_propose_rejects_invalid_but_records(tuning):
+    client, state, *_ = tuning
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"signal_interval": 0}},  # below min
+    ))
+    assert code == 422
+    assert body["status"] == "rejected"
+    assert body["validation"]["ok"] is False
+    assert body["validation"]["errors"]["signal_interval"]["error"] == "below_min"
+    # Rejected proposals still get a proposal_id and are recorded.
+    assert body["proposal_id"].startswith("prop-")
+
+
+def test_propose_rejects_locked(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"structural_to_void_decay_prob": 0.004}},
+    ))
+    assert code == 422
+    assert body["validation"]["errors"]["structural_to_void_decay_prob"]["error"] == "locked"
+
+
+def test_propose_400_when_params_missing(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post("/api/tuning/propose", json={}))
+    assert code == 400
+    assert body["error"] == "bad_request"
+
+
+def test_propose_400_when_mode_invalid(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"signal_interval": 12}, "mode": "go-wild"},
+    ))
+    assert code == 400
+
+
+# -- POST /api/tuning/commit -----------------------------------------------
+
+
+def _propose(client, params, source="human:kevin", mode="commit-pending"):
+    resp = client.post(
+        "/api/tuning/propose",
+        json={"params": params, "source": source, "justification": "t", "mode": mode},
+    )
+    return resp.get_json()["proposal_id"]
+
+
+def test_commit_auto_category_accepts_policy_auto(tuning):
+    client, state, gen, tmp_path = tuning
+    pid = _propose(client, {"signal_interval": 15})
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": "policy:auto"},
+    ))
+    assert code == 200
+    assert body["status"] == "committed"
+    assert body["applied_at_gen"] == gen.value
+    assert body["effective_after"]["signal_interval"] == 15
+    # Pending file was written.
+    pending = json.loads((tmp_path / "tuning_pending.json").read_text())
+    assert pending["effective_params"]["signal_interval"] == 15
+    assert pending["proposal_id"] == pid
+    # Effective state updated.
+    assert state.effective_params()["signal_interval"] == 15
+
+
+def test_commit_human_approval_required_rejects_policy_auto(tuning):
+    client, *_ = tuning
+    pid = _propose(client, {"magnon_coupling": 2.5})  # HUMAN_APPROVAL category
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": "policy:auto"},
+    ))
+    assert code == 403
+    assert body["error"] == "human_approval_required"
+
+
+def test_commit_human_approval_accepts_human_prefix(tuning):
+    client, *_ = tuning
+    pid = _propose(client, {"magnon_coupling": 2.5})
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": "human:kevin"},
+    ))
+    assert code == 200
+    assert body["status"] == "committed"
+
+
+def test_commit_unknown_proposal_returns_404(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": "prop-deadbeef", "approver": "human:kevin"},
+    ))
+    assert code == 404
+    assert body["error"] == "unknown_proposal"
+
+
+def test_commit_invalid_proposal_rejected_even_with_human(tuning):
+    client, *_ = tuning
+    # Proposal fails validation (below min), but is recorded.
+    resp = client.post(
+        "/api/tuning/propose",
+        json={"params": {"signal_interval": -5}, "source": "human:kevin"},
+    )
+    pid = resp.get_json()["proposal_id"]
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": "human:kevin"},
+    ))
+    assert code == 409
+    assert body["error"] == "invalid_proposal"
+
+
+def test_commit_rate_limit_rejects_quick_repeat(tuning):
+    client, state, gen, _ = tuning
+    # First commit succeeds.
+    pid1 = _propose(client, {"signal_interval": 20})
+    assert client.post("/api/tuning/commit",
+                       json={"proposal_id": pid1, "approver": "policy:auto"}).status_code == 200
+    # Advance less than the cooldown.
+    gen.advance(MIN_GEN_BETWEEN_COMMITS_PER_PARAM - 1)
+    pid2 = _propose(client, {"signal_interval": 25})
+    code, body = _json(client.post("/api/tuning/commit",
+                                    json={"proposal_id": pid2, "approver": "policy:auto"}))
+    assert code == 429
+    assert body["error"] == "rate_limited"
+    # Advance past the cooldown; second commit now succeeds.
+    gen.advance(2)
+    pid3 = _propose(client, {"signal_interval": 30})
+    assert client.post("/api/tuning/commit",
+                       json={"proposal_id": pid3, "approver": "policy:auto"}).status_code == 200
+
+
+def test_commit_400_when_body_incomplete(tuning):
+    client, *_ = tuning
+    for payload in ({}, {"proposal_id": "prop-x"}, {"approver": "human:kevin"}):
+        code, body = _json(client.post("/api/tuning/commit", json=payload))
+        assert code == 400
+        assert body["error"] == "bad_request"
+
+
+# -- POST /api/tuning/rollback ---------------------------------------------
+
+
+def test_rollback_happy_path(tuning):
+    client, state, gen, tmp_path = tuning
+    # Commit A
+    pid_a = _propose(client, {"signal_interval": 17})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "policy:auto"})
+    # Move past rate limit for next param so we can vary state a bit
+    gen.advance(MIN_GEN_BETWEEN_COMMITS_PER_PARAM + 1)
+    # Commit B (different param so no rate-limit collision)
+    pid_b = _propose(client, {"joy_beta": 0.5})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_b, "approver": "policy:auto"})
+    assert state.effective_params()["signal_interval"] == 17
+    assert state.effective_params()["joy_beta"] == 0.5
+    # Rollback to the snapshot after A — joy_beta should return to its default.
+    code, body = _json(client.post("/api/tuning/rollback", json={"to_proposal_id": pid_a}))
+    assert code == 200
+    assert body["status"] == "rolled_back"
+    assert state.effective_params()["signal_interval"] == 17     # A's change preserved
+    assert state.effective_params()["joy_beta"] == PARAMS["joy_beta"].default  # B reverted
+    # Pending file reflects the rollback.
+    pending = json.loads((tmp_path / "tuning_pending.json").read_text())
+    assert pending["kind"] == "rollback"
+    assert pending["rollback_to"] == pid_a
+
+
+def test_rollback_unknown_proposal_returns_404(tuning):
+    client, *_ = tuning
+    code, body = _json(client.post("/api/tuning/rollback", json={"to_proposal_id": "prop-none"}))
+    assert code == 404
+
+
+def test_rollback_400_when_missing(tuning):
+    client, *_ = tuning
+    code, _body = _json(client.post("/api/tuning/rollback", json={}))
+    assert code == 400
+
+
+# -- ledger persistence -----------------------------------------------------
+
+
+def test_ledger_replay_restores_state_across_restart(tuning):
+    client, state, gen, tmp_path = tuning
+    # Propose + commit + rollback, then build a fresh TuningState from the same dir.
+    pid_a = _propose(client, {"signal_interval": 22})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "policy:auto"})
+
+    fresh = TuningState(data_dir=tmp_path, gen_getter=gen)
+    assert fresh.effective_params()["signal_interval"] == 22
+    # Ledger file exists and has 2 entries (propose + commit).
+    lines = (tmp_path / "tuning_ledger.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    kinds = [json.loads(ln)["type"] for ln in lines]
+    assert kinds == ["propose", "commit"]
+
+
+def test_ledger_survives_corrupt_line(tuning):
+    client, state, gen, tmp_path = tuning
+    pid = _propose(client, {"signal_interval": 14})
+    client.post("/api/tuning/commit", json={"proposal_id": pid, "approver": "policy:auto"})
+    # Corrupt the ledger with a bad line in the middle.
+    with (tmp_path / "tuning_ledger.jsonl").open("a", encoding="utf-8") as f:
+        f.write("this-is-not-json\n")
+    fresh = TuningState(data_dir=tmp_path, gen_getter=gen)
+    # State from the valid lines is still restored.
+    assert fresh.effective_params()["signal_interval"] == 14


### PR DESCRIPTION
## Summary
- Second implementation PR of the Phase 18 roadmap. Adds the **curl-drivable write-side** of the tuning bus on top of Phase 16's read-only REST API.
- Real safety rails enforced by the API itself: LOCKED rejected, HUMAN_APPROVAL gated, per-param rate limits, invalid-proposal guard.
- Persistent audit trail (JSONL ledger) + atomic pending-file for the eventual engine-side consumer (later PR).
- Does not touch `continuous_evolution_ca.py`; Medusa's Phase 17a run is unaffected.

## New endpoints on :8080
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/params` | current effective tunable params + current generation |
| GET | `/api/params/schema` | full registry schema (types, bounds, categories) |
| POST | `/api/tuning/propose` | validate + append to ledger; **dry-run by default** |
| POST | `/api/tuning/commit` | gated by approver policy + rate limit + validity |
| POST | `/api/tuning/rollback` | revert to a prior committed snapshot |

Curl-drivable once the server is running:
```bash
curl http://localhost:8080/api/params/schema | jq .
curl -X POST http://localhost:8080/api/tuning/propose \
     -H 'content-type: application/json' \
     -d '{"params":{"signal_interval":12},"source":"human:kevin"}'
```

## Safety contract (all enforced by tests)
- **LOCKED** params rejected at propose via `validate_proposal` (PR #120).
- **Invalid proposals** cannot be committed, even with human approver — returns `409 invalid_proposal`.
- **HUMAN_APPROVAL** params require approver starting with `human:` — else `403 human_approval_required`.
- **Per-parameter rate limit**: `MIN_GEN_BETWEEN_COMMITS_PER_PARAM = 1000`. Oscillating LLM gets `429 rate_limited` until cooldown clears.
- **Unknown proposal_id** on commit/rollback → `404 unknown_proposal`.
- Ledger gracefully skips corrupt lines on replay — one bad append can't poison startup.

## Architecture notes
- `TuningState` is thread-safe (Flask `threaded=True` compatible). Writes through to:
  - `data/tuning_ledger.jsonl` — append-only audit log, one JSON object per line.
  - `data/tuning_pending.json` — single-file atomic rename for the engine-side consumer.
- `create_blueprint(state)` returns a Flask Blueprint; injectable state lets tests use `tmp_path` without touching real `data/`.
- `medusa_api.py` registers the blueprint at module load with a gen-getter that parses the current generation out of the latest snapshot filename — no engine coupling required.

## Tests — 19/19 passing in 0.26s
Full suite after this PR: **62/62** (Phase 17b + Phase 18 PRs 1+2) in 0.59s. No regressions.

Test highlights:
- ✅ propose: accepts valid, **rejects-but-records** invalid (422), rejects LOCKED.
- ✅ commit: `policy:auto` works for AUTO; rejected (403) for HUMAN_APPROVAL; `human:<name>` works; unknown (404); invalid proposal rejected even with human approver (409); **rate-limit enforcement** across clock advance (429 → 200 once cooldown clears).
- ✅ rollback: reverts only the changed-between params; pending file `kind="rollback"`.
- ✅ Ledger persistence: propose+commit **survives TuningState restart** (replay rebuilds effective state).
- ✅ Corrupt line in ledger doesn't break startup.

## Roadmap status
| PR | What | Status |
|----|------|--------|
| 1 | `params_schema.py` — tunable registry | ✅ merged #120 |
| **2** | `tuning_api.py` + `medusa_api.py` wiring | **This PR** |
| 3 | `scripts/event_bus.py` — ZMQ PUB on :8081 | Planned |
| 4 | `AgentBackend` ABC + `MockBackend` | Planned |
| 5 | `AnthropicBackend` | Planned |
| 6 | `scripts/orchestrator.py` — the loop | Planned |
| 7 | `NemoCloudBackend` | When NVIDIA Cloud is up |

After this merge, AURA's promised "curl-drivable tuning API" is real on port 8080. No agent needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)