### PR TITLE
Phase 19 PR #3 — Nextness Metrics Pipeline (Lane B implementation)

### DIFF
--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -10,7 +10,11 @@ module just implements them.
 
 Scope guarantees (carried forward from PR #138 / PR #140):
     - No engine touch.
-    - No writes outside the resolved output path's directory.
+    - **No writes outside ``log_path.parent``** — the output ``--out`` path
+      must resolve to a location inside the same directory as the input
+      JSONL log. Enforced via :class:`WriteOutsideLogDirError` reused
+      from ``scripts.nextness_observer``; the safety vocabulary is
+      unified across modules.
     - No HTTP, ZMQ, or network of any kind.
     - CPU-only.
     - allow_pickle=False (no .npz reads here; JSONL only).
@@ -43,11 +47,48 @@ from typing import Any
 
 from scripts.nextness_observer import (
     TOKEN_NAMES,
+    WriteOutsideLogDirError,
     boundary_rate as _boundary_rate,
     entropy_normalized as _entropy_normalized,
     shannon_entropy_bits as _shannon_entropy_bits,
     void_compute_balance as _void_compute_balance,
 )
+
+
+# ---------------------------------------------------------------------------
+# Write-boundary guard (Lane B safety contract; mirrors the helper in
+# nextness_observer.py without coupling to its private name)
+# ---------------------------------------------------------------------------
+
+
+def _validate_metrics_output_path(
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+) -> None:
+    """Refuse output paths that resolve outside the input log's directory.
+
+    The Lane B safety contract requires that derived metrics output land
+    only inside ``log_path.parent``. This catches both literal mismatches
+    (``--out /tmp/other.jsonl``) and traversal/symlink escapes
+    (``--out ../somewhere_else/out.jsonl``). Resolves both paths to
+    canonical absolute form before comparing — symlink-aware.
+
+    Per Jack's audit on PR #142: the PR body and module docstring claim
+    "no writes outside log_directory," and this function makes that
+    claim true rather than aspirational. Raises
+    :class:`WriteOutsideLogDirError` (reused from
+    ``scripts.nextness_observer``) so the safety vocabulary stays
+    unified across both modules.
+    """
+    log_dir_resolved = log_path.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(log_dir_resolved)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write metrics output outside log_path's directory: "
+            f"{out_resolved} is not inside {log_dir_resolved}"
+        ) from e
 
 
 # ---------------------------------------------------------------------------
@@ -295,6 +336,11 @@ def compute_run_metrics(
     if not log_path.is_file():
         raise FileNotFoundError(f"log file not found: {log_path}")
 
+    # Lane B safety contract (Jack's audit on PR #142): out_path must
+    # resolve under log_path.parent. Validate BEFORE any disk side effects
+    # — no parent-mkdir, no file open, no writes — happen.
+    _validate_metrics_output_path(out_path, log_path)
+
     # Load and sort
     entries: list[dict[str, Any]] = []
     with log_path.open("r", encoding="utf-8") as f:
@@ -451,6 +497,12 @@ def main(argv: list[str] | None = None) -> int:
             smoothing=args.smoothing,
             boundary_delta=args.boundary_delta,
         )
