### PR TITLE
test: Tier 4B — importorskip(openai) guards for openai-construction tests (#165)

### DIFF
--- a/tests/test_openai_compat_backend.py
+++ b/tests/test_openai_compat_backend.py
@@ -486,6 +486,7 @@ def test_construction_without_api_key_or_env_var_does_not_crash(monkeypatch):
     passwordless local server (Ollama, vLLM, llama.cpp). PR 7b: supply a
     placeholder so local setups Just Work; real auth-required providers
     fail later with a clearer 401."""
+    pytest.importorskip("openai")  # backend construction instantiates the real SDK
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     backend = OpenAICompatBackend(
         base_url="http://localhost:11434/v1",
@@ -496,6 +497,7 @@ def test_construction_without_api_key_or_env_var_does_not_crash(monkeypatch):
 
 def test_explicit_api_key_arg_is_passed_through(monkeypatch):
     """An explicit api_key arg must NOT be overridden by the dummy."""
+    pytest.importorskip("openai")  # backend construction instantiates the real SDK
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     backend = OpenAICompatBackend(
         base_url="https://api.deepseek.com/v1",
@@ -509,6 +511,7 @@ def test_explicit_api_key_arg_is_passed_through(monkeypatch):
 def test_env_var_api_key_does_not_trigger_dummy(monkeypatch):
     """If OPENAI_API_KEY is set, the backend should let the SDK read it
     rather than overwriting with a placeholder."""
+    pytest.importorskip("openai")  # backend construction instantiates the real SDK
     monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
     backend = OpenAICompatBackend(
         base_url="http://localhost:11434/v1",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -458,8 +458,7 @@ def test_create_backend_openai_compat():
     """PR 7a wiring: MEDUSA_AGENT_BACKEND=openai-compat instantiates
     OpenAICompatBackend with config-supplied base_url / model / api_key."""
     from scripts.agent_backends import OpenAICompatBackend
-    if OpenAICompatBackend is None:
-        pytest.skip("openai SDK not installed")
+    pytest.importorskip("openai")  # construction needs the real openai SDK
     cfg = OrchestratorConfig(
         backend_name="openai-compat",
         openai_base_url="https://api.deepseek.com/v1",
@@ -477,8 +476,7 @@ def test_create_backend_underscore_alias_accepted():
     openai-compat. Humans will inevitably type the underscore — env vars
     historically use underscores and the shell hyphen is awkward."""
     from scripts.agent_backends import OpenAICompatBackend
-    if OpenAICompatBackend is None:
-        pytest.skip("openai SDK not installed")
+    pytest.importorskip("openai")  # construction needs the real openai SDK
     cfg = OrchestratorConfig(
         backend_name="openai_compat",  # underscore!
         openai_base_url="https://api.deepseek.com/v1",


### PR DESCRIPTION
## Summary

**Tier 4B** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER4_TEST_STATUS_REPORT.md). Guards the 5 `openai`-construction tests so they self-skip when the SDK is absent. Per Jack + AURA: test-only, `openai` **not** added to CI. Two test files (+5/−4).

## The fix

5 tests construct `OpenAICompatBackend`, whose `__init__` raises `RuntimeError("requires pip install openai")` when the SDK is absent — so they hard-failed instead of skipping.

- **`test_openai_compat_backend.py` (3)** — added `pytest.importorskip("openai")` after each docstring.
- **`test_orchestrator.py` (2)** — the existing guard checked the **wrong signal** (`if OpenAICompatBackend is None`): the class is always importable; only *construction* needs the SDK. Replaced with `pytest.importorskip("openai")`.

## Verification (local)

- The 2 modules: **55 passed, 5 skipped** (the 5 now skip cleanly).
- Full suite: failures drop **9 → 4** — the remaining 4 are all `test_telemetry` async (→ Tier 4C). Skips 32 → 37.

## Scope / guardrails

- Test-only, 2 files. No `openai` added to CI, no source/engine/observer/CI changes. Telemetry async **not** bundled. No bare `pytest`, no Lane A / Swarm Hunter / tuning API / production sweeps.

## Next — Tier 4C (inspect-first, as Jack/AURA directed)

I'll read the four `test_telemetry.py` async tests for real `await`s, then recommend: drop spurious async (à la Tier 2.1) vs add `pytest-asyncio`. Not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_