### PR TITLE
Phase 19 PR #4 Chapter 8 — sweep_patch_radius (coarse-graining check)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -2524,23 +2524,360 @@ def sweep_temporal(
     return aggregate
 
 
+# ---------------------------------------------------------------------------
+# Chapter 8 — sweep_patch_radius (design doc §3.3, Jack #8 in implementation order)
+# ---------------------------------------------------------------------------
+
+
+#: Default patch radii to compare. Radius 1 is the PR #142 baseline
+#: (3x3x3 = 27 cells per patch); radius 2 is the coarse-grained variant
+#: (5x5x5 = 125 cells per patch).
+DEFAULT_PATCH_RADII: tuple[int, ...] = (1, 2)
+
+#: The canonical baseline radius (matches PR #142 + every prior chapter).
+#: Used as the reference against which other radii are compared in the
+#: §3.3 falsification criterion.
+PATCH_RADIUS_BASELINE: int = 1
+
+#: §3.3 falsification threshold: absolute CCI difference between any
+#: non-baseline radius and the baseline that exceeds this value indicates
+#: the baseline carries scale-specific structure (a patch-size artefact)
+#: rather than a real scale-robust feature.
+_PATCH_RADIUS_CCI_FALSIFICATION_THRESHOLD: float = 0.10
+
+#: Cell-count thresholds in the observer module that scale linearly with
+#: patch volume. ``ENERGY_PULSE_MIN_COUNT`` is currently the only such
+#: threshold post-#144: ``DIVERSITY_BOUNDARY`` is bounded by the state
+#: alphabet (5 states max), and the ``compute_count >= 1`` /
+#: ``sensor_count >= 1`` style predicates are intentionally minimum-
+#: presence checks that don't rescale. ``THRESHOLD_WARMTH``, ``AGE_*``,
+#: and ``FRACTION_*`` predicates are already scale-invariant.
+_COUNT_THRESHOLDS_TO_RESCALE: tuple[str, ...] = (
+    "ENERGY_PULSE_MIN_COUNT",
+)
+
+
+def _patch_cell_count(radius: int) -> int:
+    """Number of cells in a patch of the given Moore-neighbourhood radius."""
+    return (2 * radius + 1) ** 3
+
+
+def _rescale_count_threshold_for_radius(
+    baseline_value: int,
+    baseline_radius: int,
+    new_radius: int,
+) -> int:
+    """Linear rescaling of a cell-count threshold by patch volume ratio.
+
+    A patch of radius ``r`` has ``(2r+1)^3`` cells. The threshold scales
+    proportionally so the *fraction* of cells required stays constant
+    across radii. Result is rounded to the nearest integer and clamped
+    to a minimum of 1 (a count threshold of 0 would be a no-op).
+
+    Example: baseline ``ENERGY_PULSE_MIN_COUNT=3`` at radius 1 (27 cells,
+    fraction 3/27 = 0.111) rescales at radius 2 (125 cells) to
+    ``round(3 * 125/27) = round(13.89) = 14`` (fraction 14/125 = 0.112,
+    matching baseline within rounding).
+    """
+    baseline_volume = _patch_cell_count(baseline_radius)
+    new_volume = _patch_cell_count(new_radius)
+    rescaled = round(baseline_value * new_volume / baseline_volume)
+    return max(1, rescaled)
+
+
+def _clone_config_with_radius(
+    base_config: ObserverConfig,
+    radius: int,
+) -> ObserverConfig:
+    """Return a copy of ``base_config`` with ``patch_spatial_radius=radius``.
+
+    Mirrors :func:`_clone_config_with_stride` from Chapter 4 — uses
+    ``dataclasses.replace`` since ``ObserverConfig`` is frozen. Any
+    invariants on the new radius value (e.g., positive int) are enforced
+    by ``ObserverConfig.__post_init__`` at construction time, so invalid
+    combinations raise here rather than deep in the sweep loop.
+    """
+    return dataclasses.replace(base_config, patch_spatial_radius=radius)
+
+
+def sweep_patch_radius(
+    snapshots: list[pathlib.Path],
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    calibration_set: str,
+    config: ObserverConfig,
+    radii: tuple[int, ...] = DEFAULT_PATCH_RADII,
+) -> dict[str, Any]:
+    """Patch-size / coarse-graining check per design doc §3.3.
+
+    For each (snapshot, radius) pair:
+      1. Clone ``ObserverConfig`` with ``patch_spatial_radius=radius``.
+      2. Monkey-patch the count-based observer thresholds listed in
+         ``_COUNT_THRESHOLDS_TO_RESCALE`` to their volume-proportional
+         values at the new radius. Same try/finally restore pattern as
+         Chapter 5 (sweep_threshold).
+      3. Call ``process_snapshot()`` and capture per-snapshot metrics
+         (vocabulary_occupancy, shannon_entropy_bits, entropy_normalized,
+         void_compute_balance, boundary_rate) plus CCI and the full
+         ``token_counts`` distribution for cross-radius comparison.
+      4. Restore original threshold values.
+
+    Per Jack Chapter 8 guardrails from PR #153 review:
+      - Patch-radius / coarse-graining check ONLY
+      - Compare radius 1 vs radius 2
+      - Rescale ONLY count thresholds that truly need rescaling
+        (currently just ``ENERGY_PULSE_MIN_COUNT``)
+      - No engine touch, no CLI, no Lane A, no predicate redesign
+        beyond what the radius comparison requires
+      - No final "ignition" claim
+
+    Mechanical falsification_status per §3.3:
+
+      - ``"hypothesis_supported"``: |CCI(non-baseline) - CCI(baseline)|
+        stays at or below ``_PATCH_RADIUS_CCI_FALSIFICATION_THRESHOLD``
+        (= 0.10) for every non-baseline radius. The phenomenon is
+        scale-robust; the 3x3x3 baseline is not a patch-size artefact.
+      - ``"hypothesis_falsified"``: at least one non-baseline radius
+        produces |CCI diff| > 0.10. The baseline carries scale-specific
+        structure and needs reframing in a future PR.
+      - ``"inconclusive"``: ``PATCH_RADIUS_BASELINE`` not in ``radii``
+        (no reference to compare against), no snapshots, or only the
+        baseline radius requested.
+
+    Args:
+        snapshots: list of sandboxed ``.npz`` paths.
+        out_path: where to write the radius-sweep JSONL.
+        log_path: write-boundary anchor.
+        calibration_set: ``"short"`` or ``"long"``.
+        config: base ``ObserverConfig``; ``patch_spatial_radius`` is
+            overridden per sweep radius. Other fields preserved.
+        radii: tuple of integer radii to sweep. Defaults to
+            :data:`DEFAULT_PATCH_RADII` = ``(1, 2)``. Must all be
+            positive integers; baseline radius (``PATCH_RADIUS_BASELINE``
+            = 1) should be included or the falsification criterion is
+            undefined and the run falls back to ``inconclusive``.
+
+    Returns the aggregate dict for callers that want to inspect it
+    without re-reading the output file.
+
+    Raises:
+        :class:`WriteOutsideLogDirError` if ``out_path`` is outside log dir
+            or ``config.log_directory`` diverges from ``log_path.parent``.
+        ``ValueError`` for invalid calibration_set, empty radii, or
+            non-positive radius values.
+    """
+    # Lazy import of the observer module so we can monkeypatch its
+    # count threshold attributes. Same pattern as sweep_threshold (Ch5)
+    # and ablate_cascade (Ch6); only here within try/finally.
+    from scripts import nextness_observer as _observer_module
+
+    if calibration_set not in {"short", "long"}:
+        raise ValueError(
+            f"calibration_set must be 'short' or 'long', got {calibration_set!r}"
+        )
+    if not radii:
+        raise ValueError("radii must be non-empty")
+    for r in radii:
+        if not isinstance(r, int) or r <= 0:
+            raise ValueError(f"every radius must be a positive int, got {r!r}")
+
+    out_path = pathlib.Path(out_path)
+    log_path = pathlib.Path(log_path)
+    _validate_calibration_output_path(out_path, log_path)
+    _validate_config_log_directory(config, log_path)
+
+    sorted_snapshots = _sort_snapshots_by_generation(list(snapshots))
+
+    # Snapshot the baseline values of count thresholds so we can rescale
+    # them per-radius. ENERGY_PULSE_MIN_COUNT is the only entry today;
+    # the loop generalises if more get added.
+    baseline_threshold_values: dict[str, int] = {
+        name: int(getattr(_observer_module, name))
+        for name in _COUNT_THRESHOLDS_TO_RESCALE
+    }
+
+    per_snapshot_rows: list[dict[str, Any]] = []
+    # Per-radius aggregator: radius -> list of {snapshot, metrics, cci,
+    # rescaled_thresholds, token_counts}.
+    by_radius: dict[int, list[dict[str, Any]]] = {r: [] for r in radii}
+
+    for snap in sorted_snapshots:
+        generation = _extract_generation_from_filename(snap)
+        for radius in radii:
+            radius_config = _clone_config_with_radius(config, radius)
+
+            # Compute rescaled threshold values for this radius.
+            rescaled = {
+                name: _rescale_count_threshold_for_radius(
+                    baseline_value=baseline_threshold_values[name],
+                    baseline_radius=PATCH_RADIUS_BASELINE,
+                    new_radius=radius,
+                )
+                for name in _COUNT_THRESHOLDS_TO_RESCALE
+            }
+
+            # Monkey-patch + restore. Single-threaded by construction
+            # (calibration is sequential).
+            originals = {
+                name: getattr(_observer_module, name)
+                for name in _COUNT_THRESHOLDS_TO_RESCALE
+            }
+            try:
+                for name, value in rescaled.items():
+                    setattr(_observer_module, name, value)
+                entry = process_snapshot(snap, radius_config, medusa_is_live=False)
+            finally:
+                for name, value in originals.items():
+                    setattr(_observer_module, name, value)
+
+            cci_value = _cci_from_entry(entry)
+            token_counts = dict(entry.get("token_counts", {}) or {})
+            metrics = _extract_metrics_subset(entry)
+            metrics["cci"] = cci_value
+
+            per_snapshot_rows.append(_make_per_snapshot_row(
+                experiment="patch_radius_sweep",
+                snapshot_path=snap,
+                generation=generation,
+                parameter_combination={
+                    "patch_spatial_radius": radius,
+                    "patch_cell_count": _patch_cell_count(radius),
+                    "rescaled_count_thresholds": dict(sorted(rescaled.items())),
+                },
+                metrics=metrics,
+                run_metadata={
+                    # patches_processed is deterministic; elapsed_seconds
+                    # excluded per the Chapter 4 byte-identical pattern.
+                    "patches_processed": entry.get("budget", {}).get(
+                        "patches_processed"
+                    ),
+                },
+                calibration_set=calibration_set,
+            ))
+
+            by_radius[radius].append({
+                "snapshot": snap.name,
+                "metrics": metrics,
+                "token_counts": token_counts,
+            })
+
+    # --- Per-radius summary statistics ---
+    per_radius_summary: dict[str, Any] = {}
+    for radius, runs in by_radius.items():
+        if not runs:
+            per_radius_summary[str(radius)] = {"n_snapshots": 0}
+            continue
+        voc_occs = [r["metrics"]["vocabulary_occupancy"] for r in runs]
+        ccis = [r["metrics"]["cci"] for r in runs]
+        boundary_rates = [r["metrics"]["boundary_rate"] for r in runs]
+        per_radius_summary[str(radius)] = {
+            "n_snapshots": len(runs),
+            "patch_cell_count": _patch_cell_count(radius),
+            "mean_vocabulary_occupancy": sum(voc_occs) / len(voc_occs),
+            "mean_cci": sum(ccis) / len(ccis),
+            "mean_boundary_rate": sum(boundary_rates) / len(boundary_rates),
+        }
+
+    # --- Cross-radius diffs (vs baseline) ---
+    cross_radius_diffs: dict[str, float] = {}
+    if PATCH_RADIUS_BASELINE in by_radius and by_radius[PATCH_RADIUS_BASELINE]:
+        baseline_cci = per_radius_summary[str(PATCH_RADIUS_BASELINE)]["mean_cci"]
+        baseline_voc = per_radius_summary[str(PATCH_RADIUS_BASELINE)][
+            "mean_vocabulary_occupancy"
+        ]
+        for radius in radii:
+            if radius == PATCH_RADIUS_BASELINE:
+                continue
+            radius_cci = per_radius_summary[str(radius)]["mean_cci"]
+            radius_voc = per_radius_summary[str(radius)]["mean_vocabulary_occupancy"]
+            cross_radius_diffs[f"cci_diff_r{radius}_vs_r{PATCH_RADIUS_BASELINE}"] = (
+                radius_cci - baseline_cci
+            )
+            cross_radius_diffs[f"voc_occ_diff_r{radius}_vs_r{PATCH_RADIUS_BASELINE}"] = (
+                radius_voc - baseline_voc
+            )
+
+    # --- Falsification status (§3.3 |CCI diff| > 0.10 criterion) ---
+    falsification_status: str = "inconclusive"
+    falsification_evidence: dict[str, Any] = {
+        "baseline_radius": PATCH_RADIUS_BASELINE,
+        "cci_falsification_threshold": _PATCH_RADIUS_CCI_FALSIFICATION_THRESHOLD,
+    }
+    non_baseline_radii = [r for r in radii if r != PATCH_RADIUS_BASELINE]
+
+    if not sorted_snapshots:
+        falsification_evidence["reason"] = "no snapshots provided"
+    elif PATCH_RADIUS_BASELINE not in by_radius or not by_radius[PATCH_RADIUS_BASELINE]:
+        falsification_evidence["reason"] = (
+            f"baseline radius {PATCH_RADIUS_BASELINE} not in radii; "
+            f"falsification criterion needs a reference value"
+        )
+    elif not non_baseline_radii:
+        falsification_evidence["reason"] = (
+            "only baseline radius requested; no comparison radius to test against"
+        )
+    else:
+        # Max |CCI diff| across all non-baseline radii.
+        max_abs_cci_diff = 0.0
+        max_abs_diff_radius: int | None = None
+        per_radius_abs_diff: dict[str, float] = {}
+        for r in non_baseline_radii:
+            diff_key = f"cci_diff_r{r}_vs_r{PATCH_RADIUS_BASELINE}"
+            abs_diff = abs(cross_radius_diffs.get(diff_key, 0.0))
+            per_radius_abs_diff[str(r)] = abs_diff
+            if abs_diff > max_abs_cci_diff:
+                max_abs_cci_diff = abs_diff
+                max_abs_diff_radius = r
+        falsification_evidence["per_radius_abs_cci_diff"] = per_radius_abs_diff
+        falsification_evidence["max_abs_cci_diff"] = max_abs_cci_diff
+        falsification_evidence["max_abs_diff_radius"] = max_abs_diff_radius
+        if max_abs_cci_diff > _PATCH_RADIUS_CCI_FALSIFICATION_THRESHOLD:
+            falsification_status = "hypothesis_falsified"
+        else:
+            falsification_status = "hypothesis_supported"
+
+    extra_fields: dict[str, Any] = {
+        "radii_swept": list(radii),
+        "baseline_radius": PATCH_RADIUS_BASELINE,
+        "rescaled_threshold_names": list(_COUNT_THRESHOLDS_TO_RESCALE),
+        "baseline_threshold_values": baseline_threshold_values,
+        "per_radius_summary": per_radius_summary,
+        "cross_radius_diffs": cross_radius_diffs,
+        "falsification_evidence": falsification_evidence,
+    }
+
+    aggregate = _make_aggregate_row(
+        experiment="patch_radius_sweep",
+        calibration_set=calibration_set,
+        n_snapshots=len(sorted_snapshots),
+        extra_fields=extra_fields,
+        falsification_status=falsification_status,
+    )
+
+    _write_calibration_jsonl(out_path, per_snapshot_rows, aggregate)
+    return aggregate
+
+
 __all__ = [
     "CANONICAL_STRIDE",
     "DEFAULT_ABLATION_DISABLED_TOKENS",
     "DEFAULT_CANONICAL_SEED",
     "DEFAULT_GAP_SPECS_LONG",
     "DEFAULT_GAP_SPECS_SHORT",
+    "DEFAULT_PATCH_RADII",
     "DEFAULT_STRIDES",
     "DEFAULT_THRESHOLD_MULTIPLIERS",
     "DEFAULT_THRESHOLD_NAME",
     "DEFAULT_VARIANCE_SEEDS",
     "EXPECTED_MEMORY_CHANNELS",
     "EXPECTED_MEMORY_DTYPE",
+    "PATCH_RADIUS_BASELINE",
     "SHUFFLE_MODES",
     "SPARSITY_EPSILON",
     "ablate_cascade",
     "check_determinism",
     "shuffle_test",
+    "sweep_patch_radius",
     "sweep_stride",
     "sweep_temporal",
     "sweep_threshold",

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -45,17 +45,20 @@ from scripts.nextness_calibration import (
     DEFAULT_CANONICAL_SEED,
     DEFAULT_GAP_SPECS_LONG,
     DEFAULT_GAP_SPECS_SHORT,
+    DEFAULT_PATCH_RADII,
     DEFAULT_STRIDES,
     DEFAULT_THRESHOLD_MULTIPLIERS,
     DEFAULT_THRESHOLD_NAME,
     DEFAULT_VARIANCE_SEEDS,
     EXPECTED_MEMORY_CHANNELS,
     EXPECTED_MEMORY_DTYPE,
+    PATCH_RADIUS_BASELINE,
     SHUFFLE_MODES,
     SPARSITY_EPSILON,
     _ACTIVE_CASCADE_ORDER,
     _ablation_modes_for_run,
     _classify_patch_ablation,
+    _clone_config_with_radius,
     _clone_config_with_stride,
     _content_fingerprint,
     _emerging_tokens_vs_baseline,
@@ -63,7 +66,9 @@ from scripts.nextness_calibration import (
     _interpret_signal_location,
     _make_aggregate_row,
     _make_per_snapshot_row,
+    _patch_cell_count,
     _per_channel_signature,
+    _rescale_count_threshold_for_radius,
     _shuffle_falsification_status,
     _shuffled_snapshot_arrays,
     _sort_snapshots_by_generation,
@@ -74,6 +79,7 @@ from scripts.nextness_calibration import (
     ablate_cascade,
     check_determinism,
     shuffle_test,
+    sweep_patch_radius,
     sweep_stride,
     sweep_temporal,
     sweep_threshold,
@@ -2885,3 +2891,419 @@ def test_sweep_temporal_sorts_input_by_generation(tmp_path):
     # Anchor snapshot in each row is the earlier one; gens 100, 200
     generations = [r["snapshot_generation"] for r in rows]
     assert generations == [100, 200]
+
+
+# ===========================================================================
+# Chapter 8 — sweep_patch_radius (design doc §3.3)
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# Module constants + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_default_patch_radii_includes_baseline():
+    """DEFAULT_PATCH_RADII must include PATCH_RADIUS_BASELINE for the
+    §3.3 falsification criterion to have a denominator."""
+    assert PATCH_RADIUS_BASELINE in DEFAULT_PATCH_RADII
+
+
+def test_default_patch_radii_has_at_least_two_radii():
+    """A radius sweep needs at least 2 radii to compare anything."""
+    assert len(DEFAULT_PATCH_RADII) >= 2
+
+
+def test_patch_cell_count_correct_at_known_radii():
+    """(2r+1)^3 cells per Moore-neighbourhood patch."""
+    assert _patch_cell_count(1) == 27   # 3x3x3
+    assert _patch_cell_count(2) == 125  # 5x5x5
+    assert _patch_cell_count(3) == 343  # 7x7x7
+
+
+def test_rescale_count_threshold_for_baseline_radius_unchanged():
+    """A rescale from a radius to itself returns the same value."""
+    assert _rescale_count_threshold_for_radius(3, 1, 1) == 3
+    assert _rescale_count_threshold_for_radius(14, 2, 2) == 14
+
+
+def test_rescale_count_threshold_proportional_to_volume_ratio():
+    """ENERGY_PULSE_MIN_COUNT=3 at r=1 (27 cells, fraction 3/27 = 0.111)
+    rescales at r=2 (125 cells) to round(3 * 125/27) = 14
+    (fraction 14/125 = 0.112, matching baseline within rounding)."""
+    assert _rescale_count_threshold_for_radius(3, 1, 2) == 14
+
+
+def test_rescale_count_threshold_clamps_to_one_minimum():
+    """A rescaled threshold cannot drop below 1 (a count of 0 would be
+    a no-op trigger; clamp prevents that pathology)."""
+    # baseline=1 at r=2 rescales DOWN to r=1 → round(1 * 27/125) = round(0.216) = 0
+    # → clamped to 1.
+    assert _rescale_count_threshold_for_radius(1, 2, 1) == 1
+
+
+def test_clone_config_with_radius_preserves_other_fields(tmp_path):
+    """_clone_config_with_radius must change only patch_spatial_radius,
+    leaving stride/budget/log_directory etc. untouched."""
+    base = ObserverConfig(
+        log_directory="/tmp/test_log",
+        uniform_grid_stride=8,
+        budget_seconds=42.0,
+        patch_spatial_radius=1,
+    )
+    clone = _clone_config_with_radius(base, 2)
+    assert clone.patch_spatial_radius == 2
+    assert clone.log_directory == base.log_directory
+    assert clone.uniform_grid_stride == base.uniform_grid_stride
+    assert clone.budget_seconds == base.budget_seconds
+    # Original unchanged (frozen dataclass)
+    assert base.patch_spatial_radius == 1
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_patch_radius_rejects_unknown_calibration_set(tmp_path):
+    """calibration_set must be 'short' or 'long'."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="calibration_set"):
+        sweep_patch_radius([snap], out, log_path, "weekend", config)
+
+
+def test_sweep_patch_radius_rejects_empty_radii(tmp_path):
+    """Empty radii tuple is an error."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="radii"):
+        sweep_patch_radius([snap], out, log_path, "short", config, radii=())
+
+
+def test_sweep_patch_radius_rejects_non_positive_radius(tmp_path):
+    """Radius must be a positive int."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    with pytest.raises(ValueError, match="radius"):
+        sweep_patch_radius([snap], out, log_path, "short", config,
+                           radii=(0,))
+
+
+def test_sweep_patch_radius_rejects_outside_log_dir_output(tmp_path):
+    """Inherits the write-boundary contract."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = tmp_path / "elsewhere" / "out.jsonl"
+    with pytest.raises(WriteOutsideLogDirError, match="outside log_path"):
+        sweep_patch_radius([snap], out, log_path, "short", config)
+
+
+def test_sweep_patch_radius_rejects_mismatched_config_log_directory(tmp_path):
+    """Inherits the PR #149 config-log-directory guard."""
+    snaps_dir, log_path, _ = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    bad_config = ObserverConfig(
+        log_directory=str(tmp_path / "bogus_for_radius"),
+        uniform_grid_stride=4,
+        budget_seconds=30.0,
+    )
+    with pytest.raises(WriteOutsideLogDirError, match="config.log_directory"):
+        sweep_patch_radius([snap], out, log_path, "short", bad_config)
+
+
+# ---------------------------------------------------------------------------
+# Restore contract regression fences
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_patch_radius_restores_count_thresholds_after_run(tmp_path):
+    """After normal exit, observer count thresholds must be the original
+    values, not the rescaled per-radius values."""
+    from scripts import nextness_observer as _observer_module
+    original_pulse = _observer_module.ENERGY_PULSE_MIN_COUNT
+
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    sweep_patch_radius([snap], out, log_path, "short", config, radii=(1, 2))
+    assert _observer_module.ENERGY_PULSE_MIN_COUNT == original_pulse
+
+
+def test_sweep_patch_radius_restores_count_thresholds_even_if_process_snapshot_fails(
+    tmp_path, monkeypatch
+):
+    """Mid-loop exception still triggers the try/finally restore. Locks
+    the contract that no observer-state leak survives an exception."""
+    from scripts import nextness_observer as _observer_module
+    original_pulse = _observer_module.ENERGY_PULSE_MIN_COUNT
+
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+
+    def _exploding_process_snapshot(*args, **kwargs):
+        raise RuntimeError("simulated mid-sweep failure")
+
+    monkeypatch.setattr(
+        "scripts.nextness_calibration.process_snapshot",
+        _exploding_process_snapshot,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        sweep_patch_radius([snap], out, log_path, "short", config, radii=(1, 2))
+
+    # ENERGY_PULSE_MIN_COUNT restored even though we crashed mid-loop.
+    assert _observer_module.ENERGY_PULSE_MIN_COUNT == original_pulse
+
+
+# ---------------------------------------------------------------------------
+# Output structure
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_patch_radius_row_count_matches_snapshots_times_radii(tmp_path):
+    """One per-snapshot row per (snapshot * radius), plus one aggregate row."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    s1 = _make_snapshot(snaps_dir / "v070_gen1_step1_a.npz", generation=1)
+    s2 = _make_snapshot(snaps_dir / "v070_gen2_step2_b.npz", generation=2)
+    out = log_path.parent / "out.jsonl"
+    sweep_patch_radius([s1, s2], out, log_path, "short", config, radii=(1, 2))
+    lines = out.read_text().splitlines()
+    # 2 radii * 2 snapshots = 4 per-snapshot rows + 1 aggregate
+    assert len(lines) == 5
+
+
+def test_sweep_patch_radius_per_row_carries_radius_and_rescaled_thresholds(tmp_path):
+    """parameter_combination per row carries patch_spatial_radius,
+    patch_cell_count, and rescaled_count_thresholds."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    sweep_patch_radius([snap], out, log_path, "short", config, radii=(1, 2))
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    assert len(rows) == 2
+    # Row 0: radius 1
+    pc0 = rows[0]["parameter_combination"]
+    assert pc0["patch_spatial_radius"] == 1
+    assert pc0["patch_cell_count"] == 27
+    assert pc0["rescaled_count_thresholds"]["ENERGY_PULSE_MIN_COUNT"] == 3
+    # Row 1: radius 2
+    pc1 = rows[1]["parameter_combination"]
+    assert pc1["patch_spatial_radius"] == 2
+    assert pc1["patch_cell_count"] == 125
+    assert pc1["rescaled_count_thresholds"]["ENERGY_PULSE_MIN_COUNT"] == 14
+
+
+def test_sweep_patch_radius_aggregate_has_per_radius_summary_and_evidence(tmp_path):
+    """Aggregate must expose per_radius_summary, cross_radius_diffs,
+    falsification_evidence (with baseline_radius + threshold embedded)."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = sweep_patch_radius(
+        [snap], out, log_path, "short", config, radii=(1, 2),
+    )
+    assert "per_radius_summary" in aggregate
+    assert "cross_radius_diffs" in aggregate
+    assert "falsification_evidence" in aggregate
+    assert aggregate["baseline_radius"] == 1
+    assert "ENERGY_PULSE_MIN_COUNT" in aggregate["rescaled_threshold_names"]
+    evidence = aggregate["falsification_evidence"]
+    assert evidence["baseline_radius"] == 1
+    assert evidence["cci_falsification_threshold"] == 0.10
+
+
+# ---------------------------------------------------------------------------
+# Falsification logic
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_patch_radius_inconclusive_when_baseline_not_in_radii(tmp_path):
+    """Without baseline radius in the sweep, no reference to diff against
+    -> inconclusive with explicit reason."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = sweep_patch_radius(
+        [snap], out, log_path, "short", config, radii=(2,),
+    )
+    assert aggregate["falsification_status"] == "inconclusive"
+    assert "baseline radius" in aggregate["falsification_evidence"]["reason"]
+
+
+def test_sweep_patch_radius_inconclusive_when_only_baseline_requested(tmp_path):
+    """Only baseline radius, no comparison radius -> inconclusive."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    aggregate = sweep_patch_radius(
+        [snap], out, log_path, "short", config, radii=(1,),
+    )
+    assert aggregate["falsification_status"] == "inconclusive"
+    assert "comparison radius" in aggregate["falsification_evidence"]["reason"]
+
+
+def test_sweep_patch_radius_falsified_when_cci_diff_exceeds_threshold(
+    tmp_path, monkeypatch
+):
+    """Integration test for the hypothesis_falsified branch.
+
+    Monkey-patches process_snapshot to return entries with hand-crafted
+    token_counts and per-snapshot fields that produce a CCI difference
+    larger than the 0.10 falsification threshold between radius 1 and
+    radius 2. Asserts:
+
+      1. falsification_status == "hypothesis_falsified"
+      2. max_abs_cci_diff > 0.10
+      3. The triggering radius is recorded
+
+    This exercises the actual sweep_patch_radius code path through the
+    falsification branch (closing the same class of gap Jack flagged
+    on PR #153)."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+
+    call_count = {"n": 0}
+    # CCI = balance * boundary * (1 - entropy_norm). Engineer two entries
+    # such that the CCI difference exceeds the 0.10 falsification threshold.
+    #   r=1: balance=0.8, boundary=0.5, entropy_norm=0.0 -> CCI = 0.4
+    #   r=2: balance=0.0, boundary=0.0, entropy_norm=1.0 -> CCI = 0.0
+    #   |diff| = 0.4 > 0.10 -> hypothesis_falsified
+    fake_entries = [
+        {  # radius 1 invocation: high CCI
+            "snapshot_file": snap.name,
+            "generation": 1,
+            "token_counts": {"a": 60, "b": 40},
+            "vocabulary_occupancy": 0.4,
+            "shannon_entropy_bits": 0.97,
+            "entropy_normalized": 0.0,
+            "void_compute_balance": 0.8,
+            "boundary_rate": 0.5,
+            "budget": {"patches_processed": 100},
+        },
+        {  # radius 2 invocation: low CCI
+            "snapshot_file": snap.name,
+            "generation": 1,
+            "token_counts": {"a": 100},
+            "vocabulary_occupancy": 0.1,
+            "shannon_entropy_bits": 0.0,
+            "entropy_normalized": 1.0,
+            "void_compute_balance": 0.0,
+            "boundary_rate": 0.0,
+            "budget": {"patches_processed": 100},
+        },
+    ]
+
+    def _fake_process_snapshot(*args, **kwargs):
+        entry = fake_entries[call_count["n"]]
+        call_count["n"] += 1
+        return entry
+
+    monkeypatch.setattr(
+        "scripts.nextness_calibration.process_snapshot",
+        _fake_process_snapshot,
+    )
+
+    aggregate = sweep_patch_radius(
+        [snap], out, log_path, "short", config, radii=(1, 2),
+    )
+
+    assert aggregate["falsification_status"] == "hypothesis_falsified"
+    evidence = aggregate["falsification_evidence"]
+    assert evidence["max_abs_cci_diff"] > 0.10
+    assert evidence["max_abs_diff_radius"] == 2
+
+
+def test_sweep_patch_radius_supported_when_cci_diff_within_threshold(
+    tmp_path, monkeypatch
+):
+    """Integration test for the hypothesis_supported branch.
+
+    Engineer two entries where r=1 and r=2 produce nearly-identical CCI
+    (within 0.10 absolute). Assert falsification_status =
+    hypothesis_supported and max_abs_cci_diff is recorded below threshold."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+
+    call_count = {"n": 0}
+    # Both radii: identical metrics -> CCI diff = 0
+    fake_entry = {
+        "snapshot_file": snap.name,
+        "generation": 1,
+        "token_counts": {"a": 60, "b": 40},
+        "vocabulary_occupancy": 0.3,
+        "shannon_entropy_bits": 0.9,
+        "entropy_normalized": 0.9,
+        "void_compute_balance": 0.1,
+        "boundary_rate": 0.4,
+        "budget": {"patches_processed": 100},
+    }
+
+    def _fake_process_snapshot(*args, **kwargs):
+        call_count["n"] += 1
+        return dict(fake_entry)
+
+    monkeypatch.setattr(
+        "scripts.nextness_calibration.process_snapshot",
+        _fake_process_snapshot,
+    )
+
+    aggregate = sweep_patch_radius(
+        [snap], out, log_path, "short", config, radii=(1, 2),
+    )
+
+    assert aggregate["falsification_status"] == "hypothesis_supported"
+    evidence = aggregate["falsification_evidence"]
+    assert evidence["max_abs_cci_diff"] <= 0.10
+
+
+# ---------------------------------------------------------------------------
+# Determinism contract
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_patch_radius_no_fresh_generated_at_field(tmp_path):
+    """No fresh wallclock-derived generated_at field in any row."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out = log_path.parent / "out.jsonl"
+    sweep_patch_radius([snap], out, log_path, "short", config, radii=(1, 2))
+    for line in out.read_text().splitlines():
+        assert "generated_at" not in json.loads(line)
+
+
+def test_sweep_patch_radius_byte_identical_on_rerun(tmp_path):
+    """Two back-to-back runs on the same input produce byte-identical output."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz",
+                          generation=1, lattice=16)
+    out_a = log_path.parent / "calibration_radius_a.jsonl"
+    out_b = log_path.parent / "calibration_radius_b.jsonl"
+    sweep_patch_radius([snap], out_a, log_path, "short", config, radii=(1, 2))
+    sweep_patch_radius([snap], out_b, log_path, "short", config, radii=(1, 2))
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
+def test_sweep_patch_radius_sorts_input_by_generation(tmp_path):
+    """Per-snapshot rows in generation-ascending order regardless of input."""
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    s3 = _make_snapshot(snaps_dir / "v070_gen300_step3000_c.npz",
+                        generation=300, lattice=8)
+    s1 = _make_snapshot(snaps_dir / "v070_gen100_step1000_a.npz",
+                        generation=100, lattice=8)
+    s2 = _make_snapshot(snaps_dir / "v070_gen200_step2000_b.npz",
+                        generation=200, lattice=8)
+    out = log_path.parent / "out.jsonl"
+    sweep_patch_radius(
+        [s3, s1, s2], out, log_path, "short", config, radii=(1,),
+    )
+    rows = [json.loads(l) for l in out.read_text().splitlines()[:-1]]
+    generations = [r["snapshot_generation"] for r in rows]
+    assert generations == [100, 200, 300]


### PR DESCRIPTION
## Summary

Adds `sweep_patch_radius()` per design doc §3.3 (Jack #8, **last code chapter in the PR #4 calibration suite**). Compares per-snapshot metrics + CCI across `patch_spatial_radius` values (default: r=1 baseline vs r=2 coarse-grained).

For each `(snapshot, radius)` pair:
1. Clone `ObserverConfig` with `patch_spatial_radius=radius` (Ch4 pattern)
2. Monkey-patch count-based observer thresholds in `_COUNT_THRESHOLDS_TO_RESCALE` to volume-proportional values (Ch5+Ch6 pattern, `try/finally` restore)
3. Run `process_snapshot()` and capture metrics + CCI + token_counts
4. Restore original threshold values

Per Jack Chapter 8 guardrails from PR #153 review: patch-radius / coarse-graining check **only**; radius 1 vs radius 2; rescale ONLY count thresholds that truly need rescaling; no engine touch; no CLI; no Lane A; no predicate redesign beyond radius comparison; no final "ignition" claim.

- **Tests**: 24 new (188 total in `test_nextness_calibration.py`)
- **Lane B suite**: 400/400 passing

## What needs rescaling, what doesn't

Only `ENERGY_PULSE_MIN_COUNT` is rescaled:
- r=1: 3 cells out of 27 (fraction 0.111)
- r=2: 14 cells out of 125 (fraction 0.112 — matches baseline within rounding)

**Deliberately NOT rescaled** (per Jack "only what truly needs"):
- `DIVERSITY_BOUNDARY` (4 distinct states) — bounded by the 5-state alphabet; semantically "does this patch span more than 3/5 of the state alphabet?"; linear rescaling would not preserve that
- `compute_count >= 1` / `sensor_count >= 1` style — intentionally minimum-presence checks
- `THRESHOLD_WARMTH`, `AGE_SAGE`, `AGE_ANCIENT`, `FRACTION_DOMINANT`, `FRACTION_MAJORITY` — already scale-invariant (means and fractions, not counts)

## Mechanical falsification_status

- **hypothesis_supported**: |CCI(non-baseline) − CCI(baseline)| ≤ 0.10 for every non-baseline radius. Scale-robust.
- **hypothesis_falsified**: at least one non-baseline radius produces |CCI diff| > 0.10. Patch-size artefact.
- **inconclusive**: baseline not in `radii`, no snapshots, or only baseline radius requested.

## Smoke pass against real Medusa

Sandboxed run against 2 newest snapshots (gen ~999,675), r=1 vs r=2:

| Radius | Cells | mean voc_occ | mean CCI | mean boundary_rate |
|---|---|---|---|---|
| 1 | 27 | 0.4062 | 0.0692 | 0.665 |
| 2 | 125 | 0.1250 | **0.1030** | 0.985 |

**Cross-radius diffs**:
- `cci_diff_r2_vs_r1`: **+0.0339**
- `voc_occ_diff_r2_vs_r1`: −0.2812

**Falsification status**: `hypothesis_supported` — max |CCI diff| = 0.034, well below the 0.10 threshold.

## Interpretation — three findings worth recording

**1. CCI is scale-robust.** |CCI diff| = 0.034 « 0.10. The CCI signal survives coarse-graining — whatever it's measuring lives in the lattice at multiple scales. AURA's real-geometric-structure hypothesis survives this discriminating test cleanly. Issue #139 alternate hypothesis "patch-size artefact" is **NOT supported**.

**2. Vocabulary occupancy is NOT scale-robust (second-order finding worth flagging).** `voc_occ` drops from 0.406 at r=1 to **0.125** at r=2 — only 2 tokens (out of 16) fire at r=2. `boundary_rate` jumps from 0.665 to **0.985** — almost every patch lands on a boundary. Mechanism: at r=2 (125 cells), the `DIVERSITY_BOUNDARY` threshold of "≥ 4 distinct states" is way easier to hit by combinatorics alone. The Chapter 6 finding "post-#144 vocabulary is richer than PR #142 suggested" is **patch-size-dependent**. The overall phenomenon (settled-equilibrium, low CCI, boundary-dominated) survives at the qualitative level, but the specific vocabulary reshuffles.

**3. `DIVERSITY_BOUNDARY` deliberately not rescaled.** Per Jack's "rescale ONLY count thresholds that truly need rescaling", `DIVERSITY_BOUNDARY=4` is alphabet-bounded (5 possible states), not a fraction-of-cells threshold. Linear rescaling would not preserve its semantics. **Worth flagging for the calibration summary**: if its combinatorial sensitivity to patch volume is judged "should be made fraction-aware" in the synthesis, that would be a follow-up predicate-design issue (similar to #150's `metta_warmth` aggregator question).

## Scope guarantees

- No engine touch
- No writes outside `log_path.parent`
- No writes via `config.log_directory` mismatch (PR #149 guard)
- No HTTP / ZMQ / network
- CPU-only
- `allow_pickle=False` preserved
- No CCI regime thresholds
- No fresh `generated_at` field (locked by test)
- No external code pull
- No multi-snapshot mode added to observer
- No CLI (deferred to end of calibration implementation)
- No predicate redesign beyond cell-count rescaling (Jack Ch8 guardrail)
- No `metta_warmth` aggregator change (deferred to #150)
- **No final "ignition" claim** — Lane A decision happens AFTER the calibration summary report, NOT in this PR

## Test plan

- [x] All 24 new Chapter 8 tests pass
- [x] All 188 calibration tests pass
- [x] Lane B suite: 400/400 passing
- [x] Real integration tests for both `hypothesis_falsified` and `hypothesis_supported` branches (engineered CCI via monkeypatched `process_snapshot` returning hand-crafted entries — closing the same class of gap Jack flagged on PR #153)
- [x] Restore-contract regression fences cover normal exit + mid-loop exception
- [x] Determinism: no fresh `generated_at`, byte-identical rerun, generation-sorted input
- [x] Inherits both safety guards: `_validate_calibration_output_path` and `_validate_config_log_directory`
- [x] Real-Medusa smoke pass against 2 newest snapshots

Refs #139 — finding (c) parent hub. Patch-size-artefact hypothesis NOT supported. Issue stays open until the calibration summary report is written (tomorrow) and a separate Lane A decision is made.

**This is the LAST code chapter in PR #4.** Next: calibration summary report (judgment work, fresh head tomorrow), then a separate Lane A decision gate. No automatic ignition.

Approved direction: PR #143 design doc, PR #146-153 chapters 1-7 + safety guard + defaults revisions, Chapter 8 guardrails from PR #153 audit (AURA + Jack), operator gate (Kevin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)