### PR TITLE
ci: run Python test suites in CI (fixes #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,39 @@ jobs:
           else
             echo "No test script; skipping"
           fi
+
+  # Python test gate (issue #165). The Node `verify` job above skips every
+  # step when no package.json is present, so for this Python repo it was
+  # auto-passing without running anything. This job runs the maintained
+  # Python suites so a real regression fails the build visibly.
+  #
+  # Scope note: targets the two maintained nextness suites explicitly rather
+  # than bare `pytest`, because several pre-existing modules fail at
+  # collection (uft_ca / utilityfog_frontend.cli_viz imports, root-level
+  # *_test.py scripts) — tracked separately. These two files are exactly the
+  # suite verified locally for PRs #160–#164 (275 tests). Broadening coverage
+  # (fixing or excluding the broken collectors) is a follow-up under #165.
+  verify-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          # The nextness observer + calibration modules and their tests depend
+          # only on numpy + pytest (scipy is used by the profiling script, not
+          # by these suites). Kept minimal on purpose.
+          pip install numpy pytest
+
+      - name: Run maintained Python test suites
+        run: |
+          python -m pytest \
+            tests/test_nextness_observer.py \
+            tests/test_nextness_calibration.py \
+            -q


### PR DESCRIPTION
## Summary

Addresses #165 — the `verify` job gated every step on `package.json`, so this Python repo skipped all of them and **auto-passed without running any tests**. The real gate has been local `pytest`.

Adds a **`verify-python`** job that:
- sets up Python 3.12, installs `numpy` + `pytest` (the only third-party deps the maintained suites need — scipy is used by the profiling *script*, not these tests),
- runs `tests/test_nextness_observer.py` + `tests/test_nextness_calibration.py` (**275 tests** — the exact suite verified locally for PRs #160–#164),
- **fails the build visibly** if any test fails.

**Live test result (this PR):** `verify-python` ran green — `275 passed in 2.40s` on Python 3.12 / numpy 2.4.6 / pytest 9.0.3. CI now genuinely runs the Python suite.

The existing Node `verify` job is kept (harmless if a `package.json` ever appears), but it no longer constitutes full verification on its own.

## Why explicit file targets, not bare `pytest`

Several pre-existing modules error at collection (`uft_ca` / `utilityfog_frontend.cli_viz` imports, root-level `*_test.py` scripts). Bare `pytest` would fail on collection. This job targets the two maintained suites.

## Scope

- **CI/workflow only.** No observer logic, no token renames, no engine touch. Lane A parked.
- **Does NOT bundle** the post-#164 hardening items (the `sweep_threshold` default repoint, the warmth `.size` guard) — those land in a separate PR, now protected by this gate.

## Issue status

This lands the **core gate** for #165. **#165 stays open** for the coverage-broadening follow-up (fix or exclude the broken collectors: `uft_ca`, `utilityfog_frontend.cli_viz`, root `*_test.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)