### PR TITLE
test: Tier 0 pytest hygiene for #165 (scope collection + register asyncio marker)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,16 @@
+[pytest]
+# Tier 0 hygiene for Issue #165 (coverage-broadening triage plan:
+# docs/ISSUE_165_COVERAGE_BROADENING_PLAN.md).
+#
+# Scope default collection to the maintained suite so a bare `pytest`
+# invocation never sweeps in the root-level legacy integration scripts
+# (backend_test.py, final_test.py, proper_sim_test.py, quick_sim_test.py,
+# demo_test.py, test_phase3_integration.py). Explicit paths passed on the
+# command line (e.g. the CI verify-python job) still override this.
+testpaths = tests
+
+# Register the asyncio marker used by tests/test_telemetry.py to silence
+# PytestUnknownMarkWarning. Registration only — this does NOT change test
+# execution; wiring pytest-asyncio is intentionally out of scope for Tier 0.
+markers =
+    asyncio: marks async tests (registration-only; see Issue #165 Tier 1+)


### PR DESCRIPTION
## Summary

**Tier 0** of the [Issue #165 coverage-broadening plan](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_COVERAGE_BROADENING_PLAN.md) (merged in #172). Config-only pytest hygiene — the first safe layer, approved by Jack + AURA.

Adds a single `pytest.ini`:

- **`testpaths = tests`** — a bare `pytest` invocation now scopes to the maintained suite, so it never accidentally sweeps in the 6 root-level legacy integration scripts (`backend_test.py`, `final_test.py`, `proper_sim_test.py`, `quick_sim_test.py`, `demo_test.py`, `test_phase3_integration.py`). Explicit command-line paths still override, so the existing `verify-python` CI job is unaffected.
- **registers the `asyncio` marker** used by `tests/test_telemetry.py` — silences `PytestUnknownMarkWarning`. **Registration only**; it does not change test execution (wiring `pytest-asyncio` is deliberately Tier 1+).

## Verification (local)

- Bare `pytest --collect-only` now scopes to `tests/`: **549 collected**, root scripts **excluded** (grep confirms none collected).
- The pre-existing 8 collection errors are **unchanged** — they're the Tier 1–3 work and intentionally untouched here.
- `PytestUnknownMarkWarning` count: **0**.

## Scope / guardrails

- Config-only. No engine touch, no observer semantics, no CI changes, no source changes.
- Tiers 1 (optional-dep `importorskip`), 2 (`cli_viz` re-export), and 3 (architecture decisions) are explicitly **out of scope** for this PR.
- No Lane A / Swarm Hunter / tuning API / production sweeps.
- No legacy script deleted — only scoped out of default collection.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_