### PR TITLE
test+ci: Tier 4C — pytest-asyncio for telemetry async, add to allowlist (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,16 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          # The gated suites below depend only on numpy + pytest. Optional-dep
-          # modules (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension
-          # are intentionally NOT gated yet (#165 Tier 4B/4C/4D). Kept lean.
-          pip install numpy pytest
+          # The gated suites below depend only on numpy + pytest (+ pytest-asyncio
+          # for the genuinely-async test_telemetry suite). Optional-dep modules
+          # (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension are
+          # intentionally NOT gated yet (#165 Tier 4D). Kept lean.
+          pip install numpy pytest pytest-asyncio
 
       - name: Run maintained Python test suites
         run: |
-          # #165 Tier 4A: explicit allowlist of fully-green, dependency-free
-          # modules (verified pass under numpy+pytest only). Not bare `pytest`.
+          # #165 Tier 4A/4C: explicit allowlist of fully-green modules
+          # (verified pass under the install above). Not bare `pytest`.
           python -m pytest \
             tests/test_nextness_observer.py \
             tests/test_nextness_calibration.py \
@@ -109,4 +110,5 @@ jobs:
             tests/test_params_schema.py \
             tests/test_shard_protocol.py \
             tests/test_ising_tempering.py \
+            tests/test_telemetry.py \
             -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,7 @@
 # command line (e.g. the CI verify-python job) still override this.
 testpaths = tests
 
-# Register the asyncio marker used by tests/test_telemetry.py to silence
-# PytestUnknownMarkWarning. Registration only — this does NOT change test
-# execution; wiring pytest-asyncio is intentionally out of scope for Tier 0.
-markers =
-    asyncio: marks async tests (registration-only; see Issue #165 Tier 1+)
+# pytest-asyncio runs the genuinely-async tests (tests/test_telemetry.py uses
+# real `await`s). `auto` mode treats `async def` tests as asyncio tests without
+# per-test plumbing, and provides the `asyncio` marker. (#165 Tier 4C)
+asyncio_mode = auto


### PR DESCRIPTION
## Summary

**Tier 4C** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER4_TEST_STATUS_REPORT.md). Gives the genuinely-async telemetry tests a proper async runner. Per Jack + AURA's explicit sign-off on adding `pytest-asyncio`. Two infra files (`pytest.ini` + `ci.yml`, +12/−11), no source.

## Why (inspection result)

The four `test_telemetry.py` failures contain **real `await`s** (`await collector.start_collection()`, `await asyncio.sleep(...)`, `await exporter.export_metrics(...)`, `stop_collection()`) — genuinely async, **not** the `cli_viz` spurious-async case. So: add a real runner, don't strip async.

## What changed

- **`pytest.ini`** — add `asyncio_mode = auto`; retire the now-stale manual `asyncio` marker registration (pytest-asyncio provides the marker).
- **`ci.yml` `verify-python`** — add `pytest-asyncio` to the install; add `tests/test_telemetry.py` to the allowlist (**13 modules** now).

## Verification (local)

- `test_telemetry.py`: **14 passed** (was 4 failed, 10 passed).
- **Full suite: 592 passed, 37 skipped, 0 failed, 0 errors** 🎉 — every module now passes-or-skips.
- The 13-module allowlist: **537 passed**. YAML validated.

## Scope / guardrails

- Test/CI-infra only. No source/engine/observer changes, no bare `pytest` gate, no Lane A / Swarm Hunter / tuning API / production sweeps.
- `pytest-asyncio` added deliberately, with sign-off.

## Tier 4D readiness

After this, the *only* things keeping `verify-python` from being `pytest tests/` are the **clean dependency-gated skips** (matplotlib/flask/openai/pyzmq + uft_ca #180). Since they all self-skip, 4D (switching to the full suite as the gate, optionally adding those deps to convert skips→runs) is now genuinely on the table — for the next fresh-head session, once this proves green on the real runner.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_