### PR TITLE
Phase 19 PR #2 follow-up — issue #139 findings (a) and (b)

### DIFF
--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -955,22 +955,57 @@ import pathlib
 from datetime import datetime, timezone
 
 
-_LATEST_SNAPSHOT_MIN_BYTES: Final[int] = 1_000_000  # skip tiny/corrupt files
+_REQUIRED_SNAPSHOT_KEYS: Final[frozenset[str]] = frozenset(
+    {"lattice", "memory_grid", "generation"}
+)
 _LOG_FILE_NAME: Final[str] = "nextness_runs.jsonl"
+
+
+def _is_valid_snapshot_npz(path: pathlib.Path) -> bool:
+    """Cheap validity predicate for a ``.npz`` Medusa snapshot.
+
+    Opens the file with ``np.load(..., allow_pickle=False)`` and confirms
+    the three required keys (``lattice``, ``memory_grid``, ``generation``)
+    are present in the zip directory. Does NOT load or decompress array
+    data — ``NpzFile.files`` reads only the zip's central directory, so
+    this stays in the milliseconds range even for tens of MB.
+
+    Any failure mode — missing keys, malformed zip, I/O error, pickled
+    payload that ``allow_pickle=False`` refuses to materialize at
+    file-listing time — yields ``False``. The function never raises.
+
+    Per issue #139 finding (a): replaces the previous file-size
+    threshold, which was structurally wrong (real snapshots range from
+    ~900 KB sparse-VOID-early to ~54 MB mature-mixed, so size carries
+    no validity signal).
+    """
+    try:
+        with np.load(str(path), allow_pickle=False) as snap:
+            return _REQUIRED_SNAPSHOT_KEYS.issubset(set(snap.files))
+    except Exception:
+        # Catch broadly: malformed zip, missing file, permissions,
+        # pickled-payload-refused, future numpy quirks. Any failure
+        # is "this is not a valid Medusa snapshot."
+        return False
 
 
 def find_latest_snapshot(
     snapshot_dir: str | pathlib.Path,
     pattern: str = "v070_gen*.npz",
 ) -> pathlib.Path | None:
-    """Return the path of the most-recent snapshot matching ``pattern``.
+    """Return the path of the most-recent valid snapshot matching ``pattern``.
 
-    Skips files smaller than ``_LATEST_SNAPSHOT_MIN_BYTES`` (likely
-    truncated or mid-write). Returns ``None`` if no qualifying file
-    exists — INCLUDING the case where matching files are present but
-    all of them are below the size threshold (per Jack's PR #138
-    audit, the previous fallback-to-first-candidate contradicted the
-    "skip tiny files" docstring claim).
+    Iterates candidates in newest-first mtime order and returns the
+    first one that passes ``_is_valid_snapshot_npz`` (zip directory
+    contains the required keys). Returns ``None`` if no candidate
+    validates — INCLUDING the case where matching files exist but
+    none are well-formed snapshots.
+
+    Per issue #139 finding (a): validity is now a structural check on
+    required keys rather than a file-size heuristic. Sparse early-phase
+    snapshots (~900 KB) that the old size-threshold silently excluded
+    are now recognized, and corrupt ≥1 MB files that the old threshold
+    silently admitted are now rejected.
     """
     snapshot_dir = pathlib.Path(snapshot_dir)
     if not snapshot_dir.is_dir():
@@ -981,11 +1016,8 @@ def find_latest_snapshot(
         reverse=True,
     )
     for p in candidates:
-        try:
-            if p.stat().st_size >= _LATEST_SNAPSHOT_MIN_BYTES:
-                return p
-        except OSError:
-            continue
+        if _is_valid_snapshot_npz(p):
+            return p
     return None
 
 
@@ -1187,6 +1219,13 @@ def process_snapshot(
 
     report = bm.report()
 
+    # Per issue #139 finding (b): ``BudgetReport.fraction_used`` is a
+    # ``@property``, so ``dataclasses.asdict`` (which walks fields only)
+    # silently drops it. Build the budget block explicitly so the JSONL
+    # log carries the same fraction available on the live object.
+    budget_block: dict[str, object] = dict(dataclasses.asdict(report))
+    budget_block["fraction_used"] = report.fraction_used
+
     entry: dict[str, object] = {
         "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "snapshot_file": snapshot_path.name,
@@ -1201,7 +1240,7 @@ def process_snapshot(
         "medusa_is_live": medusa_is_live,
         "token_counts": dict(token_counts),
         "vocabulary_occupancy": len(token_counts) / max(1, len(TOKEN_NAMES)),
-        "budget": dataclasses.asdict(report),
+        "budget": budget_block,
     }
     write_log_entry(config.log_directory, entry)
     return entry

--- a/tests/test_nextness_observer.py
+++ b/tests/test_nextness_observer.py
@@ -486,22 +486,59 @@ def test_find_latest_snapshot_empty_dir_returns_none(tmp_path):
     assert find_latest_snapshot(tmp_path) is None
 
 
-def test_find_latest_snapshot_returns_none_when_all_files_below_threshold(tmp_path):
-    """Per Jack's PR #138 audit: previously this would fall back to the
-    first candidate even if every file was below the tiny/corrupt size
-    threshold. Now it returns None — matching the docstring claim that
-    such files are skipped.
+def test_find_latest_snapshot_skips_npz_missing_required_keys(tmp_path):
+    """Per issue #139 finding (a): validity is now structural (required
+    keys present), not size-based. An .npz matching the glob but lacking
+    the required Medusa keys is skipped, and if no candidate validates,
+    the function returns None.
     """
