### PR TITLE
fix: re-export public cli_viz API so test_cli_viz collects (#165 Tier 2)

### DIFF
--- a/utilityfog_frontend/cli_viz/__init__.py
+++ b/utilityfog_frontend/cli_viz/__init__.py
@@ -6,20 +6,28 @@ This module provides command-line visualization tools for state transitions,
 message flow rendering, and interactive tree visualization.
 """
 
-from .renderer import TreeRenderer, FlowRenderer, StateRenderer
+from .renderer import TreeRenderer, FlowRenderer, StateRenderer, InteractiveRenderer
 from .cli import VisualizationCLI
-from .exporters import HTMLExporter, SVGExporter, TextExporter
-from .models import TreeNode, MessageFlow, StateTransition
+from .exporters import HTMLExporter, SVGExporter, TextExporter, JSONExporter
+from .models import (
+    TreeNode, MessageFlow, StateTransition, VisualizationData,
+    NodeState, MessageType,
+)
 
 __all__ = [
     'TreeRenderer',
-    'FlowRenderer', 
+    'FlowRenderer',
     'StateRenderer',
+    'InteractiveRenderer',
     'VisualizationCLI',
     'HTMLExporter',
     'SVGExporter',
     'TextExporter',
+    'JSONExporter',
     'TreeNode',
     'MessageFlow',
-    'StateTransition'
+    'StateTransition',
+    'VisualizationData',
+    'NodeState',
+    'MessageType',
 ]


### PR DESCRIPTION
## Summary

**Tier 2** of the [Issue #165 coverage-broadening plan](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_COVERAGE_BROADENING_PLAN.md). Fixes the `cli_viz` re-export collection bug. Surgically contained to one file: `utilityfog_frontend/cli_viz/__init__.py` (+13/−5).

## The bug was wider than one symbol

The plan flagged `InteractiveRenderer`. On running it, `__init__.py` was actually missing **five** public symbols that live in the submodules, so `from utilityfog_frontend.cli_viz import (...)` failed at collection:

| Symbol | Submodule |
|---|---|
| `InteractiveRenderer` | `renderer.py` |
| `JSONExporter` | `exporters.py` |
| `VisualizationData`, `NodeState`, `MessageType` | `models.py` |

All five now re-exported via the package imports + `__all__`. No submodule/source-logic changes.

## Verification (local)

- `test_cli_viz.py` now **collects** (was a hard collection `ImportError`).
- `tests/` collection errors drop **4 → 3** (remaining 3 are all Tier 3).
- **17 / 19 tests pass.**

## ⚠️ Two pre-existing failures now *surfaced* (not caused by this change, NOT bundled)

These were hidden behind the old collection error and are now visible. Flagged as follow-ups for triage rather than bulldozed into this PR:

1. `TestCLI::test_parser_creation` → a **real `argparse` option conflict** in `cli.py`'s `create_parser()` (duplicate option registration). A genuine `cli.py` bug, distinct from the re-export — deserves its own small fix.
2. `TestIntegration::test_full_visualization_workflow` → an **`async` test with no `pytest-asyncio`** installed. The same async-runner gap noted in Tier 0/1; environmental, would pass once a runner is wired (a deliberate later decision).

Note: the `verify-python` CI job runs only the two nextness files, so it does not execute `test_cli_viz.py` — CI remains green regardless; I'm flagging these for honesty, not because they block CI.

## Scope / guardrails

- Re-export fix only, contained to `cli_viz/__init__.py`. No engine touch, no observer semantics, no CI changes, no Lane A / Swarm Hunter / tuning API / production sweeps.
- Tier 3 remains paused (`agent` namespace decision; `test_phase3_integration.py` retire/exclude — kept alive, not forgotten).

## Suggested follow-up tiers (for Jack + AURA)

- **Tier 2.1 (tiny):** fix the `argparse` conflict in `cli.py` so the last 2 `cli_viz` tests pass.
- **Async-runner decision:** whether to add `pytest-asyncio` (affects `test_cli_viz`, `test_telemetry`) — small but a deps/CI call.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_