### PR TITLE
Phase 19 PR #4 Chapter 5 — sweep_threshold (threshold sensitivity sweep)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -144,6 +144,51 @@ def _validate_calibration_output_path(
         ) from e
 
 
+def _validate_config_log_directory(
+    config: ObserverConfig,
+    log_path: pathlib.Path,
+) -> None:
+    """Refuse configs whose ``log_directory`` diverges from ``log_path.parent``.
+
+    Closes the gap flagged in Jack's PR #149 audit: calibration functions
+    validate ``out_path`` against ``log_path.parent`` via
+    :func:`_validate_calibration_output_path`, but functions that call
+    ``process_snapshot()`` also write through ``config.log_directory``
+    (one JSONL line per call into ``<log_directory>/nextness_runs.jsonl``).
+    If ``config.log_directory`` and ``log_path.parent`` ever diverge, the
+    calibration function may write outside the claimed boundary even though
+    ``out_path`` is validated.
+
+    This guard requires::
+
+        Path(config.log_directory).resolve() == log_path.parent.resolve()
+
+    so the side-effect log writes land in the same directory the calibration
+    function's safety contract anchors on. Symlink-aware via ``resolve()``;
+    matches the canonical-form comparison style used elsewhere.
+
+    Crucially, this raises BEFORE any ``process_snapshot()`` call, so a
+    mismatched config can never create or write into a stray log directory
+    (``process_snapshot`` calls ``_ensure_log_dir`` which would create the
+    misconfigured directory on first call).
+
+    Raises :class:`WriteOutsideLogDirError` so the safety vocabulary stays
+    unified with the existing ``out_path`` boundary check.
+    """
+    config_log_resolved = pathlib.Path(config.log_directory).resolve()
+    log_path_parent_resolved = log_path.resolve().parent
+    if config_log_resolved != log_path_parent_resolved:
+        raise WriteOutsideLogDirError(
+            f"refusing to run calibration with config.log_directory "
+            f"diverging from log_path.parent: "
+            f"config.log_directory={config_log_resolved} "
+            f"vs log_path.parent={log_path_parent_resolved}. "
+            f"process_snapshot() writes side-effect log entries to "
+            f"config.log_directory; the two must match for the Lane B "
+            f"write-boundary contract to hold."
+        )
+
+
 def _extract_generation_from_filename(path: pathlib.Path) -> int:
     """Parse generation number out of a Medusa snapshot filename.
 
@@ -396,6 +441,7 @@ def check_determinism(
     out_path = pathlib.Path(out_path)
     log_path = pathlib.Path(log_path)
     _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
 
     sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
 
@@ -713,6 +759,7 @@ def shuffle_test(
     out_path = pathlib.Path(out_path)
     log_path = pathlib.Path(log_path)
     _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
 
     sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
 
@@ -1278,6 +1325,7 @@ def sweep_stride(
     out_path = pathlib.Path(out_path)
     log_path = pathlib.Path(log_path)
     _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
 
     sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
 
@@ -1560,6 +1608,7 @@ def sweep_threshold(
     out_path = pathlib.Path(out_path)
     log_path = pathlib.Path(log_path)
     _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
 
     sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
 

--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -1433,10 +1433,295 @@ def sweep_stride(
     return aggregate
 
 
+# ---------------------------------------------------------------------------
+# Experiment 3.4 — sweep_threshold (threshold sensitivity sweep)
+# ---------------------------------------------------------------------------
+
+
+#: Default multipliers per design doc §12 Q3 (Jack's resolution: ±10%,
+#: ±25%, ±50%, including the baseline 1.0). Symmetric around 1.0 so we
+#: see whether the threshold is on a cliff in either direction.
+DEFAULT_THRESHOLD_MULTIPLIERS: tuple[float, ...] = (0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5)
+
+#: Default threshold to sweep. ``THRESHOLD_WARMTH`` is the only
+#: classifier-active threshold post-#144 (the deprecated tokens
+#: ``karuna_relief`` / ``mudita_resonance`` / ``magnon_lighthouse``
+#: don't fire, so sweeping ``THRESHOLD_COMPASSION`` / ``THRESHOLD_RESONANCE``
+#: would be no-ops). Caller can override if they want to sweep a different
+#: future threshold.
+DEFAULT_THRESHOLD_NAME: str = "THRESHOLD_WARMTH"
+
+#: Falsification threshold per design doc §3.4 (adapted post-#144):
+#: a ±25% multiplier producing > 50% relative change in the firing count
+#: of the threshold's downstream token indicates the threshold is on a
+#: knife edge. Original §3.4 spec named ``karuna_relief`` (deprecated);
+#: post-#144 the only active threshold-dependent token is ``metta_warmth``.
+_THRESHOLD_KNIFE_EDGE_REL_CHANGE: float = 0.5
+
+#: Multiplier range considered "±25%" for the knife-edge criterion.
+#: Multipliers within [0.75, 1.25] are checked; outside is too far for
+#: the criterion to apply.
+_THRESHOLD_KNIFE_EDGE_MULT_RANGE: tuple[float, float] = (0.75, 1.25)
+
+
+def sweep_threshold(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+    config: ObserverConfig,
+    threshold_name: str = DEFAULT_THRESHOLD_NAME,
+    multipliers: tuple[float, ...] = DEFAULT_THRESHOLD_MULTIPLIERS,
+    threshold_dependent_token: str = "metta_warmth",
+) -> dict[str, Any]:
+    """Threshold sensitivity sweep per design doc §3.4.
+
+    For each ``(snapshot, multiplier)`` pair, temporarily override the
+    named threshold constant on the observer module to ``base_value *
+    multiplier``, run ``process_snapshot()``, capture metrics + the
+    threshold-dependent token's firing count, then restore the original
+    value. ``try/finally`` ensures restoration even on exception.
+
+    The thresholds (``THRESHOLD_WARMTH``, etc.) live as module-level
+    ``Final[float]`` constants in ``scripts.nextness_observer`` because
+    they're typed for static analysis. Python doesn't enforce ``Final``
+    at runtime, so we can monkeypatch + restore for sweep purposes —
+    this is precisely the kind of experimental override the constants
+    were designed to be subject to during calibration. We do NOT mutate
+    the observer module from production code paths; only from inside
+    this sweep, within try/finally, single-threaded by construction.
+
+    Per design doc §12 Q3: multipliers default to ``(0.5, 0.75, 0.9,
+    1.0, 1.1, 1.25, 1.5)`` — symmetric ±10%, ±25%, ±50% around the
+    baseline of 1.0.
+
+    Per design doc §3.4 (adapted post-#144 since ``karuna_relief`` is
+    deprecated): mechanical falsification_status:
+
+        - ``"hypothesis_supported"``: relative change in the
+          threshold-dependent token's firing count across ±25% multipliers
+          stays below ``_THRESHOLD_KNIFE_EDGE_REL_CHANGE`` (= 0.5).
+          Threshold is well-positioned.
+        - ``"hypothesis_falsified"``: ±25% multiplier produces > 50%
+          relative change in the firing count. Threshold is on a cliff
+          and the current value can't be trusted as "well-calibrated."
+        - ``"inconclusive"``: the threshold-dependent token never fires
+          on any (snapshot, multiplier) combination so the relative-
+          change criterion has no denominator; OR fewer than 3
+          multipliers in the ±25% range.
+
+    Args:
+        snapshots: list of sandboxed ``.npz`` paths.
+        out_path: where to write the sweep JSONL.
+        log_path: write-boundary anchor.
+        calibration_set: ``"short"`` or ``"long"``.
+        config: base ``ObserverConfig`` (used as-is for all multipliers;
+            only the threshold constant changes).
+        threshold_name: name of the constant on ``scripts.nextness_observer``
+            to sweep. Must be an attribute of the module. Defaults to
+            ``"THRESHOLD_WARMTH"``.
+        multipliers: tuple of float multipliers to apply to the
+            threshold's base value. Must be all positive.
+        threshold_dependent_token: name of the token whose firing count
+            we track across the sweep for the knife-edge criterion.
+            Defaults to ``"metta_warmth"`` (the only ``THRESHOLD_WARMTH``-
+            dependent active token post-#144).
+
+    Returns the aggregate dict for callers that want to inspect it.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside log dir.
+        ``ValueError`` for invalid calibration_set, missing threshold
+            attribute, empty multipliers, or non-positive multipliers.
+    """
+    # Lazy import of the observer module so we can monkeypatch its
+    # threshold attribute. This is the only place in the calibration
+    # module that mutates observer state, and only within try/finally.
+    from scripts import nextness_observer as _observer_module
+
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got "
+            f"{calibration_set!r}"
+        )
+    if not hasattr(_observer_module, threshold_name):
+        raise ValueError(
+            f"threshold_name {threshold_name!r} not found on "
+            f"scripts.nextness_observer module"
+        )
+    if not multipliers:
+        raise ValueError("multipliers must be non-empty")
+    for m in multipliers:
+        if not isinstance(m, (int, float)) or m <= 0:
+            raise ValueError(
+                f"every multiplier must be a positive number, got {m!r}"
+            )
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    base_threshold_value = float(getattr(_observer_module, threshold_name))
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    # Per-multiplier aggregator: multiplier -> list of {snapshot, metrics,
+    # threshold_dependent_token_count, total_classified}.
+    by_multiplier: dict[float, list[dict[str, Any]]] = {m: [] for m in multipliers}
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        for multiplier in multipliers:
+            new_threshold_value = base_threshold_value * multiplier
+            # Monkeypatch + restore inside try/finally. Single-threaded
+            # by construction (calibration is sequential).
+            original = getattr(_observer_module, threshold_name)
+            try:
+                setattr(_observer_module, threshold_name, new_threshold_value)
+                entry = process_snapshot(snap, config, medusa_is_live=False)
+            finally:
+                setattr(_observer_module, threshold_name, original)
+
+            token_counts = entry.get("token_counts", {}) or {}
+            total_classified = sum(token_counts.values())
+            token_count = int(token_counts.get(threshold_dependent_token, 0))
+            metrics = _extract_metrics_subset(entry)
+            metrics["cci"] = _cci_from_entry(entry)
+            metrics["threshold_dependent_token_count"] = token_count
+            metrics["threshold_dependent_token_name"] = threshold_dependent_token
+            metrics["threshold_dependent_token_fraction"] = (
+                token_count / total_classified if total_classified else 0.0
+            )
+
+            per_snapshot_rows.append(_make_per_snapshot_row(
+                experiment="threshold_sweep",
+                snapshot_path=snap,
+                generation=generation,
+                parameter_combination={
+                    "threshold_name": threshold_name,
+                    "threshold_multiplier": multiplier,
+                    "threshold_effective_value": new_threshold_value,
+                    "threshold_dependent_token": threshold_dependent_token,
+                },
+                metrics=metrics,
+                run_metadata={
+                    # patches_processed is deterministic; elapsed_seconds
+                    # was wallclock-derived and removed in Chapter 4 to
+                    # preserve byte-identical re-run.
+                    "patches_processed": entry.get("budget", {}).get(
+                        "patches_processed"
+                    ),
+                },
+                calibration_set=calibration_set,
+            ))
+
+            by_multiplier[multiplier].append({
+                "snapshot": snap.name,
+                "metrics": metrics,
+                "token_count": token_count,
+                "total_classified": total_classified,
+            })
+
+    # --- Per-multiplier summary statistics ---
+    per_multiplier_summary: dict[str, Any] = {}
+    for multiplier, runs in by_multiplier.items():
+        if not runs:
+            per_multiplier_summary[str(multiplier)] = {"n_snapshots": 0}
+            continue
+        voc_occs = [r["metrics"]["vocabulary_occupancy"] for r in runs]
+        ccis = [r["metrics"]["cci"] for r in runs]
+        token_counts = [r["token_count"] for r in runs]
+        token_fractions = [r["metrics"]["threshold_dependent_token_fraction"]
+                           for r in runs]
+        per_multiplier_summary[str(multiplier)] = {
+            "n_snapshots": len(runs),
+            "effective_threshold_value": base_threshold_value * multiplier,
+            "mean_vocabulary_occupancy": sum(voc_occs) / len(voc_occs),
+            "mean_cci": sum(ccis) / len(ccis),
+            "mean_threshold_dependent_token_count": sum(token_counts) / len(token_counts),
+            "mean_threshold_dependent_token_fraction": sum(token_fractions) / len(token_fractions),
+            "max_threshold_dependent_token_count": max(token_counts),
+        }
+
+    # --- Falsification logic (knife-edge detection per §3.4) ---
+    # Find the baseline (multiplier=1.0) and compare against multipliers
+    # in [0.75, 1.25] (the ±25% range).
+    falsification_status: str = "inconclusive"
+    knife_edge_evidence: dict[str, Any] = {}
+    if 1.0 in by_multiplier and by_multiplier[1.0]:
+        baseline_summary = per_multiplier_summary["1.0"]
+        baseline_count = baseline_summary["mean_threshold_dependent_token_count"]
+        in_range = [
+            m for m in multipliers
+            if _THRESHOLD_KNIFE_EDGE_MULT_RANGE[0] <= m <= _THRESHOLD_KNIFE_EDGE_MULT_RANGE[1]
+            and m != 1.0
+        ]
+        knife_edge_evidence["baseline_multiplier"] = 1.0
+        knife_edge_evidence["baseline_mean_token_count"] = baseline_count
+        knife_edge_evidence["multipliers_in_range"] = in_range
+
+        if baseline_count == 0 and all(
+            per_multiplier_summary[str(m)]["mean_threshold_dependent_token_count"] == 0
+            for m in in_range
+        ):
+            # The token never fires anywhere in the ±25% range.
+            # No relative-change denominator → inconclusive.
+            knife_edge_evidence["reason"] = (
+                f"{threshold_dependent_token} never fires on any snapshot "
+                f"in the ±25% multiplier range; relative change undefined"
+            )
+            falsification_status = "inconclusive"
+        elif len(in_range) < 2:
+            knife_edge_evidence["reason"] = (
+                f"fewer than 2 multipliers in ±25% range; criterion needs at least 2"
+            )
+            falsification_status = "inconclusive"
+        else:
+            # Compute max relative change vs baseline across the ±25% range.
+            max_rel_change = 0.0
+            for m in in_range:
+                m_count = per_multiplier_summary[str(m)][
+                    "mean_threshold_dependent_token_count"
+                ]
+                denom = max(baseline_count, m_count, 1.0)  # avoid div-by-zero
+                rel_change = abs(m_count - baseline_count) / denom
+                if rel_change > max_rel_change:
+                    max_rel_change = rel_change
+            knife_edge_evidence["max_rel_change_in_25pct_range"] = max_rel_change
+            knife_edge_evidence["knife_edge_threshold"] = _THRESHOLD_KNIFE_EDGE_REL_CHANGE
+            if max_rel_change > _THRESHOLD_KNIFE_EDGE_REL_CHANGE:
+                falsification_status = "hypothesis_falsified"
+            else:
+                falsification_status = "hypothesis_supported"
+
+    extra_fields: dict[str, Any] = {
+        "threshold_name": threshold_name,
+        "threshold_base_value": base_threshold_value,
+        "threshold_dependent_token": threshold_dependent_token,
+        "multipliers_swept": list(multipliers),
+        "per_multiplier_summary": per_multiplier_summary,
+        "knife_edge_evidence": knife_edge_evidence,
+    }
+
+    aggregate = _make_aggregate_row(
+        experiment="threshold_sweep",
+        calibration_set=calibration_set,
+        n_snapshots=len(sorted_snapshots),
+        extra_fields=extra_fields,
+        falsification_status=falsification_status,
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
 __all__ = [
     "CANONICAL_STRIDE",
     "DEFAULT_CANONICAL_SEED",
     "DEFAULT_STRIDES",
+    "DEFAULT_THRESHOLD_MULTIPLIERS",
+    "DEFAULT_THRESHOLD_NAME",
     "DEFAULT_VARIANCE_SEEDS",
     "EXPECTED_MEMORY_CHANNELS",
     "EXPECTED_MEMORY_DTYPE",
@@ -1445,5 +1730,6 @@ __all__ = [
     "check_determinism",
     "shuffle_test",
     "sweep_stride",
+    "sweep_threshold",
     "verify_memory_channels",
 ]

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -61,6 +61,7 @@ from scripts.nextness_calibration import (
     _shuffled_snapshot_arrays,
     _sort_snapshots_by_generation,
     _validate_calibration_output_path,
+    _validate_config_log_directory,
     _verify_snapshot_memory_grid,
     check_determinism,
     shuffle_test,
@@ -290,6 +291,179 @@ def test_validate_output_traversal_escape_rejected(tmp_path):
     out_path = log_dir / ".." / ".." / "escape.jsonl"
     with pytest.raises(WriteOutsideLogDirError):
         _validate_calibration_output_path(out_path, log_path)
+
+
+# ---------------------------------------------------------------------------
+# _validate_config_log_directory (Jack PR #149 safety-contract guard)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_config_log_dir_matches_log_path_parent_succeeds(tmp_path):
+    """config.log_directory == log_path.parent passes silently."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    config = ObserverConfig(log_directory=str(log_dir))
+    # Should not raise.
+    _validate_config_log_directory(config, log_path)
+
+
+def test_validate_config_log_dir_mismatch_raises(tmp_path):
+    """Mismatched config.log_directory raises WriteOutsideLogDirError."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    log_path = log_dir / "nextness_runs.jsonl"
+    config = ObserverConfig(log_directory=str(elsewhere))
+    with pytest.raises(
+        WriteOutsideLogDirError,
+        match="config.log_directory diverging from log_path.parent",
+    ):
+        _validate_config_log_directory(config, log_path)
+
+
+def test_validate_config_log_dir_traversal_escape_rejected(tmp_path):
+    """``..`` traversal in config.log_directory is rejected via resolve()."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    # log_dir / ".." resolves to tmp_path / "data" — not the same as log_dir
+    config = ObserverConfig(log_directory=str(log_dir / ".."))
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_config_log_directory(config, log_path)
+
+
+def test_validate_config_log_dir_mismatch_creates_no_side_effect_directory(tmp_path):
+    """When the guard rejects a mismatched config, no stray log directory
+    must be created. Locks in the property that the guard fires BEFORE any
+    process_snapshot() call (which would trigger _ensure_log_dir on the
+    misconfigured path)."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    bogus_dir = tmp_path / "bogus_log_dir_should_never_be_created"
+    assert not bogus_dir.exists()
+    config = ObserverConfig(log_directory=str(bogus_dir))
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_config_log_directory(config, log_path)
+    # The bogus directory must NOT have been created as a side effect.
+    assert not bogus_dir.exists()
+
+
+def test_check_determinism_rejects_mismatched_config_log_directory(tmp_path):
+    """Integration: check_determinism must fire the config-log-dir guard
+    before any process_snapshot() call. Proves the helper is wired in."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bogus_dir = tmp_path / "bogus_for_check_determinism"
+    bad_config = ObserverConfig(
+        log_directory=str(bogus_dir),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    with pytest.raises(
+        WriteOutsideLogDirError,
+        match="config.log_directory diverging",
+    ):
+        check_determinism(
+            snapshots=[snap],
+            out_path=out,
+            log_path=log_path,
+            calibration_set="short",
+            config=bad_config,
+            repeats=2,
+        )
+    # Neither the bogus log dir nor the output file may have been created.
+    assert not bogus_dir.exists()
+    assert not out.exists()
+
+
+def test_shuffle_test_rejects_mismatched_config_log_directory(tmp_path):
+    """Integration: shuffle_test must fire the config-log-dir guard
+    before any process_snapshot() call."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bogus_dir = tmp_path / "bogus_for_shuffle_test"
+    bad_config = ObserverConfig(
+        log_directory=str(bogus_dir),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    with pytest.raises(
+        WriteOutsideLogDirError,
+        match="config.log_directory diverging",
+    ):
+        shuffle_test(
+            snapshots=[snap],
+            out_path=out,
+            log_path=log_path,
+            calibration_set="short",
+            config=bad_config,
+        )
+    assert not bogus_dir.exists()
+    assert not out.exists()
+
+
+def test_sweep_stride_rejects_mismatched_config_log_directory(tmp_path):
+    """Integration: sweep_stride must fire the config-log-dir guard
+    before any process_snapshot() call."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bogus_dir = tmp_path / "bogus_for_sweep_stride"
+    bad_config = ObserverConfig(
+        log_directory=str(bogus_dir),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    with pytest.raises(
+        WriteOutsideLogDirError,
+        match="config.log_directory diverging",
+    ):
+        sweep_stride(
+            snapshots=[snap],
+            out_path=out,
+            log_path=log_path,
+            calibration_set="short",
+            config=bad_config,
+        )
+    assert not bogus_dir.exists()
+    assert not out.exists()
+
+
+def test_sweep_threshold_rejects_mismatched_config_log_directory(tmp_path):
+    """Integration: sweep_threshold must fire the config-log-dir guard
+    before any process_snapshot() call AND before any threshold monkeypatch."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bogus_dir = tmp_path / "bogus_for_sweep_threshold"
+    bad_config = ObserverConfig(
+        log_directory=str(bogus_dir),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    # Snapshot the threshold so we can also confirm the guard fired before
+    # any monkeypatch happened (no threshold mutation if the guard rejects).
+    from scripts import nextness_observer as _observer_module
+    original_threshold = getattr(_observer_module, "THRESHOLD_WARMTH")
+    with pytest.raises(
+        WriteOutsideLogDirError,
+        match="config.log_directory diverging",
+    ):
+        sweep_threshold(
+            snapshots=[snap],
+            out_path=out,
+            log_path=log_path,
+            calibration_set="short",
+            config=bad_config,
+        )
+    assert not bogus_dir.exists()
+    assert not out.exists()
+    assert getattr(_observer_module, "THRESHOLD_WARMTH") == original_threshold
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -43,6 +43,8 @@ from scripts.nextness_calibration import (
     CANONICAL_STRIDE,
     DEFAULT_CANONICAL_SEED,
     DEFAULT_STRIDES,
+    DEFAULT_THRESHOLD_MULTIPLIERS,
+    DEFAULT_THRESHOLD_NAME,
     DEFAULT_VARIANCE_SEEDS,
     EXPECTED_MEMORY_CHANNELS,
     EXPECTED_MEMORY_DTYPE,
@@ -63,6 +65,7 @@ from scripts.nextness_calibration import (
     check_determinism,
     shuffle_test,
     sweep_stride,
+    sweep_threshold,
     verify_memory_channels,
 )
 
@@ -1406,3 +1409,224 @@ def test_sweep_stride_custom_strides_honored(tmp_path):
                              strides=(2, 4, 8))
     assert aggregate["strides_swept"] == [2, 4, 8]
     assert set(aggregate["per_stride_summary"].keys()) == {"2", "4", "8"}
+
+
+# ---------------------------------------------------------------------------
+# Chapter 5 — sweep_threshold (threshold sensitivity sweep, design doc §3.4)
+# ---------------------------------------------------------------------------
+
+
+def test_default_threshold_multipliers_symmetric_around_one():
+    """Per design doc §12 Q3: ±10%, ±25%, ±50% + baseline."""
+    assert DEFAULT_THRESHOLD_MULTIPLIERS == (0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5)
+    # Baseline included
+    assert 1.0 in DEFAULT_THRESHOLD_MULTIPLIERS
+
+
+def test_default_threshold_name_is_warmth():
+    """Post-#144, THRESHOLD_WARMTH is the only active classifier threshold."""
+    assert DEFAULT_THRESHOLD_NAME == "THRESHOLD_WARMTH"
+
+
+def test_sweep_threshold_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set validation."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        sweep_threshold([snap], out, log_path, "medium", config)
+
+
+def test_sweep_threshold_rejects_missing_threshold_attribute(tmp_path):
+    """threshold_name must exist on the observer module."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    with pytest.raises(ValueError, match="not found on"):
+        sweep_threshold([snap], out, log_path, "short", config,
+                        threshold_name="THRESHOLD_NONEXISTENT")
+
+
+def test_sweep_threshold_rejects_empty_multipliers(tmp_path):
+    """At least one multiplier required."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    with pytest.raises(ValueError, match="multipliers must be non-empty"):
+        sweep_threshold([], out, log_path, "short", config, multipliers=())
+
+
+def test_sweep_threshold_rejects_non_positive_multiplier(tmp_path):
+    """Multipliers must be positive."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    with pytest.raises(ValueError, match="positive number"):
+        sweep_threshold([], out, log_path, "short", config, multipliers=(0.0,))
+    with pytest.raises(ValueError, match="positive number"):
+        sweep_threshold([], out, log_path, "short", config, multipliers=(-0.5,))
+
+
+def test_sweep_threshold_rejects_outside_log_dir_output(tmp_path):
+    """Write-boundary inheritance."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    bad_out = tmp_path / "outside_dir" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        sweep_threshold([snap], bad_out, log_path, "short", config)
+    assert not (tmp_path / "outside_dir").exists()
+
+
+def test_sweep_threshold_restores_threshold_after_run(tmp_path):
+    """The monkeypatch must restore the original threshold value after the sweep.
+
+    Locks in the try/finally contract: even if the sweep succeeds normally,
+    the observer module's THRESHOLD_WARMTH constant must be exactly what
+    it was before the sweep started.
+    """
+    from scripts import nextness_observer as obs
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+
+    original = obs.THRESHOLD_WARMTH
+    sweep_threshold([snap], out, log_path, "short", config)
+    assert obs.THRESHOLD_WARMTH == original
+
+
+def test_sweep_threshold_restores_threshold_even_if_process_snapshot_fails(tmp_path, monkeypatch):
+    """If process_snapshot raises mid-sweep, the threshold must STILL be restored.
+
+    The whole point of the try/finally contract — observer state must not
+    leak from the calibration scope even under exception.
+    """
+    from scripts import nextness_observer as obs
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+
+    original = obs.THRESHOLD_WARMTH
+
+    # Monkeypatch process_snapshot to raise mid-iteration
+    def broken_process(*args, **kwargs):
+        raise RuntimeError("simulated mid-sweep failure")
+
+    monkeypatch.setattr(
+        "scripts.nextness_calibration.process_snapshot",
+        broken_process,
+    )
+    with pytest.raises(RuntimeError, match="simulated mid-sweep failure"):
+        sweep_threshold([snap], out, log_path, "short", config)
+    # Threshold must be restored despite the exception
+    assert obs.THRESHOLD_WARMTH == original
+
+
+def test_sweep_threshold_writes_expected_row_count(tmp_path):
+    """N snapshots × M multipliers = N*M per-snapshot rows + 1 aggregate."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snaps = [
+        _make_snapshot(snaps_dir / f"v070_gen{i}_step{i}_test.npz",
+                       generation=i, lattice=16)
+        for i in (1, 2)
+    ]
+    out = log_path.parent / "calibration_threshold.jsonl"
+    # Use a small multiplier set for test speed
+    sweep_threshold(snaps, out, log_path, "short", config,
+                    multipliers=(0.5, 1.0, 1.5))
+
+    lines = out.read_text().splitlines()
+    # 2 snapshots × 3 multipliers + 1 aggregate = 7
+    assert len(lines) == 2 * 3 + 1
+
+
+def test_sweep_threshold_per_row_has_effective_value(tmp_path):
+    """Each per-snapshot row carries the effective threshold value."""
+    from scripts import nextness_observer as obs
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    base = obs.THRESHOLD_WARMTH
+    sweep_threshold([snap], out, log_path, "short", config,
+                    multipliers=(0.5, 1.0, 2.0))
+
+    pair_rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    eff_values = sorted(r["parameter_combination"]["threshold_effective_value"]
+                        for r in pair_rows)
+    expected = sorted([0.5 * base, 1.0 * base, 2.0 * base])
+    for a, b in zip(eff_values, expected):
+        assert a == pytest.approx(b)
+
+
+def test_sweep_threshold_aggregate_has_knife_edge_evidence(tmp_path):
+    """Aggregate carries knife_edge_evidence dict + per_multiplier_summary."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    aggregate = sweep_threshold([snap], out, log_path, "short", config)
+
+    assert aggregate["experiment"] == "threshold_sweep"
+    assert "threshold_base_value" in aggregate
+    assert "per_multiplier_summary" in aggregate
+    assert "knife_edge_evidence" in aggregate
+    assert "1.0" in aggregate["per_multiplier_summary"]
+
+
+def test_sweep_threshold_inconclusive_when_token_never_fires(tmp_path):
+    """If the threshold_dependent_token never fires on any (snapshot, mult)
+    combo, the knife-edge criterion has no denominator → inconclusive."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    # Our synthetic snapshot has zero warmth (all-zero memory channel 6),
+    # so even at multiplier=0.5 metta_warmth won't fire — token count = 0
+    # across every multiplier. Status should be inconclusive, not falsified.
+    aggregate = sweep_threshold([snap], out, log_path, "short", config,
+                                multipliers=(0.5, 1.0, 1.5))
+    assert aggregate["falsification_status"] == "inconclusive"
+    assert "never fires" in aggregate["knife_edge_evidence"].get("reason", "")
+
+
+def test_sweep_threshold_no_generated_at_field(tmp_path):
+    """Determinism contract — no fresh timestamps."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    sweep_threshold([snap], out, log_path, "short", config,
+                    multipliers=(0.5, 1.0, 1.5))
+    assert "generated_at" not in out.read_text()
+
+
+def test_sweep_threshold_byte_identical_on_rerun(tmp_path):
+    """Determinism contract — byte-identical re-run on same input."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out_a = log_path.parent / "calibration_threshold_a.jsonl"
+    out_b = log_path.parent / "calibration_threshold_b.jsonl"
+    sweep_threshold([snap], out_a, log_path, "short", config,
+                    multipliers=(0.5, 1.0, 1.5))
+    sweep_threshold([snap], out_b, log_path, "short", config,
+                    multipliers=(0.5, 1.0, 1.5))
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_sweep_threshold_sorts_input_by_generation(tmp_path):
+    """Per-snapshot rows in generation-ascending order regardless of input."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    s3 = _make_snapshot(snaps_dir / "v070_gen300_step3000_test.npz",
+                        generation=300, lattice=16)
+    s1 = _make_snapshot(snaps_dir / "v070_gen100_step1000_test.npz",
+                        generation=100, lattice=16)
+    s2 = _make_snapshot(snaps_dir / "v070_gen200_step2000_test.npz",
+                        generation=200, lattice=16)
+    out = log_path.parent / "calibration_threshold.jsonl"
+    sweep_threshold([s3, s1, s2], out, log_path, "short", config,
+                    multipliers=(1.0,))  # single multiplier for predictable ordering
+
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    generations = [r["snapshot_generation"] for r in rows]
+    assert generations == [100, 200, 300]


### PR DESCRIPTION
## Summary

Adds `sweep_threshold()` per design doc S3.4 (Jack #5 in the implementation order). Sweeps `THRESHOLD_WARMTH` (the only active classifier threshold post-#144) across multipliers `(0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5)` covering symmetric ±10/25/50% per Jack PR #143 Q3. Mechanical `falsification_status` per S3.4: ±25% multiplier producing > 50% relative change in `metta_warmth` firing count indicates knife-edge calibration.

Per Jack Chapter 5 guardrails from PR #148 audit: Lane B only; thresholds only; no cascade ablation; no temporal sweep; no patch-radius; no CLI; no engine touch; no regime thresholds. Mechanical sensitivity reporting only.

- **Tests**: 16 new (103 total in `test_nextness_calibration.py`)
- **Full Phase 17b + 18 + 19 suite**: 407/407 passing

## What sweep_threshold() does

For each `(snapshot, multiplier)` pair:
1. Temporarily `setattr` the named threshold on the observer module to `base_value * multiplier`. Wrapped in `try/finally` to guarantee restoration even on exception.
2. Call `process_snapshot()` with the threshold modified.
3. Capture per-snapshot metrics + `threshold_dependent_token` firing count (default: `metta_warmth`).
4. Restore the original threshold value.

Aggregate computes:
- `per_multiplier_summary` (effective threshold value, mean voc_occ, mean CCI, mean/max token firing count, fraction of classified patches)
- `knife_edge_evidence` (baseline + multipliers in ±25% range, max relative change vs baseline, reason if inconclusive)

Mechanical `falsification_status`:
- **hypothesis_supported**: relative change in token count across ±25% multipliers stays below 0.5 (threshold well-positioned).
- **hypothesis_falsified**: ±25% multiplier produces > 50% relative change (knife edge).
- **inconclusive**: token never fires (no denominator), or fewer than 2 multipliers in the ±25% range.

## Design notes

The thresholds (`THRESHOLD_WARMTH`, `THRESHOLD_RESONANCE`, `THRESHOLD_COMPASSION`) are module-level `Final[float]` constants in `nextness_observer`. Python does not enforce `Final` at runtime, so we monkeypatch + restore the module attribute for sweep purposes. This is contained to the sweep loop, wrapped in `try/finally` for exception safety, and single-threaded by construction (calibration is sequential). It does not leak observer state from the calibration scope under any normal or exceptional execution path — this is exactly the kind of experimental override the threshold constants were designed to undergo during calibration.

Two regression-fence tests lock the restore contract:
- `test_sweep_threshold_restores_threshold_after_run` (normal exit)
- `test_sweep_threshold_restores_threshold_even_if_process_snapshot_fails` (mid-sweep exception)

## Smoke pass against real Medusa

Sandboxed run against 2 newest Medusa snapshots (gen ~1,713,759):

```
Per-multiplier summary (mean across snapshots):
  mult   eff thr   voc_occ   CCI      metta_warmth count   fraction
  0.5    0.1500    0.375     0.1919   0.0                  0.00000
  0.75   0.2250    0.375     0.1919   0.0                  0.00000
  0.9    0.2700    0.375     0.1919   0.0                  0.00000
  1.0    0.3000    0.375     0.1919   0.0                  0.00000
  1.1    0.3300    0.375     0.1919   0.0                  0.00000
  1.25   0.3750    0.375     0.1919   0.0                  0.00000
  1.5    0.4500    0.375     0.1919   0.0                  0.00000

Falsification status: inconclusive
Reason: metta_warmth never fires on any snapshot in the ±25%
        multiplier range; relative change undefined.
```

## Interpretation — a real PR #4 finding worth highlighting

The result is **correctly** inconclusive, but the underlying empirical fact is informative: `metta_warmth` does **NOT** fire across the full multiplier range, including dropping the effective threshold to 0.15 (half the default 0.3).

From PR #147 smoke pass: `warmth.max = 0.185`, sparsity 0.990. Even at threshold = 0.15, the patch-MEAN warmth (which is what the predicate checks) is too low to fire because 99% of cells have ~0 warmth and the rare loud voxels are averaged out across the 27-cell patch.

So the issue is NOT threshold calibration. It is predicate **design**: `metta_warmth` uses patch-mean warmth, which washes out rare but real warmth voxels. A future PR (4.5 / 5 / 6) could redesign `metta_warmth` to use patch-MAX warmth, or a structurally different aggregator (e.g., 95th percentile), to reflect the actual statistical character of the warmth signal.

The threshold sweep correctly diagnoses this by reporting inconclusive with an explicit machine-readable reason that points downstream analysis at the predicate aggregator rather than the threshold value.

This is exactly the kind of scientific knowledge the calibration suite was designed to produce — not just "did the threshold pass" but "what does the threshold sweep tell us about whether threshold sweeps even make sense for this token under current engine state."

For the issue #139 alternate hypotheses:
- **Alternate hypothesis 2 (threshold mis-calibrated)** is NOT supported as currently stated; the threshold is not on a knife edge because the underlying signal sparsity makes the patch-mean predicate insensitive to threshold within tested range. Further investigation should examine predicate aggregator design rather than threshold value.

## Scope guarantees (unchanged from prior chapters)

- No engine touch
- No writes outside `log_path.parent` (`WriteOutsideLogDirError`)
- No HTTP / ZMQ / network
- CPU-only
- `allow_pickle=False` preserved
- No CCI regime thresholds
- No fresh `generated_at` field (locked by test)
- No external code pull
- No multi-snapshot mode added to observer
- No CLI (deferred to end of calibration implementation)
- No predicate redesign (deferred to follow-up per Jack scope)

## Test plan

- [x] All 16 new Chapter 5 tests pass (`test_nextness_calibration.py`)
- [x] All 103 calibration tests pass
- [x] Full Phase 17b + 18 + 19 suite passes (407/407)
- [x] Restore-contract regression fences cover both normal and exception paths
- [x] Real-Medusa smoke pass against 2 newest snapshots
- [x] Byte-identical re-run determinism test passes
- [x] Write-boundary inheritance verified (rejects outside-log-dir output)

Refs #139 — finding (c) parent hub. This experiment provides empirical evidence on alternate hypothesis 2 (threshold mis-calibrated). Result for current Medusa snapshots: hypothesis NOT supported in the simple form; surfaces a separate predicate-aggregator design question for future PR. Issue stays open until all calibration sweeps complete; deliberately no auto-close keyword used.

Approved direction: PR #143 design doc, PR #146-148 chapters 1-4, Chapter 5 guardrails from PR #148 audit (AURA + Jack), operator gate (Kevin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)