### PR TITLE
fix: resolve two surfaced cli_viz test failures — argparse conflict + spurious async (#165 Tier 2.1)

### DIFF
--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -438,9 +438,12 @@ class TestCLI:
 class TestIntegration:
     """Integration tests for complete visualization workflow."""
     
-    @pytest.mark.asyncio
-    async def test_full_visualization_workflow(self, tmp_path):
-        """Test complete workflow from data generation to export."""
+    def test_full_visualization_workflow(self, tmp_path):
+        """Test complete workflow from data generation to export.
+
+        Note: this test is fully synchronous (no awaits); the previous
+        @pytest.mark.asyncio / async def was spurious. (#165 Tier 2.1)
+        """
         cli = VisualizationCLI()
         
         # Generate demo data

--- a/utilityfog_frontend/cli_viz/cli.py
+++ b/utilityfog_frontend/cli_viz/cli.py
@@ -59,7 +59,7 @@ Examples:
         tree_parser = subparsers.add_parser('tree', help='Display tree structure')
         tree_parser.add_argument('--input', '-i', required=True, help='Input JSON file')
         tree_parser.add_argument('--width', '-w', type=int, default=80, help='Display width')
-        tree_parser.add_argument('--height', '-h', type=int, default=24, help='Display height')
+        tree_parser.add_argument('--height', type=int, default=24, help='Display height')
         tree_parser.add_argument('--color-scheme', choices=['default', 'dark', 'colorblind'], 
                                default='default', help='Color scheme')
         tree_parser.add_argument('--show-ids', action='store_true', help='Show node IDs')
@@ -68,7 +68,7 @@ Examples:
         flow_parser = subparsers.add_parser('flow', help='Display message flows')
         flow_parser.add_argument('--input', '-i', required=True, help='Input JSON file')
         flow_parser.add_argument('--width', '-w', type=int, default=80, help='Display width')
-        flow_parser.add_argument('--height', '-h', type=int, default=24, help='Display height')
+        flow_parser.add_argument('--height', type=int, default=24, help='Display height')
         flow_parser.add_argument('--time-window', '-t', type=float, default=60.0, 
                                help='Time window in seconds')
         flow_parser.add_argument('--color-scheme', choices=['default', 'dark', 'colorblind'], 
@@ -78,7 +78,7 @@ Examples:
         state_parser = subparsers.add_parser('state', help='Display state transitions')
         state_parser.add_argument('--input', '-i', required=True, help='Input JSON file')
         state_parser.add_argument('--width', '-w', type=int, default=80, help='Display width')
-        state_parser.add_argument('--height', '-h', type=int, default=24, help='Display height')
+        state_parser.add_argument('--height', type=int, default=24, help='Display height')
         state_parser.add_argument('--time-window', '-t', type=float, default=300.0, 
                                help='Time window in seconds')
         state_parser.add_argument('--color-scheme', choices=['default', 'dark', 'colorblind'], 
@@ -88,7 +88,7 @@ Examples:
         interactive_parser = subparsers.add_parser('interactive', help='Interactive visualization')
         interactive_parser.add_argument('--input', '-i', required=True, help='Input JSON file')
         interactive_parser.add_argument('--width', '-w', type=int, default=80, help='Display width')
-        interactive_parser.add_argument('--height', '-h', type=int, default=24, help='Display height')
+        interactive_parser.add_argument('--height', type=int, default=24, help='Display height')
         interactive_parser.add_argument('--refresh-rate', '-r', type=float, default=1.0, 
                                       help='Refresh rate in seconds')
         interactive_parser.add_argument('--color-scheme', choices=['default', 'dark', 'colorblind'], 


### PR DESCRIPTION
## Summary

**Tier 2.1** of the [Issue #165 plan](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_COVERAGE_BROADENING_PLAN.md). Fixes the two pre-existing `test_cli_viz.py` failures that Tier 2 (#175) surfaced once the module could collect. Contained to `cli.py` + `test_cli_viz.py` (+10/−7).

## The two fixes

**1. `argparse` option conflict in `cli.py` `create_parser()` (real bug)**
The four `--height` arguments (tree/flow/state/interactive) used the short alias `-h`, which **collides with argparse's built-in `-h/--help`**. That raised `ArgumentError` at parser *construction*, so the entire CLI parser was non-functional — and `-h`-for-height never actually worked. Dropped the `-h` alias on all four; the `--height` long form is unchanged. (The `export` subcommand already used `--height` with no short alias.)

**2. `test_full_visualization_workflow` spurious async**
The test was marked `@pytest.mark.asyncio` / `async def` but contains **no `await`** — the whole body is synchronous. Removed the spurious async marking. This is the correct, **dependency-free** fix: no `pytest-asyncio` added to CI (keeping the pipeline lean, per AURA's preference). Now a plain sync test.

## Verification (local)

- `tests/test_cli_viz.py` → **19 / 19 pass** (was 17/19).
- Parser builds and parses correctly: `tree --input x.json --height 30 --width 100` → `height=30 width=100`.
- `tests/` collection errors **unchanged at 3** — all Tier 3.

## Scope / guardrails

- Contained to `cli.py` + `test_cli_viz.py`. No engine touch, no observer semantics, no CI changes, no Lane A / Swarm Hunter / tuning API / production sweeps.
- No new dependencies.
- Tier 3 remains paused: `UtilityFog_Agent_Package/agent/` canonical vs root `agent/` shadow; `test_phase3_integration.py` retire/exclude — kept alive, not forgotten.

## Where #165 stands after this

The only remaining `tests/` collection errors are the **3 Tier 3 items**, and AURA has already pre-answered both architectural decisions they depend on. After this, `cli_viz` is fully green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_