+    except WriteOutsideLogDirError as e:
+        # Lane B safety violation: --out points outside the log file's
+        # directory. Return distinct non-zero code so callers can
+        # distinguish safety refusals from data errors.
+        print(f"safety error: {e}", file=sys.stderr)
+        return 3
     except (ValueError, FileNotFoundError) as e:
         print(f"error: {e}", file=sys.stderr)
         return 2

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -1,0 +1,484 @@
+"""Across-snapshots metrics pipeline for the Nextness Observer (Phase 19 PR #3).
+
+Consumes a ``nextness_runs.jsonl`` log written by ``scripts.nextness_observer.
+process_snapshot()`` and emits a derived ``nextness_run_metrics.jsonl`` with
+one row per snapshot pair plus a final aggregate row.
+
+Reference: ``PHASE_19_PR3_METRICS_PIPELINE.md`` (design doc, merged as
+``3dfc67d``). All metric formulas live there with full justification; this
+module just implements them.
+
+Scope guarantees (carried forward from PR #138 / PR #140):
+    - No engine touch.
+    - No writes outside the resolved output path's directory.
+    - No HTTP, ZMQ, or network of any kind.
+    - CPU-only.
+    - allow_pickle=False (no .npz reads here; JSONL only).
+    - Bounded compute: O(N * K) where N = snapshots, K = vocabulary size.
+
+Determinism contract (per Jack's audit on PR #141):
+    - Snapshots are sorted by (generation, snapshot_file, ts) before any
+      pair-wise computation runs. This makes the output independent of the
+      order entries happened to be written to the log file.
+    - No fresh ``generated_at`` field is added to the output. Source-data
+      timestamps and generations only. Re-running on the same input
+      produces byte-identical output.
+    - Smoothing-and-normalization for KL / JS iterates over ``TOKEN_NAMES``
+      in its canonical declaration order (not whatever dict iteration order
+      the caller happened to pass in).
+
+CLI:
+    python -m scripts.nextness_metrics --log <jsonl-in> --out <jsonl-out>
+        [--smoothing FLOAT] [--boundary-delta FLOAT]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from scripts.nextness_observer import (
+    TOKEN_NAMES,
+    boundary_rate as _boundary_rate,
+    entropy_normalized as _entropy_normalized,
+    shannon_entropy_bits as _shannon_entropy_bits,
+    void_compute_balance as _void_compute_balance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Distribution smoothing + KL / JS divergence (design doc §4.1, §4.2)
+# ---------------------------------------------------------------------------
+
+
+def smoothed_distribution(
+    counts: Mapping[str, int],
+    smoothing: float = 1e-6,
+) -> list[float]:
+    """Smoothed probability vector over ``TOKEN_NAMES`` in canonical order.
+
+    Adds ``smoothing`` to every token (whether the token fired or not),
+    then divides by the resulting sum. This makes the output independent
+    of caller-supplied dict iteration order and avoids divide-by-zero in
+    the KL formula's log-of-ratio when a token never fires in one of the
+    two distributions being compared.
+
+    Per Jack's audit on PR #141 / design doc §4.1: this is the canonical
+    algorithm; the result vector always has length ``len(TOKEN_NAMES)``
+    and sums to 1.0 (within float precision).
+    """
+    if smoothing < 0:
+        raise ValueError(f"smoothing must be non-negative, got {smoothing}")
+    raw = [counts.get(tok, 0) + smoothing for tok in TOKEN_NAMES]
+    total = sum(raw)
+    if total <= 0:
+        # Pathological: empty counts AND zero smoothing. Return uniform
+        # rather than raise — divergence against uniform is well-defined
+        # and tells the caller the input was effectively empty.
+        return [1.0 / len(TOKEN_NAMES)] * len(TOKEN_NAMES)
+    return [v / total for v in raw]
+
+
+def kl_divergence(
+    counts_p: Mapping[str, int],
+    counts_q: Mapping[str, int],
+    smoothing: float = 1e-6,
+) -> float:
+    """Kullback-Leibler divergence (bits) from ``p`` to ``q``.
+
+    Computes :math:`D_{KL}(P || Q) = \\sum_i p_i \\log_2(p_i / q_i)` over
+    smoothed distributions (per :func:`smoothed_distribution`). Asymmetric
+    by construction; if you want a symmetric distance use
+    :func:`js_divergence` instead.
+
+    Returns 0.0 iff ``counts_p == counts_q`` after smoothing.
+    """
+    p = smoothed_distribution(counts_p, smoothing)
+    q = smoothed_distribution(counts_q, smoothing)
+    total = 0.0
+    for p_i, q_i in zip(p, q):
+        if p_i > 0.0:
+            total += p_i * math.log2(p_i / q_i)
+    return total
+
+
+def js_divergence(
+    counts_p: Mapping[str, int],
+    counts_q: Mapping[str, int],
+    smoothing: float = 1e-6,
+) -> float:
+    """Jensen-Shannon divergence (bits) — symmetric, bounded [0, 1].
+
+    Computes :math:`D_{JS}(P, Q) = 0.5 D_{KL}(P || M) + 0.5 D_{KL}(Q || M)`
+    where :math:`M = (P + Q) / 2`. With base-2 logarithms the output is
+    bounded in [0, 1] bits, with 0 iff ``P == Q``.
+
+    This is the **primary** drift metric for cross-snapshot comparison
+    per design doc §4.2.
+    """
+    p = smoothed_distribution(counts_p, smoothing)
+    q = smoothed_distribution(counts_q, smoothing)
+    m = [(p_i + q_i) / 2.0 for p_i, q_i in zip(p, q)]
+    kl_pm = 0.0
+    kl_qm = 0.0
+    for p_i, q_i, m_i in zip(p, q, m):
+        if p_i > 0.0:
+            kl_pm += p_i * math.log2(p_i / m_i)
+        if q_i > 0.0:
+            kl_qm += q_i * math.log2(q_i / m_i)
+    return 0.5 * kl_pm + 0.5 * kl_qm
+
+
+# ---------------------------------------------------------------------------
+# Boundary persistence (design doc §4.3) — pairwise + raw CV + clamped score
+# ---------------------------------------------------------------------------
+
+
+def boundary_persistence_pairwise(
+    r_prev: float,
+    r_curr: float,
+    delta: float = 1e-3,
+) -> float:
+    """Pairwise boundary-rate persistence score.
+
+    :math:`\\pi = 1 - |r_{t} - r_{t-1}| / \\max(r_{t-1}, r_{t}, \\delta)`
+
+    Bounded in [0, 1]: equals 1 when the two rates are identical; equals 0
+    when one rate is much larger than the other AND larger than ``delta``;
+    near 1 when both rates are near zero (saturated by ``delta`` in the
+    denominator, so the score doesn't whipsaw on noise).
+
+    Raises ``ValueError`` if either rate is negative.
+    """
+    if r_prev < 0 or r_curr < 0:
+        raise ValueError(
+            f"boundary rates must be non-negative; got r_prev={r_prev}, r_curr={r_curr}"
+        )
+    if delta <= 0:
+        raise ValueError(f"delta must be positive, got {delta}")
+    diff = abs(r_curr - r_prev)
+    denom = max(r_prev, r_curr, delta)
+    return 1.0 - diff / denom
+
+
+def boundary_cv(rates: Sequence[float], delta: float = 1e-3) -> float:
+    """Coefficient of variation of a sequence of boundary rates.
+
+    :math:`\\text{CV} = \\sigma(rates) / (\\mu(rates) + \\delta)`
+
+    Range: [0, ∞). 0 means constant rate; ≥ 1 means the standard
+    deviation exceeds the mean (the failure case the original
+    persistence formula had — see design doc §4.3 audit notes).
+
+    Returns 0.0 for empty or single-element sequences (no variance
+    defined).
+    """
+    if delta <= 0:
+        raise ValueError(f"delta must be positive, got {delta}")
+    if len(rates) < 2:
+        return 0.0
+    mean = sum(rates) / len(rates)
+    var = sum((r - mean) ** 2 for r in rates) / len(rates)  # population variance
+    std = math.sqrt(var)
+    return std / (mean + delta)
+
+
+def boundary_persistence_aggregate_clamped(
+    rates: Sequence[float],
+    delta: float = 1e-3,
+) -> float:
+    """Clamped aggregate boundary-rate persistence score.
+
+    :math:`\\Pi = \\max(0, 1 - \\text{CV}(rates))`
+
+    Bounded in [0, 1] by construction (per Jack's audit fix on the
+    original ``1 - sigma/mu`` formula, which could go negative). High
+    score = sustained rate; low score = drift or volatility.
+
+    Returns 1.0 for empty or single-element sequences (no variation
+    possible, treated as "perfectly persistent"). The aggregate is
+    most meaningful for runs with N ≥ 3 snapshots.
+    """
+    if len(rates) < 2:
+        return 1.0
+    return max(0.0, 1.0 - boundary_cv(rates, delta))
+
+
+# ---------------------------------------------------------------------------
+# Coexistence-Crystallization Index (design doc §4.4)
+# ---------------------------------------------------------------------------
+
+
+def cci(balance: float, boundary: float, entropy_norm: float) -> float:
+    """Coexistence-Crystallization Index.
+
+    :math:`\\text{CCI} = B_{V/C} \\cdot R_{\\text{boundary}} \\cdot
+    (1 - H_{\\text{norm}})`
+
+    A **scoring function**, not a regime classifier. Range [0, 1] assuming
+    all three inputs are in [0, 1] (the per-snapshot fields they're
+    derived from are guaranteed to be).
+
+    Interpretation guide (per design doc §4.4, post-hoc empirical):
+        - High CCI: balanced VOID/COMPUTE + high boundary rate +
+          concentrated token distribution. Candidate "stable coexistence."
+        - Low CCI from low entropy + low boundary rate: distribution
+          concentrated but boundaries collapsed. Candidate "crystallized."
+        - Low CCI from high entropy: distribution spread across many
+          tokens. Candidate "mixing / soup."
+
+    PR #4 will calibrate regime thresholds; this function is just the
+    score, not a binning.
+    """
+    return balance * boundary * (1.0 - entropy_norm)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: read JSONL log → emit derived metrics JSONL (design doc §4.5)
+# ---------------------------------------------------------------------------
+
+
+def _sort_key(entry: dict[str, Any]) -> tuple:
+    """Deterministic sort key per design doc §10 question 4.
+
+    Priority order: ``generation`` (primary, monotonic, embedded), then
+    ``snapshot_file`` (deterministic tiebreaker), then ``ts`` (final
+    fallback from the snapshot itself, not a fresh datetime.now()).
+    """
+    return (
+        entry.get("generation", 0),
+        entry.get("snapshot_file", ""),
+        entry.get("ts", ""),
+    )
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Best-effort float extraction. Used to defend against malformed log entries."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _entry_cci(entry: dict[str, Any]) -> float:
+    """CCI computed from a JSONL entry's three component fields."""
+    return cci(
+        _safe_float(entry.get("void_compute_balance", 0.0)),
+        _safe_float(entry.get("boundary_rate", 0.0)),
+        _safe_float(entry.get("entropy_normalized", 0.0)),
+    )
+
+
+def compute_run_metrics(
+    log_path: str | pathlib.Path,
+    out_path: str | pathlib.Path,
+    smoothing: float = 1e-6,
+    boundary_delta: float = 1e-3,
+) -> dict[str, Any]:
+    """Read a ``nextness_runs.jsonl`` log, emit a derived metrics JSONL.
+
+    Produces one row per snapshot pair (in sorted order) plus a final
+    ``run_aggregate`` row. Returns the aggregate summary dict for
+    callers (tests, CLI) that want to inspect it without re-reading
+    the output file.
+
+    Output is byte-identical across re-runs on the same input
+    (no fresh timestamps; deterministic ordering; canonical token
+    iteration order in KL / JS).
+    """
+    log_path = pathlib.Path(log_path)
+    out_path = pathlib.Path(out_path)
+    if not log_path.is_file():
+        raise FileNotFoundError(f"log file not found: {log_path}")
+
+    # Load and sort
+    entries: list[dict[str, Any]] = []
+    with log_path.open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                entry = json.loads(stripped)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"malformed JSONL at {log_path}:{line_no}: {e}"
+                ) from e
+            entries.append(entry)
+    entries.sort(key=_sort_key)
+
+    # Per-snapshot CCI values (used by both pair rows and the aggregate)
+    cci_values = [_entry_cci(e) for e in entries]
+    boundary_rates = [_safe_float(e.get("boundary_rate", 0.0)) for e in entries]
+
+    # Pairwise rows
+    pair_rows: list[dict[str, Any]] = []
+    js_values: list[float] = []
+    for i in range(1, len(entries)):
+        prev_e = entries[i - 1]
+        curr_e = entries[i]
+        prev_counts = prev_e.get("token_counts", {}) or {}
+        curr_counts = curr_e.get("token_counts", {}) or {}
+        kl_val = kl_divergence(prev_counts, curr_counts, smoothing)
+        js_val = js_divergence(prev_counts, curr_counts, smoothing)
+        bp_val = boundary_persistence_pairwise(
+            _safe_float(prev_e.get("boundary_rate", 0.0)),
+            _safe_float(curr_e.get("boundary_rate", 0.0)),
+            boundary_delta,
+        )
+        pair_rows.append({
+            "summary_type": "pair",
+            "prev_generation": prev_e.get("generation"),
+            "curr_generation": curr_e.get("generation"),
+            "prev_snapshot_file": prev_e.get("snapshot_file"),
+            "curr_snapshot_file": curr_e.get("snapshot_file"),
+            "kl_divergence_bits": kl_val,
+            "js_divergence_bits": js_val,
+            "boundary_persistence_pairwise": bp_val,
+            "cci_prev": cci_values[i - 1],
+            "cci_curr": cci_values[i],
+        })
+        js_values.append(js_val)
+
+    # Aggregate
+    n = len(entries)
+    n_pairs = len(pair_rows)
+    if cci_values:
+        mean_cci = sum(cci_values) / n
+        var_cci = sum((c - mean_cci) ** 2 for c in cci_values) / n
+        std_cci = math.sqrt(var_cci)
+        min_cci = min(cci_values)
+        max_cci = max(cci_values)
+        argmin_idx = cci_values.index(min_cci)
+        argmax_idx = cci_values.index(max_cci)
+        argmin_file = entries[argmin_idx].get("snapshot_file")
+        argmax_file = entries[argmax_idx].get("snapshot_file")
+    else:
+        mean_cci = std_cci = min_cci = max_cci = 0.0
+        argmin_file = argmax_file = None
+
+    if js_values:
+        mean_js = sum(js_values) / n_pairs
+        var_js = sum((j - mean_js) ** 2 for j in js_values) / n_pairs
+        std_js = math.sqrt(var_js)
+    else:
+        mean_js = std_js = 0.0
+
+    aggregate: dict[str, Any] = {
+        "summary_type": "run_aggregate",
+        "n_snapshots": n,
+        "n_pairs": n_pairs,
+        "mean_js_divergence_bits": mean_js,
+        "std_js_divergence_bits": std_js,
+        "mean_cci": mean_cci,
+        "std_cci": std_cci,
+        "min_cci": min_cci,
+        "max_cci": max_cci,
+        "argmin_cci_snapshot": argmin_file,
+        "argmax_cci_snapshot": argmax_file,
+        "boundary_cv": boundary_cv(boundary_rates, boundary_delta),
+        "boundary_persistence_aggregate_clamped": boundary_persistence_aggregate_clamped(
+            boundary_rates, boundary_delta
+        ),
+    }
+
+    # Write output deterministically. Note: NO ``generated_at`` field.
+    # ``sort_keys=True`` makes the JSON field order deterministic too.
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        for row in pair_rows:
+            f.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+        f.write(json.dumps(aggregate, sort_keys=True, default=str) + "\n")
+
+    return aggregate
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.nextness_metrics",
+        description=(
+            "Compute across-snapshots metrics on a Nextness Observer "
+            "JSONL log. Emits a derived JSONL with one row per snapshot "
+            "pair plus a final aggregate row. Deterministic: re-running "
+            "on the same input produces byte-identical output."
+        ),
+    )
+    parser.add_argument(
+        "--log",
+        required=True,
+        help="Path to input nextness_runs.jsonl",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Path for output nextness_run_metrics.jsonl",
+    )
+    parser.add_argument(
+        "--smoothing",
+        type=float,
+        default=1e-6,
+        help="Laplace smoothing constant for KL/JS (default: 1e-6)",
+    )
+    parser.add_argument(
+        "--boundary-delta",
+        type=float,
+        default=1e-3,
+        help="Stabilization constant for boundary metrics (default: 1e-3)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 on success, non-zero on error."""
+    args = _build_parser().parse_args(argv)
+    log_path = pathlib.Path(args.log)
+    out_path = pathlib.Path(args.out)
+    if not log_path.is_file():
+        print(f"error: log file not found: {log_path}", file=sys.stderr)
+        return 1
+    try:
+        agg = compute_run_metrics(
+            log_path, out_path,
+            smoothing=args.smoothing,
+            boundary_delta=args.boundary_delta,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    # Compact stdout summary
+    print(f"Wrote {out_path}")
+    print(f"  n_snapshots: {agg['n_snapshots']}")
+    print(f"  n_pairs: {agg['n_pairs']}")
+    print(f"  mean_cci: {agg['mean_cci']:.4f}  (std: {agg['std_cci']:.4f})")
+    print(f"  mean_js_divergence_bits: {agg['mean_js_divergence_bits']:.4f}  "
+          f"(std: {agg['std_js_divergence_bits']:.4f})")
+    print(f"  boundary_cv: {agg['boundary_cv']:.4f}")
+    print(f"  boundary_persistence_aggregate_clamped: "
+          f"{agg['boundary_persistence_aggregate_clamped']:.4f}")
+    return 0
+
+
+__all__ = [
+    "smoothed_distribution",
+    "kl_divergence",
+    "js_divergence",
+    "boundary_persistence_pairwise",
+    "boundary_cv",
+    "boundary_persistence_aggregate_clamped",
+    "cci",
+    "compute_run_metrics",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -1166,6 +1166,93 @@ def write_log_entry(
     return log_path
 
 
+# ---------------------------------------------------------------------------
+# PR #3 — per-snapshot metric helpers (PHASE_19_PR3_METRICS_PIPELINE.md §3)
+# ---------------------------------------------------------------------------
+
+import math
+from collections.abc import Mapping
+
+
+def shannon_entropy_bits(token_counts: Mapping[str, int]) -> float:
+    """Shannon entropy (in bits) over a token-count distribution.
+
+    Uses base-2 log so the result is in units of bits. Returns 0.0 if the
+    distribution is empty (no patches classified). Zero-count tokens are
+    skipped under the convention 0·log(0) = 0.
+
+    Maximum value for the canonical 16-token vocabulary is log₂(16) = 4.0
+    bits (uniform distribution over all tokens). The first real Medusa
+    pass at gen 1,621,779 yielded ~0.98 bits — distribution concentrated
+    in two tokens, as documented in issue #139.
+    """
+    total = sum(token_counts.values())
+    if total == 0:
+        return 0.0
+    h = 0.0
+    for count in token_counts.values():
+        if count <= 0:
+            continue
+        p = count / total
+        h -= p * math.log2(p)
+    return h
+
+
+def entropy_normalized(entropy_bits: float, vocabulary_size: int) -> float:
+    """Normalize a Shannon-entropy-in-bits value to [0, 1].
+
+    Divides by log₂(vocabulary_size) to produce a unit-comparable score
+    across different vocabulary sizes (relevant once PR #5 introduces the
+    learned 512-token embedding alongside the current 16-token hand-coded
+    vocabulary).
+
+    Returns 0.0 if vocabulary_size <= 1 (no information possible) or if
+    the supplied entropy is non-positive.
+    """
+    if vocabulary_size <= 1 or entropy_bits <= 0.0:
+        return 0.0
+    return entropy_bits / math.log2(vocabulary_size)
+
+
+def void_compute_balance(state: np.ndarray) -> float:
+    """Symmetric balance score between VOID and COMPUTE cell counts.
+
+    Computes ``2 · min(N_VOID, N_COMPUTE) / (N_VOID + N_COMPUTE)`` over the
+    raw cell-state array. Range [0, 1]; 1.0 iff the counts are equal; 0.0
+    if either state is absent or if the lattice contains neither.
+
+    Captures the "coexistence axis" of AURA's Sakana-derived 3-regime
+    framing using the two cell states that dominate the mature 256³
+    Medusa lattice. For gen 1,621,779: N_VOID = 7,909,111 (47.14%),
+    N_COMPUTE = 7,719,525 (46.01%), giving balance ≈ 0.988.
+    """
+    n_void = int(np.count_nonzero(state == STATE_VOID))
+    n_compute = int(np.count_nonzero(state == STATE_COMPUTE))
+    total = n_void + n_compute
+    if total == 0:
+        return 0.0
+    return 2.0 * min(n_void, n_compute) / total
+
+
+def boundary_rate(token_counts: Mapping[str, int]) -> float:
+    """Normalized count of the ``phase_boundary`` token.
+
+    Returns count(phase_boundary) / sum(all token counts), range [0, 1].
+    Returns 0.0 if no patches were classified or if ``phase_boundary``
+    is absent from the counts mapping.
+
+    Promoted to a top-level metric per PHASE_19_PR3_METRICS_PIPELINE.md
+    §3.4 — boundary rate is the single most-architecturally-important
+    token signal (fungal-network "growth at active boundary" intuition),
+    so it gets a first-class field rather than living only inside the
+    nested ``token_counts`` dict.
+    """
+    total = sum(token_counts.values())
+    if total == 0:
+        return 0.0
+    return token_counts.get("phase_boundary", 0) / total
+
+
 def process_snapshot(
     snapshot_path: str | pathlib.Path,
     config: ObserverConfig,
@@ -1226,6 +1313,10 @@ def process_snapshot(
     budget_block: dict[str, object] = dict(dataclasses.asdict(report))
     budget_block["fraction_used"] = report.fraction_used
 
+    # PR #3 per-snapshot metrics (PHASE_19_PR3_METRICS_PIPELINE.md §3).
+    # All computed from data already in memory; total cost ≈ 50 µs at K=16
+    # tokens on a 256³ lattice, negligible against the ~1s classification time.
+    shannon_h = shannon_entropy_bits(token_counts)
     entry: dict[str, object] = {
         "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "snapshot_file": snapshot_path.name,
@@ -1240,6 +1331,10 @@ def process_snapshot(
         "medusa_is_live": medusa_is_live,
         "token_counts": dict(token_counts),
         "vocabulary_occupancy": len(token_counts) / max(1, len(TOKEN_NAMES)),
+        "shannon_entropy_bits": shannon_h,
+        "entropy_normalized": entropy_normalized(shannon_h, len(TOKEN_NAMES)),
+        "void_compute_balance": void_compute_balance(state),
+        "boundary_rate": boundary_rate(token_counts),
         "budget": budget_block,
     }
     write_log_entry(config.log_directory, entry)
@@ -1253,6 +1348,11 @@ __all__ += [  # type: ignore[misc]
     "load_snapshot",
     "write_log_entry",
     "process_snapshot",
+    # PR #3 per-snapshot metric helpers
+    "shannon_entropy_bits",
+    "entropy_normalized",
+    "void_compute_balance",
+    "boundary_rate",
 ]
 
 

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -1,0 +1,521 @@
+"""Tests for scripts/nextness_metrics.py — Phase 19 PR #3.
+
+Locks down each metric formula plus the orchestrator's determinism
+contracts (no fresh ``generated_at``, deterministic sort across input
+orderings, byte-identical idempotent re-run).
+
+Per the design doc (PHASE_19_PR3_METRICS_PIPELINE.md §6): unit tests
+per metric with reference values, integration tests for the orchestrator,
+and a self-contained "golden" test pinning the arithmetic against
+silent regressions.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+
+import pytest
+
+from scripts.nextness_observer import TOKEN_NAMES
+from scripts.nextness_metrics import (
+    boundary_cv,
+    boundary_persistence_aggregate_clamped,
+    boundary_persistence_pairwise,
+    cci,
+    compute_run_metrics,
+    js_divergence,
+    kl_divergence,
+    main,
+    smoothed_distribution,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    *,
+    generation: int,
+    snapshot_file: str,
+    ts: str = "2026-05-18T00:00:00Z",
+    token_counts: dict[str, int] | None = None,
+    void_compute_balance: float = 0.5,
+    boundary_rate: float = 0.3,
+    entropy_normalized: float = 0.4,
+    shannon_entropy_bits: float = 1.6,
+    vocabulary_occupancy: float = 0.125,
+) -> dict:
+    """Build a minimally-valid log entry for tests."""
+    return {
+        "generation": generation,
+        "snapshot_file": snapshot_file,
+        "ts": ts,
+        "token_counts": token_counts or {"karuna_relief": 100, "phase_boundary": 50},
+        "void_compute_balance": void_compute_balance,
+        "boundary_rate": boundary_rate,
+        "entropy_normalized": entropy_normalized,
+        "shannon_entropy_bits": shannon_entropy_bits,
+        "vocabulary_occupancy": vocabulary_occupancy,
+        "lattice_shape": [256, 256, 256],
+    }
+
+
+def _write_log(path: pathlib.Path, entries: list[dict]) -> None:
+    """Write a list of log entries to a JSONL file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# smoothed_distribution — Jack's canonical-ordering spec (§4.1)
+# ---------------------------------------------------------------------------
+
+
+def test_smoothed_distribution_sums_to_one():
+    """Result always sums to 1.0 (within float precision)."""
+    p = smoothed_distribution({"karuna_relief": 100, "phase_boundary": 50})
+    assert sum(p) == pytest.approx(1.0)
+
+
+def test_smoothed_distribution_length_matches_vocabulary():
+    """Result has exactly len(TOKEN_NAMES) entries, one per canonical token."""
+    p = smoothed_distribution({"karuna_relief": 100})
+    assert len(p) == len(TOKEN_NAMES)
+
+
+def test_smoothed_distribution_canonical_order_independent_of_input_order():
+    """Two semantically equivalent count dicts produce identical vectors."""
+    # Python dicts preserve insertion order; we want the result to be
+    # independent of that order. Build two dicts with different insertion
+    # orders but the same content.
+    counts_a = {"karuna_relief": 100, "phase_boundary": 50, "void_static": 10}
+    counts_b = {"void_static": 10, "phase_boundary": 50, "karuna_relief": 100}
+    assert smoothed_distribution(counts_a) == smoothed_distribution(counts_b)
+
+
+def test_smoothed_distribution_empty_input_uniform_with_zero_smoothing():
+    """Empty + zero smoothing → uniform (defensive against div-by-zero)."""
+    p = smoothed_distribution({}, smoothing=0.0)
+    expected = 1.0 / len(TOKEN_NAMES)
+    assert all(v == pytest.approx(expected) for v in p)
+
+
+def test_smoothed_distribution_negative_smoothing_raises():
+    """Smoothing must be non-negative."""
+    with pytest.raises(ValueError):
+        smoothed_distribution({"a": 1}, smoothing=-0.1)
+
+
+# ---------------------------------------------------------------------------
+# KL divergence (§4.1)
+# ---------------------------------------------------------------------------
+
+
+def test_kl_divergence_identical_distributions_zero():
+    """D_KL(P || P) = 0 by definition."""
+    counts = {"karuna_relief": 100, "phase_boundary": 50}
+    assert kl_divergence(counts, counts) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_kl_divergence_asymmetric():
+    """D_KL(P || Q) != D_KL(Q || P) in general (asymmetry).
+
+    Care needed in test fixture: mirror-image distributions like
+    ({a:100, b:1}, {a:1, b:100}) give *symmetric* KL because the two
+    fall on the same orbit under the token-label swap. Non-mirror
+    fixtures expose the asymmetry properly.
+    """
+    p = {"karuna_relief": 100, "phase_boundary": 10}   # 10:1 ratio
+    q = {"karuna_relief": 50, "phase_boundary": 50}    # uniform between the two
+    forward = kl_divergence(p, q)
+    reverse = kl_divergence(q, p)
+    assert forward != reverse
+    # Both should be positive (the distributions are different)
+    assert forward > 0.01
+    assert reverse > 0.01
+
+
+def test_kl_divergence_with_smoothing_finite_for_disjoint_supports():
+    """Smoothing prevents infinity when a token fires in one but not the other."""
+    p = {"karuna_relief": 100}        # only this token
+    q = {"phase_boundary": 100}       # only this OTHER token
+    val = kl_divergence(p, q, smoothing=1e-6)
+    assert math.isfinite(val)
+    assert val > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Jensen-Shannon divergence (§4.2)
+# ---------------------------------------------------------------------------
+
+
+def test_js_divergence_identical_distributions_zero():
+    """D_JS(P, P) = 0."""
+    counts = {"karuna_relief": 100, "phase_boundary": 50}
+    assert js_divergence(counts, counts) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_js_divergence_symmetric():
+    """D_JS(P, Q) == D_JS(Q, P) by construction."""
+    p = {"karuna_relief": 100, "phase_boundary": 1}
+    q = {"karuna_relief": 1, "phase_boundary": 100}
+    assert js_divergence(p, q) == pytest.approx(js_divergence(q, p))
+
+
+def test_js_divergence_bounded_in_zero_one():
+    """D_JS in bits is bounded [0, 1] for any pair of distributions."""
+    # Maximum case: disjoint supports
+    p = {"karuna_relief": 1_000_000}
+    q = {"phase_boundary": 1_000_000}
+    val = js_divergence(p, q, smoothing=1e-9)
+    assert 0.0 <= val <= 1.0 + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Boundary persistence pairwise (§4.3)
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_persistence_pairwise_identical_rates_one():
+    """Identical rates → persistence = 1.0."""
+    assert boundary_persistence_pairwise(0.42, 0.42) == pytest.approx(1.0)
+    assert boundary_persistence_pairwise(0.0, 0.0) == pytest.approx(1.0)
+
+
+def test_boundary_persistence_pairwise_max_drop_zero():
+    """Rate dropping from r to 0 → persistence = 0 (full inversion)."""
+    assert boundary_persistence_pairwise(0.42, 0.0) == pytest.approx(0.0)
+    assert boundary_persistence_pairwise(0.0, 0.42) == pytest.approx(0.0)
+
+
+def test_boundary_persistence_pairwise_bounded_in_zero_one():
+    """Always in [0, 1] regardless of inputs."""
+    for r_prev, r_curr in [(0.1, 0.2), (0.5, 0.1), (0.9, 0.9), (0.0, 0.001)]:
+        val = boundary_persistence_pairwise(r_prev, r_curr)
+        assert 0.0 <= val <= 1.0, f"out of range for ({r_prev}, {r_curr}): {val}"
+
+
+def test_boundary_persistence_pairwise_negative_rate_raises():
+    """Negative rates are an input contract violation."""
+    with pytest.raises(ValueError):
+        boundary_persistence_pairwise(-0.1, 0.2)
+    with pytest.raises(ValueError):
+        boundary_persistence_pairwise(0.1, -0.2)
+
+
+# ---------------------------------------------------------------------------
+# Boundary CV + clamped aggregate persistence (§4.3)
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_cv_constant_series_zero():
+    """Constant series → CV = 0."""
+    assert boundary_cv([0.42, 0.42, 0.42, 0.42]) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_boundary_cv_high_variance_exceeds_one():
+    """The original-formula failure case (rates [0, 0.5, 0, 0.5, 0]) gives CV >= 1."""
+    # Population stats: mean = 0.2, var = 0.06, std ≈ 0.2449
+    # CV ≈ 0.2449 / 0.201 ≈ 1.218 — exceeds 1, which is exactly why the
+    # original 1-CV formula went negative (issue caught by Jack's audit).
+    cv = boundary_cv([0.0, 0.5, 0.0, 0.5, 0.0])
+    assert cv > 1.0
+
+
+def test_boundary_cv_empty_or_single_element_zero():
+    """No variance defined → CV = 0 (sane default for degenerate input)."""
+    assert boundary_cv([]) == 0.0
+    assert boundary_cv([0.42]) == 0.0
+
+
+def test_boundary_persistence_aggregate_clamped_corners():
+    """Constant → 1.0; high-variance → 0.0 (clamp engages)."""
+    # Constant series: CV=0, score=1.0
+    assert boundary_persistence_aggregate_clamped(
+        [0.42, 0.42, 0.42]
+    ) == pytest.approx(1.0)
+    # High variance: CV>1, clamp to 0
+    assert boundary_persistence_aggregate_clamped(
+        [0.0, 0.5, 0.0, 0.5, 0.0]
+    ) == pytest.approx(0.0)
+
+
+def test_boundary_persistence_aggregate_clamped_intermediate_matches_one_minus_cv():
+    """For 0 < CV < 1, clamped score equals 1 - CV exactly (no clamp)."""
+    # Pick rates with moderate variance: mean=0.4, low std
+    rates = [0.38, 0.42, 0.40, 0.40, 0.40]
+    expected = 1.0 - boundary_cv(rates)
+    assert 0.0 < expected < 1.0  # genuinely in the un-clamped regime
+    assert boundary_persistence_aggregate_clamped(rates) == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# CCI (§4.4)
+# ---------------------------------------------------------------------------
+
+
+def test_cci_corners():
+    """CCI = 0 iff any factor is 0; CCI = 1 iff all factors are 1."""
+    assert cci(0.0, 0.5, 0.5) == 0.0  # balance zero
+    assert cci(0.5, 0.0, 0.5) == 0.0  # boundary zero
+    assert cci(0.5, 0.5, 1.0) == 0.0  # H_norm = 1 → (1-H) = 0
+    assert cci(1.0, 1.0, 0.0) == pytest.approx(1.0)  # all max
+
+
+def test_cci_gen_1_6m_reference():
+    """Gen-1.6M reference values (design doc §4.4)."""
+    # B_VC = 0.988, R_boundary = 0.422, H_norm = 0.246
+    # CCI = 0.988 * 0.422 * (1 - 0.246) = 0.988 * 0.422 * 0.754 ≈ 0.3144
+    val = cci(0.988, 0.422, 0.246)
+    assert 0.31 < val < 0.32
+
+
+def test_cci_monotonicity():
+    """CCI increases with balance and boundary; decreases with entropy_norm."""
+    base = cci(0.5, 0.5, 0.5)
+    assert cci(0.6, 0.5, 0.5) > base   # higher balance
+    assert cci(0.5, 0.6, 0.5) > base   # higher boundary
+    assert cci(0.5, 0.5, 0.4) > base   # LOWER entropy → higher CCI
+
+
+# ---------------------------------------------------------------------------
+# compute_run_metrics — integration + determinism contracts (§4.5, §10 Q4)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_run_metrics_two_snapshots(tmp_path):
+    """Minimal 2-snapshot run → one pair row + one aggregate row."""
+    log_path = tmp_path / "nextness_runs.jsonl"
+    out_path = tmp_path / "nextness_run_metrics.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=100, snapshot_file="v070_gen100.npz",
+                    boundary_rate=0.40),
+        _make_entry(generation=101, snapshot_file="v070_gen101.npz",
+                    boundary_rate=0.42),
+    ])
+
+    agg = compute_run_metrics(log_path, out_path)
+
+    lines = out_path.read_text().splitlines()
+    assert len(lines) == 2  # 1 pair + 1 aggregate
+
+    pair = json.loads(lines[0])
+    assert pair["summary_type"] == "pair"
+    assert pair["prev_generation"] == 100
+    assert pair["curr_generation"] == 101
+    assert "js_divergence_bits" in pair
+    assert "kl_divergence_bits" in pair
+    assert "boundary_persistence_pairwise" in pair
+
+    aggr = json.loads(lines[1])
+    assert aggr["summary_type"] == "run_aggregate"
+    assert aggr["n_snapshots"] == 2
+    assert aggr["n_pairs"] == 1
+    assert aggr == agg
+
+
+def test_compute_run_metrics_identical_snapshots_zero_drift(tmp_path):
+    """Two identical entries → JS=0, boundary persistence=1, CCIs equal."""
+    log_path = tmp_path / "log.jsonl"
+    out_path = tmp_path / "out.jsonl"
+    entry_a = _make_entry(generation=100, snapshot_file="a.npz", boundary_rate=0.40)
+    entry_b = _make_entry(generation=101, snapshot_file="b.npz", boundary_rate=0.40)
+    # Identical token_counts means identical distributions
+    _write_log(log_path, [entry_a, entry_b])
+
+    compute_run_metrics(log_path, out_path)
+    lines = out_path.read_text().splitlines()
+    pair = json.loads(lines[0])
+
+    assert pair["js_divergence_bits"] == pytest.approx(0.0, abs=1e-9)
+    assert pair["boundary_persistence_pairwise"] == pytest.approx(1.0)
+    assert pair["cci_prev"] == pytest.approx(pair["cci_curr"])
+
+
+def test_compute_run_metrics_idempotent_byte_identical(tmp_path):
+    """Re-running on the same input produces byte-identical output.
+
+    This is the canonical determinism contract — no fresh generated_at,
+    deterministic sort, sort_keys=True in JSON serialization.
+    """
+    log_path = tmp_path / "log.jsonl"
+    out_path_a = tmp_path / "out_a.jsonl"
+    out_path_b = tmp_path / "out_b.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=10, snapshot_file="a.npz", boundary_rate=0.40),
+        _make_entry(generation=11, snapshot_file="b.npz", boundary_rate=0.41),
+        _make_entry(generation=12, snapshot_file="c.npz", boundary_rate=0.39),
+    ])
+
+    compute_run_metrics(log_path, out_path_a)
+    compute_run_metrics(log_path, out_path_b)
+    assert out_path_a.read_bytes() == out_path_b.read_bytes()
+
+
+def test_compute_run_metrics_no_generated_at_field(tmp_path):
+    """Output must NOT contain any 'generated_at' field anywhere.
+
+    Required for byte-identical re-run. Locks in §10 Q4 of the design doc.
+    """
+    log_path = tmp_path / "log.jsonl"
+    out_path = tmp_path / "out.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+    compute_run_metrics(log_path, out_path)
+    content = out_path.read_text()
+    assert "generated_at" not in content
+
+
+def test_compute_run_metrics_deterministic_sort_across_input_orderings(tmp_path):
+    """Same snapshots in three different write-orders → byte-identical output.
+
+    Locks in the sort-key contract: output depends only on the data, not
+    on how the input happened to be ordered in the JSONL file.
+    """
+    entries = [
+        _make_entry(generation=10, snapshot_file="a.npz", boundary_rate=0.40),
+        _make_entry(generation=11, snapshot_file="b.npz", boundary_rate=0.41),
+        _make_entry(generation=12, snapshot_file="c.npz", boundary_rate=0.39),
+        _make_entry(generation=13, snapshot_file="d.npz", boundary_rate=0.43),
+    ]
+
+    log_asc = tmp_path / "log_asc.jsonl"
+    log_desc = tmp_path / "log_desc.jsonl"
+    log_shuffled = tmp_path / "log_shuffled.jsonl"
+    out_asc = tmp_path / "out_asc.jsonl"
+    out_desc = tmp_path / "out_desc.jsonl"
+    out_shuffled = tmp_path / "out_shuffled.jsonl"
+
+    _write_log(log_asc, entries)
+    _write_log(log_desc, list(reversed(entries)))
+    _write_log(log_shuffled, [entries[2], entries[0], entries[3], entries[1]])
+
+    compute_run_metrics(log_asc, out_asc)
+    compute_run_metrics(log_desc, out_desc)
+    compute_run_metrics(log_shuffled, out_shuffled)
+
+    assert out_asc.read_bytes() == out_desc.read_bytes()
+    assert out_asc.read_bytes() == out_shuffled.read_bytes()
+
+
+def test_compute_run_metrics_one_snapshot_only(tmp_path):
+    """Single snapshot → no pairs, single aggregate row, no crash."""
+    log_path = tmp_path / "log.jsonl"
+    out_path = tmp_path / "out.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=42, snapshot_file="lonely.npz"),
+    ])
+
+    agg = compute_run_metrics(log_path, out_path)
+    lines = out_path.read_text().splitlines()
+    assert len(lines) == 1  # only the aggregate; no pair rows
+    aggr_line = json.loads(lines[0])
+    assert aggr_line["summary_type"] == "run_aggregate"
+    assert aggr_line["n_snapshots"] == 1
+    assert aggr_line["n_pairs"] == 0
+    assert agg == aggr_line
+
+
+def test_compute_run_metrics_missing_log_raises(tmp_path):
+    """FileNotFoundError surfaces cleanly for missing input."""
+    with pytest.raises(FileNotFoundError):
+        compute_run_metrics(tmp_path / "does_not_exist.jsonl", tmp_path / "out.jsonl")
+
+
+def test_compute_run_metrics_malformed_jsonl_raises(tmp_path):
+    """Malformed JSONL surfaces as ValueError with line context."""
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text('{"generation": 1}\nthis is not json\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed JSONL"):
+        compute_run_metrics(log_path, tmp_path / "out.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Golden self-contained: known input → analytically-computed expected output
+# ---------------------------------------------------------------------------
+
+
+def test_compute_run_metrics_golden_three_snapshots(tmp_path):
+    """Three known snapshots → assert key aggregate values against hand-computed expectations.
+
+    Inputs constructed so the expected outputs can be computed by hand
+    and locked in. Acts as the regression-fence test for the orchestrator
+    arithmetic (design doc §6 "Golden-file test", self-contained variant).
+    """
+    log_path = tmp_path / "log.jsonl"
+    out_path = tmp_path / "out.jsonl"
+    # Three identical distributions → JS=0 between adjacent pairs, but
+    # varying boundary_rate so we can verify boundary metrics
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz",
+                    boundary_rate=0.40, void_compute_balance=0.99,
+                    entropy_normalized=0.25),
+        _make_entry(generation=2, snapshot_file="b.npz",
+                    boundary_rate=0.42, void_compute_balance=0.99,
+                    entropy_normalized=0.25),
+        _make_entry(generation=3, snapshot_file="c.npz",
+                    boundary_rate=0.44, void_compute_balance=0.99,
+                    entropy_normalized=0.25),
+    ])
+
+    agg = compute_run_metrics(log_path, out_path)
+
+    # Identical token_counts (default in _make_entry) → all pair JS = 0
+    assert agg["mean_js_divergence_bits"] == pytest.approx(0.0, abs=1e-9)
+
+    # CCI for each entry: 0.99 * boundary_rate * (1 - 0.25) = 0.7425 * boundary
+    expected_ccis = [0.7425 * 0.40, 0.7425 * 0.42, 0.7425 * 0.44]
+    expected_mean_cci = sum(expected_ccis) / 3
+    assert agg["mean_cci"] == pytest.approx(expected_mean_cci)
+    assert agg["min_cci"] == pytest.approx(expected_ccis[0])
+    assert agg["max_cci"] == pytest.approx(expected_ccis[2])
+    assert agg["argmin_cci_snapshot"] == "a.npz"
+    assert agg["argmax_cci_snapshot"] == "c.npz"
+
+    # Boundary CV: mean = 0.42, population variance =
+    #   ((0.40-0.42)^2 + (0.42-0.42)^2 + (0.44-0.42)^2) / 3
+    #   = (0.0004 + 0 + 0.0004) / 3 = 0.000267
+    # std ≈ 0.01633; CV ≈ 0.01633 / 0.421 ≈ 0.0388
+    expected_cv = math.sqrt(0.0008 / 3) / (0.42 + 1e-3)
+    assert agg["boundary_cv"] == pytest.approx(expected_cv, rel=1e-6)
+    assert agg["boundary_persistence_aggregate_clamped"] == pytest.approx(
+        max(0.0, 1.0 - expected_cv), rel=1e-6
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_main_runs_on_real_input(tmp_path, capsys):
+    """CLI runs end-to-end on a valid log, returns 0, prints summary."""
+    log_path = tmp_path / "log.jsonl"
+    out_path = tmp_path / "out.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+
+    rc = main(["--log", str(log_path), "--out", str(out_path)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert str(out_path) in captured.out
+    assert "n_snapshots: 2" in captured.out
+    assert "mean_cci:" in captured.out
+
+
+def test_cli_main_missing_log_returns_nonzero(tmp_path, capsys):
+    """CLI surfaces missing-file error as non-zero exit code."""
+    rc = main(["--log", str(tmp_path / "missing.jsonl"),
+               "--out", str(tmp_path / "out.jsonl")])
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "not found" in captured.err.lower()

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -17,7 +17,7 @@ import pathlib
 
 import pytest
 
-from scripts.nextness_observer import TOKEN_NAMES
+from scripts.nextness_observer import TOKEN_NAMES, WriteOutsideLogDirError
 from scripts.nextness_metrics import (
     boundary_cv,
     boundary_persistence_aggregate_clamped,
@@ -519,3 +519,96 @@ def test_cli_main_missing_log_returns_nonzero(tmp_path, capsys):
     assert rc != 0
     captured = capsys.readouterr()
     assert "not found" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Write-boundary safety contract (Jack's PR #142 audit)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_run_metrics_accepts_output_inside_log_directory(tmp_path):
+    """Sibling output path (same directory as log) succeeds — happy path
+    for the Lane B safety contract.
+    """
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out_path = log_dir / "nextness_run_metrics.jsonl"  # sibling of log_path
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+
+    # Should not raise
+    agg = compute_run_metrics(log_path, out_path)
+    assert out_path.is_file()
+    assert agg["n_snapshots"] == 2
+
+
+def test_compute_run_metrics_rejects_output_outside_log_directory(tmp_path):
+    """Output path outside log_path.parent raises WriteOutsideLogDirError.
+
+    Lane B contract: derived metrics output must land inside the same
+    directory as the input JSONL log. Per Jack's PR #142 audit; before
+    this fix, the function would happily write anywhere on disk.
+    """
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    # Output path is a sibling of log_dir, not inside it — outside the boundary
+    out_path = tmp_path / "outside_dir" / "out.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        compute_run_metrics(log_path, out_path)
+
+    # And the parent directory of the rejected out_path must NOT have been
+    # created — validation happens before any disk side effects.
+    assert not (tmp_path / "outside_dir").exists()
+
+
+def test_compute_run_metrics_rejects_traversal_escape(tmp_path):
+    """``..`` traversal must also be rejected, not just literal mismatch.
+
+    Defensive: ensures the validation resolves paths to canonical absolute
+    form rather than doing literal string comparison.
+    """
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    # Looks-inside but actually escapes via ..
+    out_path = log_dir / ".." / ".." / "escape.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+
+    with pytest.raises(WriteOutsideLogDirError):
+        compute_run_metrics(log_path, out_path)
+
+
+def test_cli_main_returns_nonzero_for_outside_log_dir_output(tmp_path, capsys):
+    """CLI propagates WriteOutsideLogDirError as a non-zero exit code.
+
+    Distinct exit code from the data-error path so external callers can
+    distinguish a safety refusal from a malformed-input error.
+    """
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out_path = tmp_path / "elsewhere" / "out.jsonl"  # outside log_dir
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+
+    rc = main(["--log", str(log_path), "--out", str(out_path)])
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "safety error" in captured.err.lower()
+    assert "outside log_path" in captured.err.lower()
+    # No side effects: the outside-of-boundary parent dir must not exist
+    assert not (tmp_path / "elsewhere").exists()

--- a/tests/test_nextness_observer.py
+++ b/tests/test_nextness_observer.py
@@ -48,8 +48,10 @@ from scripts.nextness_observer import (
     TOKEN_NAMES,
     WriteOutsideLogDirError,
     ZmqUseInPR2Error,
+    boundary_rate,
     classify_patch,
     compute_safe_stride,
+    entropy_normalized,
     find_latest_snapshot,
     is_medusa_live,
     iter_dense_patches,
@@ -58,6 +60,8 @@ from scripts.nextness_observer import (
     iter_uniform_grid_patches,
     load_snapshot,
     process_snapshot,
+    shannon_entropy_bits,
+    void_compute_balance,
     write_log_entry,
 )
 
@@ -812,3 +816,130 @@ def test_process_snapshot_budget_block_includes_fraction_used(tmp_path):
     entry = json.loads(jsonl[-1])
     assert "fraction_used" in entry["budget"]
     assert entry["budget"]["fraction_used"] == frac
+
+
+# ---------------------------------------------------------------------------
+# PR #3 per-snapshot metric extensions (PHASE_19_PR3_METRICS_PIPELINE.md §3)
+# ---------------------------------------------------------------------------
+
+
+def test_shannon_entropy_bits_basic_cases():
+    """Empty counts → 0; single-token concentration → 0; uniform over K tokens → log2(K)."""
+    import math
+    # Empty distribution
+    assert shannon_entropy_bits({}) == 0.0
+    # All-zero counts
+    assert shannon_entropy_bits({"a": 0, "b": 0}) == 0.0
+    # Single-token concentration: H = -1·log2(1) = 0
+    assert shannon_entropy_bits({"a": 100}) == 0.0
+    # Uniform over 4 tokens: H = log2(4) = 2.0 bits
+    assert shannon_entropy_bits({"a": 25, "b": 25, "c": 25, "d": 25}) == pytest.approx(2.0)
+    # Two-token 50/50: H = log2(2) = 1.0 bit
+    assert shannon_entropy_bits({"a": 10, "b": 10}) == pytest.approx(1.0)
+    # Gen-1.6M Medusa reference: karuna_relief 18941 + phase_boundary 13827
+    # Manually computed in design doc §4.4: H ≈ 0.983 bits.
+    medusa_h = shannon_entropy_bits({"karuna_relief": 18941, "phase_boundary": 13827})
+    assert 0.97 < medusa_h < 0.99
+
+
+def test_entropy_normalized_basic_cases():
+    """vocabulary_size ≤ 1 → 0; H = log2(K) → 1.0; range [0, 1] otherwise."""
+    import math
+    # Degenerate cases
+    assert entropy_normalized(1.0, 1) == 0.0
+    assert entropy_normalized(1.0, 0) == 0.0
+    assert entropy_normalized(0.0, 16) == 0.0
+    assert entropy_normalized(-1.0, 16) == 0.0  # nonsense input → 0, not negative
+    # Full saturation: H = log2(K) for K=16 → 4.0 bits → normalized 1.0
+    assert entropy_normalized(math.log2(16), 16) == pytest.approx(1.0)
+    # Half saturation: H = 0.5·log2(K) → normalized 0.5
+    assert entropy_normalized(0.5 * math.log2(16), 16) == pytest.approx(0.5)
+
+
+def test_void_compute_balance_basic_cases():
+    """Equal counts → 1.0; one absent → 0; lattice with no VOID/COMPUTE → 0."""
+    # Equal counts: 50% VOID + 50% COMPUTE → balance = 1.0
+    state = np.zeros((4, 4, 4), dtype=np.uint8)
+    state[:2] = STATE_VOID
+    state[2:] = STATE_COMPUTE
+    assert void_compute_balance(state) == pytest.approx(1.0)
+    # All VOID, no COMPUTE → balance = 0
+    state_v = np.full((4, 4, 4), STATE_VOID, dtype=np.uint8)
+    assert void_compute_balance(state_v) == 0.0
+    # All COMPUTE, no VOID → balance = 0
+    state_c = np.full((4, 4, 4), STATE_COMPUTE, dtype=np.uint8)
+    assert void_compute_balance(state_c) == 0.0
+    # Neither VOID nor COMPUTE → balance = 0
+    state_s = np.full((4, 4, 4), STATE_STRUCTURAL, dtype=np.uint8)
+    assert void_compute_balance(state_s) == 0.0
+    # Gen-1.6M reference scaled to 16³ (4096 cells): P_VOID = 0.4714,
+    # P_COMPUTE = 0.4601 → balance ≈ 0.988. Synthetic counts:
+    # 47.14% × 4096 ≈ 1931 VOID; 46.01% × 4096 ≈ 1884 COMPUTE; rest STRUCTURAL.
+    state_m = np.full((16, 16, 16), STATE_STRUCTURAL, dtype=np.uint8)  # filler
+    flat = state_m.ravel()
+    flat[:1931] = STATE_VOID
+    flat[1931:1931 + 1884] = STATE_COMPUTE
+    # Expected: 2 * 1884 / (1931 + 1884) = 0.98765
+    assert 0.985 < void_compute_balance(state_m) < 0.990
+
+
+def test_boundary_rate_basic_cases():
+    """phase_boundary absent → 0; present → correct fraction; empty counts → 0."""
+    # Empty
+    assert boundary_rate({}) == 0.0
+    # phase_boundary absent
+    assert boundary_rate({"karuna_relief": 100}) == 0.0
+    # phase_boundary present but not exclusive
+    assert boundary_rate({"phase_boundary": 25, "karuna_relief": 75}) == pytest.approx(0.25)
+    # Only phase_boundary
+    assert boundary_rate({"phase_boundary": 50}) == pytest.approx(1.0)
+    # Gen-1.6M reference: 13827 boundary / 32768 total ≈ 0.4220
+    r = boundary_rate({"karuna_relief": 18941, "phase_boundary": 13827})
+    assert 0.421 < r < 0.423
+
+
+def test_process_snapshot_emits_all_pr3_per_snapshot_fields(tmp_path):
+    """End-to-end: process_snapshot emits all four new PR #3 fields in the
+    JSONL log entry with correct types and ranges. Locks in §3 of the
+    PR #3 design doc against silent regression.
+    """
+    snap = _make_snapshot(tmp_path / "v070_gen1.npz", lattice=16, generation=1)
+    log_dir = tmp_path / "log"
+    log_dir.parent.mkdir(exist_ok=True)
+    cfg = ObserverConfig(log_directory=str(log_dir),
+                         uniform_grid_stride=4, budget_seconds=30.0)
+    summary = process_snapshot(snap, cfg, medusa_is_live=False)
+
+    # All four PR #3 per-snapshot fields present in returned summary
+    assert "shannon_entropy_bits" in summary
+    assert "entropy_normalized" in summary
+    assert "void_compute_balance" in summary
+    assert "boundary_rate" in summary
+    # vocabulary_occupancy preserved + still present (PR #138 field)
+    assert "vocabulary_occupancy" in summary
+
+    # Type + range checks
+    for field in ("shannon_entropy_bits", "entropy_normalized",
+                  "void_compute_balance", "boundary_rate",
+                  "vocabulary_occupancy"):
+        val = summary[field]
+        assert isinstance(val, float), f"{field} should be float, got {type(val).__name__}"
+        assert val >= 0.0, f"{field} should be non-negative, got {val}"
+
+    # Normalized entropy bounded above by 1.0
+    assert summary["entropy_normalized"] <= 1.0
+    # Shannon entropy bounded above by log2(K) for K=len(TOKEN_NAMES)
+    import math
+    assert summary["shannon_entropy_bits"] <= math.log2(len(TOKEN_NAMES)) + 1e-9
+    # Balance and boundary rate in [0, 1]
+    assert 0.0 <= summary["void_compute_balance"] <= 1.0
+    assert 0.0 <= summary["boundary_rate"] <= 1.0
+
+    # All fields round-trip through JSONL identically
+    jsonl = (log_dir / "nextness_runs.jsonl").read_text().splitlines()
+    entry = json.loads(jsonl[-1])
+    for field in ("shannon_entropy_bits", "entropy_normalized",
+                  "void_compute_balance", "boundary_rate",
+                  "vocabulary_occupancy"):
+        assert entry[field] == summary[field], \
+            f"{field} differs between summary and JSONL: {summary[field]!r} vs {entry[field]!r}"


### PR DESCRIPTION
## Summary

Implements the Nextness Metrics Pipeline designed in PR #141 (merged as `3dfc67d`). Per-snapshot fields extend the existing JSONL log; a new module computes across-snapshots drift, persistence, and the Coexistence-Crystallization Index. Plus Jack's write-boundary safety latch (commit `98c9b0e`) ensuring the Lane B "no writes outside log_directory" guarantee is enforced, not aspirational.

**No engine touch.** No HTTP. No ZMQ. No dashboard. CPU-only. `allow_pickle=False` preserved.

**Tests: 297/297 pass** (up from 254 pre-PR-#3; +43 net tests across observer extension, new metrics module, and write-boundary coverage).

**Final diff:** `4 files changed, 1383 insertions(+), 2 deletions(-)` after the safety-latch revision.

---

## Commits in this PR

| Commit | Purpose |
|---|---|
| `41400a5` | Initial PR #3 implementation: per-snapshot fields + metrics module + tests |
| `98c9b0e` | Jack's audit fix: enforce write-boundary contract before disk side effects |

---

## What landed

### `scripts/nextness_observer.py` (+100 lines)

Four new public per-snapshot metric helpers, exported via `__all__`:
- `shannon_entropy_bits(token_counts)` — Shannon entropy in bits
- `entropy_normalized(entropy_bits, vocabulary_size)` — H / log₂(K), range [0, 1]
- `void_compute_balance(state)` — 2·min(N_V, N_C) / (N_V + N_C)
- `boundary_rate(token_counts)` — `phase_boundary` count normalized

`process_snapshot()` extended to emit all four as top-level JSONL fields alongside the preserved `vocabulary_occupancy` (PR #138).

### `scripts/nextness_metrics.py` (NEW, ~430 lines after safety patch)

| Function | Purpose |
|---|---|
| `smoothed_distribution()` | Jack's canonical-TOKEN_NAMES-order Laplace smoothing |
| `kl_divergence()` | Asymmetric KL in bits |
| `js_divergence()` | Symmetric, bounded [0, 1] in bits — primary drift metric |
| `boundary_persistence_pairwise()` | `1 - |Δr|/max(r1, r2, δ)`, bounded |
| `boundary_cv()` | Raw coefficient of variation (unbounded diagnostic) |
| `boundary_persistence_aggregate_clamped()` | `max(0, 1-CV)` per Jack's audit fix |
| `cci()` | Coexistence-Crystallization Index = B_VC · R_b · (1 - H_norm). **Scoring function, NOT a classifier.** |
| `compute_run_metrics()` | Orchestrator: read JSONL log → emit derived metrics JSONL |
| `_validate_metrics_output_path()` | **NEW per Jack's audit:** enforces `out_path` resolves under `log_path.parent` BEFORE any disk side effects |
| `main()` | CLI entry point with distinct exit code 3 for safety refusals |

**CLI usage:**

```
python -m scripts.nextness_metrics --log <input.jsonl> --out <output.jsonl>
                                   [--smoothing FLOAT] [--boundary-delta FLOAT]
```

Output `--out` path must resolve under the input log file's directory or the CLI returns exit code 3 with `safety error:` in stderr. No parent dir is created for outside-boundary targets.

### `tests/test_nextness_observer.py` (+5 tests, now 78 total)

Unit tests for the 4 new helpers with gen-1.6M reference values from issue #139 (`shannon ≈ 0.983 bits`, `balance ≈ 0.988`, `boundary_rate ≈ 0.422`) as regression fences. End-to-end integration test verifies all four new fields land in the JSONL with correct types/ranges plus `vocabulary_occupancy` preservation per PR #141 §3.0.

### `tests/test_nextness_metrics.py` (NEW, ~530 lines, 38 tests after safety patch)

Coverage by category:

| Category | Tests | Includes |
|---|---|---|
| `smoothed_distribution` | 5 | canonical-order independence, sums to 1, negative-smoothing rejection |
| KL divergence | 3 | identical → 0, asymmetry (with non-mirror fixtures), finite under smoothing |
| JS divergence | 3 | identical → 0, symmetry, bounded [0, 1] |
| Boundary persistence pairwise | 4 | identical → 1, max-drop → 0, range, negative-rate rejection |
| Boundary CV + clamped | 5 | constant → 0; **original-formula failure case `[0, 0.5, 0, 0.5, 0]` verified to clamp to 0.0**; intermediate matches `1-CV` exactly |
| CCI | 3 | corners (zero/one), gen-1.6M reference (0.314), monotonicity in each factor |
| `compute_run_metrics` integration | 7 | two-snapshot, identical, idempotent byte-identical, **no `generated_at` field**, **deterministic sort across 3 input orderings**, one-snapshot-only, malformed input |
| Golden regression | 1 | 3 known snapshots → analytically-computed expected CCI, JS, CV |
| CLI smoke | 2 | end-to-end + missing-file error path |
| **Write-boundary safety** (per Jack's audit) | 4 | sibling output succeeds; outside-dir raises + no parent dir created; `..` traversal rejected; CLI non-zero exit + correct stderr |

---

## Smoke test results — first real Medusa cross-snapshot metrics

Sandboxed run against 5 newest Medusa snapshots (gens **1,665,615** to **1,665,781**, spanning ~50 minutes of evolution). Medusa's original data directory untouched.

### Per-snapshot results

| Generation | H (bits) | H_norm | B_V/C | R_boundary |
|---|---|---|---|---|
| 1,665,615 | 0.981 | 0.245 | 0.988 | 0.420 |
| 1,665,659 | 0.981 | 0.245 | 0.989 | 0.418 |
| 1,665,700 | 0.983 | 0.246 | 0.988 | 0.424 |
| 1,665,740 | 0.982 | 0.245 | 0.988 | 0.420 |
| 1,665,781 | 0.982 | 0.245 | 0.988 | 0.421 |

### Aggregate metrics

| Metric | Value |
|---|---|
| JS divergence between adjacent pairs | **3-29 microbits** (effectively 0) |
| CCI range | 0.312065 to 0.315993 (Δ = 0.4%) |
| mean_cci | 0.313695 (std 0.001314) |
| boundary_cv | 0.004715 |
| boundary_persistence_aggregate_clamped | **0.995285** |

### Determinism contract verified on real data

```
first  run sha256[:16]: aeeda6a9512968b0
second run sha256[:16]: aeeda6a9512968b0
byte-identical:         True ✓
```

### Empirical interpretation (held loosely per Jack's audit posture)

**Strong evidence consistent with AURA's "Karuna/Boundary equilibrium" hypothesis** — distribution is stable across the 50-minute observation window, with drift below detection floor. Not yet proof — PR #4 will run the alternate-hypothesis discriminating experiments (memory-channel layout vs Phase 14e acoustic map, threshold sensitivity sweep, stride sweep, cascade ablation). But the attractor signature is exactly what the framing predicts.

Per Jack: *"early attraction signs, seated posture advised. But we keep the champagne in the fridge until PR #4 has had its calibration dinner."*

---

## Scope guarantees (now actually enforced, not aspirational)

- ✅ No engine touch. Medusa untouched.
- ✅ **No writes outside `log_path.parent`** — enforced via `_validate_metrics_output_path()` before any disk side effects. Test-locked.
- ✅ No HTTP. No ZMQ. No network.
- ✅ CPU-only default.
- ✅ `allow_pickle=False` preserved.
- ✅ `WriteOutsideLogDirError` gating preserved AND extended to the metrics module (unified safety vocabulary).
- ✅ Bounded compute: O(N·K) where N=snapshots, K=vocabulary size.
- ✅ No CCI regime thresholds (calibration deferred to PR #4 per directive).
- ✅ No multi-snapshot observer mode in PR #3.
- ✅ No fresh `generated_at` field in derived output (locked by test).

## Out of scope

| Out of scope | Where it lands |
|---|---|
| Threshold tuning (`THRESHOLD_COMPASSION` etc.) | PR #4 |
| Vocabulary cascade redesign | PR #4 |
| Memory-channel layout verification vs Phase 14e | PR #4 |
| Stride sweep / sampling experiments | PR #4 |
| Cascade ablation studies | PR #4 |
| CCI regime-threshold definitions | PR #4 |
| Learned 512-token embedding | PR #5+ |
| Multi-snapshot observer mode | PR #5+ or shell wrapper |
| Engine-state perturbation experiments | Lane A (parked) |
| Closed-loop tuning to `tuning_pending.json` | Lane A (parked) |

## Builds on

- PR #137 (Phase 19 design doc, merged)
- PR #138 (PR #2 observer skeleton, merged as `d651f2c`)
- PR #140 (PR #2 follow-up, merged as `d2b5db9`)
- PR #141 (PR #3 design doc, merged as `3dfc67d`)
- Issue #139 (calibration findings; finding (c) remains open as PR #4's home)

Refs #139 — per-snapshot `vocabulary_occupancy` preserved as the top-level diagnostic central to issue #139's findings discussion. Finding (c) remains open for PR #4 calibration experiments.

Approved by AURA (lead architect) and Jack (auditor); operator gate-approval received 2026-05-19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)