### PR TITLE
Phase 19 PR #4 Chapter 3 — verify_memory_channels() runtime regression-fence

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -839,10 +839,337 @@ def shuffle_test(
     return aggregate
 
 
+# ---------------------------------------------------------------------------
+# Experiment 3.6 — verify_memory_channels (Jack's #2 in implementation order;
+# runtime regression-fence complementing PR #145's static layout check)
+# ---------------------------------------------------------------------------
+
+
+#: Number of memory channels the engine writes per snapshot, per
+#: ``scripts/continuous_evolution_ca.py:646`` (``MEMORY_CHANNELS = 8``).
+#: A future engine change that adds or removes channels should be caught
+#: by this runtime check.
+EXPECTED_MEMORY_CHANNELS: int = 8
+
+#: Expected dtype of the engine's ``memory_grid`` array. Engine writes
+#: float32 throughout (see ``init_memory_grid`` at line 652). A dtype
+#: change would be a structural drift worth catching.
+EXPECTED_MEMORY_DTYPE: str = "float32"
+
+#: Sparsity threshold for the per-channel signature. Voxels with
+#: ``abs(value) <= SPARSITY_EPSILON`` are counted as "near-zero" for
+#: the sparsity fraction. Chosen conservative — does not depend on any
+#: per-channel semantic meaning.
+SPARSITY_EPSILON: float = 1e-6
+
+
+def _per_channel_signature(channel_array: "np.ndarray") -> dict[str, Any]:
+    """Compute a small, robust per-channel statistical signature.
+
+    Returns a dict with min/max/mean/std/sparsity, plus a ``finite``
+    flag indicating whether every voxel in the channel is a finite
+    real number (no ``NaN``, no ``Inf``).
+
+    The fields are designed to be diagnostic — analysts can spot at a
+    glance whether a channel looks healthy (varying values, no NaNs,
+    sensible mean/std) or pathological (all zero, dominated by NaN,
+    constant value across the lattice). The verification status logic
+    in :func:`verify_memory_channels` uses only the structural checks
+    (shape, dtype, finiteness); the signature numbers are emitted for
+    human and downstream-tool inspection.
+    """
+    flat = channel_array.flatten()
+    finite_mask = np.isfinite(flat)
+    all_finite = bool(finite_mask.all())
+    if all_finite:
+        n_near_zero = int(np.sum(np.abs(flat) <= SPARSITY_EPSILON))
+        sparsity = n_near_zero / float(flat.size) if flat.size > 0 else 0.0
+        return {
+            "min": float(flat.min()),
+            "max": float(flat.max()),
+            "mean": float(flat.mean()),
+            "std": float(flat.std()),
+            "sparsity": sparsity,
+            "n_voxels": int(flat.size),
+            "finite": True,
+            "n_non_finite": 0,
+        }
+    # Partial-finite case: report what we can from the finite subset
+    # plus an explicit count of non-finite voxels.
+    n_non_finite = int((~finite_mask).sum())
+    finite_values = flat[finite_mask]
+    if finite_values.size > 0:
+        signature = {
+            "min": float(finite_values.min()),
+            "max": float(finite_values.max()),
+            "mean": float(finite_values.mean()),
+            "std": float(finite_values.std()),
+            "sparsity": float(
+                (np.abs(finite_values) <= SPARSITY_EPSILON).sum()
+            ) / float(flat.size),
+            "n_voxels": int(flat.size),
+            "finite": False,
+            "n_non_finite": n_non_finite,
+        }
+    else:
+        # Every voxel is non-finite — return null stats but a clear status
+        signature = {
+            "min": None,
+            "max": None,
+            "mean": None,
+            "std": None,
+            "sparsity": None,
+            "n_voxels": int(flat.size),
+            "finite": False,
+            "n_non_finite": n_non_finite,
+        }
+    return signature
+
+
+def _verify_snapshot_memory_grid(
+    snapshot_path: pathlib.Path,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    """Load a snapshot's memory_grid and verify shape/dtype/finiteness.
+
+    Returns ``(channel_signatures, drift_reasons)``:
+        - ``channel_signatures``: dict mapping channel name → per-channel
+          signature dict (see :func:`_per_channel_signature`). Only
+          populated for channels that exist; uses the canonical
+          ``MEMORY_CHANNEL_LAYOUT`` channel names from
+          :mod:`scripts.nextness_observer`.
+        - ``drift_reasons``: list of human-readable strings describing
+          any structural drift detected. Empty list = no drift, snapshot
+          verifies clean.
+
+    Per Jack's Chapter 3 guardrails: we do NOT touch the engine, and
+    we do NOT cross-reference against the Phase 14e acoustic map (that's
+    deferred). The check is strictly: does the snapshot's
+    ``memory_grid`` array match the structural invariants we expect
+    given PR #145's corrected layout?
+    """
+    # Import lazily so the module's top-level import graph doesn't
+    # depend on the observer at all for non-channel-verification
+    # code paths.
+    from scripts.nextness_observer import MEMORY_CHANNEL_LAYOUT
+
+    drift_reasons: list[str] = []
+
+    try:
+        with np.load(str(snapshot_path), allow_pickle=False) as data:
+            if "memory_grid" not in data.files:
+                drift_reasons.append(
+                    f"snapshot missing 'memory_grid' key (found: "
+                    f"{sorted(data.files)})"
+                )
+                return {}, drift_reasons
+            memory = data["memory_grid"]
+            # Materialize the array (np.load returns a lazy view)
+            memory = np.asarray(memory)
+    except Exception as e:
+        drift_reasons.append(f"snapshot load failed: {type(e).__name__}: {e}")
+        return {}, drift_reasons
+
+    # Structural check 1: number of channels
+    if memory.ndim != 4:
+        drift_reasons.append(
+            f"memory_grid has {memory.ndim} dimensions; expected 4 "
+            f"(channels, x, y, z)"
+        )
+    elif memory.shape[0] != EXPECTED_MEMORY_CHANNELS:
+        drift_reasons.append(
+            f"memory_grid has {memory.shape[0]} channels; "
+            f"expected {EXPECTED_MEMORY_CHANNELS} per "
+            f"continuous_evolution_ca.py MEMORY_CHANNELS constant"
+        )
+
+    # Structural check 2: dtype
+    if str(memory.dtype) != EXPECTED_MEMORY_DTYPE:
+        drift_reasons.append(
+            f"memory_grid dtype is {memory.dtype}; expected "
+            f"{EXPECTED_MEMORY_DTYPE} per engine init_memory_grid"
+        )
+
+    # Per-channel signatures (computed for as many channels as exist,
+    # even if the count is wrong, so analysts can see what is in the
+    # file). Map channel index to name where possible.
+    index_to_name: dict[int, str] = {
+        idx: name for name, idx in MEMORY_CHANNEL_LAYOUT.items()
+    }
+    channel_signatures: dict[str, dict[str, Any]] = {}
+    if memory.ndim == 4:
+        for ch_idx in range(memory.shape[0]):
+            name = index_to_name.get(
+                ch_idx,
+                f"channel_{ch_idx}_unknown",  # extra channels beyond expected layout
+            )
+            signature = _per_channel_signature(memory[ch_idx])
+            channel_signatures[name] = signature
+            if not signature["finite"]:
+                drift_reasons.append(
+                    f"channel {ch_idx} ({name}) contains "
+                    f"{signature['n_non_finite']} non-finite voxel(s) "
+                    f"(NaN or Inf)"
+                )
+
+    return channel_signatures, drift_reasons
+
+
+def verify_memory_channels(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+) -> dict[str, Any]:
+    """Runtime per-snapshot regression-fence for the memory-channel layout.
+
+    Complements the static layout check from PR #145 (`tests/
+    test_nextness_observer.py::test_layout_matches_engine_documented_
+    8_channel_map`). The static check confirms that the observer's
+    constants match what the engine code documents *at test time*;
+    this runtime check confirms that *every actual snapshot* matches
+    the same invariants. Catches drift that wouldn't show up in a unit
+    test — e.g., the engine added a 9th channel mid-run, or a snapshot
+    became corrupted, or a dtype changed.
+
+    Per issue #144 / PR #145: the layout that was wrong has been
+    corrected and locked in. This experiment is the live runtime
+    sentinel ensuring no future drift slips past.
+
+    Per Jack's Chapter 3 guardrails (PR #146 follow-up direction):
+        - Lane B only. No engine touch.
+        - No threshold / stride / cascade / temporal / patch-radius
+          sweeps. No CLI.
+        - No vocabulary redesign. No reopening of the Karuna naming.
+        - Uses the PR #145-corrected layout as source of truth.
+        - Same write-boundary safety contract.
+        - Same deterministic JSONL style.
+
+    For each snapshot:
+        - Load memory_grid via ``np.load(..., allow_pickle=False)``.
+        - Verify shape == (8, X, Y, Z) per engine's MEMORY_CHANNELS = 8.
+        - Verify dtype == float32 per engine's init_memory_grid.
+        - Per-channel signature: min, max, mean, std, sparsity,
+          finite-flag, non-finite-count.
+        - Aggregate any drift reasons.
+
+    Falsification status:
+        - ``"hypothesis_supported"`` — every snapshot verifies cleanly
+          (shape + dtype + finiteness). The corrected layout is holding.
+        - ``"hypothesis_falsified"`` — at least one snapshot fails
+          verification. Blocking for downstream calibration runs.
+        - ``"inconclusive"`` — only emitted for an empty snapshot list.
+
+    Output JSONL: one row per snapshot containing the per-channel
+    signatures + drift reasons; final aggregate row summarising
+    overall verification status across the run.
+
+    Args:
+        snapshots: list of sandboxed ``.npz`` paths.
+        out_path: where to write the verification JSONL. Must resolve
+            under ``log_path.parent`` per the Lane B safety contract.
+        log_path: anchor for the write-boundary check.
+        calibration_set: ``"short"`` or ``"long"``; recorded on every row.
+
+    Returns the aggregate dict for callers that want to inspect it
+    without re-reading the output file.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside the
+            log directory.
+        ``ValueError`` if ``calibration_set`` isn't ``"short"`` or
+            ``"long"``.
+
+    Note: unlike :func:`check_determinism` and :func:`shuffle_test`,
+    this function does NOT take an ``ObserverConfig`` because it does
+    not call ``process_snapshot()``. It reads the raw ``.npz`` files
+    directly to inspect structural invariants, deliberately bypassing
+    the observer pipeline so it can catch drift that would otherwise
+    silently propagate through it.
+    """
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got "
+            f"{calibration_set!r}"
+        )
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    n_snapshots_verified = 0
+    n_snapshots_with_drift = 0
+    all_drift_reasons: list[str] = []
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        signatures, drift_reasons = _verify_snapshot_memory_grid(snap)
+
+        snapshot_verified = (len(drift_reasons) == 0)
+        if snapshot_verified:
+            n_snapshots_verified += 1
+        else:
+            n_snapshots_with_drift += 1
+            for reason in drift_reasons:
+                all_drift_reasons.append(f"{snap.name}: {reason}")
+
+        per_snapshot_rows.append(_make_per_snapshot_row(
+            experiment="verify_memory_channels",
+            snapshot_path=snap,
+            generation=generation,
+            parameter_combination={
+                "expected_channels": EXPECTED_MEMORY_CHANNELS,
+                "expected_dtype": EXPECTED_MEMORY_DTYPE,
+            },
+            metrics={
+                "channel_signatures": signatures,
+                "snapshot_verified": snapshot_verified,
+                "n_drift_reasons": len(drift_reasons),
+            },
+            run_metadata={
+                "drift_reasons": drift_reasons,
+            },
+            calibration_set=calibration_set,
+        ))
+
+    n_snapshots = len(sorted_snapshots)
+    if n_snapshots == 0:
+        falsification_status = "inconclusive"
+    elif n_snapshots_with_drift == 0:
+        falsification_status = "hypothesis_supported"
+    else:
+        falsification_status = "hypothesis_falsified"
+
+    aggregate = _make_aggregate_row(
+        experiment="verify_memory_channels",
+        calibration_set=calibration_set,
+        n_snapshots=n_snapshots,
+        extra_fields={
+            "expected_channels": EXPECTED_MEMORY_CHANNELS,
+            "expected_dtype": EXPECTED_MEMORY_DTYPE,
+            "n_snapshots_verified": n_snapshots_verified,
+            "n_snapshots_with_drift": n_snapshots_with_drift,
+            # First 10 drift reasons across the run (full list is in the
+            # per-snapshot rows; this is a quick-glance aggregate).
+            "first_drift_reasons": all_drift_reasons[:10],
+        },
+        falsification_status=falsification_status,
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
 __all__ = [
     "DEFAULT_CANONICAL_SEED",
     "DEFAULT_VARIANCE_SEEDS",
+    "EXPECTED_MEMORY_CHANNELS",
+    "EXPECTED_MEMORY_DTYPE",
     "SHUFFLE_MODES",
+    "SPARSITY_EPSILON",
     "check_determinism",
     "shuffle_test",
+    "verify_memory_channels",
 ]

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -31,18 +31,24 @@ from scripts.nextness_observer import (
 from scripts.nextness_calibration import (
     DEFAULT_CANONICAL_SEED,
     DEFAULT_VARIANCE_SEEDS,
+    EXPECTED_MEMORY_CHANNELS,
+    EXPECTED_MEMORY_DTYPE,
     SHUFFLE_MODES,
+    SPARSITY_EPSILON,
     _content_fingerprint,
     _extract_generation_from_filename,
     _interpret_signal_location,
     _make_aggregate_row,
     _make_per_snapshot_row,
+    _per_channel_signature,
     _shuffle_falsification_status,
     _shuffled_snapshot_arrays,
     _sort_snapshots_by_generation,
     _validate_calibration_output_path,
+    _verify_snapshot_memory_grid,
     check_determinism,
     shuffle_test,
+    verify_memory_channels,
 )
 
 
@@ -812,3 +818,359 @@ def test_shuffle_test_subset_of_modes_marks_aggregate_incomplete(tmp_path):
                              modes=("unshuffled", "lattice_only_shuffle"))
     assert aggregate["signal_location_interpretation"] == "incomplete_modes"
     assert aggregate["falsification_status"] == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Chapter 3 — verify_memory_channels runtime regression-fence
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot_with_options(
+    path: pathlib.Path,
+    *,
+    n_channels: int = 8,
+    dtype: type = np.float32,
+    inject_nan_at: tuple[int, int, int, int] | None = None,
+    inject_inf_at: tuple[int, int, int, int] | None = None,
+    lattice: int = 4,
+    generation: int = 1,
+) -> pathlib.Path:
+    """Make a synthetic snapshot with explicit control over structural
+    properties. Used to test verify_memory_channels under various drift
+    scenarios.
+    """
+    state = np.zeros((lattice, lattice, lattice), dtype=np.uint8)
+    state[::4, ::4, ::4] = STATE_COMPUTE
+    memory = np.zeros((n_channels, lattice, lattice, lattice), dtype=dtype)
+    memory[0, 0, 0, 0] = 1.0  # at least one non-zero
+    if inject_nan_at is not None:
+        memory[inject_nan_at] = np.nan
+    if inject_inf_at is not None:
+        memory[inject_inf_at] = np.inf
+    np.savez(
+        str(path),
+        lattice=state, memory_grid=memory,
+        generation=np.array(generation), best_fitness=np.array(0.5),
+    )
+    return path
+
+
+# --- _per_channel_signature unit tests ---
+
+
+def test_per_channel_signature_clean_channel_returns_complete_stats():
+    """All-finite channel returns min/max/mean/std/sparsity + finite=True."""
+    arr = np.array([[[0.0, 1.0], [2.0, 3.0]],
+                    [[4.0, 5.0], [6.0, 7.0]]], dtype=np.float32)
+    sig = _per_channel_signature(arr)
+    assert sig["min"] == 0.0
+    assert sig["max"] == 7.0
+    assert sig["mean"] == pytest.approx(3.5)
+    assert sig["finite"] is True
+    assert sig["n_non_finite"] == 0
+    assert sig["n_voxels"] == 8
+
+
+def test_per_channel_signature_with_nan_flags_non_finite():
+    """A NaN in the channel yields finite=False + non-zero n_non_finite."""
+    arr = np.array([1.0, 2.0, np.nan, 4.0], dtype=np.float32)
+    sig = _per_channel_signature(arr)
+    assert sig["finite"] is False
+    assert sig["n_non_finite"] == 1
+
+
+def test_per_channel_signature_with_inf_flags_non_finite():
+    """An Inf in the channel yields finite=False."""
+    arr = np.array([1.0, np.inf, 3.0], dtype=np.float32)
+    sig = _per_channel_signature(arr)
+    assert sig["finite"] is False
+    assert sig["n_non_finite"] == 1
+
+
+def test_per_channel_signature_all_nan_returns_null_stats():
+    """If every value is non-finite, min/max/mean/std are null but n_voxels
+    and n_non_finite are still reported."""
+    arr = np.array([np.nan, np.nan, np.nan], dtype=np.float32)
+    sig = _per_channel_signature(arr)
+    assert sig["min"] is None
+    assert sig["max"] is None
+    assert sig["mean"] is None
+    assert sig["finite"] is False
+    assert sig["n_non_finite"] == 3
+
+
+def test_per_channel_signature_sparsity_counts_near_zero():
+    """Sparsity = fraction of voxels with |value| <= SPARSITY_EPSILON."""
+    # 6/8 voxels are zero
+    arr = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0], dtype=np.float32)
+    sig = _per_channel_signature(arr)
+    assert sig["sparsity"] == pytest.approx(6.0 / 8.0)
+
+
+# --- _verify_snapshot_memory_grid unit tests ---
+
+
+def test_verify_snapshot_clean_returns_no_drift(tmp_path):
+    """Standard 8-channel float32 snapshot verifies cleanly."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        n_channels=8, dtype=np.float32,
+    )
+    signatures, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert drift_reasons == []
+    assert len(signatures) == 8
+
+
+def test_verify_snapshot_wrong_channel_count_flags_drift(tmp_path):
+    """7-channel grid flags shape drift."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        n_channels=7, dtype=np.float32,
+    )
+    _, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert any("7 channels" in r for r in drift_reasons)
+    assert any("expected 8" in r for r in drift_reasons)
+
+
+def test_verify_snapshot_extra_channels_flag_drift(tmp_path):
+    """9-channel grid flags shape drift (engine added a channel)."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        n_channels=9, dtype=np.float32,
+    )
+    _, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert any("9 channels" in r for r in drift_reasons)
+
+
+def test_verify_snapshot_wrong_dtype_flags_drift(tmp_path):
+    """float64 instead of float32 flags dtype drift."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        n_channels=8, dtype=np.float64,
+    )
+    _, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert any("dtype" in r.lower() for r in drift_reasons)
+    assert any("float64" in r for r in drift_reasons)
+
+
+def test_verify_snapshot_nan_in_channel_flags_drift(tmp_path):
+    """A single NaN voxel in the memory_grid is flagged in drift reasons."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        inject_nan_at=(3, 1, 1, 1),  # channel 3, voxel (1,1,1)
+    )
+    signatures, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert any("non-finite" in r for r in drift_reasons)
+    assert any("channel 3" in r for r in drift_reasons)
+    # The named channel for index 3 in post-#145 layout is "energy_reserve"
+    assert "energy_reserve" in signatures
+    assert signatures["energy_reserve"]["finite"] is False
+
+
+def test_verify_snapshot_inf_in_channel_flags_drift(tmp_path):
+    """A single Inf voxel is flagged the same way as NaN."""
+    snap = _make_snapshot_with_options(
+        tmp_path / "v070_gen1_step1_test.npz",
+        inject_inf_at=(0, 0, 0, 0),  # channel 0
+    )
+    signatures, drift_reasons = _verify_snapshot_memory_grid(snap)
+    assert any("non-finite" in r for r in drift_reasons)
+    assert signatures["compute_age"]["finite"] is False
+
+
+def test_verify_snapshot_missing_memory_grid_key_flags_drift(tmp_path):
+    """An .npz file that lacks the memory_grid key is flagged."""
+    bad = tmp_path / "v070_gen1_step1_test.npz"
+    np.savez(
+        str(bad),
+        lattice=np.zeros((4, 4, 4), dtype=np.uint8),
+        generation=np.array(1),
+        # NO memory_grid key
+    )
+    signatures, drift_reasons = _verify_snapshot_memory_grid(bad)
+    assert signatures == {}
+    assert any("memory_grid" in r for r in drift_reasons)
+
+
+# --- verify_memory_channels orchestrator integration tests ---
+
+
+def test_verify_memory_channels_happy_path_all_snapshots_clean(tmp_path):
+    """3 clean synthetic snapshots → hypothesis_supported, 0 drift."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+
+    snaps = [
+        _make_snapshot_with_options(
+            snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i
+        ) for i in (1, 2, 3)
+    ]
+    out = log_path.parent / "calibration_verify.jsonl"
+    aggregate = verify_memory_channels(snaps, out, log_path, "short")
+
+    assert aggregate["experiment"] == "verify_memory_channels"
+    assert aggregate["summary_type"] == "run_aggregate"
+    assert aggregate["n_snapshots"] == 3
+    assert aggregate["n_snapshots_verified"] == 3
+    assert aggregate["n_snapshots_with_drift"] == 0
+    assert aggregate["falsification_status"] == "hypothesis_supported"
+    assert aggregate["expected_channels"] == EXPECTED_MEMORY_CHANNELS
+    assert aggregate["expected_dtype"] == EXPECTED_MEMORY_DTYPE
+    assert aggregate["first_drift_reasons"] == []
+
+
+def test_verify_memory_channels_mixed_set_flags_hypothesis_falsified(tmp_path):
+    """Mix of clean + drifted snapshots → hypothesis_falsified, drift counted."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+
+    clean = _make_snapshot_with_options(
+        snaps_dir / "v070_gen1_step1_test.npz", generation=1,
+    )
+    bad_channels = _make_snapshot_with_options(
+        snaps_dir / "v070_gen2_step2_test.npz", generation=2, n_channels=9,
+    )
+    bad_dtype = _make_snapshot_with_options(
+        snaps_dir / "v070_gen3_step3_test.npz", generation=3, dtype=np.float64,
+    )
+    out = log_path.parent / "calibration_verify.jsonl"
+    aggregate = verify_memory_channels(
+        [clean, bad_channels, bad_dtype], out, log_path, "short",
+    )
+
+    assert aggregate["n_snapshots_verified"] == 1
+    assert aggregate["n_snapshots_with_drift"] == 2
+    assert aggregate["falsification_status"] == "hypothesis_falsified"
+    assert len(aggregate["first_drift_reasons"]) >= 2
+
+
+def test_verify_memory_channels_empty_set_returns_inconclusive(tmp_path):
+    """Empty snapshot list → inconclusive (nothing to verify)."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out = log_path.parent / "calibration_verify.jsonl"
+
+    aggregate = verify_memory_channels([], out, log_path, "short")
+    assert aggregate["falsification_status"] == "inconclusive"
+    assert aggregate["n_snapshots"] == 0
+
+
+def test_verify_memory_channels_per_row_has_channel_signatures(tmp_path):
+    """Per-snapshot rows expose channel_signatures dict keyed by channel name."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    snap = _make_snapshot_with_options(
+        snaps_dir / "v070_gen1_step1_test.npz", generation=1,
+    )
+    out = log_path.parent / "calibration_verify.jsonl"
+    verify_memory_channels([snap], out, log_path, "short")
+
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    assert len(rows) == 1
+    sigs = rows[0]["metrics"]["channel_signatures"]
+    # Post-#145 layout — all 8 named channels present
+    expected_names = {
+        "compute_age", "structural_age", "memory_strength",
+        "energy_reserve", "last_active_gen", "signal_field",
+        "warmth", "compassion_cooldown",
+    }
+    assert set(sigs.keys()) == expected_names
+
+
+def test_verify_memory_channels_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set validation — must be 'short' or 'long'."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    out = log_path.parent / "calibration_verify.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        verify_memory_channels([], out, log_path, "medium")
+
+
+def test_verify_memory_channels_rejects_outside_log_dir_output(tmp_path):
+    """Write-boundary inheritance — output outside log dir raises."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    snap = _make_snapshot_with_options(
+        snaps_dir / "v070_gen1_step1_test.npz", generation=1,
+    )
+    bad_out = tmp_path / "outside_dir" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        verify_memory_channels([snap], bad_out, log_path, "short")
+    assert not (tmp_path / "outside_dir").exists()
+
+
+def test_verify_memory_channels_no_generated_at_field(tmp_path):
+    """Output JSONL must not include a fresh generated_at field."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    snap = _make_snapshot_with_options(
+        snaps_dir / "v070_gen1_step1_test.npz", generation=1,
+    )
+    out = log_path.parent / "calibration_verify.jsonl"
+    verify_memory_channels([snap], out, log_path, "short")
+    assert "generated_at" not in out.read_text()
+
+
+def test_verify_memory_channels_deterministic_output(tmp_path):
+    """Re-running on the same input produces byte-identical output.
+
+    Same determinism contract as the other calibration functions — no
+    fresh timestamps, sorted snapshot ordering, sort_keys=True in JSON.
+    """
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    snaps = [
+        _make_snapshot_with_options(
+            snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i
+        ) for i in (1, 2, 3)
+    ]
+    out_a = log_path.parent / "calibration_verify_a.jsonl"
+    out_b = log_path.parent / "calibration_verify_b.jsonl"
+    verify_memory_channels(snaps, out_a, log_path, "short")
+    verify_memory_channels(snaps, out_b, log_path, "short")
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_verify_memory_channels_sorts_input_by_generation(tmp_path):
+    """Per-snapshot rows in output appear in generation-ascending order."""
+    snaps_dir = tmp_path / "snapshots"
+    snaps_dir.mkdir()
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    # Create out of order
+    s3 = _make_snapshot_with_options(
+        snaps_dir / "v070_gen300_step3000_test.npz", generation=300,
+    )
+    s1 = _make_snapshot_with_options(
+        snaps_dir / "v070_gen100_step1000_test.npz", generation=100,
+    )
+    s2 = _make_snapshot_with_options(
+        snaps_dir / "v070_gen200_step2000_test.npz", generation=200,
+    )
+    out = log_path.parent / "calibration_verify.jsonl"
+    verify_memory_channels([s3, s1, s2], out, log_path, "short")
+
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    generations = [r["snapshot_generation"] for r in rows]
+    assert generations == [100, 200, 300]

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -1,17 +1,28 @@
-"""Tests for scripts/nextness_calibration.py — Phase 19 PR #4, Chapter 1.
+"""Tests for scripts/nextness_calibration.py — Phase 19 PR #4 calibration suite.
 
-Covers the shared module infrastructure (write-boundary safety,
-deterministic snapshot ordering, content fingerprinting, JSONL output
-writer, falsification-status reporting) plus ``check_determinism()`` —
-Jack's #1 in the implementation order.
+Currently covers Chapters 1, 2, and 3 of the eight-chapter PR #4
+implementation:
 
-Per design doc PHASE_19_PR4_CALIBRATION.md §3.7 + §6: this experiment is
-the sanity floor for the rest of the calibration suite, so we lock down
-both happy-path and edge-case behavior here.
+  - Chapter 1: Shared module infrastructure (write-boundary safety,
+    deterministic snapshot ordering, content fingerprinting, JSONL
+    output writer, falsification-status reporting) plus
+    ``check_determinism()`` (Jack's #1 in the implementation order —
+    the sanity floor for the rest of the calibration suite).
 
-Later chapters will add tests for the other seven experiments (memory-
-channel verification, shuffle test with two modes, stride sweep, threshold
-sweep, cascade ablation, temporal sweep, patch-radius coarse-graining).
+  - Chapter 2: ``shuffle_test()`` (Jack's #3) with **three modes** —
+    ``unshuffled``, ``lattice_only_shuffle``, and
+    ``joint_lattice_memory_shuffle`` — for the null-model
+    discriminating test (signal_location_interpretation +
+    falsification_status).
+
+  - Chapter 3: ``verify_memory_channels()`` (Jack's #2) — runtime
+    per-snapshot regression-fence complementing PR #145's static
+    layout check. Verifies channel count, dtype, finiteness, and
+    emits per-channel statistical signatures as diagnostic readout.
+
+Later chapters will add tests for the remaining four experiments
+(stride sweep, threshold sweep, cascade ablation, temporal sweep,
+patch-radius coarse-graining).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Chapter 3 of PR #4 calibration implementation per Jack's "serial PRs from here" direction. Adds `verify_memory_channels()` runtime regression-fence converting PR #145's static layout fix into a per-snapshot runtime check that catches future engine drift before calibration interpretation runs.

**Lane B only.** No engine touch, no sweeps, no CLI, no vocabulary redesign, no Karuna resurrection. Per Jack's Chapter 3 guardrails from PR #146 audit.

**Tests:** 21 new in `test_nextness_calibration.py` (51 → 72). Full suite: **376/376 passing** (was 355 pre-Ch3).

**Diff:** `2 files changed, 689 insertions(+)`.

---

## Why this is a *runtime* check, not just another test

PR #145's `test_layout_matches_engine_documented_8_channel_map` confirms the observer's constants match the engine's documented map **at test time** (a one-shot check). Chapter 3 confirms the same invariants hold **for every actual snapshot** the observer processes — catching:

- Engine adding a 9th channel mid-run
- A snapshot corrupted between write and read
- A dtype change (engine started writing float64)
- NaN/Inf values appearing in any channel
- A snapshot missing `memory_grid` entirely

These wouldn't show up in the static unit test because the static test doesn't see live snapshots.

## What `verify_memory_channels()` does

Per snapshot:
1. Load `memory_grid` via `np.load(allow_pickle=False)`
2. Verify shape `(8, X, Y, Z)` per engine's `MEMORY_CHANNELS = 8`
3. Verify dtype `float32` per engine's `init_memory_grid`
4. Per-channel signature: min, max, mean, std, sparsity, finite flag, n_non_finite count
5. Aggregate drift reasons

**Mechanical `falsification_status`:**
- `hypothesis_supported` — every snapshot verifies cleanly
- `hypothesis_falsified` — at least one snapshot fails verification (blocking)
- `inconclusive` — empty snapshot list (degenerate)

Unlike `check_determinism` and `shuffle_test`, this function does NOT take an `ObserverConfig` — it bypasses `process_snapshot()` entirely and reads the raw `.npz` files directly, so it can catch drift that would otherwise propagate silently through the observer pipeline.

## Test coverage (+21 tests)

| Category | Tests | Includes |
|---|---|---|
| `_per_channel_signature` | 5 | clean stats, NaN flagged, Inf flagged, all-NaN null stats, sparsity counts near-zero correctly |
| `_verify_snapshot_memory_grid` | 7 | clean returns no drift, 7-channel/9-channel both flag, dtype drift, NaN injection, Inf injection, missing memory_grid key |
| `verify_memory_channels` orchestrator | 9 | happy path, mixed clean+drifted, empty set, per-snapshot row structure, calibration_set validation, write-boundary, no-fresh-generated_at, byte-identical re-run, sorts by generation |

New test helper `_make_snapshot_with_options()` gives explicit control over `n_channels`, `dtype`, NaN/Inf injection at specific `(channel, x, y, z)` coordinates — powers the drift-scenario tests.

## Smoke pass against real Medusa

Sandboxed run against 3 newest Medusa snapshots (~gen 1,713,759). Result: **`hypothesis_supported`** across all 3, zero drift. The corrected layout is holding on live engine output.

Bonus empirical readout — the per-channel signatures **double as a live diagnostic of engine state**:

| Channel | Min | Max | Mean | Sparsity | Reading |
|---|---|---|---|---|---|
| `compute_age` | 0 | **68** | 1.77 | 0.540 | A Legend-tier Sage (age ≥ 50) exists in this snapshot! |
| `structural_age` | 0 | 4 | 0.017 | 0.983 | Structurals are rare |
| `memory_strength` | 1.15 | 2.0 | 1.95 | 0.000 | Near saturation (init was 1.0) |
| `energy_reserve` | 0.048 | 1.01 | 0.061 | 0.000 | Being consumed by compassion cost |
| `last_active_gen` | ~1.71e7 | ~1.71e7 | ~1.71e7 | 0.000 | **Essentially uniform across cells — confirms exactly why pre-fix `karuna_relief` (which checked `mean(last_active_gen) > 0.3`) was firing trivially** |
| `signal_field` | 0 | 0.489 | 0.0001 | 0.999 | Rare mycelial signal |
| `warmth` | 0 | 0.185 | 0.0002 | 0.990 | Below `THRESHOLD_WARMTH = 0.3` — so `metta_warmth` predicate naturally rare-firing in current state |
| `compassion_cooldown` | 0 | 0 | 0 | **1.000** | All zero — no active cooldowns on this snapshot |

So the runtime check **scientifically vindicates PR #145 from the opposite direction**: not "the labels match the engine code" but "the actual values per channel match what we'd expect for those labels."

## Scope guarantees (unchanged from PR #138 / #140 / #142 / #145 / #146)

- ✅ No engine touch
- ✅ No writes outside `log_path.parent` (`WriteOutsideLogDirError`)
- ✅ No HTTP / ZMQ / network
- ✅ CPU-only
- ✅ `allow_pickle=False` preserved (used directly in `_verify_snapshot_memory_grid`)
- ✅ No CCI regime thresholds
- ✅ No fresh `generated_at` field
- ✅ No external code pull
- ✅ No multi-snapshot mode added to observer
- ✅ No CLI (deferred to end of calibration implementation per Jack)

## What's NOT in this PR (deliberate, per Jack's guardrails)

- ❌ Phase 14e acoustic-map cross-correlation (also mentioned in design doc §3.6) — deferred. Keep Chapter 3 tight.
- ❌ Per-channel value-range assertions (would be brittle; PR #4.5+ territory)
- ❌ Sweeps of any kind — Chapter 4+ work
- ❌ CLI surface

## Builds on

- PR #137 / #138 / #140 / #141 / #142 / #143 / #145 / #146 (see prior PR descriptions)
- Issue #139 — finding (c) parent hub (stays open)
- Issue #144 (closed) — this PR is the runtime complement to PR #145's static fix; together they form a defense-in-depth pair

Refs #139 — finding (c) addressed by this PR. Issue stays open until all calibration sweeps complete; deliberately no auto-close keyword used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)