### PR TITLE
test: Tier 3A — fix stale hardcoded sys.path in agent tests (#165)

### DIFF
--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -10,8 +10,8 @@ import tempfile
 from unittest.mock import patch, mock_open
 import sys
 
-# Import the feature flags module
-sys.path.append('/home/ubuntu/github_repos/UtilityFog-Fractal-TreeOpen/UtilityFog_Agent_Package')
+# Import the feature flags module (canonical package lives in UtilityFog_Agent_Package)
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "UtilityFog_Agent_Package"))
 from agent.feature_flags import (
     FeatureFlags, FeatureFlagManager,
     get_feature_flags, initialize_feature_flags,

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -13,8 +13,9 @@ from unittest.mock import patch, MagicMock
 from io import StringIO
 import sys
 
-# Import the observability modules
-sys.path.append('/home/ubuntu/github_repos/UtilityFog-Fractal-TreeOpen/UtilityFog_Agent_Package')
+# Import the observability modules (canonical package lives in UtilityFog_Agent_Package)
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "UtilityFog_Agent_Package"))
 from agent.observability import (
     TraceContext, StructuredLogger, RateLimitedErrorLogger,
     EventLogger, TracingDecorator, ObservabilityManager,


### PR DESCRIPTION
## Summary

**Tier 3A** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER3_PLAN.md). Fixes the stale hardcoded `sys.path` in the two `agent` tests. Per Jack + AURA's decision: **per-test path fix**, not a central `pytest.ini pythonpath`. Two test files (+5/−4).

## The fix

`test_feature_flags.py` and `test_observability.py` appended a hardcoded absolute path from another machine:

```python
sys.path.append('/home/ubuntu/github_repos/UtilityFog-Fractal-TreeOpen/UtilityFog_Agent_Package')
```

That path doesn't exist in this checkout, so `UtilityFog_Agent_Package` never reached `sys.path` and `from agent.feature_flags/observability import ...` failed at collection. Replaced with a `__file__`-relative path (the idiom other tests already use). Since both `agent/` dirs are PEP 420 namespace packages, the canonical portion simply merges onto the existing root portion — no layout change needed.

## Verification (local)

- `test_feature_flags.py` + `test_observability.py` → **51 tests pass** (was a hard collection error).
- `tests/` collection errors drop **3 → 1** (only `test_state_observation.py`/`uft_ca` remains → Tier 3B).
- 619 tests now collected.

## Scope / guardrails

- Test-path-only change, 2 files. No source/engine/observer/CI changes, no central `pythonpath`, no Lane A / Swarm Hunter / tuning API / production sweeps.

Part of finishing Tier 3 tonight (3A → 3B → 3C), each as its own tiny PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_