### PR TITLE
feat: demote metta_warmth to diagnostic_only (Workstream B/C implementation)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -1572,8 +1572,15 @@ def sweep_threshold(
             threshold's base value. Must be all positive.
         threshold_dependent_token: name of the token whose firing count
             we track across the sweep for the knife-edge criterion.
-            Defaults to ``"metta_warmth"`` (the only ``THRESHOLD_WARMTH``-
-            dependent active token post-#144).
+            Defaults to ``"metta_warmth"`` for backward compatibility.
+            NOTE (Workstream B/C, PR #163): metta_warmth was demoted to
+            status ``diagnostic_only`` and removed from the active cascade,
+            so it now never fires and the sweep reports ``inconclusive`` for
+            it by construction. The tokens that actually depend on
+            ``THRESHOLD_WARMTH`` post-demotion are ``compute_decay`` and
+            ``acoustic_stress`` (both gate on ``warmth_mean < THRESHOLD_WARMTH``);
+            a future calibration PR may repoint this default to one of them.
+            Left unchanged here to keep the demotion PR narrow.
 
     Returns the aggregate dict for callers that want to inspect it.
 
@@ -1793,10 +1800,13 @@ DEFAULT_ABLATION_DISABLED_TOKENS: tuple[str, ...] = (
 #: non-ablated calibration cascade against the observer cascade on
 #: synthetic patches covering every branch. ``unclassified`` is the
 #: fall-through bucket, not an explicit cascade step.
+# metta_warmth removed from the active cascade per Workstream B/C (PR #163):
+# it is now status "diagnostic_only" in the observer's TOKEN_STATUS and no
+# longer routes classification. The observer's classify_patch skips it; this
+# mirror must match (parity regression-fence test enforces agreement).
 _ACTIVE_CASCADE_ORDER: tuple[str, ...] = (
     "phase_boundary",
     "compute_aging",
-    "metta_warmth",
     "sensor_alert",
     "energy_pulse",
     "compute_decay",
@@ -1845,8 +1855,10 @@ def _predicate_fires(token: str, features: Any) -> bool:
         return f.distinct_states >= DIVERSITY_BOUNDARY
     if token == "compute_aging":
         return f.compute_frac >= FRACTION_DOMINANT and f.compute_age_mean >= AGE_SAGE
-    if token == "metta_warmth":
-        return (f.compute_count >= 1 or f.energy_count >= 1) and f.warmth_mean >= THRESHOLD_WARMTH
+    # metta_warmth intentionally absent: demoted to diagnostic_only (PR #163),
+    # no longer a routing token. It is not in _ACTIVE_CASCADE_ORDER, so this
+    # mirror is never asked to evaluate it; a stray call would (correctly)
+    # fall through to the ValueError below.
     if token == "sensor_alert":
         return f.sensor_count >= 1
     if token == "energy_pulse":

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -1493,8 +1493,18 @@ def process_snapshot(
     # status "diagnostic_only" — it no longer routes classification, so its
     # underlying warmth signal is reported here as numeric diagnostics instead.
     # Computed over the whole warmth channel (deterministic regardless of the
-    # stride backoff, unlike the sampled patches). Defensive over grids with
-    # fewer than 7 channels (mirrors _safe_mean's guard).
+    # stride backoff, unlike the sampled patches).
+    #
+    # AXIS: the memory grid is CHANNEL-FIRST ``(channels, X, Y, Z)`` — the
+    # channel is axis 0. This matches load_snapshot's validation
+    # (``memory.shape[1:] == state.shape``), iter_uniform_grid_patches
+    # (``memory[:, sx, sy, sz]``), and _safe_mean (``memory[idx]``). So we
+    # index ``memory[warmth_idx]`` and guard on ``memory.shape[0]``, NOT
+    # ``memory[..., warmth_idx]`` / ``shape[-1]`` (a channel-last read would
+    # return a spatial cross-section — verified to surface the step counter,
+    # max ~1.7e7, not warmth). Locked by
+    # test_warmth_diagnostics_read_correct_memory_axis. Also defensive over
+    # grids with fewer than 7 channels (mirrors _safe_mean's guard).
     warmth_idx = MEMORY_CHANNEL_LAYOUT["warmth"]
     if warmth_idx < memory.shape[0]:
         warmth_channel = memory[warmth_idx]

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -117,6 +117,22 @@ TOKEN_INDEX: Final[dict[str, int]] = {name: i for i, name in enumerate(TOKEN_NAM
 #:                                        no memory-grid dependency.
 #:   "stored"                           — predicate reads stored memory
 #:                                        channels via ``MEMORY_CHANNEL_LAYOUT``.
+#:   "diagnostic_only"                  — the underlying signal is real and
+#:                                        measured, but too sparse / non-
+#:                                        discriminating to route patch
+#:                                        classification in current Medusa
+#:                                        state. Skipped by the cascade; the
+#:                                        signal is instead reported as a
+#:                                        numeric diagnostic field. Set for
+#:                                        ``metta_warmth`` per Workstream B/C
+#:                                        (PR #160–#163): warmth exists but
+#:                                        does not cluster (issue #150).
+#:                                        Distinct from ``deprecated_no_engine
+#:                                        _channel``: there is a real signal;
+#:                                        it is just not useful for routing.
+#:                                        Re-promotable to ``stored`` if a
+#:                                        future profiling pass shows a
+#:                                        stronger signal.
 #:   "deprecated_no_engine_channel"     — predicate previously referenced
 #:                                        a memory channel that the engine
 #:                                        does not store. Disabled until
@@ -127,11 +143,14 @@ TOKEN_INDEX: Final[dict[str, int]] = {name: i for i, name in enumerate(TOKEN_NAM
 #:                                        observer reimplements the
 #:                                        derivation (follow-up TODO).
 #:
-#: The classifier cascade skips any token with status
-#: ``"deprecated_no_engine_channel"`` or ``"derived_future"`` —
-#: ``vocabulary_occupancy`` will accordingly be capped at
-#: (active_tokens / total_tokens) until the deprecated tokens have a
-#: home in the engine.
+#: The classifier cascade skips any token whose status is in
+#: ``NON_ROUTING_STATUSES`` (``"diagnostic_only"``,
+#: ``"deprecated_no_engine_channel"``, ``"derived_future"``). Two occupancy
+#: metrics result: ``vocabulary_occupancy`` (fraction of all TOKEN_NAMES that
+#: appeared — full historical-vocabulary view) and
+#: ``active_vocabulary_occupancy`` (fraction of *routing* tokens that appeared
+#: — so Lane A does not mistake diagnostic vocabulary for active routing
+#: vocabulary). See Workstream C (PR #163) for the status/occupancy model.
 TOKEN_STATUS: Final[dict[str, str]] = {
     "void_static":        "state_only",
     "compute_static":     "state_only",
@@ -142,7 +161,7 @@ TOKEN_STATUS: Final[dict[str, str]] = {
     "structural_decay":   "stored",      # reads structural_age (idx 1)
     "energy_pulse":       "state_only",
     "sensor_alert":       "state_only",
-    "metta_warmth":       "stored",      # reads warmth (idx 6) post-#144 fix
+    "metta_warmth":       "diagnostic_only",  # warmth real but too sparse to route — Workstream B/C, issue #150
     "karuna_relief":      "deprecated_no_engine_channel",  # no compassion channel
     "mudita_resonance":   "deprecated_no_engine_channel",  # no resonance channel
     "magnon_lighthouse":  "derived_future",   # magnon is derived from compute_age, not stored
@@ -153,6 +172,22 @@ TOKEN_STATUS: Final[dict[str, str]] = {
 
 assert set(TOKEN_STATUS.keys()) == set(TOKEN_NAMES), (
     "TOKEN_STATUS must cover every token in TOKEN_NAMES"
+)
+
+#: Statuses whose tokens are skipped by the classifier cascade (they do not
+#: route patch classification). Used to derive the routing-token set for
+#: ``active_vocabulary_occupancy``.
+NON_ROUTING_STATUSES: Final[frozenset[str]] = frozenset({
+    "diagnostic_only",
+    "deprecated_no_engine_channel",
+    "derived_future",
+})
+
+#: Tokens that actively participate in cascade routing (status not in
+#: NON_ROUTING_STATUSES). Denominator for ``active_vocabulary_occupancy``.
+ROUTING_TOKENS: Final[frozenset[str]] = frozenset(
+    name for name, status in TOKEN_STATUS.items()
+    if status not in NON_ROUTING_STATUSES
 )
 
 
@@ -634,6 +669,12 @@ THRESHOLD_WARMTH: Final[float] = 0.3
 THRESHOLD_RESONANCE: Final[float] = 0.3   # unused post-#144
 THRESHOLD_COMPASSION: Final[float] = 0.3  # unused post-#144
 
+# Per-cell warmth floor for the ``warm_cell_count`` diagnostic (Workstream B/C,
+# PR #161 profiling used 0.05 as the lowest threshold at which any warm-cell
+# pairing was observed). Counts cells whose warmth >= this value across the
+# snapshot's warmth channel. Diagnostic only — not consumed by classify_patch.
+WARMTH_DIAGNOSTIC_FLOOR: Final[float] = 0.05
+
 # --- State-fraction thresholds (over the patch's 27 cells at radius=1) ---
 FRACTION_DOMINANT: Final[float] = 0.5    # > 50% of cells (≥14 of 27)
 FRACTION_MAJORITY: Final[float] = 0.7    # > 70% of cells (≥19 of 27)
@@ -765,10 +806,19 @@ def classify_patch(patch: Patch) -> str:
     #      if f.compute_count >= 1 and f.compassion_mean >= THRESHOLD_COMPASSION:
     #          return "karuna_relief"
 
-    # 6. Metta warmth — warmth field around COMPUTE/ENERGY.
-    #    Post-#144: now reads engine's actual warmth channel (idx 6).
-    if (f.compute_count >= 1 or f.energy_count >= 1) and f.warmth_mean >= THRESHOLD_WARMTH:
-        return "metta_warmth"
+    # 6. (DIAGNOSTIC-ONLY per Workstream B/C, PR #160–#163) metta_warmth —
+    #    warmth field around COMPUTE/ENERGY. Post-#144 it correctly reads the
+    #    engine's warmth channel (idx 6), but empirical profiling (PR #161)
+    #    showed warmth is real yet too sparse to cluster: at the 0.990-sparse
+    #    current state the patch-mean predicate never fires, and even max-
+    #    pooling finds only isolated single-cell specks (no multi-cell
+    #    clusters at any threshold). Demoted to status "diagnostic_only" —
+    #    the warmth signal is reported as the ``warmth_max`` / ``warm_cell_count``
+    #    JSONL diagnostics instead of routing classification. Re-promotable if
+    #    a future profiling pass shows a stronger signal (issue #150).
+    #    Original predicate, preserved for future rehabilitation:
+    #      if (f.compute_count >= 1 or f.energy_count >= 1) and f.warmth_mean >= THRESHOLD_WARMTH:
+    #          return "metta_warmth"
 
     # 7. Sensor alert — any SENSOR present (intrinsically rare and notable)
     if f.sensor_count >= 1:
@@ -1358,6 +1408,27 @@ def boundary_rate(token_counts: Mapping[str, int]) -> float:
     return token_counts.get("phase_boundary", 0) / total
 
 
+def active_vocabulary_occupancy(token_counts: Mapping[str, int]) -> float:
+    """Fraction of *routing* tokens that appeared in this snapshot.
+
+    Numerator: distinct routing tokens (status not in
+    ``NON_ROUTING_STATUSES``) with a positive count. Denominator:
+    ``len(ROUTING_TOKENS)`` — the count of tokens that can actually fire in
+    the cascade. Range [0, 1]; 0.0 if no routing tokens exist.
+
+    Distinct from ``vocabulary_occupancy`` (which divides by all 16
+    ``TOKEN_NAMES``, including ``diagnostic_only`` / deprecated / derived-
+    future tokens that cannot fire). Defined per Workstream C (PR #163) so a
+    downstream Lane A agent does not mistake diagnostic vocabulary for active
+    routing vocabulary: ``vocabulary_occupancy`` is the full historical-
+    vocabulary view; this is the routing-only view.
+    """
+    if not ROUTING_TOKENS:
+        return 0.0
+    appeared = sum(1 for t in ROUTING_TOKENS if token_counts.get(t, 0) > 0)
+    return appeared / len(ROUTING_TOKENS)
+
+
 def process_snapshot(
     snapshot_path: str | pathlib.Path,
     config: ObserverConfig,
@@ -1418,6 +1489,21 @@ def process_snapshot(
     budget_block: dict[str, object] = dict(dataclasses.asdict(report))
     budget_block["fraction_used"] = report.fraction_used
 
+    # Warmth diagnostics (Workstream B/C, PR #163): metta_warmth is now
+    # status "diagnostic_only" — it no longer routes classification, so its
+    # underlying warmth signal is reported here as numeric diagnostics instead.
+    # Computed over the whole warmth channel (deterministic regardless of the
+    # stride backoff, unlike the sampled patches). Defensive over grids with
+    # fewer than 7 channels (mirrors _safe_mean's guard).
+    warmth_idx = MEMORY_CHANNEL_LAYOUT["warmth"]
+    if warmth_idx < memory.shape[0]:
+        warmth_channel = memory[warmth_idx]
+        warmth_max = float(warmth_channel.max())
+        warm_cell_count = int(np.count_nonzero(warmth_channel >= WARMTH_DIAGNOSTIC_FLOOR))
+    else:
+        warmth_max = 0.0
+        warm_cell_count = 0
+
     # PR #3 per-snapshot metrics (PHASE_19_PR3_METRICS_PIPELINE.md §3).
     # All computed from data already in memory; total cost ≈ 50 µs at K=16
     # tokens on a 256³ lattice, negligible against the ~1s classification time.
@@ -1435,11 +1521,20 @@ def process_snapshot(
         "stride_backoff_fired": safe_stride != config.uniform_grid_stride,
         "medusa_is_live": medusa_is_live,
         "token_counts": dict(token_counts),
+        # Full historical-vocabulary occupancy: fraction of ALL 16 TOKEN_NAMES
+        # (including diagnostic_only / deprecated / derived-future) that appeared.
         "vocabulary_occupancy": len(token_counts) / max(1, len(TOKEN_NAMES)),
+        # Routing-only occupancy: fraction of tokens that can actually fire.
+        # Lane A should read this, not vocabulary_occupancy, to gauge how much
+        # of the *active* cascade lit up (Workstream C, PR #163).
+        "active_vocabulary_occupancy": active_vocabulary_occupancy(token_counts),
         "shannon_entropy_bits": shannon_h,
         "entropy_normalized": entropy_normalized(shannon_h, len(TOKEN_NAMES)),
         "void_compute_balance": void_compute_balance(state),
         "boundary_rate": boundary_rate(token_counts),
+        # Warmth diagnostics (metta_warmth demoted to diagnostic_only).
+        "warmth_max": warmth_max,
+        "warm_cell_count": warm_cell_count,
         "budget": budget_block,
     }
     write_log_entry(config.log_directory, entry)
@@ -1458,6 +1553,11 @@ __all__ += [  # type: ignore[misc]
     "entropy_normalized",
     "void_compute_balance",
     "boundary_rate",
+    # Workstream C (PR #163): routing-status model + occupancy/diagnostics
+    "active_vocabulary_occupancy",
+    "NON_ROUTING_STATUSES",
+    "ROUTING_TOKENS",
+    "WARMTH_DIAGNOSTIC_FLOOR",
 ]
 
 

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -1842,13 +1842,17 @@ def test_default_ablation_disabled_tokens_are_active_cascade_tokens():
         )
 
 
-def test_active_cascade_order_excludes_deprecated_tokens():
-    """_ACTIVE_CASCADE_ORDER must NOT contain any deprecated tokens
-    (karuna_relief, mudita_resonance, magnon_lighthouse per #144).
-    Locks the post-#144 cascade composition."""
-    deprecated = {"karuna_relief", "mudita_resonance", "magnon_lighthouse"}
-    overlap = set(_ACTIVE_CASCADE_ORDER) & deprecated
-    assert not overlap, f"deprecated tokens in active cascade: {overlap}"
+def test_active_cascade_order_excludes_non_routing_tokens():
+    """_ACTIVE_CASCADE_ORDER must NOT contain any non-routing token:
+    the #144 deprecated tokens (karuna_relief, mudita_resonance,
+    magnon_lighthouse) and the Workstream B/C diagnostic_only token
+    (metta_warmth, PR #163). Locks the cascade composition against drift."""
+    non_routing = {
+        "karuna_relief", "mudita_resonance", "magnon_lighthouse",
+        "metta_warmth",
+    }
+    overlap = set(_ACTIVE_CASCADE_ORDER) & non_routing
+    assert not overlap, f"non-routing tokens in active cascade: {overlap}"
 
 
 # ---------------------------------------------------------------------------
@@ -1872,7 +1876,6 @@ def _make_synthetic_patch_for_branch(branch: str):
         STATE_SENSOR,
         STATE_STRUCTURAL,
         STATE_VOID,
-        THRESHOLD_WARMTH,
     )
     # 3x3x3 patches everywhere; deterministic content.
     R = 1  # patch_spatial_radius -> 3x3x3 = 27 cells
@@ -1887,11 +1890,9 @@ def _make_synthetic_patch_for_branch(branch: str):
     elif branch == "compute_aging":
         state[:, :, :] = STATE_COMPUTE  # compute_frac = 1.0
         memory[CH["compute_age"], :, :, :] = float(AGE_SAGE + 5)
-    elif branch == "metta_warmth":
-        # compute_count>=1 + warmth_mean >= THRESHOLD_WARMTH, but NOT
-        # compute_frac dominant (so compute_static won't catch it first).
-        state[0, 0, 0] = STATE_COMPUTE
-        memory[CH["warmth"], :, :, :] = float(THRESHOLD_WARMTH + 0.1)
+    # (metta_warmth branch removed: demoted to diagnostic_only per PR #163,
+    #  no longer in _ACTIVE_CASCADE_ORDER, so the parity battery never builds
+    #  a patch for it.)
     elif branch == "sensor_alert":
         # sensor_count>=1, no compute/energy dominance, distinct_states<4
         state[0, 0, 0] = STATE_SENSOR

--- a/tests/test_nextness_observer.py
+++ b/tests/test_nextness_observer.py
@@ -275,14 +275,28 @@ def test_classifier_magnon_lighthouse_disabled_post_144_falls_through_to_compute
     )
 
 
-def test_classifier_metta_warmth_with_compute():
+def test_classifier_metta_warmth_demoted_to_diagnostic_falls_through():
+    """Post-Workstream-B/C (PR #163): metta_warmth is status
+    "diagnostic_only" and no longer routes classification. A patch that
+    *would have* triggered the old predicate (a COMPUTE cell with warmth
+    above THRESHOLD_WARMTH) must now fall through the cascade instead of
+    returning metta_warmth.
+
+    Here: 1 COMPUTE in a 26-VOID patch with warmth filled to 0.4 (> 0.3).
+    metta_warmth is skipped; compute_decay needs warmth_mean < THRESHOLD
+    (fails, warmth is high); the patch lands on void_birth (void-dominant
+    with >1 distinct state).
+    """
     s = np.zeros((3, 3, 3), dtype=np.uint8); s[1, 1, 1] = STATE_COMPUTE
     m = np.zeros((8, 3, 3, 3), dtype=np.float32)
-    # Post-#144: CH["warmth"] now resolves to engine index 6 (the actual
-    # warmth channel). The predicate logic is unchanged; it just reads the
-    # correct field now.
     m[CH["warmth"]].fill(THRESHOLD_WARMTH + 0.1)
-    assert classify_patch(Patch((0, 0, 0), s, m)) == "metta_warmth"
+    result = classify_patch(Patch((0, 0, 0), s, m))
+    assert result != "metta_warmth", (
+        f"metta_warmth must not fire after diagnostic_only demotion; got {result!r}"
+    )
+    assert result == "void_birth", (
+        f"expected fall-through to void_birth; got {result!r}"
+    )
 
 
 def test_classifier_mudita_resonance_disabled_post_144_falls_through_to_compute_decay():
@@ -854,11 +868,12 @@ def test_token_status_covers_every_token_in_vocabulary():
 
 
 def test_token_status_uses_only_documented_status_values():
-    """Every status value must be one of the four documented options."""
+    """Every status value must be one of the documented options."""
     from scripts.nextness_observer import TOKEN_STATUS
     valid_statuses = {
         "state_only",
         "stored",
+        "diagnostic_only",  # Workstream C (PR #163): real-but-non-routing signal
         "deprecated_no_engine_channel",
         "derived_future",
     }
@@ -870,24 +885,30 @@ def test_token_status_uses_only_documented_status_values():
 
 
 def test_deprecated_tokens_never_appear_in_classifier_output():
-    """Tokens with deprecated/derived-future status must never fire.
+    """Tokens with a non-routing status must never fire.
 
-    Per issue #144: even if the prior triggering conditions for these
-    tokens happen to be met in a patch, classify_patch must skip them
-    and the patch must fall through to another predicate.
+    Per issue #144 (deprecated_no_engine_channel / derived_future) and
+    Workstream B/C (PR #163, diagnostic_only for metta_warmth): even if the
+    prior triggering conditions for these tokens happen to be met in a patch,
+    classify_patch must skip them and the patch must fall through to another
+    predicate.
 
     Exhaustive test: synthesize a wide range of patches and assert no
-    deprecated token ever appears in the output across all of them.
+    non-routing token ever appears in the output across all of them. The
+    ``warmth``-set config below specifically exercises the metta_warmth
+    demotion.
     """
-    from scripts.nextness_observer import TOKEN_STATUS
+    from scripts.nextness_observer import TOKEN_STATUS, NON_ROUTING_STATUSES
     deprecated_tokens = {
         name for name, status in TOKEN_STATUS.items()
-        if status in {"deprecated_no_engine_channel", "derived_future"}
+        if status in NON_ROUTING_STATUSES
     }
-    # Sanity: there ARE deprecated tokens to check (otherwise this test
-    # would silently pass).
-    assert len(deprecated_tokens) >= 3, (
-        "Expected at least 3 deprecated tokens post-#144"
+    # Sanity: there ARE non-routing tokens to check (karuna_relief,
+    # mudita_resonance, magnon_lighthouse, metta_warmth) — otherwise this
+    # test would silently pass.
+    assert len(deprecated_tokens) >= 4, (
+        "Expected at least 4 non-routing tokens (3 deprecated/derived + "
+        "metta_warmth diagnostic_only)"
     )
 
     # Try a wide variety of patch configurations
@@ -1185,5 +1206,55 @@ def test_process_snapshot_emits_all_pr3_per_snapshot_fields(tmp_path):
     for field in ("shannon_entropy_bits", "entropy_normalized",
                   "void_compute_balance", "boundary_rate",
                   "vocabulary_occupancy"):
+        assert entry[field] == summary[field], \
+            f"{field} differs between summary and JSONL: {summary[field]!r} vs {entry[field]!r}"
+
+
+def test_process_snapshot_emits_workstream_c_diagnostic_fields(tmp_path):
+    """Workstream C (PR #163): process_snapshot emits warmth_max,
+    warm_cell_count, and active_vocabulary_occupancy. metta_warmth is now
+    diagnostic_only, so its warmth signal surfaces as numeric diagnostics
+    instead of a classification token, and the active-occupancy metric is
+    distinct from the historical vocabulary_occupancy.
+    """
+    from scripts.nextness_observer import ROUTING_TOKENS, TOKEN_NAMES
+    snap = _make_snapshot(tmp_path / "v070_gen1.npz", lattice=16, generation=1)
+    log_dir = tmp_path / "log"
+    log_dir.parent.mkdir(exist_ok=True)
+    cfg = ObserverConfig(log_directory=str(log_dir),
+                         uniform_grid_stride=4, budget_seconds=30.0)
+    summary = process_snapshot(snap, cfg, medusa_is_live=False)
+
+    # New fields present
+    assert "warmth_max" in summary
+    assert "warm_cell_count" in summary
+    assert "active_vocabulary_occupancy" in summary
+
+    # Types
+    assert isinstance(summary["warmth_max"], float)
+    assert isinstance(summary["warm_cell_count"], int)
+    assert isinstance(summary["active_vocabulary_occupancy"], float)
+
+    # Ranges
+    assert summary["warmth_max"] >= 0.0
+    assert summary["warm_cell_count"] >= 0
+    assert 0.0 <= summary["active_vocabulary_occupancy"] <= 1.0
+
+    # The synthetic snapshot has an all-zero warmth channel -> no warmth.
+    assert summary["warmth_max"] == 0.0
+    assert summary["warm_cell_count"] == 0
+
+    # Demotion shrank the routing-token set below the full vocabulary.
+    assert len(ROUTING_TOKENS) < len(TOKEN_NAMES)
+    # Same appeared-token numerator, smaller denominator -> active >= historical.
+    assert summary["active_vocabulary_occupancy"] >= summary["vocabulary_occupancy"]
+
+    # metta_warmth must never appear in token_counts (it cannot route).
+    assert summary["token_counts"].get("metta_warmth", 0) == 0
+
+    # New fields round-trip through JSONL identically.
+    jsonl = (log_dir / "nextness_runs.jsonl").read_text().splitlines()
+    entry = json.loads(jsonl[-1])
+    for field in ("warmth_max", "warm_cell_count", "active_vocabulary_occupancy"):
         assert entry[field] == summary[field], \
             f"{field} differs between summary and JSONL: {summary[field]!r} vs {entry[field]!r}"

--- a/tests/test_nextness_observer.py
+++ b/tests/test_nextness_observer.py
@@ -1258,3 +1258,57 @@ def test_process_snapshot_emits_workstream_c_diagnostic_fields(tmp_path):
     for field in ("warmth_max", "warm_cell_count", "active_vocabulary_occupancy"):
         assert entry[field] == summary[field], \
             f"{field} differs between summary and JSONL: {summary[field]!r} vs {entry[field]!r}"
+
+
+def test_warmth_diagnostics_read_correct_memory_axis(tmp_path):
+    """Axis regression fence (Jack's PR #164 audit): warmth_max /
+    warm_cell_count must read the warmth CHANNEL from the channel-first grid
+    (``memory[idx]``, axis 0), NOT a spatial cross-section
+    (``memory[..., idx]``, the channel-last layout Jack flagged).
+
+    The memory grid is channel-first ``(channels, X, Y, Z)`` — enforced by
+    load_snapshot's ``memory.shape[1:] == state.shape`` validation, and used
+    by ``iter_uniform_grid_patches`` (``memory[:, ...]``) and ``_safe_mean``
+    (``memory[idx]``). This test makes the convention executable: it injects
+    warmth ONLY into the true warmth channel while a DIFFERENT channel
+    (compute_age) holds a large distinctive value. A channel-first read sees
+    the injected 0.5; a wrong-axis ``memory[..., 6]`` read would pick up the
+    999.0 compute_age slice and fail these assertions. The prior all-zero
+    test cannot catch this because both axes read zero there.
+    """
+    from scripts.nextness_observer import WARMTH_DIAGNOSTIC_FLOOR
+    L = 16
+    state = np.zeros((L, L, L), dtype=np.uint8)
+    state[::4, ::4, ::4] = STATE_COMPUTE
+    memory = np.zeros((8, L, L, L), dtype=np.float32)
+    # A non-warmth channel holds a large distinctive value: a wrong-axis read
+    # would surface this instead of warmth.
+    memory[CH["compute_age"]].fill(999.0)
+    # Inject warmth ONLY into the true warmth channel at 7 known cells.
+    warm_value = 0.5
+    warm_cells = [(0, 0, 0), (1, 2, 3), (4, 5, 6), (7, 8, 9),
+                  (10, 11, 12), (13, 14, 15), (2, 9, 4)]
+    for (x, y, z) in warm_cells:
+        memory[CH["warmth"], x, y, z] = warm_value
+    snap = tmp_path / "v070_gen1.npz"
+    np.savez(str(snap), lattice=state, memory_grid=memory,
+             generation=np.array(1), best_fitness=np.array(0.5))
+
+    log_dir = tmp_path / "log"
+    log_dir.parent.mkdir(exist_ok=True)
+    cfg = ObserverConfig(log_directory=str(log_dir),
+                         uniform_grid_stride=4, budget_seconds=30.0)
+    summary = process_snapshot(snap, cfg, medusa_is_live=False)
+
+    # warm_value (0.5) is well above WARMTH_DIAGNOSTIC_FLOOR (0.05).
+    assert warm_value >= WARMTH_DIAGNOSTIC_FLOOR
+    assert summary["warmth_max"] == pytest.approx(warm_value), (
+        f"warmth_max={summary['warmth_max']!r}; expected {warm_value}. A value "
+        f"near 999 would indicate a wrong-axis (channel-last) read of the "
+        f"compute_age channel instead of the warmth channel."
+    )
+    assert summary["warm_cell_count"] == len(warm_cells), (
+        f"warm_cell_count={summary['warm_cell_count']!r}; expected "
+        f"{len(warm_cells)} warmth cells >= {WARMTH_DIAGNOSTIC_FLOOR}. A much "
+        f"larger count would indicate a wrong-axis read."
+    )


### PR DESCRIPTION
## Summary

First **code** PR of the second-pass calibration arc. Implements the ratified Workstream B/C decision (PRs #160–#163): warmth is real but too sparse to cluster, so `metta_warmth` is demoted from an active cascade predicate to status `diagnostic_only`. Its signal now surfaces as numeric JSONL diagnostics instead of routing classification.

## ⚠️ Review note: CI does not run the Python tests

The `verify` CI job only runs for Node projects; this repo is Python, so CI skips it and auto-passes. **The real gate is the local test run**, which I ran:

```
tests/test_nextness_observer.py + tests/test_nextness_calibration.py
274 passed
```

including the **parity regression-fence** (`test_classify_patch_ablation_parity_with_observer_on_synthetic_battery`) that locks the calibration cascade mirror to the observer.

## Behavioral invariant (low risk)

On **real Medusa data, token classification is unchanged.** `metta_warmth` never fired at the profiled 0.990 sparsity (max `warmth_mean` ~0.009 vs. threshold 0.3), so removing it from the cascade is a no-op on real `token_counts`. Only synthetic high-warmth test patches reclassify (now fall through to e.g. `void_birth`). The demotion **only adds diagnostics; it removes no signal.**

## Changes

**Observer (`scripts/nextness_observer.py`):**
- `TOKEN_STATUS`: `metta_warmth` `stored` → `diagnostic_only`; documented the new status (distinct from `deprecated_no_engine_channel` — real signal, just non-discriminating; re-promotable).
- `classify_patch`: `metta_warmth` predicate commented out (same pattern as the deprecated `karuna_relief` / `magnon_lighthouse` predicates).
- Added `NON_ROUTING_STATUSES` + `ROUTING_TOKENS` (12 of 16 tokens route).
- New metric `active_vocabulary_occupancy(token_counts)` — routing-only occupancy, per Jack's Q3 requirement, so Lane A does not mistake diagnostic vocabulary for active routing vocabulary.
- `process_snapshot` JSONL entry gains: `warmth_max`, `warm_cell_count` (warmth ≥ 0.05, over the full warmth channel for stride-independence), `active_vocabulary_occupancy`. `vocabulary_occupancy` retained + re-documented as full historical-vocabulary occupancy.
- `WARMTH_DIAGNOSTIC_FLOOR = 0.05`; `__all__` updated.

**Calibration (`scripts/nextness_calibration.py`):**
- `_ACTIVE_CASCADE_ORDER`: `metta_warmth` removed (mirror must match observer; parity test enforces).
- `_predicate_fires`: `metta_warmth` branch removed.
- `sweep_threshold` docstring: noted `metta_warmth` now reports inconclusive by construction; default left unchanged to keep scope narrow (future PR may repoint to `compute_decay` / `acoustic_stress`).

**Tests:** firing test → demotion/fall-through; `diagnostic_only` added to status + never-fires tests; new test for the three JSONL diagnostic fields; cascade-order exclusion now covers `metta_warmth`.

## Scope held

- No engine touch. No token rename. No Lane A. No tuning API. No Swarm Hunter.
- Forward-pointer doc updates kept **separate** (per Jack's Q8 lean) — not in this PR.
- Lane A remains parked.

## Not merging yet

This is the first code-touching PR of the arc. Leaving it open for **Jack's measurement/parity audit and AURA's architectural review** before merge, per the established gate.

## Test plan

- [ ] Jack: audit the cascade-mirror parity and the `active_vocabulary_occupancy` semantics
- [ ] AURA: confirm the diagnostic demotion preserves the spark-detector intent
- [ ] Kevin: operator gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)