-    # Create files matching the pattern but all below the 1 MB threshold.
     for i in range(3):
         p = tmp_path / f"v070_gen{i}_step{i}_test.npz"
-        # Save a tiny snapshot — well below the 1MB threshold.
-        np.savez(str(p),
-                 lattice=np.zeros((4, 4, 4), dtype=np.uint8),
-                 memory_grid=np.zeros((8, 4, 4, 4), dtype=np.float32),
-                 generation=np.array(i))
-        assert p.stat().st_size < 1_000_000
+        # Intentionally wrong shape: no lattice/memory_grid/generation
+        np.savez(str(p), wrong_key=np.zeros((4, 4, 4), dtype=np.uint8))
     assert find_latest_snapshot(tmp_path) is None
+
+
+def test_find_latest_snapshot_prefers_newest_valid_skipping_invalid(tmp_path):
+    """Per issue #139 finding (a): when valid and invalid candidates
+    coexist, the iteration walks newest-first by mtime and skips
+    invalid candidates until it finds one with the required keys.
+    """
+    older_valid = _make_snapshot(tmp_path / "v070_gen10.npz", lattice=16,
+                                 generation=10)
+    time.sleep(0.05)
+    # Newest by mtime, but invalid: missing required keys.
+    invalid = tmp_path / "v070_gen20.npz"
+    np.savez(str(invalid), wrong_key=np.zeros((4, 4, 4), dtype=np.uint8))
+    found = find_latest_snapshot(tmp_path)
+    assert found is not None
+    assert found.name == older_valid.name
+
+
+def test_find_latest_snapshot_skips_corrupt_npz(tmp_path):
+    """Per issue #139 finding (a): files matching the glob but with
+    garbage content (not valid zip archives) must not crash the
+    iteration — they're skipped silently like any other invalid file.
+    """
+    corrupt = tmp_path / "v070_gen1_step1_test.npz"
+    corrupt.write_bytes(b"this is not a valid npz file" * 100)
+    assert find_latest_snapshot(tmp_path) is None
+
+
+def test_find_latest_snapshot_accepts_small_but_valid_snapshot(tmp_path):
+    """Per issue #139 finding (a): a synthetic snapshot with the required
+    keys but well under any size heuristic must now be accepted. This
+    locks in the regression that fix (a) is meant to prevent (real
+    sparse-early Medusa snapshots are ~900 KB and were silently
+    excluded by the old 1 MB size threshold).
+    """
+    p = _make_snapshot(tmp_path / "v070_gen1.npz", lattice=4, generation=1)
+    # Confirm the synthetic snapshot is genuinely tiny (well below the
+    # 1 MB heuristic the old code used).
+    assert p.stat().st_size < 100_000
+    found = find_latest_snapshot(tmp_path)
+    assert found is not None
+    assert found.name == p.name
 
 
 def test_is_medusa_live_with_fresh_snapshot(tmp_path):
