### PR TITLE
chore: gitignore data/ runtime output (snapshots, telemetry, exports, renders) — Packet B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,16 @@ crates/*/target/
 # --- Python bytecode caches ---
 __pycache__/
 *.pyc
+
+# --- data/ runtime-generated output (snapshots, telemetry, exports, renders) ---
+# kept on disk + warm backup, never committed. Deliberately granular to preserve the
+# curated files tracked/visible in data/ (viewers, QR, genomes) — see Packet B notes.
+data/*.npz
+data/telemetry_*.json
+data/*.stl
+data/*.csv
+data/*.glb
+data/observatory_*.html
+data/observatory_*.png
+data/geometry/
+data/voxel_slices/


### PR DESCRIPTION
Adds GRANULAR .gitignore patterns for data/ runtime-generated output so it stops
cluttering git status (data/ holds ~47.8k untracked runtime files):
  data/*.npz · data/telemetry_*.json · data/*.stl · data/*.csv · data/*.glb
  data/observatory_*.{html,png} · data/geometry/ · data/voxel_slices/

Deliberately granular (telemetry_*, observatory_*, NOT *.json/*.html/*.png) to preserve
the curated files in data/: tracked viewers (medusa_*.html), the genome QR, and the
genome JSON(s) — including the still-untracked organism_*_epi.genome.json, left visible
for a separate track/ignore decision.

Deletes nothing; moves nothing; untracks nothing. Single file: .gitignore. Reversible.
