### PR TITLE
ci: Tier 4A — expand verify-python allowlist to 10 fully-green modules (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,14 +87,26 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          # The nextness observer + calibration modules and their tests depend
-          # only on numpy + pytest (scipy is used by the profiling script, not
-          # by these suites). Kept minimal on purpose.
+          # The gated suites below depend only on numpy + pytest. Optional-dep
+          # modules (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension
+          # are intentionally NOT gated yet (#165 Tier 4B/4C/4D). Kept lean.
           pip install numpy pytest
 
       - name: Run maintained Python test suites
         run: |
+          # #165 Tier 4A: explicit allowlist of fully-green, dependency-free
+          # modules (verified pass under numpy+pytest only). Not bare `pytest`.
           python -m pytest \
             tests/test_nextness_observer.py \
             tests/test_nextness_calibration.py \
+            tests/test_nextness_metrics.py \
+            tests/test_agent_backend.py \
+            tests/test_anthropic_backend.py \
+            tests/test_cli_viz.py \
+            tests/test_continuous_evolution_ca.py \
+            tests/test_feature_flags.py \
+            tests/test_observability.py \
+            tests/test_params_schema.py \
+            tests/test_shard_protocol.py \
+            tests/test_ising_tempering.py \
             -q


### PR DESCRIPTION
## Summary

**Tier 4A** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER4_TEST_STATUS_REPORT.md) — the first CI-gate broadening. Per Jack + AURA's greenlight. Expands `verify-python` from the 2 nextness files to an **explicit allowlist of 12 fully-green, dependency-free modules**. One file (`.github/workflows/ci.yml`, +15/−3).

## What changed

The gate now runs (2 existing + 10 new):

`nextness_observer`, `nextness_calibration`, `nextness_metrics`, `agent_backend`, `anthropic_backend`, `cli_viz`, `continuous_evolution_ca`, `feature_flags`, `observability`, `params_schema`, `shard_protocol`, `ising_tempering`.

- **Explicit allowlist — NOT bare `pytest`.**
- Lean install unchanged (`numpy pytest`).
- The 3 failing modules (`openai` ×2, telemetry async) and all dep-gated/optional modules stay **out** pending Tier 4B/4C/4D.

## Verification (local, exact CI invocation under numpy+pytest)

**523 passed, 0 failed, 0 skipped.** YAML validated. Gates ~523 tests (up from ~282).

## Roadmap (unchanged)

4A (this) → **4B** `importorskip("openai")` → **4C** telemetry async (inspect-first) → **4D** full-suite gate once 4B+4C green.

## Tier 4C note (for when authorized)

I'll inspect whether the four `test_telemetry.py` async tests contain real `await`s before recommending: drop spurious async (à la Tier 2.1) vs add `pytest-asyncio`. Not touched here.

## Scope / guardrails

CI allowlist change only. No source/engine/observer changes, no new deps, no bare `pytest` gate, no Lane A / Swarm Hunter / tuning API / production sweeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_