@@ -746,3 +783,32 @@ def test_end_to_end_stride_backoff_recorded(tmp_path):
     # So stride_used should equal stride_initial in this case.
     assert summary["stride_used"] == summary["stride_initial"]
     assert summary["stride_backoff_fired"] is False
+
+
+def test_process_snapshot_budget_block_includes_fraction_used(tmp_path):
+    """Per issue #139 finding (b): ``BudgetReport.fraction_used`` is a
+    ``@property``, so ``dataclasses.asdict()`` drops it. ``process_snapshot``
+    must explicitly add it to the budget block in both the returned summary
+    and the JSONL log entry so downstream metrics (PR #3) can consume the
+    fraction without recomputing it from elapsed/budget seconds.
+    """
+    snap = _make_snapshot(tmp_path / "v070_gen1.npz", lattice=16, generation=1)
+    log_dir = tmp_path / "log"
+    log_dir.parent.mkdir(exist_ok=True)
+    cfg = ObserverConfig(log_directory=str(log_dir),
+                         uniform_grid_stride=4, budget_seconds=30.0)
+    summary = process_snapshot(snap, cfg, medusa_is_live=False)
+
+    # Live summary should expose fraction_used
+    assert "fraction_used" in summary["budget"]
+    frac = summary["budget"]["fraction_used"]
+    assert isinstance(frac, float)
+    # Synthetic 16^3 run finishes in milliseconds against a 30s budget
+    assert 0.0 <= frac < 1.0
+
+    # And it must round-trip through JSONL — that's the canonical
+    # post-mortem record for PR #3 metrics consumption.
+    jsonl = (log_dir / "nextness_runs.jsonl").read_text().splitlines()
+    entry = json.loads(jsonl[-1])
+    assert "fraction_used" in entry["budget"]
+    assert entry["budget"]["fraction_used"] == frac


### PR DESCRIPTION
## Summary

Small Lane B revision PR scoped per AURA + Jack's direction on issue #139. Addresses findings **(a)** and **(b)** only. **Finding (c) (vocabulary saturation) is parked for PR #4** — this PR explicitly does not touch the classifier cascade, thresholds, or memory-channel layout.

**No engine touch.** No HTTP. No ZMQ. CPU-only. No writes outside `log_directory`.

**Tests:** **254/254 pass** in 4.54s (Phase 17b + 18 + 19 full suite). Net +4 tests in `test_nextness_observer.py` (69 → 73).

---

## Finding (a) — `find_latest_snapshot` used the wrong validity signal

The previous implementation skipped `.npz` candidates below 1 MB on the assumption they were corrupt or truncated. Real Medusa `np.savez_compressed` snapshots vary widely:
- Sparse-VOID early snapshots (~gen 1M era): ~900 KB
- Mature mixed snapshots (gen 1.6M): ~54 MB

A 1 MB threshold structurally excluded valid early-phase snapshots while admitting corrupt ≥1 MB files. The fix replaces it with a key-validity check.

**Changes:**
- Removed `_LATEST_SNAPSHOT_MIN_BYTES` constant.
- Added `_REQUIRED_SNAPSHOT_KEYS = frozenset({"lattice", "memory_grid", "generation"})`.
- Added `_is_valid_snapshot_npz(path)`: opens with `np.load(..., allow_pickle=False)`, checks `NpzFile.files` against the required-keys set. No array data is loaded — `NpzFile.files` reads only the zip directory, so the check stays in milliseconds. Catches `Exception` broadly: any failure mode means "not a valid snapshot."
- Rewrote `find_latest_snapshot` to iterate newest-first by mtime and return the first candidate that passes the validity check, or `None`.

