### PR TITLE
ci: Tier 4D — gate the full tests/ suite in verify-python (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,28 +87,16 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          # The gated suites below depend only on numpy + pytest (+ pytest-asyncio
-          # for the genuinely-async test_telemetry suite). Optional-dep modules
-          # (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension are
-          # intentionally NOT gated yet (#165 Tier 4D). Kept lean.
+          # Lean install: numpy + pytest + pytest-asyncio. Optional-dep modules
+          # (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension are NOT
+          # installed — their tests self-skip cleanly (importorskip). Converting
+          # those skips into real runs is future work (uft_ca tracked by #180).
           pip install numpy pytest pytest-asyncio
 
-      - name: Run maintained Python test suites
+      - name: Run maintained Python test suite
         run: |
-          # #165 Tier 4A/4C: explicit allowlist of fully-green modules
-          # (verified pass under the install above). Not bare `pytest`.
-          python -m pytest \
-            tests/test_nextness_observer.py \
-            tests/test_nextness_calibration.py \
-            tests/test_nextness_metrics.py \
-            tests/test_agent_backend.py \
-            tests/test_anthropic_backend.py \
-            tests/test_cli_viz.py \
-            tests/test_continuous_evolution_ca.py \
-            tests/test_feature_flags.py \
-            tests/test_observability.py \
-            tests/test_params_schema.py \
-            tests/test_shard_protocol.py \
-            tests/test_ising_tempering.py \
-            tests/test_telemetry.py \
-            -q
+          # #165 Tier 4D: gate the full tests/ suite. Under the lean install
+          # every module either passes or self-skips (verified: 592 passed,
+          # 37 skipped, 0 failed, 0 errors). pytest.ini scopes collection to
+          # tests/ and keeps root-level legacy scripts out.
+          python -m pytest tests/ -q


### PR DESCRIPTION
## Summary

**Tier 4D** of [Issue #165](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/main/docs/ISSUE_165_TIER4_TEST_STATUS_REPORT.md) — the final floorboard. Switches `verify-python` from the explicit 13-module allowlist to the **full suite**: `python -m pytest tests/ -q`. Per Jack + AURA, after the confirmation pass. One file (`.github/workflows/ci.yml`, +10/−22).

## Confirmation pass (done first, on updated `main`)

`d2f0e37` → full `pytest tests/` under the lean install (`numpy pytest pytest-asyncio`): **592 passed, 37 skipped, 0 failed, 0 collection errors.** Every module passes-or-skips.

## What changed

- `verify-python` run step → `python -m pytest tests/ -q` (was the 13-module allowlist).
- Install stays lean (`numpy pytest pytest-asyncio`).
- Optional-dep modules (matplotlib/flask/openai/pyzmq) and `uft_ca` are **not** installed — their tests `importorskip` cleanly. `pytest.ini`'s `testpaths = tests` keeps root-level legacy scripts out.

## Verification (local, exact gate command)

`python -m pytest tests/ -q` → **592 passed, 37 skipped, 0 failed**. YAML validated.

## What this means

The gate is now **honest and complete**: the entire maintained suite runs on every PR, with the 37 dependency-gated tests transparently skipping. This is the #165 coverage-broadening end state.

## Future work (separate, not now)

Convert clean skips into real runs incrementally — add optional deps (matplotlib/flask/openai/pyzmq) and build `uft_ca` via maturin (tracked in **#180**).

## Scope / guardrails

CI-only. No source/engine/observer changes, no new deps beyond the already-merged `pytest-asyncio`, no Lane A / Swarm Hunter / tuning API / production sweeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_