### PR TITLE
Phase 19 PR #4 Chapter 6 — ablate_cascade (cascade ablation / cascade-order test)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -1765,8 +1765,478 @@ def sweep_threshold(
     return aggregate
 
 
+# ---------------------------------------------------------------------------
+# Chapter 6 — ablate_cascade (design doc §3.5, Jack #6 in implementation order)
+# ---------------------------------------------------------------------------
+
+
+#: Default dominant tokens to disable one-at-a-time. Per PR #142 / #147 smoke
+#: results: phase_boundary, compute_static, void_static are the dominant tokens
+#: in current Medusa state. Disabling each in turn exposes whatever predicate
+#: would have fired "next" — the §3.5 cascade-ablation hidden-token probe.
+DEFAULT_ABLATION_DISABLED_TOKENS: tuple[str, ...] = (
+    "phase_boundary",
+    "compute_static",
+    "void_static",
+)
+
+#: The ACTIVE classifier cascade order (deprecated tokens excluded per
+#: TOKEN_STATUS post-#144). This must mirror :func:`classify_patch` in
+#: ``nextness_observer.py``; a parity regression-fence test locks the
+#: non-ablated calibration cascade against the observer cascade on
+#: synthetic patches covering every branch. ``unclassified`` is the
+#: fall-through bucket, not an explicit cascade step.
+_ACTIVE_CASCADE_ORDER: tuple[str, ...] = (
+    "phase_boundary",
+    "compute_aging",
+    "metta_warmth",
+    "sensor_alert",
+    "energy_pulse",
+    "compute_decay",
+    "compute_static",
+    "structural_growth",
+    "structural_decay",
+    "void_birth",
+    "void_static",
+    "acoustic_stress",
+)
+
+#: Per design doc §3.5: a non-baseline ablation mode that reveals more than
+#: this many additional tokens firing above the rate threshold indicates the
+#: cascade is hiding signal.
+_CASCADE_ABLATION_HIDDEN_TOKEN_COUNT_THRESHOLD: int = 5
+
+#: Per design doc §3.5: per-token rate threshold for "additional token firing"
+#: — tokens that go from < 5% in baseline to > 5% in an ablation mode count
+#: as emerging. Symmetric: tokens already > 5% in baseline don't re-count
+#: just because they shifted within the > 5% band.
+_CASCADE_ABLATION_HIDDEN_TOKEN_RATE_THRESHOLD: float = 0.05
+
+
+def _predicate_fires(token: str, features: Any) -> bool:
+    """Return True if the cascade predicate for ``token`` matches ``features``.
+
+    Mirrors the inline predicates in
+    :func:`scripts.nextness_observer.classify_patch` for ablation purposes.
+    Drift is locked out by the parity regression-fence test
+    ``test_classify_patch_ablation_parity_with_observer_on_synthetic_battery``
+    in ``test_nextness_calibration.py``.
+    """
+    # Lazy import so observer-module constants are picked up live (matches
+    # the sweep_threshold pattern of reading thresholds at call-time).
+    from scripts.nextness_observer import (
+        AGE_ANCIENT,
+        AGE_SAGE,
+        DIVERSITY_BOUNDARY,
+        ENERGY_PULSE_MIN_COUNT,
+        FRACTION_DOMINANT,
+        FRACTION_MAJORITY,
+        THRESHOLD_WARMTH,
+    )
+    f = features
+    if token == "phase_boundary":
+        return f.distinct_states >= DIVERSITY_BOUNDARY
+    if token == "compute_aging":
+        return f.compute_frac >= FRACTION_DOMINANT and f.compute_age_mean >= AGE_SAGE
+    if token == "metta_warmth":
+        return (f.compute_count >= 1 or f.energy_count >= 1) and f.warmth_mean >= THRESHOLD_WARMTH
+    if token == "sensor_alert":
+        return f.sensor_count >= 1
+    if token == "energy_pulse":
+        return f.energy_count >= ENERGY_PULSE_MIN_COUNT
+    if token == "compute_decay":
+        return (
+            f.compute_count >= 1
+            and f.void_frac >= FRACTION_DOMINANT
+            and f.warmth_mean < THRESHOLD_WARMTH
+        )
+    if token == "compute_static":
+        return f.compute_frac >= FRACTION_DOMINANT
+    if token == "structural_growth":
+        return f.structural_frac >= FRACTION_DOMINANT and f.structural_age_mean < AGE_SAGE
+    if token == "structural_decay":
+        return f.structural_frac >= FRACTION_DOMINANT and f.structural_age_mean >= AGE_ANCIENT
+    if token == "void_birth":
+        return f.void_frac >= FRACTION_DOMINANT and f.distinct_states >= 2
+    if token == "void_static":
+        return f.void_frac >= FRACTION_MAJORITY
+    if token == "acoustic_stress":
+        return f.distinct_states >= 3 and f.warmth_mean < THRESHOLD_WARMTH
+    raise ValueError(f"unknown cascade token {token!r}")
+
+
+def _classify_patch_ablation(
+    patch: Any,
+    *,
+    disabled_tokens: frozenset[str] = frozenset(),
+    reverse_order: bool = False,
+) -> str:
+    """Calibration-side classify_patch with cascade-ablation knobs.
+
+    Mirrors :func:`scripts.nextness_observer.classify_patch`'s ACTIVE
+    cascade (deprecated tokens skipped per TOKEN_STATUS). Two knobs:
+
+    * ``disabled_tokens`` — set of token names whose predicates are skipped.
+      If a disabled token's predicate would have fired, the cascade
+      continues to the next token instead, revealing what was "hiding"
+      one rung below.
+    * ``reverse_order`` — if True, cascade order is reversed (least-specific
+      first). Stress-tests the cascade-ordering decision per design doc §3.5.
+
+    With ``disabled_tokens=frozenset()`` and ``reverse_order=False`` this
+    function MUST agree with the observer's ``classify_patch`` bit-for-bit.
+    The parity regression-fence test enforces this.
+
+    Returns ``"unclassified"`` if no predicate fires (the cascade's
+    fall-through bucket).
+    """
+    from scripts.nextness_observer import _patch_features
+    f = _patch_features(patch)
+    order = (
+        tuple(reversed(_ACTIVE_CASCADE_ORDER)) if reverse_order
+        else _ACTIVE_CASCADE_ORDER
+    )
+    for token in order:
+        if token in disabled_tokens:
+            continue
+        if _predicate_fires(token, f):
+            return token
+    return "unclassified"
+
+
+def _make_ablating_classifier(
+    disabled_tokens: frozenset[str],
+    reverse_order: bool,
+):
+    """Return a closure suitable for monkey-patching observer.classify_patch.
+
+    The returned callable signature matches the observer's
+    ``classify_patch(patch) -> str``. Used by :func:`ablate_cascade` inside
+    a try/finally to install + restore the classifier for one ablation
+    mode at a time.
+    """
+    def _ablating_classifier(patch: Any) -> str:
+        return _classify_patch_ablation(
+            patch,
+            disabled_tokens=disabled_tokens,
+            reverse_order=reverse_order,
+        )
+    return _ablating_classifier
+
+
+def _ablation_modes_for_run(
+    disabled_tokens: tuple[str, ...],
+    include_baseline: bool,
+    include_reverse: bool,
+) -> list[dict[str, Any]]:
+    """Build the ordered list of modes to run.
+
+    Each mode is a dict with ``label`` (string for parameter_combination),
+    ``disabled_tokens`` (frozenset for the classifier), and ``reverse_order``
+    (bool). Order is: baseline (if requested) → one disable_<token> per
+    token (in input order) → reverse_order (if requested).
+    """
+    modes: list[dict[str, Any]] = []
+    if include_baseline:
+        modes.append({
+            "label": "baseline",
+            "disabled_tokens": frozenset(),
+            "reverse_order": False,
+        })
+    for token in disabled_tokens:
+        modes.append({
+            "label": f"disable_{token}",
+            "disabled_tokens": frozenset({token}),
+            "reverse_order": False,
+        })
+    if include_reverse:
+        modes.append({
+            "label": "reverse_order",
+            "disabled_tokens": frozenset(),
+            "reverse_order": True,
+        })
+    return modes
+
+
+def _emerging_tokens_vs_baseline(
+    baseline_counts: dict[str, int],
+    mode_counts: dict[str, int],
+    rate_threshold: float,
+) -> dict[str, Any]:
+    """Compute which tokens emerge in ``mode_counts`` vs ``baseline_counts``.
+
+    A token is "emerging" if its rate in mode_counts crosses
+    ``rate_threshold`` while its rate in baseline_counts was below it.
+    Returns the emerging-token list, both totals, and the count for the
+    falsification criterion.
+    """
+    baseline_total = sum(baseline_counts.values())
+    mode_total = sum(mode_counts.values())
+    baseline_rate = lambda t: (baseline_counts.get(t, 0) / baseline_total) if baseline_total else 0.0
+    mode_rate = lambda t: (mode_counts.get(t, 0) / mode_total) if mode_total else 0.0
+    all_tokens = set(baseline_counts) | set(mode_counts)
+    emerging = sorted(
+        t for t in all_tokens
+        if baseline_rate(t) <= rate_threshold and mode_rate(t) > rate_threshold
+    )
+    return {
+        "emerging_tokens": emerging,
+        "emerging_token_count": len(emerging),
+        "baseline_total": baseline_total,
+        "mode_total": mode_total,
+        "rate_threshold": rate_threshold,
+    }
+
+
+def ablate_cascade(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+    config: ObserverConfig,
+    disabled_tokens: tuple[str, ...] = DEFAULT_ABLATION_DISABLED_TOKENS,
+    include_baseline: bool = True,
+    include_reverse: bool = True,
+) -> dict[str, Any]:
+    """Cascade ablation / cascade-order test per design doc §3.5.
+
+    For each snapshot, run ``process_snapshot()`` once per ablation mode.
+    Modes:
+
+      * ``"baseline"`` — unmodified cascade (sanity reference; required
+        as denominator for the emerging-token criterion)
+      * ``"disable_<token>"`` — for each ``disabled_tokens`` entry, run
+        with that token's predicate skipped (observe what fires "next")
+      * ``"reverse_order"`` — run with the active cascade reversed
+        (least-specific first)
+
+    Each mode is installed by monkey-patching ``classify_patch`` on the
+    observer module with an ablating closure, wrapped in ``try/finally``
+    to guarantee restoration even on exception. Mirrors the
+    ``sweep_threshold`` monkey-patch + restore pattern.
+
+    Mechanical falsification_status per design doc §3.5:
+
+      * ``"hypothesis_supported"``: across all non-baseline modes, the
+        max additional-token count (tokens crossing the 5% rate threshold
+        in a mode while ≤ 5% in baseline) is ≤ 5. The cascade is sensibly
+        ordered; ablation does not expose a long tail.
+      * ``"hypothesis_falsified"``: at least one non-baseline mode reveals
+        > 5 additional tokens crossing the 5% rate threshold. The cascade
+        ordering is the dominant cause of the apparent two-token saturation.
+      * ``"inconclusive"``: no baseline mode requested (no denominator),
+        or baseline produced no patches, or only the baseline mode was run.
+
+    Args:
+        snapshots: list of sandboxed ``.npz`` paths. Sorted by generation.
+        out_path: where to write the cascade ablation JSONL.
+        log_path: write-boundary anchor. Same canonical
+            ``nextness_runs.jsonl`` path used everywhere else.
+        calibration_set: ``"short"`` or ``"long"``.
+        config: ``ObserverConfig`` used for every ``process_snapshot()``
+            call. ``config.log_directory`` must equal ``log_path.parent``
+            (enforced by ``_validate_config_log_directory`` per Jack
+            PR #149 audit).
+        disabled_tokens: tuple of token names whose predicates to ablate
+            one-at-a-time. Defaults to the dominant tokens in current
+            Medusa state. Every entry must be an active cascade token.
+        include_baseline: whether to include the unmodified-cascade mode.
+            Defaults to True. Disabling this forces ``inconclusive``
+            because emerging-token computation has no denominator.
+        include_reverse: whether to include the cascade-order-reversal
+            mode. Defaults to True. Disabling skips that stress test.
+
+    Returns the aggregate dict for callers that want to inspect it
+    without re-reading the output file.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside log dir
+            or ``config.log_directory`` diverges from ``log_path.parent``.
+        ``ValueError`` for invalid calibration_set, unknown token in
+            ``disabled_tokens``, or empty mode set.
+    """
+    # Lazy import of the observer module so we can monkeypatch its
+    # classify_patch attribute. Only place in the calibration module that
+    # mutates observer state besides sweep_threshold; only within try/finally.
+    from scripts import nextness_observer as _observer_module
+
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got {calibration_set!r}"
+        )
+    for t in disabled_tokens:
+        if t not in _ACTIVE_CASCADE_ORDER:
+            raise ValueError(
+                f"disabled token {t!r} is not an active cascade token "
+                f"(active: {_ACTIVE_CASCADE_ORDER})"
+            )
+
+    modes = _ablation_modes_for_run(
+        disabled_tokens=disabled_tokens,
+        include_baseline=include_baseline,
+        include_reverse=include_reverse,
+    )
+    if not modes:
+        raise ValueError(
+            "no modes selected; at least one of include_baseline, "
+            "include_reverse, or non-empty disabled_tokens is required"
+        )
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    # Per-mode aggregator: mode_label -> per-snapshot list of token_counts
+    # (for the aggregate's per_mode_summary and emerging-token analysis).
+    by_mode: dict[str, list[dict[str, Any]]] = {m["label"]: [] for m in modes}
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        for mode in modes:
+            # Monkeypatch + restore inside try/finally. Single-threaded by
+            # construction (calibration is sequential).
+            original_classifier = _observer_module.classify_patch
+            ablating_classifier = _make_ablating_classifier(
+                disabled_tokens=mode["disabled_tokens"],
+                reverse_order=mode["reverse_order"],
+            )
+            try:
+                _observer_module.classify_patch = ablating_classifier
+                entry = process_snapshot(snap, config, medusa_is_live=False)
+            finally:
+                _observer_module.classify_patch = original_classifier
+
+            token_counts = dict(entry.get("token_counts", {}) or {})
+            metrics = _extract_metrics_subset(entry)
+            metrics["cci"] = _cci_from_entry(entry)
+
+            per_snapshot_rows.append(_make_per_snapshot_row(
+                experiment="cascade_ablation",
+                snapshot_path=snap,
+                generation=generation,
+                parameter_combination={
+                    "mode": mode["label"],
+                    "disabled_tokens": sorted(mode["disabled_tokens"]),
+                    "reverse_order": mode["reverse_order"],
+                },
+                metrics=metrics,
+                run_metadata={
+                    # patches_processed is deterministic; elapsed_seconds
+                    # is wallclock-derived and excluded to preserve
+                    # byte-identical re-run (Chapter 4 pattern).
+                    "patches_processed": entry.get("budget", {}).get(
+                        "patches_processed"
+                    ),
+                },
+                calibration_set=calibration_set,
+            ))
+
+            by_mode[mode["label"]].append({
+                "snapshot": snap.name,
+                "metrics": metrics,
+                "token_counts": token_counts,
+            })
+
+    # --- Per-mode summary statistics ---
+    per_mode_summary: dict[str, Any] = {}
+    # Aggregate token_counts across snapshots per mode for emerging-token
+    # computation. Per-snapshot rows above carry the raw per-snapshot
+    # distribution; the aggregate uses the summed distribution to avoid
+    # noise from any single snapshot dominating.
+    summed_counts_by_mode: dict[str, dict[str, int]] = {}
+    for mode_label, runs in by_mode.items():
+        summed: dict[str, int] = {}
+        for r in runs:
+            for tok, n in r["token_counts"].items():
+                summed[tok] = summed.get(tok, 0) + int(n)
+        summed_counts_by_mode[mode_label] = summed
+
+        if not runs:
+            per_mode_summary[mode_label] = {"n_snapshots": 0}
+            continue
+        voc_occs = [r["metrics"]["vocabulary_occupancy"] for r in runs]
+        ccis = [r["metrics"]["cci"] for r in runs]
+        per_mode_summary[mode_label] = {
+            "n_snapshots": len(runs),
+            "mean_vocabulary_occupancy": sum(voc_occs) / len(voc_occs),
+            "mean_cci": sum(ccis) / len(ccis),
+            "summed_token_counts": summed,
+        }
+
+    # --- Falsification logic (§3.5 cascade-hiding-signal criterion) ---
+    falsification_status: str = "inconclusive"
+    emerging_token_evidence: dict[str, Any] = {}
+    non_baseline_modes = [m["label"] for m in modes if m["label"] != "baseline"]
+
+    if not include_baseline or not by_mode.get("baseline"):
+        emerging_token_evidence["reason"] = (
+            "baseline mode not included or produced no patches; "
+            "emerging-token criterion has no denominator"
+        )
+    elif not non_baseline_modes:
+        emerging_token_evidence["reason"] = (
+            "only baseline mode requested; no ablation to compare against"
+        )
+    else:
+        baseline_counts = summed_counts_by_mode["baseline"]
+        per_mode_emerging: dict[str, Any] = {}
+        max_emerging_count = 0
+        max_emerging_mode = None
+        for mode_label in non_baseline_modes:
+            mode_counts = summed_counts_by_mode[mode_label]
+            evidence = _emerging_tokens_vs_baseline(
+                baseline_counts=baseline_counts,
+                mode_counts=mode_counts,
+                rate_threshold=_CASCADE_ABLATION_HIDDEN_TOKEN_RATE_THRESHOLD,
+            )
+            per_mode_emerging[mode_label] = evidence
+            if evidence["emerging_token_count"] > max_emerging_count:
+                max_emerging_count = evidence["emerging_token_count"]
+                max_emerging_mode = mode_label
+
+        emerging_token_evidence["per_mode"] = per_mode_emerging
+        emerging_token_evidence["max_emerging_token_count"] = max_emerging_count
+        emerging_token_evidence["max_emerging_mode"] = max_emerging_mode
+        emerging_token_evidence["hidden_token_count_threshold"] = (
+            _CASCADE_ABLATION_HIDDEN_TOKEN_COUNT_THRESHOLD
+        )
+        emerging_token_evidence["hidden_token_rate_threshold"] = (
+            _CASCADE_ABLATION_HIDDEN_TOKEN_RATE_THRESHOLD
+        )
+
+        if max_emerging_count > _CASCADE_ABLATION_HIDDEN_TOKEN_COUNT_THRESHOLD:
+            falsification_status = "hypothesis_falsified"
+        else:
+            falsification_status = "hypothesis_supported"
+
+    extra_fields: dict[str, Any] = {
+        "disabled_tokens": list(disabled_tokens),
+        "modes_run": [m["label"] for m in modes],
+        "include_baseline": include_baseline,
+        "include_reverse": include_reverse,
+        "per_mode_summary": per_mode_summary,
+        "emerging_token_evidence": emerging_token_evidence,
+    }
+
+    aggregate = _make_aggregate_row(
+        experiment="cascade_ablation",
+        calibration_set=calibration_set,
+        n_snapshots=len(sorted_snapshots),
+        extra_fields=extra_fields,
+        falsification_status=falsification_status,
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
 __all__ = [
     "CANONICAL_STRIDE",
+    "DEFAULT_ABLATION_DISABLED_TOKENS",
     "DEFAULT_CANONICAL_SEED",
     "DEFAULT_STRIDES",
     "DEFAULT_THRESHOLD_MULTIPLIERS",
@@ -1776,6 +2246,7 @@ __all__ = [
     "EXPECTED_MEMORY_DTYPE",
     "SHUFFLE_MODES",
     "SPARSITY_EPSILON",
+    "ablate_cascade",
     "check_determinism",
     "shuffle_test",
     "sweep_stride",

--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -1770,14 +1770,21 @@ def sweep_threshold(
 # ---------------------------------------------------------------------------
 
 
-#: Default dominant tokens to disable one-at-a-time. Per PR #142 / #147 smoke
-#: results: phase_boundary, compute_static, void_static are the dominant tokens
-#: in current Medusa state. Disabling each in turn exposes whatever predicate
-#: would have fired "next" — the §3.5 cascade-ablation hidden-token probe.
+#: Default dominant tokens to disable one-at-a-time. Per the Chapter 6
+#: real-Medusa smoke pass (post-#145 layout fix), the currently dominant
+#: active tokens above the 5% rate threshold are:
+#:
+#:     phase_boundary 66.5%, sensor_alert 20.9%, void_birth 9.5%
+#:
+#: Disabling each in turn exposes whatever predicate would have fired
+#: "next" — the §3.5 cascade-ablation hidden-token probe. Aimed at the
+#: post-#145 dominant cascade rather than pre-#145 ghosts per Jack's
+#: PR #152 audit (``compute_static`` / ``void_static`` are no-ops in
+#: the corrected post-#145 distribution and were dropped from the default).
 DEFAULT_ABLATION_DISABLED_TOKENS: tuple[str, ...] = (
     "phase_boundary",
-    "compute_static",
-    "void_static",
+    "sensor_alert",
+    "void_birth",
 )
 
 #: The ACTIVE classifier cascade order (deprecated tokens excluded per

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -41,6 +41,7 @@ from scripts.nextness_observer import (
 )
 from scripts.nextness_calibration import (
     CANONICAL_STRIDE,
+    DEFAULT_ABLATION_DISABLED_TOKENS,
     DEFAULT_CANONICAL_SEED,
     DEFAULT_STRIDES,
     DEFAULT_THRESHOLD_MULTIPLIERS,
@@ -50,8 +51,12 @@ from scripts.nextness_calibration import (
     EXPECTED_MEMORY_DTYPE,
     SHUFFLE_MODES,
     SPARSITY_EPSILON,
+    _ACTIVE_CASCADE_ORDER,
+    _ablation_modes_for_run,
+    _classify_patch_ablation,
     _clone_config_with_stride,
     _content_fingerprint,
+    _emerging_tokens_vs_baseline,
     _extract_generation_from_filename,
     _interpret_signal_location,
     _make_aggregate_row,
@@ -63,6 +68,7 @@ from scripts.nextness_calibration import (
     _validate_calibration_output_path,
     _validate_config_log_directory,
     _verify_snapshot_memory_grid,
+    ablate_cascade,
     check_determinism,
     shuffle_test,
     sweep_stride,
@@ -1801,6 +1807,585 @@ def test_sweep_threshold_sorts_input_by_generation(tmp_path):
     sweep_threshold([s3, s1, s2], out, log_path, "short", config,
                     multipliers=(1.0,))  # single multiplier for predictable ordering
 
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    generations = [r["snapshot_generation"] for r in rows]
+    assert generations == [100, 200, 300]
+
+
+# ===========================================================================
+# Chapter 6 — ablate_cascade (design doc §3.5)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+def test_default_ablation_disabled_tokens_are_active_cascade_tokens():
+    """Every DEFAULT_ABLATION_DISABLED_TOKENS entry must be in the active
+    cascade — guards against typos and against accidentally trying to
+    ablate a deprecated token."""
+    for token in DEFAULT_ABLATION_DISABLED_TOKENS:
+        assert token in _ACTIVE_CASCADE_ORDER, (
+            f"default ablation token {token!r} not in active cascade"
+        )
+
+
+def test_active_cascade_order_excludes_deprecated_tokens():
+    """_ACTIVE_CASCADE_ORDER must NOT contain any deprecated tokens
+    (karuna_relief, mudita_resonance, magnon_lighthouse per #144).
+    Locks the post-#144 cascade composition."""
+    deprecated = {"karuna_relief", "mudita_resonance", "magnon_lighthouse"}
+    overlap = set(_ACTIVE_CASCADE_ORDER) & deprecated
+    assert not overlap, f"deprecated tokens in active cascade: {overlap}"
+
+
+# ---------------------------------------------------------------------------
+# _classify_patch_ablation — parity regression-fence + ablation correctness
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_patch_for_branch(branch: str):
+    """Synthetic Patch built to trigger a specific cascade branch.
+
+    Returns a minimal Patch object with hand-built state + memory arrays.
+    Mirrors the lazy-import pattern used by the observer's _patch_features.
+    """
+    from scripts.nextness_observer import (
+        AGE_ANCIENT,
+        AGE_SAGE,
+        ENERGY_PULSE_MIN_COUNT,
+        Patch,
+        STATE_COMPUTE,
+        STATE_ENERGY,
+        STATE_SENSOR,
+        STATE_STRUCTURAL,
+        STATE_VOID,
+        THRESHOLD_WARMTH,
+    )
+    # 3x3x3 patches everywhere; deterministic content.
+    R = 1  # patch_spatial_radius -> 3x3x3 = 27 cells
+    state = np.full((3, 3, 3), STATE_VOID, dtype=np.uint8)
+    memory = np.zeros((8, 3, 3, 3), dtype=np.float32)
+    if branch == "phase_boundary":
+        # distinct_states >= DIVERSITY_BOUNDARY (>=4 by default).
+        state[0, 0, 0] = STATE_COMPUTE
+        state[0, 0, 1] = STATE_STRUCTURAL
+        state[0, 0, 2] = STATE_ENERGY
+        state[0, 1, 0] = STATE_SENSOR
+    elif branch == "compute_aging":
+        state[:, :, :] = STATE_COMPUTE  # compute_frac = 1.0
+        memory[CH["compute_age"], :, :, :] = float(AGE_SAGE + 5)
+    elif branch == "metta_warmth":
+        # compute_count>=1 + warmth_mean >= THRESHOLD_WARMTH, but NOT
+        # compute_frac dominant (so compute_static won't catch it first).
+        state[0, 0, 0] = STATE_COMPUTE
+        memory[CH["warmth"], :, :, :] = float(THRESHOLD_WARMTH + 0.1)
+    elif branch == "sensor_alert":
+        # sensor_count>=1, no compute/energy dominance, distinct_states<4
+        state[0, 0, 0] = STATE_SENSOR
+    elif branch == "energy_pulse":
+        # energy_count >= ENERGY_PULSE_MIN_COUNT, no compute, no sensors,
+        # not dominant in any single category.
+        for i in range(ENERGY_PULSE_MIN_COUNT):
+            state.flat[i] = STATE_ENERGY
+    elif branch == "compute_decay":
+        # compute_count>=1, void_frac dominant, warmth_mean < THRESHOLD_WARMTH
+        state[0, 0, 0] = STATE_COMPUTE
+        # rest stays VOID -> void_frac high
+        memory[CH["warmth"], :, :, :] = 0.0
+    elif branch == "compute_static":
+        # compute_frac >= FRACTION_DOMINANT, compute_age below SAGE,
+        # warmth below threshold (so metta_warmth/decay don't catch first).
+        state[:, :, :] = STATE_COMPUTE
+        memory[CH["compute_age"], :, :, :] = float(AGE_SAGE - 1)
+        memory[CH["warmth"], :, :, :] = 0.0
+    elif branch == "structural_growth":
+        state[:, :, :] = STATE_STRUCTURAL
+        memory[CH["structural_age"], :, :, :] = float(AGE_SAGE - 1)
+    elif branch == "structural_decay":
+        state[:, :, :] = STATE_STRUCTURAL
+        memory[CH["structural_age"], :, :, :] = float(AGE_ANCIENT + 1)
+    elif branch == "void_birth":
+        # void_frac dominant but distinct_states>=2 (and <4 so phase_boundary
+        # doesn't catch).
+        state[0, 0, 0] = STATE_STRUCTURAL
+        state[0, 0, 1] = STATE_STRUCTURAL
+    elif branch == "void_static":
+        # All void -> distinct_states=1, void_frac=1.0
+        pass  # state already all-VOID
+    elif branch == "acoustic_stress":
+        # distinct_states>=3, distinct<4 (else phase_boundary), warmth low,
+        # no compute/energy dominant, no sensors.
+        state[0, 0, 0] = STATE_STRUCTURAL
+        state[0, 0, 1] = STATE_ENERGY
+        # void + structural + energy = 3 distinct states; default
+        # DIVERSITY_BOUNDARY is 4 so phase_boundary won't catch.
+    elif branch == "unclassified":
+        # We want NO predicate to fire. Hardest to construct. A patch
+        # with: void_frac < FRACTION_MAJORITY, no dominance anywhere,
+        # distinct_states < 3, no sensors, energy_count < min.
+        # Try: half void, half structural with mature age (>= ANCIENT).
+        # If FRACTION_MAJORITY is 0.5 (typical), set void_frac < 0.5 too.
+        state[0, 0, 0] = STATE_STRUCTURAL
+        state[0, 0, 1] = STATE_STRUCTURAL
+        state[0, 0, 2] = STATE_STRUCTURAL
+        state[0, 1, 0] = STATE_STRUCTURAL
+        state[0, 1, 1] = STATE_STRUCTURAL
+        state[0, 1, 2] = STATE_STRUCTURAL
+        state[0, 2, 0] = STATE_STRUCTURAL
+        state[0, 2, 1] = STATE_STRUCTURAL
+        state[0, 2, 2] = STATE_STRUCTURAL
+        state[1, 0, 0] = STATE_STRUCTURAL
+        state[1, 0, 1] = STATE_STRUCTURAL
+        state[1, 0, 2] = STATE_STRUCTURAL
+        state[1, 1, 0] = STATE_STRUCTURAL
+        # 13 structural / 27 = 0.48 < FRACTION_MAJORITY (0.5) but high
+        # enough that void_frac is also < 0.5 -> nothing dominant.
+        memory[CH["structural_age"], :, :, :] = float(AGE_SAGE)
+        # structural_age_mean is SAGE (not < SAGE for growth, not >= ANCIENT
+        # for decay), structural_frac < DOMINANT so neither growth nor decay
+        # fire. distinct=2 not >=3. No sensors. compute=0, energy=0. The
+        # only risk is acoustic_stress (distinct>=3) - here distinct=2.
+    else:
+        raise ValueError(f"unknown branch {branch}")
+    return Patch(
+        center=(R, R, R),
+        state=state,
+        memory=memory,
+    )
+
+
+def test_classify_patch_ablation_parity_with_observer_on_synthetic_battery():
+    """Regression fence: non-ablated, non-reversed _classify_patch_ablation
+    must agree with observer.classify_patch bit-for-bit on synthetic
+    patches built to hit each ACTIVE cascade branch. Locks out silent
+    drift between the calibration cascade mirror and the observer's
+    source-of-truth cascade."""
+    from scripts.nextness_observer import classify_patch as observer_classify
+    branches = list(_ACTIVE_CASCADE_ORDER) + ["unclassified"]
+    for branch in branches:
+        patch = _make_synthetic_patch_for_branch(branch)
+        observer_result = observer_classify(patch)
+        calibration_result = _classify_patch_ablation(patch)
+        assert observer_result == calibration_result, (
+            f"parity drift on branch {branch!r}: "
+            f"observer={observer_result!r} vs calibration={calibration_result!r}"
+        )
+
+
+def test_classify_patch_ablation_skips_disabled_token():
+    """When a token's predicate would fire, disabling it must yield a
+    different result — proves the ablation knob actually skips."""
+    patch = _make_synthetic_patch_for_branch("phase_boundary")
+    # Baseline: fires phase_boundary
+    assert _classify_patch_ablation(patch) == "phase_boundary"
+    # Ablation: must NOT return phase_boundary
+    result = _classify_patch_ablation(
+        patch, disabled_tokens=frozenset({"phase_boundary"})
+    )
+    assert result != "phase_boundary", (
+        f"ablation did not skip phase_boundary; got {result!r}"
+    )
+
+
+def test_classify_patch_ablation_unclassified_when_all_active_disabled():
+    """If every active cascade token is disabled, the patch must fall
+    through to ``unclassified`` (the catch-all bucket)."""
+    patch = _make_synthetic_patch_for_branch("phase_boundary")
+    result = _classify_patch_ablation(
+        patch, disabled_tokens=frozenset(_ACTIVE_CASCADE_ORDER)
+    )
+    assert result == "unclassified"
+
+
+def test_classify_patch_ablation_reverse_order_differs_when_appropriate():
+    """Reverse order must produce a different result for at least one
+    patch where multiple predicates could fire (forward picks the
+    most-specific; reversed picks the least-specific). Otherwise the
+    reverse_order knob is a no-op and the chapter has nothing to probe."""
+    # A patch that triggers both phase_boundary (specific) and void_birth
+    # / void_static (less specific). Use the phase_boundary patch which
+    # has multiple distinct states.
+    patch = _make_synthetic_patch_for_branch("phase_boundary")
+    forward = _classify_patch_ablation(patch, reverse_order=False)
+    reversed_ = _classify_patch_ablation(patch, reverse_order=True)
+    # forward should pick phase_boundary; reversed should pick something
+    # later in the original cascade order (acoustic_stress / void_static).
+    assert forward != reversed_, (
+        f"reverse_order produced same result as forward: {forward!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _ablation_modes_for_run
+# ---------------------------------------------------------------------------
+
+
+def test_ablation_modes_for_run_includes_baseline_first():
+    """Baseline mode (when requested) must come first; downstream code
+    relies on it being the reference for emerging-token comparison."""
+    modes = _ablation_modes_for_run(
+        disabled_tokens=("phase_boundary",),
+        include_baseline=True,
+        include_reverse=True,
+    )
+    assert modes[0]["label"] == "baseline"
+    assert modes[0]["disabled_tokens"] == frozenset()
+    assert modes[0]["reverse_order"] is False
+
+
+def test_ablation_modes_for_run_skips_baseline_when_disabled():
+    """include_baseline=False must omit the baseline mode entirely."""
+    modes = _ablation_modes_for_run(
+        disabled_tokens=("phase_boundary",),
+        include_baseline=False,
+        include_reverse=False,
+    )
+    labels = [m["label"] for m in modes]
+    assert "baseline" not in labels
+
+
+def test_ablation_modes_for_run_disable_modes_in_order():
+    """disable_<token> modes must appear in disabled_tokens input order
+    so the parameter_combination output is deterministic."""
+    modes = _ablation_modes_for_run(
+        disabled_tokens=("compute_static", "phase_boundary", "void_static"),
+        include_baseline=False,
+        include_reverse=False,
+    )
+    labels = [m["label"] for m in modes]
+    assert labels == [
+        "disable_compute_static",
+        "disable_phase_boundary",
+        "disable_void_static",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _emerging_tokens_vs_baseline
+# ---------------------------------------------------------------------------
+
+
+def test_emerging_tokens_identifies_threshold_crossers():
+    """A token below rate_threshold in baseline and above it in mode is
+    emerging. Tokens that stay below or stay above don't count."""
+    baseline = {"phase_boundary": 100, "void_static": 5, "metta_warmth": 0}
+    # 100 total in baseline; phase_boundary=1.0, void_static=0.05, metta_warmth=0
+    mode = {"compute_static": 20, "void_static": 60, "metta_warmth": 20}
+    # 100 total in mode; compute_static=0.2 (emerging), void_static=0.6
+    # (already > 5% in baseline at exactly 5%, but baseline is <= 5%, mode > 5%
+    # -> qualifies), metta_warmth=0.2 (was 0, now 0.2 -> emerging)
+    result = _emerging_tokens_vs_baseline(
+        baseline_counts=baseline,
+        mode_counts=mode,
+        rate_threshold=0.05,
+    )
+    assert "compute_static" in result["emerging_tokens"]
+    assert "metta_warmth" in result["emerging_tokens"]
+    assert "phase_boundary" not in result["emerging_tokens"]  # was > 5%
+    assert result["emerging_token_count"] == len(result["emerging_tokens"])
+
+
+def test_emerging_tokens_handles_empty_baseline():
+    """Empty baseline counts produce baseline_rate of 0 for everything,
+    so any token above threshold in mode counts as emerging."""
+    result = _emerging_tokens_vs_baseline(
+        baseline_counts={},
+        mode_counts={"a": 50, "b": 50},
+        rate_threshold=0.05,
+    )
+    assert set(result["emerging_tokens"]) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# ablate_cascade — input validation
+# ---------------------------------------------------------------------------
+
+
+def test_ablate_cascade_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set must be 'short' or 'long'."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        ablate_cascade([snap], out, log_path, "weekend", config)
+
+
+def test_ablate_cascade_rejects_unknown_disabled_token(tmp_path):
+    """Disabling a token name that isn't in the active cascade raises."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="not an active cascade token"):
+        ablate_cascade([snap], out, log_path, "short", config,
+                       disabled_tokens=("not_a_real_token",))
+
+
+def test_ablate_cascade_rejects_no_modes(tmp_path):
+    """Empty disabled_tokens + include_baseline=False + include_reverse=False
+    leaves no modes to run."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="no modes selected"):
+        ablate_cascade(
+            [snap], out, log_path, "short", config,
+            disabled_tokens=(),
+            include_baseline=False,
+            include_reverse=False,
+        )
+
+
+def test_ablate_cascade_rejects_outside_log_dir_output(tmp_path):
+    """Inherits the write-boundary contract via
+    _validate_calibration_output_path."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = tmp_path / "elsewhere" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        ablate_cascade([snap], out, log_path, "short", config)
+
+
+def test_ablate_cascade_rejects_mismatched_config_log_directory(tmp_path):
+    """Inherits the config-log-directory guard from PR #149."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bad_config = ObserverConfig(
+        log_directory=str(tmp_path / "bogus_for_ablate"),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    with pytest.raises(WriteOutsideLogDirError, match="config.log_directory"):
+        ablate_cascade([snap], out, log_path, "short", bad_config)
+
+
+# ---------------------------------------------------------------------------
+# ablate_cascade — restore contract regression fences
+# ---------------------------------------------------------------------------
+
+
+def test_ablate_cascade_restores_classify_patch_after_run(tmp_path):
+    """After normal exit, observer.classify_patch must be the original
+    callable, not the monkey-patched ablating version."""
+    from scripts import nextness_observer as _observer_module
+    original_classifier = _observer_module.classify_patch
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_reverse=False,
+    )
+    assert _observer_module.classify_patch is original_classifier
+
+
+def test_ablate_cascade_restores_classify_patch_even_if_process_snapshot_fails(
+    tmp_path, monkeypatch
+):
+    """Mid-loop exception still triggers the try/finally restore. Locks
+    the contract that no observer-state leak survives an exception."""
+    from scripts import nextness_observer as _observer_module
+    original_classifier = _observer_module.classify_patch
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+
+    # Force process_snapshot to raise after one call to simulate mid-loop
+    # failure. Patch it on the calibration module (where it was imported).
+    call_count = {"n": 0}
+    def _exploding_process_snapshot(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise RuntimeError("simulated mid-sweep failure")
+        # First call - delegate to a minimal fake entry so the row builder works
+        return {
+            "snapshot_file": str(args[0].name) if args else "x.npz",
+            "generation": 1,
+            "token_counts": {"phase_boundary": 1},
+            "vocabulary_occupancy": 0.5,
+            "shannon_entropy_bits": 0.0,
+            "entropy_normalized": 0.0,
+            "void_compute_balance": 0.0,
+            "boundary_rate": 0.0,
+            "budget": {"patches_processed": 1},
+        }
+    monkeypatch.setattr(
+        "scripts.nextness_calibration.process_snapshot",
+        _exploding_process_snapshot,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated mid-sweep failure"):
+        ablate_cascade(
+            [snap], out, log_path, "short", config,
+            disabled_tokens=("phase_boundary",),
+            include_reverse=False,
+        )
+    # Even with mid-loop exception, classify_patch must be restored.
+    assert _observer_module.classify_patch is original_classifier
+
+
+# ---------------------------------------------------------------------------
+# ablate_cascade — output structure
+# ---------------------------------------------------------------------------
+
+
+def test_ablate_cascade_row_count_matches_snapshots_times_modes(tmp_path):
+    """One per-snapshot row per (snapshot * mode), plus one aggregate row."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    s1 = _make_snapshot(snaps_dir / "v070_gen1_step1_a.npz", generation=1)
+    s2 = _make_snapshot(snaps_dir / "v070_gen2_step2_b.npz", generation=2)
+    out = log_path.parent / "out.jsonl"
+    ablate_cascade(
+        [s1, s2], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary", "compute_static"),  # 2 disable modes
+        include_baseline=True,   # +1
+        include_reverse=True,    # +1
+    )
+    # 4 modes per snapshot * 2 snapshots = 8 per-snapshot rows + 1 aggregate
+    lines = out.read_text().splitlines()
+    assert len(lines) == 9
+    rows = [json.loads(l) for l in lines[:-1]]
+    aggregate = json.loads(lines[-1])
+    assert all(r.get("experiment") == "cascade_ablation" for r in rows)
+    assert aggregate.get("experiment") == "cascade_ablation"
+
+
+def test_ablate_cascade_per_row_carries_mode_in_parameter_combination(tmp_path):
+    """parameter_combination per row carries mode + disabled_tokens + reverse_order."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_baseline=True,
+        include_reverse=True,
+    )
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    modes = [r["parameter_combination"]["mode"] for r in rows]
+    assert modes == ["baseline", "disable_phase_boundary", "reverse_order"]
+    # Disabled tokens echo back as sorted list
+    for r in rows:
+        if r["parameter_combination"]["mode"] == "disable_phase_boundary":
+            assert r["parameter_combination"]["disabled_tokens"] == ["phase_boundary"]
+            assert r["parameter_combination"]["reverse_order"] is False
+        elif r["parameter_combination"]["mode"] == "reverse_order":
+            assert r["parameter_combination"]["reverse_order"] is True
+
+
+def test_ablate_cascade_aggregate_has_emerging_token_evidence(tmp_path):
+    """Aggregate must expose per_mode_summary + emerging_token_evidence."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_baseline=True,
+        include_reverse=False,
+    )
+    assert "per_mode_summary" in aggregate
+    assert "emerging_token_evidence" in aggregate
+    assert "modes_run" in aggregate
+    assert aggregate["modes_run"] == ["baseline", "disable_phase_boundary"]
+
+
+# ---------------------------------------------------------------------------
+# ablate_cascade — falsification logic
+# ---------------------------------------------------------------------------
+
+
+def test_ablate_cascade_inconclusive_when_baseline_omitted(tmp_path):
+    """Without a baseline, the emerging-token criterion has no denominator
+    -> inconclusive (even if other modes run)."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_baseline=False,
+        include_reverse=False,
+    )
+    assert aggregate["falsification_status"] == "inconclusive"
+
+
+def test_ablate_cascade_inconclusive_when_only_baseline_requested(tmp_path):
+    """Only baseline, no non-baseline modes -> no ablation to compare,
+    falsification_status is inconclusive."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=(),
+        include_baseline=True,
+        include_reverse=False,
+    )
+    assert aggregate["falsification_status"] == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# ablate_cascade — determinism contract
+# ---------------------------------------------------------------------------
+
+
+def test_ablate_cascade_no_fresh_generated_at_field(tmp_path):
+    """No fresh wallclock-derived generated_at field in any row."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    ablate_cascade(
+        [snap], out, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_reverse=False,
+    )
+    for line in out.read_text().splitlines():
+        row = json.loads(line)
+        assert "generated_at" not in row
+
+
+def test_ablate_cascade_byte_identical_on_rerun(tmp_path):
+    """Two back-to-back runs on the same input produce byte-identical
+    output. Locks the determinism contract for this chapter."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out_a = log_path.parent / "calibration_ablate_a.jsonl"
+    out_b = log_path.parent / "calibration_ablate_b.jsonl"
+    ablate_cascade(
+        [snap], out_a, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_reverse=True,
+    )
+    ablate_cascade(
+        [snap], out_b, log_path, "short", config,
+        disabled_tokens=("phase_boundary",),
+        include_reverse=True,
+    )
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_ablate_cascade_sorts_input_by_generation(tmp_path):
+    """Per-snapshot rows in generation-ascending order regardless of input."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    s3 = _make_snapshot(snaps_dir / "v070_gen300_step3000_test.npz",
+                        generation=300, lattice=16)
+    s1 = _make_snapshot(snaps_dir / "v070_gen100_step1000_test.npz",
+                        generation=100, lattice=16)
+    s2 = _make_snapshot(snaps_dir / "v070_gen200_step2000_test.npz",
+                        generation=200, lattice=16)
+    out = log_path.parent / "out.jsonl"
+    ablate_cascade(
+        [s3, s1, s2], out, log_path, "short", config,
+        disabled_tokens=(),
+        include_baseline=True,
+        include_reverse=False,
+    )
     rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
     generations = [r["snapshot_generation"] for r in rows]
     assert generations == [100, 200, 300]


### PR DESCRIPTION
## Summary

Adds `ablate_cascade()` per design doc §3.5 (Jack #6 in the implementation order). For each snapshot, runs `process_snapshot()` once per ablation mode and computes whether the cascade is hiding signal beneath its dominant tokens.

Per Jack Chapter 6 guardrails from PR #149 review: Lane B only; cascade ablation only; no temporal sweep; no patch-radius; no CLI; no engine touch; no predicate redesign; no `metta_warmth` aggregator change. Mechanical / falsifiable outcomes only.

- **Tests**: 26 new (137 total in `test_nextness_calibration.py`)
- **Lane B suite**: 349/349 passing

## What `ablate_cascade()` does

Three mode families:
- `"baseline"` — unmodified cascade (sanity reference; required denominator)
- `"disable_<token>"` — for each entry in `disabled_tokens`, run with that predicate skipped (observe what fires "next")
- `"reverse_order"` — active cascade reversed (least-specific first; stress test)

Each mode is installed by monkey-patching `scripts.nextness_observer.classify_patch` with an ablating closure, wrapped in `try/finally` for guaranteed restoration. Same pattern as Chapter 5's `THRESHOLD_WARMTH` monkey-patch.

## Default disabled tokens (post-Jack-audit, commit `5c80593`)

Per Jack's PR #152 scope/data-coherence audit, the defaults aim at the **actually-dominant post-#145 active tokens**:

```python
DEFAULT_ABLATION_DISABLED_TOKENS = (
    "phase_boundary",
    "sensor_alert",
    "void_birth",
)
```

The earlier candidates `compute_static` and `void_static` were dropped because they are no-ops in the post-#145 corrected distribution (their predicates never fire under current Medusa state). `compute_decay` (2.0%) is omitted as below the 5% rate threshold per Jack's top-three-above-5% guidance; callers can pass it explicitly via `disabled_tokens=("...",)` if needed.

## Mechanical falsification_status

- **hypothesis_supported**: across all non-baseline modes, max additional-token count (tokens crossing 5% rate in a mode while ≤ 5% in baseline) is ≤ 5. Cascade is sensibly ordered.
- **hypothesis_falsified**: at least one non-baseline mode reveals > 5 additional tokens crossing 5% rate. Cascade ordering is the dominant cause of two-token saturation.
- **inconclusive**: no baseline (no denominator), or baseline produced no patches, or only baseline requested.

## Cascade mirror + parity regression-fence

`_classify_patch_ablation()` reimplements the **active** cascade with the two ablation knobs. Deprecated tokens (`karuna_relief`, `mudita_resonance`, `magnon_lighthouse` per `TOKEN_STATUS` post-#144) are excluded, matching what the observer cascade actually executes.

To prevent silent drift between the calibration mirror and the observer's source-of-truth, `test_classify_patch_ablation_parity_with_observer_on_synthetic_battery` runs both implementations on synthetic patches built for every active cascade branch (plus `unclassified` fall-through) and asserts bit-for-bit equality.

## Smoke pass against real Medusa (post-revision, commit `5c80593`)

Sandboxed run against 2 newest Medusa snapshots (gen ~999,675), all 5 modes:

| Mode | Top tokens (rate ≥ 5%) | Emerging tokens |
|---|---|---|
| `baseline` | phase_boundary 66.5%, sensor_alert 20.9%, void_birth 9.5% | — |
| `disable_phase_boundary` | sensor_alert **85.4%** (was 20.9%), void_birth 9.5% | 0 |
| `disable_sensor_alert` | phase_boundary 66.5%, void_birth **28.8%** (was 9.5%) | 0 |
| `disable_void_birth` | phase_boundary 66.5%, sensor_alert 20.9%, **void_static 9.5%** (new!) | 1 |
| `reverse_order` | acoustic_stress 92.2%, void_static 7.4% | 2 |

Baseline `mean_voc_occ=0.406`, `mean_CCI=0.069`.

**Falsification status**: `hypothesis_supported` (max emerging = 2 in `reverse_order`; threshold = 5).

## Interpretation — real PR #4 findings

**1. Cascade is NOT hiding signal.** Each disable mode produces **predictable, semantically-coherent routing** rather than long-tail emergence:
- `disable_phase_boundary` → sensor_alert (next-specific for high-distinct-states + sensor patches)
- `disable_sensor_alert` → mostly void_birth (next predicate that fires for sensor-containing patches dominated by void with > 1 distinct state)
- `disable_void_birth` → void_static absorbs (broader VOID-dominant catch-all one rung below)

Each disabled predicate's territory moves to a specific, semantically related neighbour — not to a long tail of random tokens. Issue #139 alternate hypothesis 4 (cascade order swallowing subtler tokens) is **NOT supported**.

**2. Post-#144 equilibrium is richer than PR #142's apparent "two-token saturation".** The PR #142 saturation finding was based on the pre-#144 (broken-layout) classifier. Post-#144 the actual distribution is **four tokens above 1% rate**, with `vocabulary_occupancy=0.406` (was 0.125 in PR #142). The "two-token saturation" was a layout-bug artifact. PR #145's fix didn't just change which channel `metta_warmth` reads — it changed the shape of the entire token distribution.

**3. Cascade ordering matters structurally.** Reverse-order classification produces a totally different distribution (`acoustic_stress` 92.2%, `void_static` 7.4%). That's "ordering choice", not "hiding". Forward (specificity-first) is the right default. Reversal is a stress test, not an alternative to ship.

## Scope guarantees (unchanged from prior chapters)

- No engine touch
- No writes outside `log_path.parent` (`WriteOutsideLogDirError`)
- No writes via `config.log_directory` mismatch (PR #149 guard)
- No HTTP / ZMQ / network
- CPU-only
- `allow_pickle=False` preserved
- No CCI regime thresholds
- No fresh `generated_at` field (locked by test)
- No external code pull
- No multi-snapshot mode added to observer
- No CLI (deferred to end of calibration implementation)
- No predicate redesign (Jack Ch6 guardrail)
- No `metta_warmth` aggregator change (deferred to #150)

## Test plan

- [x] All 26 new Chapter 6 tests pass
- [x] Parity regression-fence: calibration cascade mirror matches `observer.classify_patch` bit-for-bit on synthetic per-branch patches
- [x] Restore-contract regression fences cover normal exit + mid-loop exception
- [x] Output structure: row count, parameter_combination, aggregate fields
- [x] Falsification logic for both inconclusive paths
- [x] Determinism: no fresh `generated_at`, byte-identical rerun, generation-sorted input
- [x] Inherits both safety guards: `_validate_calibration_output_path` and `_validate_config_log_directory` (PR #149)
- [x] All 137 calibration tests pass
- [x] Lane B suite (calibration + observer + metrics + observatory + visualization): 349/349 passing
- [x] Real-Medusa smoke pass against 2 newest snapshots, post-revision defaults

Refs #139 — finding (c) parent hub. Alternate hypothesis 4 (cascade order swallowing subtler tokens) NOT supported. Issue stays open until all calibration sweeps complete; deliberately no auto-close keyword used.

Refs #150 — the post-#144 richer-than-PR-#142 finding is consistent with #150's predicate-aggregator redesign question but distinct from it. This chapter is about cascade ordering; #150 is about per-predicate aggregator design.

Approved direction: PR #143 design doc, PR #146-149 chapters 1-5 + safety guard, Chapter 6 guardrails from PR #149 audit + defaults revision from PR #152 audit (AURA + Jack), operator gate (Kevin).