### PR TITLE
test: Tier 1 importorskip guards for optional deps (#165)

### DIFF
--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -15,6 +15,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+# vis.observatory rendering pulls in matplotlib (optional, heavy). Skip the
+# whole module when it is absent rather than erroring at collection. (#165 Tier 1)
+pytest.importorskip("matplotlib")
+
 # ---------------------------------------------------------------------------
 # Observatory imports
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -39,6 +39,10 @@ from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
+
+# flask is an optional dependency for the provider HTTP surface. Skip this
+# module when it is absent rather than erroring at collection. (#165 Tier 1)
+pytest.importorskip("flask")
 from flask import Flask
 
 from scripts.agent_backends import (

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -17,6 +17,10 @@ import json
 from pathlib import Path
 
 import pytest
+
+# flask is an optional dependency for the tuning HTTP API. Skip this module
+# when it is absent rather than erroring at collection. (#165 Tier 1)
+pytest.importorskip("flask")
 from flask import Flask
 
 from scripts.tuning_api import (

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -5,6 +5,10 @@ import tempfile
 
 import pytest
 import numpy as np
+
+# matplotlib is an optional, heavy visualization dependency. Skip this module
+# when it is absent rather than erroring at collection. (#165 Tier 1)
+pytest.importorskip("matplotlib")
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary

**Tier 1** of the [Issue #165 coverage-broadening plan](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_COVERAGE_BROADENING_PLAN.md). Adds `pytest.importorskip()` guards so the four optional-dependency test modules **self-skip** when the dep is absent, instead of erroring at collection. Approved approach (Jack + AURA): keep CI lean, make deps self-documenting — no heavy libs added to the pipeline.

| Module | Guard |
|---|---|
| `tests/test_observatory.py` | `importorskip("matplotlib")` |
| `tests/test_visualization.py` | `importorskip("matplotlib")` |
| `tests/test_provider_parity.py` | `importorskip("flask")` |
| `tests/test_tuning_api.py` | `importorskip("flask")` |

## Verification (local, deps absent)

- The 4 guarded modules now **skip cleanly** (no collection error).
- Full `tests/` collection errors drop **8 → 4**.
- The remaining 4 are exactly the later-tier work and are **untouched**:
  - `test_cli_viz.py` → Tier 2 (`InteractiveRenderer` re-export bug)
  - `test_feature_flags.py`, `test_observability.py` → Tier 3 (`agent` namespace decision)
  - `test_state_observation.py` → Tier 3 (`uft_ca` Rust build)

## Scope / guardrails

- Test-guards only (+16 lines across 4 files). No source, engine, observer, or CI changes.
- Tiers 2 (`cli_viz` re-export) and 3 (architecture decisions) explicitly **out of scope**.
- No Lane A / Swarm Hunter / tuning API / production sweeps.

## Standing note (kept alive, not forgotten)

`test_phase3_integration.py` remains scoped-out by Tier 0 and still awaits its **Tier 3** explicit retire/exclude decision (per Jack + AURA: Phase-3 debris). Tracked, not dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_