### PR TITLE
test: Tier 3B — importorskip(uft_ca) for unbuilt Rust extension (#165)

### DIFF
--- a/tests/test_state_observation.py
+++ b/tests/test_state_observation.py
@@ -1,4 +1,10 @@
 import pytest
+
+# uft_ca is a Rust/pyo3 extension (crates/uft_ca) that must be built (maturin)
+# to be importable. Skip this module when the built extension is absent rather
+# than erroring at collection. Building it in CI is tracked as a follow-up.
+# (#165 Tier 3B)
+pytest.importorskip("uft_ca")
 from uft_ca import MultiStateGraphLattice
 
 VOID, STRUCTURAL, COMPUTE, ENERGY, SENSOR = 0, 1, 2, 3, 4


### PR DESCRIPTION
## Summary

**Tier 3B** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER3_PLAN.md). Guards the unbuilt `uft_ca` Rust extension. Per Jack + AURA's decision: **`importorskip` now**, maturin CI build tracked as a separate follow-up. One test file (+6 lines).

## The fix

`test_state_observation.py` does `from uft_ca import MultiStateGraphLattice`. `uft_ca` is a Rust/pyo3 extension (`crates/uft_ca`, `cdylib`) that isn't built/installed for Python in CI, so it errored at collection. Added `pytest.importorskip("uft_ca")` so the module self-skips when the extension is absent (mirrors the Tier 1 pattern).

## Verification (local)

- `test_state_observation.py` → **1 skipped** (was a hard collection error).
- **`tests/` now collects with 0 collection errors** — 619 tests collected. 🎉

## Follow-up tracked

Maturin/pyo3 build support (so this test actually *runs* in CI rather than skipping) is filed as a separate issue — flagged here so the skip doesn't become a silent permanent blind spot.

## Scope / guardrails

- Test-guard only, 1 file. No source/engine/observer/CI changes, no Lane A / Swarm Hunter / tuning API / production sweeps. No new deps.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_