### PR TITLE
ci: skip-conversion — add matplotlib/flask/pyzmq so their suites run (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,17 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          # Lean install: numpy + pytest + pytest-asyncio. Optional-dep modules
-          # (matplotlib/flask/openai/pyzmq) and the uft_ca Rust extension are NOT
-          # installed — their tests self-skip cleanly (importorskip). Converting
-          # those skips into real runs is future work (uft_ca tracked by #180).
-          pip install numpy pytest pytest-asyncio
+          # numpy + pytest + pytest-asyncio, plus the cheap pip-installable test
+          # deps (matplotlib/flask/pyzmq) so their suites RUN instead of skip
+          # (#165 skip-conversion). Still NOT installed: openai (deferred) and the
+          # uft_ca Rust extension (needs a maturin build — tracked by #180); those
+          # tests self-skip cleanly via importorskip.
+          pip install numpy pytest pytest-asyncio matplotlib flask pyzmq
 
       - name: Run maintained Python test suite
         run: |
-          # #165 Tier 4D: gate the full tests/ suite. Under the lean install
-          # every module either passes or self-skips (verified: 592 passed,
-          # 37 skipped, 0 failed, 0 errors). pytest.ini scopes collection to
+          # #165: gate the full tests/ suite. Under this install every module
+          # either passes or self-skips (verified locally: 713 passed,
+          # 38 skipped, 0 failed, 0 errors). pytest.ini scopes collection to
           # tests/ and keeps root-level legacy scripts out.
           python -m pytest tests/ -q


### PR DESCRIPTION
## Summary

**Skip-conversion (cheap deps)** — the next small brick after the #165 floor. Adds the three pip-installable optional deps to `verify-python` so their suites **run instead of self-skipping**. CI-only, one file.

| Dep added | Unblocks |
|---|---|
| `matplotlib` | `test_observatory`, `test_visualization` |
| `flask` | `test_provider_parity`, `test_tuning_api` |
| `pyzmq` | `test_event_bus`, `test_shard_transport_zmq` |

## Verified locally first (as promised — these had never run in CI)

Each of the 6 modules **passes** with its dep present (no hidden failures, unlike the openai case). Full suite with all three:

**713 passed, 38 skipped, 0 failed, 0 collection errors** (was 592 / 37). → **+121 tests now genuinely running.**

The `importorskip` guards stay in place, so the suite still self-skips gracefully if a dep is ever absent — this only *adds* coverage, it doesn't make any test mandatory-or-bust.

## Deliberately deferred (their own arcs)

- **`openai`** construction tests — deferred (Jack's "cheap deps only" call; openai needs more care).
- **`uft_ca`** (~25 skips) — needs a maturin Rust build, tracked in **#180**. Still self-skips here.

## Scope / guardrails

CI-only (`.github/workflows/ci.yml`). No source/engine/observer changes, no test-file changes, no Lane A / Swarm Hunter / tuning API / production sweeps.

---

Draft for **Jack + AURA review**. Note for the runner: GitHub's `setup-python` gives a clean Python, so the deps install fresh (no system-`blinker` conflict like a local Debian env). Watching the first real CI run closely.

---
_Generated by [Claude Code](https://claude.ai/code/session_0116KHXkg8ouu2XnWnpHCwJv)_