### PR TITLE
Phase 19 PR #4 implementation — Chapters 1 + 2 (foundation + check_determinism + shuffle_test)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -2,24 +2,34 @@
 
 Implements the eight calibration experiments designed in
 ``PHASE_19_PR4_CALIBRATION.md`` (merged as ``3346014``). Each experiment
-discriminates AURA's leading "Karuna/Boundary equilibrium" hypothesis from
-the alternates flagged in issue #139.
+discriminates the **phase-boundary stability hypothesis** from the
+alternate observer-artifact hypotheses flagged in issue #139.
+
+(The earlier "Karuna/Boundary equilibrium" semantic interpretation was
+superseded per issue #144 / PR #145: the pre-fix ``karuna_relief`` token
+was reading the engine's ``last_active_gen`` channel due to a
+``MEMORY_CHANNEL_LAYOUT`` mismatch. ``phase_boundary`` stability is the
+well-anchored part of the prior result and is what the calibration
+sweeps test for robustness.)
 
 Per Jack's implementation order from the design doc §12 Q7:
 
-    1. check_determinism                    <- THIS CHAPTER
-    2. verify_memory_channels               (upcoming)
-    3. shuffle_test                         (upcoming, two modes)
+    1. check_determinism                    LANDED (Chapter 1)
+    2. verify_memory_channels               (upcoming, runtime regression-fence
+                                             complementing PR #145's static check)
+    3. shuffle_test                         LANDED (Chapter 2, three-mode null-model)
     4. sweep_stride                         (upcoming)
     5. sweep_threshold                      (upcoming)
     6. ablate_cascade                       (upcoming)
     7. sweep_temporal                       (upcoming)
     8. sweep_patch_radius                   (upcoming, possibly deferred)
 
-This Chapter 1 lands the shared module infrastructure (write-boundary safety,
+Chapters 1 + 2 land the shared module infrastructure (write-boundary safety,
 deterministic snapshot ordering, content fingerprinting, JSONL output writer,
 falsification-status reporting) plus ``check_determinism()`` (Jack's #1 — the
-sanity floor for everything that follows).
+sanity floor) and ``shuffle_test()`` (Jack's #3 — the three-mode null-model
+test that pinpoints whether signal lives in lattice geometry, memory_grid
+spatial structure, or classifier behaviour).
 
 Scope guarantees (carried forward from PR #138 / PR #140 / PR #142 / PR #143):
     - No engine touch.

--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -1,0 +1,838 @@
+"""Calibration experiments orchestrator for the Nextness Observer (Phase 19 PR #4).
+
+Implements the eight calibration experiments designed in
+``PHASE_19_PR4_CALIBRATION.md`` (merged as ``3346014``). Each experiment
+discriminates AURA's leading "Karuna/Boundary equilibrium" hypothesis from
+the alternates flagged in issue #139.
+
+Per Jack's implementation order from the design doc §12 Q7:
+
+    1. check_determinism                    <- THIS CHAPTER
+    2. verify_memory_channels               (upcoming)
+    3. shuffle_test                         (upcoming, two modes)
+    4. sweep_stride                         (upcoming)
+    5. sweep_threshold                      (upcoming)
+    6. ablate_cascade                       (upcoming)
+    7. sweep_temporal                       (upcoming)
+    8. sweep_patch_radius                   (upcoming, possibly deferred)
+
+This Chapter 1 lands the shared module infrastructure (write-boundary safety,
+deterministic snapshot ordering, content fingerprinting, JSONL output writer,
+falsification-status reporting) plus ``check_determinism()`` (Jack's #1 — the
+sanity floor for everything that follows).
+
+Scope guarantees (carried forward from PR #138 / PR #140 / PR #142 / PR #143):
+    - No engine touch.
+    - **No writes outside ``log_path.parent``** — enforced via
+      :class:`WriteOutsideLogDirError` reused from ``scripts.nextness_observer``
+      so the safety vocabulary stays unified across modules.
+    - No HTTP / ZMQ / network of any kind.
+    - CPU-only.
+    - ``allow_pickle=False`` preserved in any snapshot reads (delegated to
+      ``nextness_observer.process_snapshot()``).
+    - Bounded compute: each experiment is O(N * P) where N = snapshots and
+      P = parameter combinations per experiment. Both small.
+
+Determinism contracts (per design doc §8 + PR #143 revision):
+    - Snapshots are sorted by (generation, snapshot_file) before any
+      parameter-combination iteration runs. Output is independent of input
+      file order.
+    - No fresh ``generated_at`` field is added to any output JSONL row.
+    - Content fingerprinting for the ``check_determinism`` experiment
+      excludes the volatile ``ts`` field that ``process_snapshot()`` writes
+      (current timestamp at log-write time); fingerprint covers all
+      *content-bearing* fields.
+    - All JSONL writes use ``sort_keys=True`` for deterministic field order.
+
+CLI: deferred to a later chapter; this module exposes Python entry points
+only for now. The CLI sub-command surface is specified in design doc §5 and
+will land alongside the final sweep functions.
+"""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+import pathlib
+import re
+import tempfile
+from typing import Any
+
+import numpy as np
+
+from scripts.nextness_observer import (
+    ObserverConfig,
+    WriteOutsideLogDirError,
+    process_snapshot,
+)
+from scripts.nextness_metrics import cci as _cci
+
+
+# ---------------------------------------------------------------------------
+# Shared module constants
+# ---------------------------------------------------------------------------
+
+
+#: Default RNG seed for canonical-run results (e.g. shuffle test). Variance
+#: estimates use this plus 5 additional seeds per design doc §12 Q6.
+DEFAULT_CANONICAL_SEED: int = 42
+
+#: Additional seeds for variance estimation. Used together with
+#: ``DEFAULT_CANONICAL_SEED`` so each experiment that involves randomization
+#: produces one canonical value + 5 variance-estimate values.
+DEFAULT_VARIANCE_SEEDS: tuple[int, ...] = (1, 2, 3, 4, 5)
+
+#: Top-level fields excluded from the content fingerprint used by
+#: ``check_determinism``. ``ts`` is the wallclock timestamp written by
+#: ``process_snapshot()`` at log-emit time.
+_VOLATILE_TOP_LEVEL_FIELDS: frozenset[str] = frozenset({"ts"})
+
+#: Fields inside the ``budget`` block that are wallclock-derived and must
+#: also be excluded from the fingerprint. ``elapsed_seconds`` is measured;
+#: ``fraction_used`` and ``exceeded`` are derived from elapsed_seconds vs
+#: budget_seconds and so also vary across runs.
+_VOLATILE_BUDGET_FIELDS: frozenset[str] = frozenset({
+    "elapsed_seconds", "fraction_used", "exceeded",
+})
+
+#: Regex for extracting the generation number from a Medusa snapshot
+#: filename like ``v070_gen1665781_step16657819_20260518T224644.npz``.
+_SNAPSHOT_GENERATION_RE = re.compile(r"v\d+_gen(\d+)_step\d+_")
+
+
+# ---------------------------------------------------------------------------
+# Shared infrastructure: write-boundary, sort key, fingerprint, JSONL writer
+# ---------------------------------------------------------------------------
+
+
+def _validate_calibration_output_path(
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+) -> None:
+    """Refuse output paths that resolve outside the input log's directory.
+
+    Mirrors ``nextness_metrics._validate_metrics_output_path`` so the same
+    Lane B safety contract applies to calibration outputs. Resolves both
+    paths to canonical absolute form before comparing — symlink-aware.
+
+    Raises :class:`WriteOutsideLogDirError` (reused from
+    ``scripts.nextness_observer``) so the safety vocabulary stays unified
+    across all three Lane B modules (observer + metrics + calibration).
+    """
+    log_dir_resolved = log_path.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(log_dir_resolved)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write calibration output outside log_path's "
+            f"directory: {out_resolved} is not inside {log_dir_resolved}"
+        ) from e
+
+
+def _extract_generation_from_filename(path: pathlib.Path) -> int:
+    """Parse generation number out of a Medusa snapshot filename.
+
+    Expects the canonical ``v070_gen<N>_step<M>_<ts>.npz`` format. Returns
+    ``-1`` for filenames that don't match (sorted to the front so unparseable
+    paths fail noisily rather than silently re-ordering).
+    """
+    match = _SNAPSHOT_GENERATION_RE.match(path.name)
+    if match is None:
+        return -1
+    return int(match.group(1))
+
+
+def _sort_snapshots_by_generation(
+    paths: list[pathlib.Path],
+) -> list[pathlib.Path]:
+    """Sort snapshot paths deterministically by ``(generation, filename)``.
+
+    Generation is the primary key (monotonic, embedded in filename); filename
+    is the deterministic tiebreaker. Same priority order as the
+    ``nextness_metrics`` sort key, minus ``ts`` since calibration receives
+    pathlib.Path objects rather than JSONL entries.
+    """
+    return sorted(
+        paths,
+        key=lambda p: (_extract_generation_from_filename(p), p.name),
+    )
+
+
+def _scrub_volatile_fields(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of ``entry`` with all wallclock-derived fields removed.
+
+    Removes both the top-level ``ts`` and the nested wallclock-derived
+    fields inside the ``budget`` block (``elapsed_seconds``, ``fraction_used``,
+    ``exceeded``). Leaves all other fields — including ``patches_processed``
+    and ``patches_skipped_due_to_budget``, which ARE deterministic — intact.
+
+    This is the schema-aware version of "remove volatile fields" — it knows
+    about ``process_snapshot()``'s output structure. If that schema changes
+    (new wallclock-derived fields added), the lists above need updating.
+    """
+    scrubbed = {k: v for k, v in entry.items() if k not in _VOLATILE_TOP_LEVEL_FIELDS}
+    budget = scrubbed.get("budget")
+    if isinstance(budget, dict):
+        scrubbed["budget"] = {
+            k: v for k, v in budget.items() if k not in _VOLATILE_BUDGET_FIELDS
+        }
+    return scrubbed
+
+
+def _content_fingerprint(entry: dict[str, Any]) -> str:
+    """Hash the content-bearing fields of a ``process_snapshot()`` entry.
+
+    Returns a hex SHA256 of the canonical JSON serialization of the entry
+    with all wallclock-derived fields removed (see ``_scrub_volatile_fields``).
+    Two runs of ``process_snapshot()`` on identical inputs produce identical
+    fingerprints despite their timing fields differing.
+
+    Used by ``check_determinism()`` as the byte-identical-on-content test.
+    """
+    scrubbed = _scrub_volatile_fields(entry)
+    canonical = json.dumps(scrubbed, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _write_calibration_jsonl(
+    out_path: pathlib.Path,
+    pair_rows: list[dict[str, Any]],
+    aggregate_row: dict[str, Any],
+) -> None:
+    """Deterministic JSONL writer.
+
+    Writes ``pair_rows`` in order, then ``aggregate_row`` as the final line.
+    ``sort_keys=True`` makes per-row field order deterministic. No fresh
+    ``generated_at`` field is added anywhere; the determinism contract from
+    PR #142 / PR #143 is preserved.
+
+    Creates parent directories if needed. ``_validate_calibration_output_path``
+    should already have been called by the caller to ensure ``out_path`` lives
+    inside the log directory.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        for row in pair_rows:
+            f.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+        f.write(json.dumps(aggregate_row, sort_keys=True, default=str) + "\n")
+
+
+def _make_per_snapshot_row(
+    experiment: str,
+    snapshot_path: pathlib.Path,
+    generation: int,
+    parameter_combination: dict[str, Any],
+    metrics: dict[str, Any],
+    run_metadata: dict[str, Any],
+    calibration_set: str,
+) -> dict[str, Any]:
+    """Build a per-snapshot JSONL row matching the design doc §8 schema.
+
+    Used by every calibration experiment as the row-emit helper so the
+    output schema stays uniform across experiments.
+    """
+    return {
+        "experiment": experiment,
+        "snapshot_file": snapshot_path.name,
+        "snapshot_generation": generation,
+        "parameter_combination": parameter_combination,
+        "metrics": metrics,
+        "run_metadata": run_metadata,
+        "calibration_set": calibration_set,
+    }
+
+
+def _make_aggregate_row(
+    experiment: str,
+    calibration_set: str,
+    n_snapshots: int,
+    extra_fields: dict[str, Any],
+    falsification_status: str,
+) -> dict[str, Any]:
+    """Build the final aggregate JSONL row matching design doc §8 schema.
+
+    ``falsification_status`` must be one of ``"hypothesis_supported"``,
+    ``"hypothesis_falsified"``, or ``"inconclusive"`` — the three values
+    specified by the design doc as mechanically-computed (not judgment-call)
+    status reports.
+
+    ``extra_fields`` lets each experiment carry its own additional aggregate
+    fields (e.g. ``all_byte_identical`` for determinism;
+    ``mean_cci_per_stride`` for stride sweep).
+    """
+    if falsification_status not in {
+        "hypothesis_supported",
+        "hypothesis_falsified",
+        "inconclusive",
+    }:
+        raise ValueError(
+            f"falsification_status must be one of "
+            f"'hypothesis_supported', 'hypothesis_falsified', 'inconclusive'; "
+            f"got {falsification_status!r}"
+        )
+    aggregate: dict[str, Any] = {
+        "experiment": experiment,
+        "summary_type": "run_aggregate",
+        "calibration_set": calibration_set,
+        "n_snapshots": n_snapshots,
+        "falsification_status": falsification_status,
+    }
+    aggregate.update(extra_fields)
+    return aggregate
+
+
+def _extract_metrics_subset(entry: dict[str, Any]) -> dict[str, Any]:
+    """Pull the per-snapshot metrics out of a ``process_snapshot()`` entry.
+
+    Returns a small dict containing the six per-snapshot metric fields
+    (the five PR #142 fields plus the vocabulary occupancy preserved from
+    PR #138). Used to populate the ``metrics`` block of a per-snapshot row.
+    """
+    return {
+        "vocabulary_occupancy": entry.get("vocabulary_occupancy"),
+        "shannon_entropy_bits": entry.get("shannon_entropy_bits"),
+        "entropy_normalized": entry.get("entropy_normalized"),
+        "void_compute_balance": entry.get("void_compute_balance"),
+        "boundary_rate": entry.get("boundary_rate"),
+        "token_counts": entry.get("token_counts"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Experiment 3.7 — check_determinism (Jack's #1 in implementation order)
+# ---------------------------------------------------------------------------
+
+
+def check_determinism(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+    config: ObserverConfig,
+    repeats: int = 2,
+) -> dict[str, Any]:
+    """Run ``process_snapshot()`` ``repeats`` times per snapshot; verify
+    that the *content* of each run's output JSONL entry is byte-identical
+    across repeats.
+
+    "Content" excludes the volatile ``ts`` field (the wallclock timestamp
+    each ``process_snapshot()`` call writes), since identical inputs
+    inevitably produce different timestamps. The fingerprint covers every
+    other field — token counts, all per-snapshot metrics, lattice shape,
+    sampling parameters, budget block, etc.
+
+    This is **the sanity floor** for the rest of the calibration suite
+    (per Jack's PR #143 implementation order): if ``process_snapshot()``
+    isn't deterministic, every downstream experiment's results are suspect.
+
+    Per design doc §3.7: runs on **both** calibration sets (caller specifies
+    which set this invocation covers via the ``calibration_set`` parameter
+    — typically called twice, once for "short" and once for "long").
+
+    Falsification status:
+        - ``"hypothesis_supported"`` — all repeats produced byte-identical
+          content for every snapshot. Determinism holds.
+        - ``"hypothesis_falsified"`` — at least one snapshot's repeats
+          produced different content fingerprints. Determinism violated;
+          a blocker for the rest of the calibration suite.
+
+    Output JSONL has one row per (snapshot × repeat) plus the aggregate row.
+
+    Args:
+        snapshots: list of sandboxed snapshot ``.npz`` paths. Sorted
+            deterministically before iteration.
+        out_path: where to write the ``calibration_determinism.jsonl``
+            output. Must resolve under ``log_path.parent`` per the Lane B
+            safety contract.
+        log_path: the canonical ``nextness_runs.jsonl`` log path. Used both
+            as the write-boundary anchor and as the destination for
+            ``process_snapshot()``'s side-effect log writes.
+        calibration_set: ``"short"`` or ``"long"`` — recorded on every row
+            so downstream analysis can filter.
+        config: the ``ObserverConfig`` to use for every call to
+            ``process_snapshot()``. All ``repeats`` use this same config
+            (otherwise determinism testing would be meaningless).
+        repeats: how many times to run ``process_snapshot()`` per snapshot.
+            Minimum 2 (otherwise the byte-identical comparison is vacuous).
+            Defaults to 2 since determinism either holds or it doesn't —
+            larger ``repeats`` just spend more compute confirming the same
+            thing.
+
+    Returns the aggregate dict for callers that want to inspect it without
+    re-reading the output file.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside the
+            log directory.
+        ``ValueError`` if ``calibration_set`` isn't ``"short"`` or
+            ``"long"``, or ``repeats`` < 2.
+    """
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got "
+            f"{calibration_set!r}"
+        )
+    if repeats < 2:
+        raise ValueError(
+            f"repeats must be >= 2 (byte-identical comparison needs at "
+            f"least two runs), got {repeats}"
+        )
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    all_byte_identical = True
+    n_snapshots_with_drift = 0
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        # Run process_snapshot ``repeats`` times; capture each return value.
+        # Note: process_snapshot() also writes one JSONL line per call into
+        # log_path's directory as a side effect. That's intended — the log
+        # accumulates run history. The determinism check operates on the
+        # returned dicts, not on the log file.
+        run_entries = []
+        for _ in range(repeats):
+            entry = process_snapshot(snap, config, medusa_is_live=False)
+            run_entries.append(entry)
+
+        # Fingerprint each run's content (ts excluded).
+        fingerprints = [_content_fingerprint(e) for e in run_entries]
+        snapshot_byte_identical = len(set(fingerprints)) == 1
+        if not snapshot_byte_identical:
+            all_byte_identical = False
+            n_snapshots_with_drift += 1
+
+        # Emit one row per (snapshot × repeat_index). Each row carries the
+        # fingerprint and a flag for whether that snapshot's repeats matched.
+        for repeat_idx, (entry, fp) in enumerate(zip(run_entries, fingerprints)):
+            per_snapshot_rows.append(_make_per_snapshot_row(
+                experiment="determinism",
+                snapshot_path=snap,
+                generation=generation,
+                parameter_combination={
+                    "repeat_index": repeat_idx,
+                    "total_repeats": repeats,
+                },
+                metrics=_extract_metrics_subset(entry),
+                run_metadata={
+                    "content_fingerprint_sha256_16": fp[:16],
+                    "snapshot_byte_identical_across_repeats": snapshot_byte_identical,
+                    "elapsed_seconds": entry.get("budget", {}).get(
+                        "elapsed_seconds"
+                    ),
+                    "patches_processed": entry.get("budget", {}).get(
+                        "patches_processed"
+                    ),
+                },
+                calibration_set=calibration_set,
+            ))
+
+    aggregate = _make_aggregate_row(
+        experiment="determinism",
+        calibration_set=calibration_set,
+        n_snapshots=len(sorted_snapshots),
+        extra_fields={
+            "repeats_per_snapshot": repeats,
+            "all_byte_identical": all_byte_identical,
+            "n_snapshots_with_drift": n_snapshots_with_drift,
+        },
+        falsification_status=(
+            "hypothesis_supported" if all_byte_identical
+            else "hypothesis_falsified"
+        ),
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
+# ---------------------------------------------------------------------------
+# Experiment 3.8 — shuffle_test (3-mode null model, Jack's #3 in order)
+# ---------------------------------------------------------------------------
+
+
+#: The three shuffle modes per design doc §3.8. Each snapshot is processed
+#: in all three modes per call so the three-way comparison is built-in.
+SHUFFLE_MODES: tuple[str, ...] = (
+    "unshuffled",
+    "lattice_only_shuffle",
+    "joint_lattice_memory_shuffle",
+)
+
+#: Threshold below which we call all three modes "similar" (signal is in
+#: the classifier). Per design doc §3.8 falsification criterion.
+_SHUFFLE_CLASSIFIER_ARTEFACT_THRESHOLD: float = 0.05
+
+#: Threshold above which the joint shuffle is said to "collapse" the
+#: distribution (signal is in the lattice geometry / memory_grid structure).
+#: Per design doc §3.8 falsification criterion.
+_SHUFFLE_HYPOTHESIS_SUPPORT_THRESHOLD: float = 0.10
+
+
+def _shuffled_snapshot_arrays(
+    lattice: np.ndarray,
+    memory: np.ndarray,
+    mode: str,
+    rng: np.random.Generator,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(shuffled_lattice, shuffled_memory)`` for the requested mode.
+
+    Per design doc §3.8:
+        - ``unshuffled``: arrays returned as-is. Reference baseline.
+        - ``lattice_only_shuffle``: lattice cells randomly permuted;
+          memory_grid untouched. Tests whether lattice spatial structure
+          carries the signal.
+        - ``joint_lattice_memory_shuffle``: the **same permutation** is
+          applied to both arrays. Lattice cell at original position p moves
+          to perm[p]; memory_grid voxels at position p (across all channels)
+          also move to perm[p]. Destroys all spatial correlations while
+          preserving per-cell lattice/memory pairing.
+
+    The shape contract: ``lattice.shape == (X, Y, Z)``; ``memory.shape ==
+    (channels, X, Y, Z)``. Both arrays are NOT mutated; new arrays are
+    returned.
+
+    Raises ``ValueError`` for any mode outside :data:`SHUFFLE_MODES`.
+    """
+    if mode == "unshuffled":
+        return lattice, memory
+    if mode not in SHUFFLE_MODES:
+        raise ValueError(
+            f"unknown shuffle mode {mode!r}; expected one of {SHUFFLE_MODES}"
+        )
+
+    spatial_size = lattice.size  # X * Y * Z
+    perm = rng.permutation(spatial_size)
+
+    flat_lattice = lattice.flatten()
+    shuffled_lattice = flat_lattice[perm].reshape(lattice.shape)
+
+    if mode == "lattice_only_shuffle":
+        return shuffled_lattice, memory
+
+    # joint_lattice_memory_shuffle: same permutation applied to memory_grid
+    n_channels = memory.shape[0]
+    flat_memory = memory.reshape(n_channels, spatial_size)
+    shuffled_memory = flat_memory[:, perm].reshape(memory.shape)
+    return shuffled_lattice, shuffled_memory
+
+
+def _write_temp_snapshot(
+    lattice: np.ndarray,
+    memory: np.ndarray,
+    generation: int,
+    tmp_dir: pathlib.Path,
+    filename: str,
+) -> pathlib.Path:
+    """Write arrays to a temporary ``.npz`` Medusa-format snapshot.
+
+    The temp file is intended to be consumed by ``process_snapshot()`` and
+    then deleted by the caller. Format mirrors the real Medusa snapshot
+    schema (lattice, memory_grid, generation keys).
+    """
+    out = tmp_dir / filename
+    np.savez(
+        str(out),
+        lattice=lattice,
+        memory_grid=memory,
+        generation=np.array(generation),
+        best_fitness=np.array(0.0),
+    )
+    return out
+
+
+def _cci_from_entry(entry: dict[str, Any]) -> float:
+    """Compute CCI from a ``process_snapshot()`` entry's per-snapshot fields."""
+    return _cci(
+        balance=float(entry.get("void_compute_balance", 0.0)),
+        boundary=float(entry.get("boundary_rate", 0.0)),
+        entropy_norm=float(entry.get("entropy_normalized", 0.0)),
+    )
+
+
+def _interpret_signal_location(
+    mean_cci_unshuffled: float,
+    mean_cci_lattice_only: float,
+    mean_cci_joint: float,
+) -> str:
+    """Interpret the three mean-CCI values per design doc §3.8 outcome table.
+
+    Returns one of:
+        - ``"classifier_artefact"``: all three modes give similar CCIs.
+          Spatial structure isn't load-bearing; pattern lives in the
+          classifier rules.
+        - ``"lattice_geometry"``: lattice_only and joint give similar
+          CCIs, both differ meaningfully from unshuffled. Shuffling the
+          lattice alone was sufficient to destroy the signal; shuffling
+          memory in addition added nothing. Lattice carries the signal.
+        - ``"memory_grid_structure"``: lattice_only ≈ unshuffled but
+          joint differs from both. Shuffling lattice alone didn't matter,
+          but adding the memory shuffle broke things. Memory carries
+          the signal.
+        - ``"both_arrays_contribute"``: each shuffle individually
+          produces a meaningful drop, AND joint produces additional drop
+          beyond lattice_only. Both arrays carry independent signal.
+          Strongest evidence for AURA's "real geometric structure" hypothesis.
+        - ``"ambiguous"``: pattern doesn't cleanly match any of the above.
+
+    Rule precedence matters: ``lattice_geometry`` requires
+    ``lattice_only ≈ joint`` (memory shuffle adds nothing), so we test
+    that first. ``both_arrays_contribute`` requires
+    ``lattice_only ≠ joint`` (memory shuffle adds further drop).
+    """
+    d_u_l = abs(mean_cci_unshuffled - mean_cci_lattice_only)
+    d_u_j = abs(mean_cci_unshuffled - mean_cci_joint)
+    d_l_j = abs(mean_cci_lattice_only - mean_cci_joint)
+    eps = _SHUFFLE_CLASSIFIER_ARTEFACT_THRESHOLD
+
+    # Rule 1: all three close → classifier artefact
+    if max(d_u_l, d_u_j, d_l_j) < eps:
+        return "classifier_artefact"
+
+    # Rule 2: lattice carries signal alone — unshuffled differs from both
+    # shuffled modes, but the two shuffled modes are close to each other
+    # (memory shuffle adds nothing on top of the lattice shuffle)
+    if d_u_l >= eps and d_u_j >= eps and d_l_j < eps:
+        return "lattice_geometry"
+
+    # Rule 3: memory carries signal alone — lattice_only ≈ unshuffled
+    # (lattice shuffle alone didn't affect the result), but joint differs
+    # (adding the memory shuffle is what broke things)
+    if d_u_l < eps and d_u_j >= eps and d_l_j >= eps:
+        return "memory_grid_structure"
+
+    # Rule 4: both arrays contribute — lattice shuffle alone produces a
+    # meaningful drop (d_u_l >= eps), AND joint produces additional drop
+    # beyond that (d_l_j >= eps). Each array's spatial structure carries
+    # independent signal.
+    if d_u_l >= eps and d_l_j >= eps:
+        return "both_arrays_contribute"
+
+    return "ambiguous"
+
+
+def _shuffle_falsification_status(
+    mean_cci_unshuffled: float,
+    mean_cci_joint: float,
+    max_pairwise_diff: float,
+) -> str:
+    """Mechanical falsification status per design doc §3.8 criteria.
+
+    - ``"hypothesis_falsified"`` if all three modes are within
+      :data:`_SHUFFLE_CLASSIFIER_ARTEFACT_THRESHOLD` of each other.
+    - ``"hypothesis_supported"`` if the joint shuffle drops CCI by more
+      than :data:`_SHUFFLE_HYPOTHESIS_SUPPORT_THRESHOLD` absolute.
+    - ``"inconclusive"`` otherwise.
+    """
+    if max_pairwise_diff < _SHUFFLE_CLASSIFIER_ARTEFACT_THRESHOLD:
+        return "hypothesis_falsified"
+    if abs(mean_cci_unshuffled - mean_cci_joint) > _SHUFFLE_HYPOTHESIS_SUPPORT_THRESHOLD:
+        return "hypothesis_supported"
+    return "inconclusive"
+
+
+def shuffle_test(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+    config: ObserverConfig,
+    modes: tuple[str, ...] | None = None,
+    seeds: tuple[int, ...] | None = None,
+) -> dict[str, Any]:
+    """Null-model shuffle test with three modes (per design doc §3.8).
+
+    For each snapshot, runs ``process_snapshot()`` under each requested
+    shuffle mode and seed combination, then aggregates the resulting CCI
+    distributions to determine whether the equilibrium signal lives in
+    the lattice geometry, the memory_grid spatial structure, or the
+    classifier behaviour itself.
+
+    Per Jack's PR #143 revision: this is the carpenter's level on the
+    floor *plus* a stud finder — the three-way comparison pinpoints which
+    array's spatial structure carries the signal, not just whether *any*
+    spatial structure does.
+
+    Args:
+        snapshots: list of sandboxed ``.npz`` paths to test. Sorted
+            deterministically before iteration.
+        out_path: output JSONL path. Must resolve under ``log_path.parent``.
+        log_path: anchor for the write-boundary safety check; also where
+            ``process_snapshot()`` writes its log entries as a side effect.
+        calibration_set: ``"short"`` or ``"long"``; recorded on every row.
+        config: ``ObserverConfig`` used for every ``process_snapshot()`` call.
+        modes: which shuffle modes to run. Defaults to all three. ``"unshuffled"``
+            uses only one seed (the canonical one) since it doesn't involve
+            randomization; shuffled modes use the full seed list.
+        seeds: which RNG seeds to use for shuffled modes. Defaults to
+            ``(DEFAULT_CANONICAL_SEED, *DEFAULT_VARIANCE_SEEDS)`` per
+            design doc §12 Q6 (one canonical + 5 variance estimates).
+
+    Returns the aggregate dict for callers that want to inspect it without
+    re-reading the output file.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside the
+            log directory.
+        ``ValueError`` for unknown modes or invalid calibration_set.
+    """
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got {calibration_set!r}"
+        )
+    if modes is None:
+        modes = SHUFFLE_MODES
+    for mode in modes:
+        if mode not in SHUFFLE_MODES:
+            raise ValueError(
+                f"unknown shuffle mode {mode!r}; expected one of {SHUFFLE_MODES}"
+            )
+    if seeds is None:
+        seeds = (DEFAULT_CANONICAL_SEED,) + DEFAULT_VARIANCE_SEEDS
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    # Collect per-mode CCI values across all (snapshot × seed) runs for the
+    # aggregate's mean computation.
+    cci_by_mode: dict[str, list[float]] = {m: [] for m in modes}
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        # Load snapshot arrays once per snapshot; shuffle in-memory per mode.
+        with np.load(str(snap), allow_pickle=False) as data:
+            lattice = data["lattice"]
+            memory = data["memory_grid"]
+            snap_generation = int(data["generation"])
+
+        for mode in modes:
+            # unshuffled mode uses only one seed (no randomization involved);
+            # shuffled modes use the full seed list per design doc §12 Q6.
+            mode_seeds = (seeds[0],) if mode == "unshuffled" else seeds
+
+            for seed in mode_seeds:
+                rng = np.random.default_rng(seed)
+                shuffled_lattice, shuffled_memory = _shuffled_snapshot_arrays(
+                    lattice, memory, mode, rng,
+                )
+
+                # Write to a uniquely-named temp file inside a per-snapshot
+                # tempdir so process_snapshot can load it. Cleanup is
+                # automatic via the context manager.
+                with tempfile.TemporaryDirectory(prefix="nextness_shuffle_") as tmp:
+                    tmp_dir = pathlib.Path(tmp)
+                    temp_snap = _write_temp_snapshot(
+                        shuffled_lattice, shuffled_memory, snap_generation,
+                        tmp_dir,
+                        f"v070_gen{snap_generation}_step{snap_generation*10}_shuffle.npz",
+                    )
+                    entry = process_snapshot(temp_snap, config, medusa_is_live=False)
+
+                cci_value = _cci_from_entry(entry)
+                cci_by_mode[mode].append(cci_value)
+
+                per_snapshot_rows.append(_make_per_snapshot_row(
+                    experiment="shuffle",
+                    snapshot_path=snap,  # original snapshot, not the temp file
+                    generation=generation,
+                    parameter_combination={
+                        "shuffle_mode": mode,
+                        "shuffle_seed": int(seed),
+                    },
+                    metrics={
+                        **_extract_metrics_subset(entry),
+                        "cci": cci_value,
+                    },
+                    run_metadata={
+                        "elapsed_seconds": entry.get("budget", {}).get(
+                            "elapsed_seconds"
+                        ),
+                        "patches_processed": entry.get("budget", {}).get(
+                            "patches_processed"
+                        ),
+                    },
+                    calibration_set=calibration_set,
+                ))
+
+    # Aggregate: mean CCI per mode + pairwise differences + interpretation
+    mean_cci_per_mode = {
+        m: (sum(vs) / len(vs) if vs else 0.0)
+        for m, vs in cci_by_mode.items()
+    }
+    std_cci_per_mode = {
+        m: (
+            math.sqrt(sum((v - mean_cci_per_mode[m]) ** 2 for v in vs) / len(vs))
+            if len(vs) > 1 else 0.0
+        )
+        for m, vs in cci_by_mode.items()
+    }
+
+    # Pairwise diffs (only meaningful when all three modes are present)
+    extra_fields: dict[str, Any] = {
+        "mean_cci_per_mode": mean_cci_per_mode,
+        "std_cci_per_mode": std_cci_per_mode,
+        "n_runs_per_mode": {m: len(vs) for m, vs in cci_by_mode.items()},
+        "modes_run": list(modes),
+        "seeds_used": list(seeds),
+    }
+
+    has_all_three_modes = all(m in cci_by_mode for m in SHUFFLE_MODES) and all(
+        len(cci_by_mode[m]) > 0 for m in SHUFFLE_MODES
+    )
+
+    if has_all_three_modes:
+        mean_u = mean_cci_per_mode["unshuffled"]
+        mean_l = mean_cci_per_mode["lattice_only_shuffle"]
+        mean_j = mean_cci_per_mode["joint_lattice_memory_shuffle"]
+        diff_u_l = abs(mean_u - mean_l)
+        diff_u_j = abs(mean_u - mean_j)
+        diff_l_j = abs(mean_l - mean_j)
+        max_pairwise = max(diff_u_l, diff_u_j, diff_l_j)
+        extra_fields["pairwise_cci_diffs"] = {
+            "unshuffled_vs_lattice_only": diff_u_l,
+            "unshuffled_vs_joint": diff_u_j,
+            "lattice_only_vs_joint": diff_l_j,
+            "max_pairwise": max_pairwise,
+        }
+        extra_fields["signal_location_interpretation"] = _interpret_signal_location(
+            mean_u, mean_l, mean_j,
+        )
+        falsification_status = _shuffle_falsification_status(
+            mean_u, mean_j, max_pairwise,
+        )
+    else:
+        # Partial run (subset of modes): can't compute the three-way
+        # comparison, so we declare inconclusive rather than guess.
+        extra_fields["signal_location_interpretation"] = "incomplete_modes"
+        falsification_status = "inconclusive"
+
+    aggregate = _make_aggregate_row(
+        experiment="shuffle",
+        calibration_set=calibration_set,
+        n_snapshots=len(sorted_snapshots),
+        extra_fields=extra_fields,
+        falsification_status=falsification_status,
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
+__all__ = [
+    "DEFAULT_CANONICAL_SEED",
+    "DEFAULT_VARIANCE_SEEDS",
+    "SHUFFLE_MODES",
+    "check_determinism",
+    "shuffle_test",
+]

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -1,0 +1,814 @@
+"""Tests for scripts/nextness_calibration.py — Phase 19 PR #4, Chapter 1.
+
+Covers the shared module infrastructure (write-boundary safety,
+deterministic snapshot ordering, content fingerprinting, JSONL output
+writer, falsification-status reporting) plus ``check_determinism()`` —
+Jack's #1 in the implementation order.
+
+Per design doc PHASE_19_PR4_CALIBRATION.md §3.7 + §6: this experiment is
+the sanity floor for the rest of the calibration suite, so we lock down
+both happy-path and edge-case behavior here.
+
+Later chapters will add tests for the other seven experiments (memory-
+channel verification, shuffle test with two modes, stride sweep, threshold
+sweep, cascade ablation, temporal sweep, patch-radius coarse-graining).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import time
+
+import numpy as np
+import pytest
+
+from scripts.nextness_observer import (
+    MEMORY_CHANNEL_LAYOUT,
+    ObserverConfig,
+    STATE_COMPUTE,
+    WriteOutsideLogDirError,
+)
+from scripts.nextness_calibration import (
+    DEFAULT_CANONICAL_SEED,
+    DEFAULT_VARIANCE_SEEDS,
+    SHUFFLE_MODES,
+    _content_fingerprint,
+    _extract_generation_from_filename,
+    _interpret_signal_location,
+    _make_aggregate_row,
+    _make_per_snapshot_row,
+    _shuffle_falsification_status,
+    _shuffled_snapshot_arrays,
+    _sort_snapshots_by_generation,
+    _validate_calibration_output_path,
+    check_determinism,
+    shuffle_test,
+)
+
+
+CH = MEMORY_CHANNEL_LAYOUT
+
+
+# ---------------------------------------------------------------------------
+# Helpers — same pattern as test_nextness_observer.py / test_nextness_metrics.py
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(
+    path: pathlib.Path,
+    lattice: int = 16,
+    generation: int = 100,
+) -> pathlib.Path:
+    """Create a synthetic Medusa-format ``.npz`` snapshot for calibration tests.
+
+    Mirrors the helper used by ``test_nextness_observer.py``; tiny lattice
+    (default 16^3) keeps tests fast. No pad_bytes — post-PR-#140 the
+    validity check is structural, not size-based.
+    """
+    state = np.zeros((lattice, lattice, lattice), dtype=np.uint8)
+    state[::4, ::4, ::4] = STATE_COMPUTE
+    memory = np.zeros((8, lattice, lattice, lattice), dtype=np.float32)
+    memory[CH["compute_age"]].fill(15.0)
+    np.savez(
+        str(path),
+        lattice=state, memory_grid=memory,
+        generation=np.array(generation), best_fitness=np.array(0.5),
+    )
+    return path
+
+
+def _calibration_setup(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path, ObserverConfig]:
+    """Build the standard test scaffolding: data dir, log_path, config.
+
+    Returns (snapshots_dir, log_path, config). Caller still needs to create
+    snapshot files in snapshots_dir.
+    """
+    snapshots_dir = tmp_path / "snapshots"
+    snapshots_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    config = ObserverConfig(
+        log_directory=str(log_dir),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    return snapshots_dir, log_path, config
+
+
+# ---------------------------------------------------------------------------
+# _extract_generation_from_filename
+# ---------------------------------------------------------------------------
+
+
+def test_extract_generation_canonical_filename():
+    """Canonical Medusa filenames parse correctly."""
+    p = pathlib.Path("v070_gen1665781_step16657819_20260518T224644.npz")
+    assert _extract_generation_from_filename(p) == 1665781
+
+
+def test_extract_generation_returns_negative_one_for_unparseable():
+    """Filenames that don't match the canonical format sort to the front."""
+    p = pathlib.Path("random_other_file.npz")
+    assert _extract_generation_from_filename(p) == -1
+
+
+def test_extract_generation_works_with_various_prefixes():
+    """Different prefix versions (v060, v070, v080) all parse."""
+    for prefix in ("v060", "v070", "v080", "v999"):
+        p = pathlib.Path(f"{prefix}_gen42_step420_20260101T000000.npz")
+        assert _extract_generation_from_filename(p) == 42
+
+
+# ---------------------------------------------------------------------------
+# _sort_snapshots_by_generation
+# ---------------------------------------------------------------------------
+
+
+def test_sort_snapshots_orders_by_generation(tmp_path):
+    """Sorted result is ascending by generation regardless of input order."""
+    paths = [
+        tmp_path / "v070_gen300_step3000_20260101T000003.npz",
+        tmp_path / "v070_gen100_step1000_20260101T000001.npz",
+        tmp_path / "v070_gen200_step2000_20260101T000002.npz",
+    ]
+    sorted_ = _sort_snapshots_by_generation(paths)
+    assert [p.name for p in sorted_] == [
+        "v070_gen100_step1000_20260101T000001.npz",
+        "v070_gen200_step2000_20260101T000002.npz",
+        "v070_gen300_step3000_20260101T000003.npz",
+    ]
+
+
+def test_sort_snapshots_deterministic_across_input_orderings(tmp_path):
+    """Same paths in three different orderings → byte-identical sorted output.
+
+    Mirrors test_nextness_metrics.py's determinism contract test.
+    """
+    base = [
+        tmp_path / "v070_gen100_step1000_20260101T000001.npz",
+        tmp_path / "v070_gen200_step2000_20260101T000002.npz",
+        tmp_path / "v070_gen300_step3000_20260101T000003.npz",
+    ]
+    s1 = [p.name for p in _sort_snapshots_by_generation(base)]
+    s2 = [p.name for p in _sort_snapshots_by_generation(list(reversed(base)))]
+    s3 = [p.name for p in _sort_snapshots_by_generation([base[1], base[2], base[0]])]
+    assert s1 == s2 == s3
+
+
+# ---------------------------------------------------------------------------
+# _content_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_content_fingerprint_excludes_ts_field():
+    """Two entries differing only in ``ts`` produce identical fingerprints."""
+    entry_a = {"ts": "2026-05-23T10:00:00Z", "generation": 100, "boundary_rate": 0.42}
+    entry_b = {"ts": "2026-05-23T11:00:00Z", "generation": 100, "boundary_rate": 0.42}
+    assert _content_fingerprint(entry_a) == _content_fingerprint(entry_b)
+
+
+def test_content_fingerprint_differs_when_content_differs():
+    """Two entries with identical ``ts`` but different content → different fingerprints."""
+    entry_a = {"ts": "2026-05-23T10:00:00Z", "generation": 100, "boundary_rate": 0.42}
+    entry_b = {"ts": "2026-05-23T10:00:00Z", "generation": 100, "boundary_rate": 0.43}
+    assert _content_fingerprint(entry_a) != _content_fingerprint(entry_b)
+
+
+def test_content_fingerprint_independent_of_dict_insertion_order():
+    """sort_keys=True in the canonical JSON makes fingerprint order-independent."""
+    entry_a = {"ts": "x", "a": 1, "b": 2, "c": 3}
+    entry_b = {"ts": "y", "c": 3, "a": 1, "b": 2}
+    assert _content_fingerprint(entry_a) == _content_fingerprint(entry_b)
+
+
+def test_content_fingerprint_returns_hex_sha256():
+    """Output is a 64-char hex string (full SHA-256 digest)."""
+    fp = _content_fingerprint({"ts": "x", "value": 42})
+    assert len(fp) == 64
+    int(fp, 16)  # raises if not hex
+
+
+def test_content_fingerprint_scrubs_nested_budget_wallclock_fields():
+    """Wallclock-derived fields INSIDE the budget block must also be scrubbed.
+
+    Regression fence for the bug caught by
+    test_check_determinism_passes_on_synthetic_snapshots: budget.elapsed_seconds,
+    budget.fraction_used, and budget.exceeded all vary across runs even when
+    the computation is fully deterministic. They must be excluded from the
+    fingerprint or determinism testing produces false negatives.
+    """
+    entry_a = {
+        "ts": "2026-05-23T10:00:00Z",
+        "boundary_rate": 0.42,
+        "budget": {
+            "elapsed_seconds": 0.001234,
+            "fraction_used": 0.0000411,
+            "exceeded": False,
+            "patches_processed": 4096,  # deterministic — should be in fingerprint
+        },
+    }
+    entry_b = {
+        "ts": "2026-05-23T11:00:00Z",  # different ts
+        "boundary_rate": 0.42,
+        "budget": {
+            "elapsed_seconds": 0.002567,  # different elapsed
+            "fraction_used": 0.0000855,  # different fraction
+            "exceeded": False,
+            "patches_processed": 4096,  # same patches_processed
+        },
+    }
+    assert _content_fingerprint(entry_a) == _content_fingerprint(entry_b)
+
+
+def test_content_fingerprint_detects_budget_patches_processed_drift():
+    """Deterministic budget fields (patches_processed) MUST stay in fingerprint.
+
+    Regression fence: ensure the scrub doesn't accidentally remove the
+    deterministic budget fields. If patches_processed differs across runs,
+    that's a real determinism violation and the fingerprint must catch it.
+    """
+    entry_a = {"ts": "x", "budget": {"elapsed_seconds": 0.1, "patches_processed": 100}}
+    entry_b = {"ts": "x", "budget": {"elapsed_seconds": 0.1, "patches_processed": 101}}
+    assert _content_fingerprint(entry_a) != _content_fingerprint(entry_b)
+
+
+# ---------------------------------------------------------------------------
+# _validate_calibration_output_path
+# ---------------------------------------------------------------------------
+
+
+def test_validate_output_inside_log_dir_succeeds(tmp_path):
+    """Sibling output path (same dir as log) passes validation silently."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out_path = log_dir / "calibration_determinism.jsonl"
+    # Should not raise
+    _validate_calibration_output_path(out_path, log_path)
+
+
+def test_validate_output_outside_log_dir_raises(tmp_path):
+    """Output path outside log_path.parent raises WriteOutsideLogDirError."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out_path = tmp_path / "elsewhere" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        _validate_calibration_output_path(out_path, log_path)
+
+
+def test_validate_output_traversal_escape_rejected(tmp_path):
+    """``..`` traversal must also be rejected, not just literal mismatch."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out_path = log_dir / ".." / ".." / "escape.jsonl"
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_calibration_output_path(out_path, log_path)
+
+
+# ---------------------------------------------------------------------------
+# _make_aggregate_row falsification_status validation
+# ---------------------------------------------------------------------------
+
+
+def test_make_aggregate_row_accepts_three_valid_statuses():
+    """Each of the three documented statuses is accepted."""
+    for status in ("hypothesis_supported", "hypothesis_falsified", "inconclusive"):
+        row = _make_aggregate_row(
+            experiment="test",
+            calibration_set="short",
+            n_snapshots=1,
+            extra_fields={},
+            falsification_status=status,
+        )
+        assert row["falsification_status"] == status
+
+
+def test_make_aggregate_row_rejects_unknown_status():
+    """Arbitrary status strings are rejected — protects the schema contract."""
+    with pytest.raises(ValueError, match="falsification_status"):
+        _make_aggregate_row(
+            experiment="test",
+            calibration_set="short",
+            n_snapshots=1,
+            extra_fields={},
+            falsification_status="vibes_say_yes",  # not a documented value
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_determinism — input validation
+# ---------------------------------------------------------------------------
+
+
+def test_check_determinism_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set must be 'short' or 'long' — protects schema."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        check_determinism([snap], out, log_path, "medium", config)
+
+
+def test_check_determinism_rejects_repeats_below_two(tmp_path):
+    """repeats < 2 is meaningless (no comparison possible) — rejected."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="repeats must be >= 2"):
+        check_determinism([snap], out, log_path, "short", config, repeats=1)
+
+
+# ---------------------------------------------------------------------------
+# check_determinism — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_check_determinism_passes_on_synthetic_snapshots(tmp_path):
+    """3 synthetic snapshots × 2 repeats → all byte-identical content.
+
+    process_snapshot() is deterministic by design (no randomness in the
+    classifier cascade, deterministic stride iteration), so this should
+    pass cleanly.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snaps = [
+        _make_snapshot(snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i)
+        for i in (1, 2, 3)
+    ]
+    out = log_path.parent / "calibration_determinism.jsonl"
+
+    aggregate = check_determinism(snaps, out, log_path, "short", config, repeats=2)
+
+    assert aggregate["experiment"] == "determinism"
+    assert aggregate["summary_type"] == "run_aggregate"
+    assert aggregate["calibration_set"] == "short"
+    assert aggregate["n_snapshots"] == 3
+    assert aggregate["repeats_per_snapshot"] == 2
+    assert aggregate["all_byte_identical"] is True
+    assert aggregate["n_snapshots_with_drift"] == 0
+    assert aggregate["falsification_status"] == "hypothesis_supported"
+
+
+def test_check_determinism_writes_correct_number_of_rows(tmp_path):
+    """Output JSONL has (N_snapshots × repeats) per-snapshot rows + 1 aggregate."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snaps = [
+        _make_snapshot(snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i)
+        for i in (1, 2, 3)
+    ]
+    out = log_path.parent / "calibration_determinism.jsonl"
+    check_determinism(snaps, out, log_path, "short", config, repeats=2)
+
+    lines = out.read_text().splitlines()
+    assert len(lines) == 3 * 2 + 1  # 3 snapshots × 2 repeats + 1 aggregate
+    aggregate_line = json.loads(lines[-1])
+    assert aggregate_line["summary_type"] == "run_aggregate"
+
+
+def test_check_determinism_emits_no_generated_at_field(tmp_path):
+    """Determinism contract from PR #142 — no fresh timestamps in output.
+
+    Locks in that the calibration JSONL doesn't accidentally re-introduce
+    a generated_at field that would break byte-identical re-run.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_determinism.jsonl"
+    check_determinism([snap], out, log_path, "short", config, repeats=2)
+    content = out.read_text()
+    assert "generated_at" not in content
+
+
+def test_check_determinism_calibration_set_field_propagates(tmp_path):
+    """Every row (per-snapshot AND aggregate) carries the calibration_set tag."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_determinism.jsonl"
+    check_determinism([snap], out, log_path, "long", config, repeats=2)
+
+    for line in out.read_text().splitlines():
+        row = json.loads(line)
+        assert row["calibration_set"] == "long"
+
+
+def test_check_determinism_sorts_snapshots_by_generation(tmp_path):
+    """Per-snapshot rows appear in generation-ascending order regardless of input order."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    # Create three snapshots; pass them in reverse-generation order
+    snap_a = _make_snapshot(snaps_dir / "v070_gen300_step3000_test.npz", generation=300)
+    snap_b = _make_snapshot(snaps_dir / "v070_gen100_step1000_test.npz", generation=100)
+    snap_c = _make_snapshot(snaps_dir / "v070_gen200_step2000_test.npz", generation=200)
+    out = log_path.parent / "calibration_determinism.jsonl"
+    check_determinism([snap_a, snap_b, snap_c], out, log_path, "short", config, repeats=2)
+
+    lines = [json.loads(l) for l in out.read_text().splitlines()[:-1]]  # exclude aggregate
+    # 3 snapshots × 2 repeats; per-snapshot rows grouped by snapshot in sorted order
+    generations_in_order = [r["snapshot_generation"] for r in lines]
+    # Should be [100, 100, 200, 200, 300, 300] — sorted, with each snapshot's repeats adjacent
+    assert generations_in_order == [100, 100, 200, 200, 300, 300]
+
+
+# ---------------------------------------------------------------------------
+# check_determinism — write-boundary safety inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_check_determinism_rejects_outside_log_dir_output(tmp_path):
+    """Output outside log directory raises WriteOutsideLogDirError.
+
+    Inherits the Lane B write-boundary safety contract from PR #142 via
+    _validate_calibration_output_path. Locked in by an explicit test here
+    so future refactors can't quietly drop it.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    bad_out = tmp_path / "outside_dir" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        check_determinism([snap], bad_out, log_path, "short", config, repeats=2)
+    # No side effects — outside parent must not have been created
+    assert not (tmp_path / "outside_dir").exists()
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants exposed via __all__
+# ---------------------------------------------------------------------------
+
+
+def test_default_canonical_seed_is_42():
+    """The canonical RNG seed is 42 — used by shuffle test and other randomized experiments."""
+    assert DEFAULT_CANONICAL_SEED == 42
+
+
+def test_default_variance_seeds_has_five_entries():
+    """Per design doc §12 Q6: canonical seed + 5 variance-estimate seeds."""
+    assert len(DEFAULT_VARIANCE_SEEDS) == 5
+    assert all(isinstance(s, int) for s in DEFAULT_VARIANCE_SEEDS)
+
+
+# ---------------------------------------------------------------------------
+# Shuffle mechanics — Chapter 2 (design doc §3.8)
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_arrays(lattice_size: int = 16):
+    """Build a synthetic (lattice, memory_grid) pair for shuffle-mechanics tests.
+
+    Memory channels carry a position-dependent gradient on top of a per-channel
+    constant offset. The gradient is crucial — without intra-channel spatial
+    variation, permuting a constant-valued array gives back the same array
+    and we can't verify the shuffle actually changed anything.
+    """
+    state = np.zeros((lattice_size, lattice_size, lattice_size), dtype=np.uint8)
+    # Sprinkle COMPUTE cells in a recognizable pattern
+    state[::4, ::4, ::4] = STATE_COMPUTE
+    # Position-dependent gradient (linear over flat index) + per-channel
+    # constant offset. Result: each (channel, x, y, z) cell has a unique
+    # value, so any permutation produces a visibly different array.
+    n_voxels = lattice_size ** 3
+    gradient = np.arange(n_voxels, dtype=np.float32).reshape(
+        (lattice_size, lattice_size, lattice_size)
+    ) / float(n_voxels)
+    memory = np.zeros(
+        (8, lattice_size, lattice_size, lattice_size), dtype=np.float32,
+    )
+    for c in range(8):
+        memory[c] = float(c) + gradient
+    return state, memory
+
+
+def test_shuffle_modes_tuple_has_three_entries():
+    """SHUFFLE_MODES is the canonical 3-mode tuple from design doc §3.8."""
+    assert SHUFFLE_MODES == (
+        "unshuffled",
+        "lattice_only_shuffle",
+        "joint_lattice_memory_shuffle",
+    )
+
+
+def test_shuffle_unshuffled_mode_returns_arrays_unchanged():
+    """unshuffled mode is the baseline — no permutation applied."""
+    lattice, memory = _synthetic_arrays()
+    rng = np.random.default_rng(42)
+    out_lattice, out_memory = _shuffled_snapshot_arrays(
+        lattice, memory, "unshuffled", rng,
+    )
+    assert np.array_equal(out_lattice, lattice)
+    assert np.array_equal(out_memory, memory)
+
+
+def test_shuffle_lattice_only_preserves_memory_grid_exactly():
+    """lattice_only_shuffle leaves memory_grid byte-identical to input."""
+    lattice, memory = _synthetic_arrays()
+    rng = np.random.default_rng(42)
+    out_lattice, out_memory = _shuffled_snapshot_arrays(
+        lattice, memory, "lattice_only_shuffle", rng,
+    )
+    # Lattice changes (with overwhelming probability for a 16^3 grid)
+    assert not np.array_equal(out_lattice, lattice)
+    # Memory is identical — same object reference is fine; same content
+    # is what we actually require
+    assert np.array_equal(out_memory, memory)
+
+
+def test_shuffle_lattice_only_preserves_per_state_cell_counts():
+    """lattice_only_shuffle is a permutation: per-state counts unchanged."""
+    lattice, memory = _synthetic_arrays()
+    rng = np.random.default_rng(42)
+    out_lattice, _ = _shuffled_snapshot_arrays(
+        lattice, memory, "lattice_only_shuffle", rng,
+    )
+    # All unique state counts identical between input and output
+    in_counts = dict(zip(*np.unique(lattice, return_counts=True)))
+    out_counts = dict(zip(*np.unique(out_lattice, return_counts=True)))
+    assert in_counts == out_counts
+
+
+def test_shuffle_joint_applies_same_permutation_to_both_arrays():
+    """joint mode applies the SAME permutation to both lattice and memory.
+
+    Verification: for each cell position p in the shuffled output, the
+    lattice value at p and the memory value at p must come from the same
+    original position (i.e., the local pairing is preserved). We verify
+    this by reconstructing the permutation from the lattice change and
+    checking the memory change is consistent.
+    """
+    lattice, memory = _synthetic_arrays()
+    rng = np.random.default_rng(42)
+    out_lattice, out_memory = _shuffled_snapshot_arrays(
+        lattice, memory, "joint_lattice_memory_shuffle", rng,
+    )
+    # Both arrays changed
+    assert not np.array_equal(out_lattice, lattice)
+    assert not np.array_equal(out_memory, memory)
+    # Per-state lattice counts preserved (joint is also a permutation)
+    in_counts = dict(zip(*np.unique(lattice, return_counts=True)))
+    out_counts = dict(zip(*np.unique(out_lattice, return_counts=True)))
+    assert in_counts == out_counts
+    # Per-channel memory marginals preserved (same permutation, per-channel
+    # value distributions unchanged)
+    for c in range(memory.shape[0]):
+        assert np.allclose(np.sort(memory[c].flatten()),
+                           np.sort(out_memory[c].flatten()))
+
+
+def test_shuffle_joint_preserves_per_cell_lattice_memory_pairing():
+    """In joint mode, the local lattice/memory correspondence is preserved.
+
+    For any cell that was originally COMPUTE with memory channel 0 value
+    of 1.0, after joint shuffle there must STILL be a cell where lattice
+    is COMPUTE and memory channel 0 is 1.0 — they moved together. This
+    is the structural-correlation contract of the joint mode.
+    """
+    # Setup: distinct memory values at COMPUTE positions vs VOID positions
+    lattice = np.zeros((4, 4, 4), dtype=np.uint8)
+    memory = np.zeros((1, 4, 4, 4), dtype=np.float32)
+    # Mark COMPUTE cells with memory value 99.0; VOID cells with 0.0
+    lattice[0, 0, 0] = STATE_COMPUTE
+    lattice[1, 1, 1] = STATE_COMPUTE
+    lattice[2, 2, 2] = STATE_COMPUTE
+    memory[0, 0, 0, 0] = 99.0
+    memory[0, 1, 1, 1] = 99.0
+    memory[0, 2, 2, 2] = 99.0
+
+    rng = np.random.default_rng(42)
+    out_lattice, out_memory = _shuffled_snapshot_arrays(
+        lattice, memory, "joint_lattice_memory_shuffle", rng,
+    )
+    # Every cell where lattice is COMPUTE must STILL have memory == 99.0
+    compute_positions = np.argwhere(out_lattice == STATE_COMPUTE)
+    for pos in compute_positions:
+        assert out_memory[0, pos[0], pos[1], pos[2]] == 99.0, (
+            f"Joint shuffle broke lattice/memory pairing at {tuple(pos)}: "
+            f"lattice=COMPUTE but memory != 99.0"
+        )
+
+
+def test_shuffle_same_seed_produces_same_permutation():
+    """Reproducibility — same RNG seed → identical output arrays."""
+    lattice, memory = _synthetic_arrays()
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(42)
+    out1_l, out1_m = _shuffled_snapshot_arrays(
+        lattice, memory, "joint_lattice_memory_shuffle", rng1,
+    )
+    out2_l, out2_m = _shuffled_snapshot_arrays(
+        lattice, memory, "joint_lattice_memory_shuffle", rng2,
+    )
+    assert np.array_equal(out1_l, out2_l)
+    assert np.array_equal(out1_m, out2_m)
+
+
+def test_shuffle_different_seeds_produce_different_permutations():
+    """Different seeds yield different permutations (sanity)."""
+    lattice, memory = _synthetic_arrays()
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(43)
+    out1_l, _ = _shuffled_snapshot_arrays(
+        lattice, memory, "lattice_only_shuffle", rng1,
+    )
+    out2_l, _ = _shuffled_snapshot_arrays(
+        lattice, memory, "lattice_only_shuffle", rng2,
+    )
+    # With overwhelming probability for a 16^3 lattice, two random
+    # permutations differ.
+    assert not np.array_equal(out1_l, out2_l)
+
+
+def test_shuffle_unknown_mode_raises():
+    """Mode validation — unknown mode strings rejected."""
+    lattice, memory = _synthetic_arrays()
+    rng = np.random.default_rng(42)
+    with pytest.raises(ValueError, match="unknown shuffle mode"):
+        _shuffled_snapshot_arrays(lattice, memory, "rotate_lattice", rng)
+
+
+# ---------------------------------------------------------------------------
+# _interpret_signal_location + _shuffle_falsification_status — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_interpret_signal_location_classifier_artefact():
+    """All three modes give similar CCIs → classifier_artefact."""
+    assert _interpret_signal_location(0.30, 0.30, 0.30) == "classifier_artefact"
+    assert _interpret_signal_location(0.30, 0.32, 0.31) == "classifier_artefact"
+
+
+def test_interpret_signal_location_lattice_geometry():
+    """unshuffled differs from both shuffled, AND lattice_only ≈ joint."""
+    # unshuffled=0.30, lattice_only=0.10, joint=0.11
+    # → diff(u,l)=0.20, diff(u,j)=0.19, diff(l,j)=0.01
+    # → both shuffled modes collapsed similarly = lattice geometry was carrying
+    assert _interpret_signal_location(0.30, 0.10, 0.11) == "lattice_geometry"
+
+
+def test_interpret_signal_location_memory_grid_structure():
+    """unshuffled ≈ lattice_only but ≠ joint → memory carries signal."""
+    # unshuffled=0.30, lattice_only=0.31 (≈unshuffled), joint=0.10 (much lower)
+    assert _interpret_signal_location(0.30, 0.31, 0.10) == "memory_grid_structure"
+
+
+def test_interpret_signal_location_lattice_geometry_when_shuffled_modes_close():
+    """lattice_only ≈ joint AND both differ from unshuffled → lattice_geometry.
+
+    Per the rule precedence: when both shuffle modes give similar CCIs,
+    the lattice shuffle alone was sufficient — memory shuffle adds nothing
+    on top. Lattice geometry was carrying the signal.
+    """
+    # u=0.30, l=0.20 (diff=0.10), j=0.21 (diff=0.09), l vs j = 0.01 (close)
+    assert _interpret_signal_location(0.30, 0.20, 0.21) == "lattice_geometry"
+
+
+def test_interpret_signal_location_both_arrays_contribute():
+    """Both shuffles produce meaningful drops AND joint drops further than lattice_only.
+
+    Per design doc §3.8: each array's spatial structure carries independent
+    signal. Strongest evidence for AURA's "real geometric structure"
+    hypothesis. Requires d_u_l ≥ eps (lattice shuffle alone matters) AND
+    d_l_j ≥ eps (joint shuffle drops further beyond lattice_only).
+    """
+    # u=0.30, l=0.20 (drop of 0.10 from lattice shuffle), j=0.10 (further
+    # 0.10 drop from adding memory shuffle on top). Both arrays contributed.
+    assert _interpret_signal_location(0.30, 0.20, 0.10) == "both_arrays_contribute"
+    # Asymmetric drops still classify as both_arrays_contribute as long as
+    # the joint shuffle adds meaningful further drop beyond lattice_only:
+    assert _interpret_signal_location(0.30, 0.22, 0.12) == "both_arrays_contribute"
+
+
+def test_shuffle_falsification_status_falsified_when_all_close():
+    """All three modes within 0.05 → hypothesis_falsified (classifier artefact)."""
+    # max_pairwise = 0.04 < 0.05 → falsified
+    assert _shuffle_falsification_status(0.30, 0.30, 0.04) == "hypothesis_falsified"
+
+
+def test_shuffle_falsification_status_supported_when_joint_collapses():
+    """Joint shuffle drops CCI by >0.10 → hypothesis_supported."""
+    # diff(unshuffled, joint) = 0.30 - 0.10 = 0.20, which is > 0.10
+    assert _shuffle_falsification_status(0.30, 0.10, 0.20) == "hypothesis_supported"
+
+
+def test_shuffle_falsification_status_inconclusive_in_middle():
+    """Modest drops that don't meet either criterion → inconclusive."""
+    # max_pairwise = 0.07 (not < 0.05) and joint diff = 0.07 (not > 0.10)
+    assert _shuffle_falsification_status(0.30, 0.23, 0.07) == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# shuffle_test — orchestrator integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_shuffle_test_writes_expected_row_counts(tmp_path):
+    """N snapshots × (1 unshuffled + N_seeds × 2 shuffled modes) rows + 1 aggregate.
+
+    With 2 snapshots and default seeds (1 canonical + 5 variance = 6 total):
+    per snapshot: 1 (unshuffled) + 6 (lattice_only) + 6 (joint) = 13 rows.
+    Total: 2 × 13 + 1 aggregate = 27 lines.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snaps = [
+        _make_snapshot(snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i)
+        for i in (1, 2)
+    ]
+    out = log_path.parent / "calibration_shuffle.jsonl"
+
+    aggregate = shuffle_test(snaps, out, log_path, "short", config)
+    lines = out.read_text().splitlines()
+    assert len(lines) == 2 * 13 + 1  # 26 per-snapshot + 1 aggregate
+    assert aggregate["experiment"] == "shuffle"
+    assert aggregate["summary_type"] == "run_aggregate"
+
+
+def test_shuffle_test_per_row_has_correct_parameter_combination(tmp_path):
+    """Each per-snapshot row carries shuffle_mode and shuffle_seed."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+    shuffle_test([snap], out, log_path, "short", config)
+
+    pair_rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    for row in pair_rows:
+        params = row["parameter_combination"]
+        assert "shuffle_mode" in params
+        assert "shuffle_seed" in params
+        assert params["shuffle_mode"] in SHUFFLE_MODES
+
+
+def test_shuffle_test_aggregate_has_signal_location_interpretation(tmp_path):
+    """Aggregate row carries the signal_location_interpretation field."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+
+    aggregate = shuffle_test([snap], out, log_path, "short", config)
+    assert "signal_location_interpretation" in aggregate
+    assert aggregate["signal_location_interpretation"] in {
+        "classifier_artefact",
+        "lattice_geometry",
+        "memory_grid_structure",
+        "both_arrays_contribute",
+        "ambiguous",
+        "incomplete_modes",
+    }
+    assert aggregate["falsification_status"] in {
+        "hypothesis_supported",
+        "hypothesis_falsified",
+        "inconclusive",
+    }
+
+
+def test_shuffle_test_rejects_unknown_mode(tmp_path):
+    """Unknown mode in the modes parameter → ValueError before any work happens."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+    with pytest.raises(ValueError, match="unknown shuffle mode"):
+        shuffle_test([snap], out, log_path, "short", config,
+                     modes=("unshuffled", "rotate_lattice"))
+
+
+def test_shuffle_test_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set must be 'short' or 'long'."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        shuffle_test([snap], out, log_path, "medium", config)
+
+
+def test_shuffle_test_rejects_outside_log_dir_output(tmp_path):
+    """Write-boundary safety inherited (per PR #142 pattern)."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    bad_out = tmp_path / "outside_dir" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        shuffle_test([snap], bad_out, log_path, "short", config)
+    assert not (tmp_path / "outside_dir").exists()
+
+
+def test_shuffle_test_no_generated_at_field(tmp_path):
+    """Determinism contract — no fresh timestamps in output."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+    shuffle_test([snap], out, log_path, "short", config)
+    content = out.read_text()
+    assert "generated_at" not in content
+
+
+def test_shuffle_test_subset_of_modes_marks_aggregate_incomplete(tmp_path):
+    """If caller requests fewer than all three modes, aggregate is marked incomplete.
+
+    Per the orchestrator's design: a partial run can't produce the
+    three-way comparison, so falsification_status is 'inconclusive' and
+    signal_location_interpretation is 'incomplete_modes'.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_shuffle.jsonl"
+    aggregate = shuffle_test([snap], out, log_path, "short", config,
+                             modes=("unshuffled", "lattice_only_shuffle"))
+    assert aggregate["signal_location_interpretation"] == "incomplete_modes"
+    assert aggregate["falsification_status"] == "inconclusive"


### PR DESCRIPTION
## Summary

First two chapters of the PR #4 calibration implementation per the design doc merged in PR #143 (`3346014`) and the layout fix landed in PR #145 (`f09407d`). Opened early per Jack's "small reviewable chunks" preference — Chapters 3-8 will land as follow-up commits on this branch (or follow-up PRs if AURA + Jack prefer that for review hygiene).

**Lane B only.** No engine touch. No HTTP. No ZMQ. CPU-only. `allow_pickle=False` preserved. Write-boundary safety contract inherited from PR #142 and extended to the calibration module via `WriteOutsideLogDirError` (unified safety vocabulary across all three Lane B modules).

**Tests:** 51 in new `tests/test_nextness_calibration.py`. Full Phase 17b + 18 + 19 suite: **355/355 passing** post-rebase onto PR #145's corrected layout.

**Diff:** `2 files changed, 1652 insertions(+)`.

---

## Chapter 1 — Foundation + `check_determinism` (Jack's #1)

### Shared infrastructure (all 7 remaining sweeps plug into this)

| Function | Purpose |
|---|---|
| `_validate_calibration_output_path` | Write-boundary safety mirror of `nextness_metrics` pattern. Reuses `WriteOutsideLogDirError`. |
| `_extract_generation_from_filename` + `_sort_snapshots_by_generation` | Deterministic snapshot ordering by `(generation, filename)` regardless of input order. |
| `_scrub_volatile_fields` + `_content_fingerprint` | Schema-aware scrubbing of wallclock-derived fields (top-level `ts` AND nested `budget.elapsed_seconds` / `fraction_used` / `exceeded`) before hashing. |
| `_write_calibration_jsonl` | Deterministic JSONL writer (sort_keys=True, no fresh `generated_at`). |
| `_make_per_snapshot_row` + `_make_aggregate_row` | Schema-uniform row builders matching design doc §8. `_make_aggregate_row` enforces `falsification_status ∈ {hypothesis_supported, hypothesis_falsified, inconclusive}`. |
| `_extract_metrics_subset` | Pulls the 6 per-snapshot metric fields out of a `process_snapshot()` entry. |

### Experiment 3.7 — `check_determinism()`

Runs `process_snapshot()` N times per snapshot, fingerprints content (excluding wallclock fields), reports byte-identical-on-content status per snapshot + aggregate. Mechanical `falsification_status`. Input validation rejects unknown `calibration_set` values and `repeats < 2`.

**Chapter 1 tests: 26.**

---

## Chapter 2 — `shuffle_test` with 3-mode null-model (Jack's #3)

### Three shuffle modes (per design doc §3.8)

1. **`unshuffled`** — baseline reference
2. **`lattice_only_shuffle`** — permute lattice cells; leave memory_grid spatial structure intact
3. **`joint_lattice_memory_shuffle`** — apply the **same permutation** to both arrays, destroying all spatial structure

Each snapshot runs in all three modes per call so the three-way comparison is built-in. Shuffled modes use canonical seed (42) + 5 variance-estimate seeds per design doc §12 Q6; `unshuffled` uses canonical only (no randomization).

### Helper functions

- `_shuffled_snapshot_arrays(lattice, memory, mode, rng)` — handles all three modes
- `_write_temp_snapshot()` — writes shuffled arrays to temp .npz so `process_snapshot()` can consume them; auto-cleaned via `tempfile.TemporaryDirectory`
- `_cci_from_entry()` — computes CCI from a `process_snapshot()` entry, importing `cci()` from `nextness_metrics`
- `_interpret_signal_location()` — maps three mean-CCI values to one of six labels: `classifier_artefact` / `lattice_geometry` / `memory_grid_structure` / `both_arrays_contribute` / `ambiguous` / `incomplete_modes`
- `_shuffle_falsification_status()` — mechanical status per §3.8 criteria

### Output

`shuffle_test()` orchestrator emits per-snapshot rows + aggregate with:
- `mean_cci_per_mode`, `std_cci_per_mode`
- `n_runs_per_mode`, `modes_run`, `seeds_used`
- `pairwise_cci_diffs` (unshuffled-vs-lattice_only, unshuffled-vs-joint, lattice_only-vs-joint, max_pairwise)
- `signal_location_interpretation` + mechanical `falsification_status`

**Chapter 2 tests: 25.**

---

## Bug fixes caught in-chapter (locked in by regression tests)

| Chapter | Bug | Fix |
|---|---|---|
| 1 | Fingerprint only scrubbed top-level `ts`; nested `budget.elapsed_seconds`/`fraction_used`/`exceeded` slipped through and broke determinism testing | Schema-aware scrub of both layers |
| 2a | Test fixture used constant-valued memory channels — permutation gave back same array (looked like code bug, was fixture bug) | Synthetic memory channels now carry position-dependent gradient + per-channel constant offset |
| 2b | `_interpret_signal_location` had a logical impossibility — `both_arrays_contribute` could never trigger due to rule precedence with `lattice_geometry` | Restructured rules so each has a unique trigger pattern |

---

## What's NOT in this PR yet

Deferred to follow-up commits on the same PR (or separate follow-up PRs per AURA + Jack's preference — see open question 1 below):

- **Chapter 3:** `verify_memory_channels()` as runtime regression-fence — static layout check landed in PR #145; this adds the per-snapshot statistical signature verification
- **Chapter 4:** `sweep_stride` (4 / 8 / 16)
- **Chapter 5:** `sweep_threshold` (±10%, ±25%, ±50%)
- **Chapter 6:** `ablate_cascade`
- **Chapter 7:** `sweep_temporal` (long calibration set)
- **Chapter 8:** `sweep_patch_radius` (5×5×5)
- **CLI surface** for all sweep sub-commands

---

## Scope guarantees (unchanged from PR #138 / #140 / #142 / #145)

- ✅ No engine touch
- ✅ No writes outside `log_path.parent` (`WriteOutsideLogDirError` extended to calibration module)
- ✅ No HTTP / ZMQ / network
- ✅ CPU-only
- ✅ `allow_pickle=False` preserved
- ✅ No CCI regime thresholds
- ✅ No fresh `generated_at` field in output
- ✅ No external code pull (Continual Harness still deferred to future Lane A)
- ✅ No multi-snapshot mode added to `nextness_observer.py`; calibration uses a separate orchestrator

---

## Open questions for AURA + Jack

1. **Single PR vs serial PRs?** Should Chapters 3-8 land as follow-up commits on THIS PR (one big PR with many commits), or as separate follow-up PRs (one per chapter)? My recommendation: follow-up commits on this PR up through Chapter 4; if the diff gets unwieldy, split Chapters 5-8 into a PR #4.5. But preference yours.

2. **Should I push Chapter 3 (verify_memory_channels runtime check) before or after this PR merges?** It's the natural next chunk and complements PR #145's static layout check. Could land as commit `2/N` on this branch, OR as a separate small PR after this merges. My recommendation: follow-up commit on this branch.

3. **CLI surface timing.** The CLI sub-commands (`python -m scripts.nextness_calibration stride --snapshots-dir ... --out ...` etc) can land per-chapter or all together at the end. My recommendation: all together at the end, after all sweep functions exist, so the CLI design can reflect the actual function signatures.

## Builds on

- PR #137 — Phase 19 design doc
- PR #138 — observer skeleton (`d651f2c`)
- PR #140 — PR #2 follow-up (`d2b5db9`)
- PR #141 — PR #3 design doc (`3dfc67d`)
- PR #142 — metrics pipeline (`f06b1c5`)
- PR #143 — PR #4 calibration design doc (`3346014`)
- PR #145 — layout fix for issue #144 (`f09407d`)
- Issue #139 — calibration findings (finding (c) parent hub)
- Issue #144 (closed) — layout mismatch (resolved by PR #145; this PR builds on the corrected foundation)

Refs #139 — finding (c) addressed by this PR's experimental design + later chapters' implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)