**Behavioral implications:**
- Real sparse-early Medusa snapshots that the old size threshold silently excluded are now recognized.
- Corrupt files ≥1 MB that the old threshold silently admitted are now rejected.
- Garbage file content (non-zip bytes) no longer crashes the iteration.

## Finding (b) — `BudgetReport.fraction_used` was dropped from the JSONL log

`BudgetReport.fraction_used` is a `@property`. `dataclasses.asdict()` walks dataclass fields only, not properties, so the JSONL log entry's `budget` block contained `budget_seconds`, `elapsed_seconds`, `exceeded`, `patches_processed`, `patches_skipped_due_to_budget`, but no `fraction_used`. The field is trivially recomputable downstream, but the omission would bite PR #3 metrics if left in place.

**Changes:**
- `process_snapshot` now builds the budget block explicitly:
  ```python
  budget_block = dict(dataclasses.asdict(report))
  budget_block["fraction_used"] = report.fraction_used
  entry = {..., "budget": budget_block}
  ```
- Less invasive than promoting `fraction_used` from `@property` to a dataclass field.

---

## Test changes

Net +4 tests on `tests/test_nextness_observer.py` (69 → 73).

**Removed (semantics now obsolete):**
- `test_find_latest_snapshot_returns_none_when_all_files_below_threshold` — the size-threshold semantics are gone; this test would fail under the new key-validity check because the synthetic files it created had all required keys.

**Added (4 new tests):**
1. `test_find_latest_snapshot_skips_npz_missing_required_keys` — files matching the glob but lacking required keys → returns `None`.
2. `test_find_latest_snapshot_prefers_newest_valid_skipping_invalid` — mixed valid + invalid candidates → returns newest *valid* by mtime.
3. `test_find_latest_snapshot_skips_corrupt_npz` — non-zip garbage content → no crash, returns `None`.
4. `test_find_latest_snapshot_accepts_small_but_valid_snapshot` — locks in the regression fix (a) targets: sub-100 KB snapshots with required keys are now accepted (the old threshold would have silently dropped them).
5. `test_process_snapshot_budget_block_includes_fraction_used` — verifies `fraction_used` is present in both the returned summary and the JSONL round-trip, with float type and `0.0 <= frac < 1.0` sanity.

---

## What this PR explicitly does NOT do

| Out of scope | Where it lands |
|---|---|
| Vocabulary cascade redesign | PR #4 (calibration) |
| Threshold tuning (`THRESHOLD_COMPASSION` etc.) | PR #4 |
| Memory-channel layout verification | PR #4 (cross-check vs Phase 14e acoustic map) |
| Stride sweep / sampling experiments | PR #4 |
| Multi-snapshot temporal context | PR #5+ |
| Metrics pipeline (KL drift, transition matrix) | PR #3 |

Per AURA's reframe in issue #139: finding (c) is not a vocabulary failure but the first successful macroscopic read of Phase 17a equilibrium. PR #4 will design experiments to discriminate her leading hypothesis from four alternates (memory-channel index, threshold calibration, sampling resolution, cascade ordering, missing temporal context).

---

## Scope guarantees (unchanged from PR #138)

- No engine touch. Medusa untouched.
- No new writes outside `log_directory`.
- No HTTP. No ZMQ. No network.
- CPU-only default.
- `WriteOutsideLogDirError` still gates all writes via realpath check.
- `allow_pickle=False` preserved in `_is_valid_snapshot_npz` and `load_snapshot`.

Diff: `2 files changed, 132 insertions(+), 27 deletions(-)`.

Refs #139 — addresses findings **(a)** and **(b)**; finding **(c)** remains open for PR #4 (vocabulary calibration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)