### PR TITLE
Phase 19 layout fix — align Nextness Observer memory channels with engine (issue #144)

### DIFF
--- a/PHASE_19_PR4_CALIBRATION.md
+++ b/PHASE_19_PR4_CALIBRATION.md
@@ -168,7 +168,9 @@ This is a probe, not a redesign. We learn which predicates are "claiming territo
 
 ### Experiment 3.6 — Memory-channel layout verification
 
-**Tests:** alternate hypothesis 1 (memory-channel layout misindexed). **This is potentially the biggest hidden assumption.**
+> **⚠️ Result already known.** This experiment was effectively executed during pre-implementation exploration in the PR #4 Chapter 3 work. The observer's `MEMORY_CHANNEL_LAYOUT` was found to be wrong in 6 of 8 positions versus the engine's actual `memory_grid` definition. See **issue #144** for the full finding and **the layout-fix PR** that corrected it. Post-fix, this experiment becomes a *regression fence* (does the corrected layout still match the engine?) rather than a *discovery* of whether the layout is correct. Spec below describes the original experiment design; the post-fix interpretation is "verify the fix held and produces stable corrected metrics."
+
+**Tests:** alternate hypothesis 1 (memory-channel layout misindexed). **This was the biggest hidden assumption** — and the assumption was wrong, surfaced before any calibration code was written.
 
 **Method:** Compare the observer's assumed `MEMORY_CHANNEL_LAYOUT` (which maps `"compassion"` to a specific index, etc.) against:
 - The engine's actual `memory_grid` semantics (read-only inspection of `scripts/continuous_evolution_ca.py` or equivalent — code-read only, no engine modification)

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -104,6 +104,57 @@ TOKEN_BY_INDEX: Final[dict[int, str]] = {i: name for i, name in enumerate(TOKEN_
 #: Name → index lookup.
 TOKEN_INDEX: Final[dict[str, int]] = {name: i for i, name in enumerate(TOKEN_NAMES)}
 
+#: Per-token status metadata. Added per issue #144 stop-the-line: some tokens
+#: that previously fired in the classifier cascade referenced memory channels
+#: that the engine either does not store ("compassion", "resonance",
+#: "mindsight") or computes on-the-fly ("magnon", "ampere"). Those tokens
+#: are now disabled in :func:`classify_patch` until either the engine adds
+#: the channel (no_engine_channel case) or the observer implements the
+#: derivation locally (derived_future case).
+#:
+#: Status values:
+#:   "state_only"                       — predicate reads only ``state``;
+#:                                        no memory-grid dependency.
+#:   "stored"                           — predicate reads stored memory
+#:                                        channels via ``MEMORY_CHANNEL_LAYOUT``.
+#:   "deprecated_no_engine_channel"     — predicate previously referenced
+#:                                        a memory channel that the engine
+#:                                        does not store. Disabled until
+#:                                        the engine adds the channel.
+#:   "derived_future"                   — predicate previously referenced
+#:                                        a value the engine derives on-
+#:                                        the-fly. Disabled until the
+#:                                        observer reimplements the
+#:                                        derivation (follow-up TODO).
+#:
+#: The classifier cascade skips any token with status
+#: ``"deprecated_no_engine_channel"`` or ``"derived_future"`` —
+#: ``vocabulary_occupancy`` will accordingly be capped at
+#: (active_tokens / total_tokens) until the deprecated tokens have a
+#: home in the engine.
+TOKEN_STATUS: Final[dict[str, str]] = {
+    "void_static":        "state_only",
+    "compute_static":     "state_only",
+    "void_birth":         "state_only",
+    "compute_aging":      "stored",      # reads compute_age (idx 0)
+    "compute_decay":      "stored",      # reads warmth (idx 6) post-#144 fix
+    "structural_growth":  "stored",      # reads structural_age (idx 1)
+    "structural_decay":   "stored",      # reads structural_age (idx 1)
+    "energy_pulse":       "state_only",
+    "sensor_alert":       "state_only",
+    "metta_warmth":       "stored",      # reads warmth (idx 6) post-#144 fix
+    "karuna_relief":      "deprecated_no_engine_channel",  # no compassion channel
+    "mudita_resonance":   "deprecated_no_engine_channel",  # no resonance channel
+    "magnon_lighthouse":  "derived_future",   # magnon is derived from compute_age, not stored
+    "acoustic_stress":    "state_only",
+    "phase_boundary":     "state_only",
+    "unclassified":       "state_only",
+}
+
+assert set(TOKEN_STATUS.keys()) == set(TOKEN_NAMES), (
+    "TOKEN_STATUS must cover every token in TOKEN_NAMES"
+)
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -286,6 +337,7 @@ __all__ = [
     "TOKEN_NAMES",
     "TOKEN_BY_INDEX",
     "TOKEN_INDEX",
+    "TOKEN_STATUS",
     # Configuration
     "SamplingMode",
     "ObserverConfig",
@@ -523,18 +575,48 @@ STATE_COMPUTE: Final[int] = 2
 STATE_ENERGY: Final[int] = 3
 STATE_SENSOR: Final[int] = 4
 
-# --- Memory-grid channel layout (BEST GUESS; verify when calibrating) ---
-# If wrong, update these and the classifier should still hold its shape.
+# --- Memory-grid channel layout (CORRECTED per issue #144) ---
+# Engine-actual layout per scripts/continuous_evolution_ca.py lines 634-655.
+# The observer's prior layout was wrong in 6 of 8 positions; this version
+# matches the engine documented channel map exactly.
+#
+# Engine convention (Phase 6 expansion, MEMORY_CHANNELS = 8):
+#   0: compute_age        (Phase 1+)
+#   1: structural_age     (Phase 1+)
+#   2: memory_strength    (Phase 1+; default 1.0 at init)
+#   3: energy_reserve     (Phase 1+; repurposed Phase 6c for compassion cost)
+#   4: last_active_gen    (Phase 1+)
+#   5: signal_field       (Phase 6c mycelial signal amplitude)
+#   6: warmth             (Phase 6a metta/loving-kindness accumulation)
+#   7: compassion_cooldown (Phase 6c; prevents echo/spam)
 MEMORY_CHANNEL_LAYOUT: Final[dict[str, int]] = {
-    "compute_age":       0,   # COMPUTE cell age (per Phase 4 onwards)
-    "structural_age":    1,   # STRUCTURAL cell age
-    "warmth":            2,   # Phase 6a metta accumulator
-    "resonance":         3,   # Phase 6b mudita joy/resonance signal
-    "compassion":        4,   # Phase 6c karuna relief signal
-    "mindsight":         5,   # Phase 6c mindsight signal magnitude
-    "magnon":            6,   # Phase 17a magnon field magnitude
-    "ampere":            7,   # Ampere unified-field accumulator
+    "compute_age":         0,
+    "structural_age":      1,
+    "memory_strength":     2,
+    "energy_reserve":      3,
+    "last_active_gen":     4,
+    "signal_field":        5,
+    "warmth":              6,
+    "compassion_cooldown": 7,
 }
+
+# Conceptual fields the observer USED to assume were stored but which the
+# engine either does not store or computes on the fly. Reading these via
+# MEMORY_CHANNEL_LAYOUT now raises KeyError loudly rather than silently
+# returning wrong data:
+#
+#   - "resonance"    (Phase 6b "mudita" — never landed as a stored channel)
+#   - "compassion"   (Phase 6c — the *cooldown* is stored at 7, but the raw
+#                     compassion signal itself is not a stored field)
+#   - "mindsight"    (Phase 6c — not stored as a channel)
+#   - "magnon"       (Phase 17a — DERIVED on-the-fly in
+#                     continuous_evolution_ca.py at line 884: Gaussian
+#                     convolution over compute_age >= magnon_sage_age_min)
+#   - "ampere"       (engine parameter + on-the-fly potential computation,
+#                     not a stored channel)
+#
+# Tokens that referenced these names are now marked
+# deprecated_no_engine_channel / derived_future via TOKEN_STATUS below.
 
 # --- Age thresholds (matched to the engine's MemoryParams Sage tiers) ---
 AGE_SAGE: Final[float] = 8.0       # magnon_sage_age_min default
@@ -544,8 +626,13 @@ AGE_LEGEND: Final[float] = 50.0    # Legend (5x; the 148 lighthouse Sages)
 # --- Memory-signal detection thresholds (normalised; tunable) ---
 # These are starting values. PR #4 may tune them via baseline calibration.
 THRESHOLD_WARMTH: Final[float] = 0.3
-THRESHOLD_RESONANCE: Final[float] = 0.3
-THRESHOLD_COMPASSION: Final[float] = 0.3
+# THRESHOLD_RESONANCE and THRESHOLD_COMPASSION are retained as documentation
+# of the original observer design but are not consumed by classify_patch
+# post-#144 — the mudita_resonance and karuna_relief predicates that read
+# them are disabled per TOKEN_STATUS until the engine adds the corresponding
+# stored channels.
+THRESHOLD_RESONANCE: Final[float] = 0.3   # unused post-#144
+THRESHOLD_COMPASSION: Final[float] = 0.3  # unused post-#144
 
 # --- State-fraction thresholds (over the patch's 27 cells at radius=1) ---
 FRACTION_DOMINANT: Final[float] = 0.5    # > 50% of cells (≥14 of 27)
@@ -579,9 +666,13 @@ class _PatchFeatures:
     compute_age_mean: float
     structural_age_mean: float
     warmth_mean: float
-    resonance_mean: float
-    compassion_mean: float
-    magnon_mean: float
+    # Per issue #144: resonance_mean, compassion_mean, magnon_mean fields
+    # were removed when the corresponding memory channels were found to
+    # not exist in the engine. The predicates that consumed them
+    # (mudita_resonance, karuna_relief, magnon_lighthouse) are disabled
+    # via TOKEN_STATUS until the engine adds the channels (resonance,
+    # compassion) or the observer implements the derivation locally
+    # (magnon from compute_age + Gaussian kernel).
 
 
 def _patch_features(patch: Patch) -> _PatchFeatures:
@@ -625,9 +716,10 @@ def _patch_features(patch: Patch) -> _PatchFeatures:
         compute_age_mean=_safe_mean("compute_age"),
         structural_age_mean=_safe_mean("structural_age"),
         warmth_mean=_safe_mean("warmth"),
-        resonance_mean=_safe_mean("resonance"),
-        compassion_mean=_safe_mean("compassion"),
-        magnon_mean=_safe_mean("magnon"),
+        # resonance_mean, compassion_mean, magnon_mean removed per issue
+        # #144: those channels are not stored in the engine's memory_grid.
+        # Their consumers (mudita_resonance, karuna_relief, magnon_lighthouse)
+        # are disabled in classify_patch via TOKEN_STATUS.
     )
 
 
@@ -645,23 +737,36 @@ def classify_patch(patch: Patch) -> str:
     if f.distinct_states >= DIVERSITY_BOUNDARY:
         return "phase_boundary"
 
-    # 2. Magnon lighthouse — COMPUTE-dominant under Legend-tier influence
-    if f.compute_frac >= FRACTION_DOMINANT and f.compute_age_mean >= AGE_LEGEND:
-        return "magnon_lighthouse"
+    # 2. (DEPRECATED per issue #144) magnon_lighthouse — was reading the
+    #    engine's warmth channel as if it were magnon. Disabled until the
+    #    observer implements derived-magnon (Gaussian convolution over
+    #    compute_age, mirroring continuous_evolution_ca.py line 884).
+    #    Original predicate kept here as comment for future resurrection:
+    #      if f.compute_frac >= FRACTION_DOMINANT and f.compute_age_mean >= AGE_LEGEND:
+    #          return "magnon_lighthouse"
 
     # 3. Compute aging — COMPUTE-dominant at Sage age tier (typical Sage)
     if f.compute_frac >= FRACTION_DOMINANT and f.compute_age_mean >= AGE_SAGE:
         return "compute_aging"
 
-    # 4. Mudita resonance — joy/resonance signal alongside any COMPUTE
-    if f.compute_count >= 1 and f.resonance_mean >= THRESHOLD_RESONANCE:
-        return "mudita_resonance"
+    # 4. (DEPRECATED per issue #144) mudita_resonance — was reading the
+    #    engine's energy_reserve channel as if it were resonance. The
+    #    engine has no resonance channel. Disabled until/unless the engine
+    #    adds one. Original predicate:
+    #      if f.compute_count >= 1 and f.resonance_mean >= THRESHOLD_RESONANCE:
+    #          return "mudita_resonance"
 
-    # 5. Karuna relief — compassion signal alongside any COMPUTE
-    if f.compute_count >= 1 and f.compassion_mean >= THRESHOLD_COMPASSION:
-        return "karuna_relief"
+    # 5. (DEPRECATED per issue #144) karuna_relief — was reading the
+    #    engine's last_active_gen channel as if it were compassion. The
+    #    engine has no compassion channel (only compassion_cooldown at
+    #    idx 7, which is a cooldown counter, not a compassion signal).
+    #    Disabled until/unless the engine adds a compassion field.
+    #    Original predicate:
+    #      if f.compute_count >= 1 and f.compassion_mean >= THRESHOLD_COMPASSION:
+    #          return "karuna_relief"
 
-    # 6. Metta warmth — warmth field around COMPUTE/ENERGY
+    # 6. Metta warmth — warmth field around COMPUTE/ENERGY.
+    #    Post-#144: now reads engine's actual warmth channel (idx 6).
     if (f.compute_count >= 1 or f.energy_count >= 1) and f.warmth_mean >= THRESHOLD_WARMTH:
         return "metta_warmth"
 

--- a/tests/test_nextness_observer.py
+++ b/tests/test_nextness_observer.py
@@ -258,30 +258,71 @@ def test_classifier_compute_aging_at_sage_age():
     assert classify_patch(p) == "compute_aging"
 
 
-def test_classifier_magnon_lighthouse_at_legend_age():
+def test_classifier_magnon_lighthouse_disabled_post_144_falls_through_to_compute_aging():
+    """Post-issue-#144: magnon_lighthouse is disabled (status: derived_future).
+    A COMPUTE-dominant patch at Legend-tier age now falls through to the
+    next-priority predicate, ``compute_aging``, since AGE_LEGEND > AGE_SAGE.
+    """
     p = _zero_patch(STATE_COMPUTE, {"compute_age": AGE_LEGEND + 5.0})
-    assert classify_patch(p) == "magnon_lighthouse"
+    result = classify_patch(p)
+    assert result != "magnon_lighthouse", (
+        "magnon_lighthouse should never fire post-#144 (channel is "
+        "derived, not stored; disabled until observer implements the "
+        "derivation)"
+    )
+    assert result == "compute_aging", (
+        f"Expected cascade fallthrough to compute_aging; got {result!r}"
+    )
 
 
 def test_classifier_metta_warmth_with_compute():
     s = np.zeros((3, 3, 3), dtype=np.uint8); s[1, 1, 1] = STATE_COMPUTE
     m = np.zeros((8, 3, 3, 3), dtype=np.float32)
+    # Post-#144: CH["warmth"] now resolves to engine index 6 (the actual
+    # warmth channel). The predicate logic is unchanged; it just reads the
+    # correct field now.
     m[CH["warmth"]].fill(THRESHOLD_WARMTH + 0.1)
     assert classify_patch(Patch((0, 0, 0), s, m)) == "metta_warmth"
 
 
-def test_classifier_mudita_resonance_with_compute():
+def test_classifier_mudita_resonance_disabled_post_144_falls_through_to_compute_decay():
+    """Post-issue-#144: mudita_resonance is disabled (status:
+    deprecated_no_engine_channel) — the engine has no resonance channel.
+    A patch that *would have* triggered the old predicate now falls
+    through to compute_decay (1 COMPUTE in mostly-VOID cold patch).
+
+    Setup must not use CH["resonance"] (the key was removed); we just
+    place a COMPUTE cell in a VOID-dominant patch with all-zero memory.
+    """
     s = np.zeros((3, 3, 3), dtype=np.uint8); s[1, 1, 1] = STATE_COMPUTE
     m = np.zeros((8, 3, 3, 3), dtype=np.float32)
-    m[CH["resonance"]].fill(THRESHOLD_RESONANCE + 0.1)
-    assert classify_patch(Patch((0, 0, 0), s, m)) == "mudita_resonance"
+    result = classify_patch(Patch((0, 0, 0), s, m))
+    assert result != "mudita_resonance", (
+        "mudita_resonance should never fire post-#144"
+    )
+    assert result == "compute_decay", (
+        f"Expected cascade fallthrough to compute_decay; got {result!r}"
+    )
 
 
-def test_classifier_karuna_relief_with_compute():
+def test_classifier_karuna_relief_disabled_post_144_falls_through_to_compute_decay():
+    """Post-issue-#144: karuna_relief is disabled (status:
+    deprecated_no_engine_channel) — the engine has no compassion channel.
+    A patch that *would have* triggered the old predicate now falls
+    through to compute_decay.
+
+    Setup must not use CH["compassion"] (the key was removed); we just
+    place a COMPUTE cell in a VOID-dominant patch with all-zero memory.
+    """
     s = np.zeros((3, 3, 3), dtype=np.uint8); s[1, 1, 1] = STATE_COMPUTE
     m = np.zeros((8, 3, 3, 3), dtype=np.float32)
-    m[CH["compassion"]].fill(THRESHOLD_COMPASSION + 0.1)
-    assert classify_patch(Patch((0, 0, 0), s, m)) == "karuna_relief"
+    result = classify_patch(Patch((0, 0, 0), s, m))
+    assert result != "karuna_relief", (
+        "karuna_relief should never fire post-#144"
+    )
+    assert result == "compute_decay", (
+        f"Expected cascade fallthrough to compute_decay; got {result!r}"
+    )
 
 
 def test_classifier_sensor_alert():
@@ -720,6 +761,209 @@ def test_invariant_8_bounded_compute_per_snapshot(tmp_path):
     s = compute_safe_stride((256, 256, 256), radius=1,
                               budget_seconds=0.001, initial_stride=8)
     assert s > 8
+
+
+# ---------------------------------------------------------------------------
+# Issue #144 regression fences — memory-channel layout integrity
+# ---------------------------------------------------------------------------
+
+
+def test_layout_matches_engine_documented_8_channel_map():
+    """Observer's MEMORY_CHANNEL_LAYOUT must match the engine's documented map.
+
+    Per issue #144: the prior layout was wrong in 6 of 8 positions. This
+    test pins the corrected layout against the engine's documented channel
+    map from scripts/continuous_evolution_ca.py:634-655. If the engine
+    ever changes its memory_grid layout (e.g., a Phase 17b adds a 9th
+    channel), this test fails loudly and the observer must be updated
+    in lockstep.
+
+    The expected map is hand-maintained here rather than parsed from
+    engine source because:
+        - Hand-maintained = explicit & reviewable; every layout change
+          must touch both files & this test.
+        - Parsed = brittle to comment-formatting changes in engine code.
+    """
+    from scripts.nextness_observer import MEMORY_CHANNEL_LAYOUT
+    engine_documented_layout = {
+        "compute_age":         0,
+        "structural_age":      1,
+        "memory_strength":     2,
+        "energy_reserve":      3,
+        "last_active_gen":     4,
+        "signal_field":        5,
+        "warmth":              6,
+        "compassion_cooldown": 7,
+    }
+    assert MEMORY_CHANNEL_LAYOUT == engine_documented_layout, (
+        f"MEMORY_CHANNEL_LAYOUT drift from engine documented map.\n"
+        f"  Observer: {MEMORY_CHANNEL_LAYOUT}\n"
+        f"  Engine:   {engine_documented_layout}\n"
+        f"If the engine's layout changed, update MEMORY_CHANNEL_LAYOUT "
+        f"AND update the expected layout in this test in the same PR."
+    )
+
+
+def test_layout_has_exactly_eight_channels():
+    """Engine has MEMORY_CHANNELS = 8 — observer must mirror exactly.
+
+    No more, no fewer. A 9th observer channel would index past the end
+    of the engine's memory_grid array and read undefined memory.
+    """
+    from scripts.nextness_observer import MEMORY_CHANNEL_LAYOUT
+    assert len(MEMORY_CHANNEL_LAYOUT) == 8
+    # Indices must be exactly the contiguous range [0, 8)
+    assert sorted(MEMORY_CHANNEL_LAYOUT.values()) == list(range(8))
+
+
+def test_layout_does_not_contain_deprecated_channel_names():
+    """The observer must not silently expose access to channels that
+    don't exist in the engine.
+
+    Per issue #144: pre-fix MEMORY_CHANNEL_LAYOUT contained keys
+    "warmth"/"resonance"/"compassion"/"mindsight"/"magnon"/"ampere" that
+    either didn't match the engine's actual layout or referenced
+    non-stored channels. This test ensures none of those misleading
+    keys come back.
+
+    (Note: "warmth" IS a legitimate engine channel at idx 6 post-fix.
+    What this test forbids is the *old wrong-index* warmth + the
+    not-actually-stored channel names.)
+    """
+    from scripts.nextness_observer import MEMORY_CHANNEL_LAYOUT
+    forbidden_names = {"resonance", "compassion", "mindsight", "magnon", "ampere"}
+    overlap = forbidden_names & set(MEMORY_CHANNEL_LAYOUT.keys())
+    assert overlap == set(), (
+        f"MEMORY_CHANNEL_LAYOUT contains channel names that don't exist "
+        f"in the engine: {sorted(overlap)}. These were the misleading "
+        f"names from the pre-#144 layout. If you genuinely need to "
+        f"reference these conceptually, add them to TOKEN_STATUS as "
+        f"deprecated_no_engine_channel or derived_future, not as a "
+        f"stored MEMORY_CHANNEL_LAYOUT entry."
+    )
+
+
+def test_token_status_covers_every_token_in_vocabulary():
+    """TOKEN_STATUS dict must have an entry for every TOKEN_NAMES entry."""
+    from scripts.nextness_observer import TOKEN_NAMES, TOKEN_STATUS
+    assert set(TOKEN_STATUS.keys()) == set(TOKEN_NAMES), (
+        f"TOKEN_STATUS does not match TOKEN_NAMES.\n"
+        f"  In TOKEN_NAMES but not TOKEN_STATUS: {set(TOKEN_NAMES) - set(TOKEN_STATUS.keys())}\n"
+        f"  In TOKEN_STATUS but not TOKEN_NAMES: {set(TOKEN_STATUS.keys()) - set(TOKEN_NAMES)}"
+    )
+
+
+def test_token_status_uses_only_documented_status_values():
+    """Every status value must be one of the four documented options."""
+    from scripts.nextness_observer import TOKEN_STATUS
+    valid_statuses = {
+        "state_only",
+        "stored",
+        "deprecated_no_engine_channel",
+        "derived_future",
+    }
+    for token, status in TOKEN_STATUS.items():
+        assert status in valid_statuses, (
+            f"Token {token!r} has invalid status {status!r}; "
+            f"must be one of {sorted(valid_statuses)}"
+        )
+
+
+def test_deprecated_tokens_never_appear_in_classifier_output():
+    """Tokens with deprecated/derived-future status must never fire.
+
+    Per issue #144: even if the prior triggering conditions for these
+    tokens happen to be met in a patch, classify_patch must skip them
+    and the patch must fall through to another predicate.
+
+    Exhaustive test: synthesize a wide range of patches and assert no
+    deprecated token ever appears in the output across all of them.
+    """
+    from scripts.nextness_observer import TOKEN_STATUS
+    deprecated_tokens = {
+        name for name, status in TOKEN_STATUS.items()
+        if status in {"deprecated_no_engine_channel", "derived_future"}
+    }
+    # Sanity: there ARE deprecated tokens to check (otherwise this test
+    # would silently pass).
+    assert len(deprecated_tokens) >= 3, (
+        "Expected at least 3 deprecated tokens post-#144"
+    )
+
+    # Try a wide variety of patch configurations
+    seed_configurations = [
+        # (lattice fill, channels-to-set-with-value)
+        (STATE_VOID, {}),
+        (STATE_COMPUTE, {}),
+        (STATE_COMPUTE, {"compute_age": AGE_SAGE}),
+        (STATE_COMPUTE, {"compute_age": AGE_LEGEND + 5.0}),
+        (STATE_COMPUTE, {"warmth": THRESHOLD_WARMTH + 0.1}),
+        (STATE_STRUCTURAL, {"structural_age": AGE_SAGE}),
+        (STATE_STRUCTURAL, {"structural_age": AGE_ANCIENT + 5.0}),
+        (STATE_ENERGY, {}),
+        (STATE_SENSOR, {}),
+    ]
+    observed_tokens = set()
+    for state_fill, channels in seed_configurations:
+        patch = _zero_patch(state_fill, channels)
+        token = classify_patch(patch)
+        observed_tokens.add(token)
+        assert token not in deprecated_tokens, (
+            f"Deprecated token {token!r} fired on config "
+            f"(state_fill={state_fill}, channels={channels}). "
+            f"Status: {TOKEN_STATUS[token]}. Classifier cascade must "
+            f"skip deprecated tokens entirely."
+        )
+
+
+def test_patch_features_does_not_attempt_to_read_nonexistent_channels():
+    """_patch_features must only request channels that exist in the layout.
+
+    Per issue #144: pre-fix _patch_features called _safe_mean("resonance"),
+    _safe_mean("compassion"), _safe_mean("magnon") — all of which were
+    bogus channel names. The corrected _patch_features removed those
+    calls. This test AST-walks the module to verify that any string
+    literal passed to a function that does memory-channel lookup names
+    a key that actually exists in MEMORY_CHANNEL_LAYOUT.
+    """
+    import ast
+    import inspect
+    from scripts.nextness_observer import MEMORY_CHANNEL_LAYOUT
+    valid_channels = set(MEMORY_CHANNEL_LAYOUT.keys())
+    source = inspect.getsource(nextness_observer)
+    tree = ast.parse(source)
+    # Find calls to _safe_mean and any MEMORY_CHANNEL_LAYOUT[<literal>]
+    # subscript expressions.
+    bad_references: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        # Subscript: MEMORY_CHANNEL_LAYOUT["name"]
+        if isinstance(node, ast.Subscript):
+            value_node = node.value
+            if (isinstance(value_node, ast.Name)
+                    and value_node.id == "MEMORY_CHANNEL_LAYOUT"):
+                slice_node = node.slice
+                if (isinstance(slice_node, ast.Constant)
+                        and isinstance(slice_node.value, str)):
+                    if slice_node.value not in valid_channels:
+                        bad_references.append((slice_node.value, node.lineno))
+        # Call: _safe_mean("name")
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "_safe_mean":
+                if (node.args
+                        and isinstance(node.args[0], ast.Constant)
+                        and isinstance(node.args[0].value, str)):
+                    if node.args[0].value not in valid_channels:
+                        bad_references.append(
+                            (node.args[0].value, node.lineno)
+                        )
+    assert not bad_references, (
+        f"Found references to channel names not in MEMORY_CHANNEL_LAYOUT:\n"
+        + "\n".join(
+            f"  line {lineno}: {name!r}"
+            for name, lineno in bad_references
+        )
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves the stop-the-line finding from issue #144: the observer's `MEMORY_CHANNEL_LAYOUT` was wrong in 6 of 8 channel positions versus the engine's actual `memory_grid` definition. This PR corrects the layout, disables the classifier predicates that referenced non-existent channels, adds regression fences, updates the PR #4 design doc, and ships a corrected-layout smoke pass against 5 real Medusa snapshots.

**Scope per Jack's audit:** small, dedicated, focused. No vocabulary redesign, no derived-magnon implementation, no calibration sweep work. Just the honest-labels fix and its regression fences.

**Tests:** 304/304 pass (Phase 17b + 18 + 19 PR #3). 85/85 in `test_nextness_observer.py` (+7 new regression fences). Zero regressions.

**Diff:** `3 files changed, 390 insertions(+), 39 deletions(-)`.

---

## Layout correction

The observer claimed (pre-fix):
```
0: compute_age      4: compassion      
1: structural_age   5: mindsight       
2: warmth           6: magnon          
3: resonance        7: ampere          
```

The engine actually defines (per [`continuous_evolution_ca.py:634-655`](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/scripts/continuous_evolution_ca.py#L634-L655)):
```
0: compute_age      4: last_active_gen     
1: structural_age   5: signal_field        
2: memory_strength  6: warmth              
3: energy_reserve   7: compassion_cooldown 
```

Only indices 0 and 1 matched pre-fix. `warmth` does exist in the engine but at index 6, not 2. The other 5 names in the observer (`resonance`, `compassion`, `mindsight`, `magnon`, `ampere`) refer to channels the engine does NOT store — `magnon` and `ampere` are derived on-the-fly, the others were never landed as stored fields.

## Classifier predicate adjustments

Added `TOKEN_STATUS` dict mapping each token to one of four documented status values:

| Status | Meaning |
|---|---|
| `state_only` | predicate reads only `state`, no memory deps |
| `stored` | predicate reads stored memory channels |
| `deprecated_no_engine_channel` | references a channel engine doesn't store; disabled |
| `derived_future` | references a value engine derives on-the-fly; disabled until observer implements derivation |

Three tokens disabled (predicate code retained as comments for future resurrection):
- `karuna_relief` — `deprecated_no_engine_channel` (no compassion field)
- `mudita_resonance` — `deprecated_no_engine_channel` (no resonance field)
- `magnon_lighthouse` — `derived_future` (magnon derived from compute_age + Gaussian kernel)

`metta_warmth` predicate **logic unchanged**; it now reads engine's actual warmth channel at idx 6 rather than (wrong) idx 2.

`_PatchFeatures` dataclass dropped `resonance_mean`, `compassion_mean`, `magnon_mean` fields. Three remaining memory-derived fields (`compute_age_mean`, `structural_age_mean`, `warmth_mean`) all read correct engine channels.

## Regression fences (+7 tests)

| Test | Purpose |
|---|---|
| `test_layout_matches_engine_documented_8_channel_map` | Hand-maintained mirror of engine's documented layout; fails loudly if either side drifts |
| `test_layout_has_exactly_eight_channels` | `MEMORY_CHANNELS = 8` invariant |
| `test_layout_does_not_contain_deprecated_channel_names` | Pre-#144 misleading keys can't return as stored channels |
| `test_token_status_covers_every_token_in_vocabulary` | TOKEN_STATUS keys == TOKEN_NAMES |
| `test_token_status_uses_only_documented_status_values` | Status values restricted to the 4 documented options |
| `test_deprecated_tokens_never_appear_in_classifier_output` | Exhaustive sweep across patch configurations; no deprecated token ever fires |
| `test_patch_features_does_not_attempt_to_read_nonexistent_channels` | AST-walk: any `_safe_mean()` or `MEMORY_CHANNEL_LAYOUT[...]` string literal must name a valid layout key |

Updated 3 existing tests (`karuna_relief`, `mudita_resonance`, `magnon_lighthouse` cases) to assert deprecated tokens don't fire AND that cascade falls through to the correct next predicate.

## Corrected-layout smoke pass

Sandboxed run against 5 newest Medusa snapshots (gens **1,702,067 → 1,702,236**, ~50 minutes wall-clock). Medusa's actual data dir untouched.

### Per-snapshot results (incredibly stable, same structural signature as PR #142 baseline)

| Generation | voc_occ | H_norm | B_v/c | R_boundary |
|---|---|---|---|---|
| 1,702,067 | 0.375 | 0.539 | 0.988 | 0.419 |
| 1,702,108 | 0.375 | 0.538 | 0.988 | 0.420 |
| 1,702,149 | 0.375 | 0.538 | 0.988 | 0.421 |
| 1,702,196 | 0.375 | 0.537 | 0.988 | 0.423 |
| 1,702,236 | 0.375 | 0.539 | 0.987 | 0.421 |

### Token distribution comparison (5-snapshot avg, ~163k patches)

| Token | PR #142 (wrong layout) | Post-#144 fix |
|---|---|---|
| `karuna_relief` | **57.80%** (was reading `last_active_gen`) | **0%** (deprecated) |
| `phase_boundary` | 42.20% | **42.08%** (unchanged — state-only ✓) |
| `compute_static` | 0% | **19.07%** (newly visible) |
| `compute_decay` | 0% | **18.59%** |
| `sensor_alert` | 0% | **12.96%** |
| `acoustic_stress` | 0% | **5.26%** |
| `energy_pulse` | 0% | **2.03%** |

**The pre-fix 57.80% `karuna_relief` bucket decomposes cleanly into 5 newly-visible tokens summing to ~57.9%** — same patches, finally with honest labels.

Vocabulary occupancy jumped from 0.125 (2 tokens) to 0.375 (6 tokens), with a ceiling of 13/16 = 0.8125 under TOKEN_STATUS (3 deprecated tokens cannot fire).

## Interpretation update

> The "Karuna/Boundary equilibrium" interpretation is **superseded**.
>
> Pre-fix `karuna_relief` was reading `last_active_gen` (a generation counter), not compassion. Going forward use "phase-boundary stability with prior semantic labels superseded" until either the engine adds a compassion channel or the observer implements derived-compassion.
>
> `phase_boundary` stability is unaffected by the layout fix and is now the well-anchored part of the PR #142 stability finding.

## Out of scope (deliberate)

- ❌ Derived-magnon implementation. Tracked as `magnon_lighthouse` = `derived_future` in TOKEN_STATUS; create a follow-up issue when ready.
- ❌ Vocabulary redesign (decision for after PR #4 calibration sweeps).
- ❌ Renaming deprecated tokens to what they accidentally measured. Jack: *"Do not preserve bug-shaped semantics."*
- ❌ PR #4 implementation. Preserved on local branch `claude/phase-19-pr4-implementation`; resumes after this merges.

## Scope guarantees (unchanged from PR #138 / #140 / #142)

- ✅ No engine touch.
- ✅ No writes outside log directory (`WriteOutsideLogDirError` preserved).
- ✅ No HTTP. No ZMQ. No network.
- ✅ CPU-only.
- ✅ `allow_pickle=False` preserved.
- ✅ Bounded compute.
- ✅ No fresh `generated_at` field in derived output.
- ✅ No CCI regime thresholds.
- ✅ No multi-snapshot observer mode added.

## Builds on

- PR #137 — Phase 19 design doc
- PR #138 — observer skeleton (`d651f2c`)
- PR #140 — PR #2 follow-up (`d2b5db9`)
- PR #141 — PR #3 design doc (`3dfc67d`)
- PR #142 — metrics pipeline (`f06b1c5`)
- PR #143 — PR #4 calibration design doc (`3346014`)
- Issue #139 — calibration findings (finding (c) parent)
- **Issue #144** — memory-channel layout mismatch (this PR resolves it)

Refs #144 — addresses the layout mismatch. Issue stays open until merged; will be closed manually after merge to ensure the audit trail is intact.

Approved direction: Jack (auditor) + AURA (architect) + Kevin (operator gate). Finding raised by 84 during PR #4 Chapter 3 pre-implementation exploration; verified independently by Jack against the engine code; co-signed by AURA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)