### PR TITLE
chore: gitignore Rust/Python build & cache artifacts (Packet A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ tmp/
 temp/
 # Theory sandbox outputs (experiments are non-canonical; outputs never committed)
 experiments/theory_sandbox/out/
+
+# --- Rust build artifacts ---
+crates/*/target/
+# --- Python bytecode caches ---
+__pycache__/
+*.pyc


### PR DESCRIPTION
Adds Rust/Python build & cache patterns to .gitignore (the repo's .gitignore was
Node/JS-derived and missing them):
  crates/*/target/ · __pycache__/ · *.pyc

Effect: hides ~4,320 untracked files (git status ~52,159 → ~47,839, the remainder
being data/ + Cargo.lock, handled in later packets). Deletes nothing; moves nothing.
Does NOT untrack the 19 already-committed .pyc (separate follow-up). Single file:
.gitignore. Fully reversible.
