### PR TITLE
chore: gitignore the regenerable epi-genome snapshot export (Packet Epi-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,8 @@ data/observatory_*.html
 data/observatory_*.png
 data/geometry/
 data/voxel_slices/
+
+# --- regenerable epigenetic-snapshot genome export (derived from an npz; preserved in warm backup) ---
+# ~11.5 MB base64-encoded lattice+memory state; reconstructable via scripts/portable_genome.py.
+# Targeted (*_epi.genome.json) so the curated base genome organism_*.genome.json stays tracked/visible.
+data/*_epi.genome.json


### PR DESCRIPTION
Adds a targeted .gitignore pattern for the epigenetic-snapshot genome export:
  data/*_epi.genome.json

Why it's safe: data/organism_v075_phase6c_epi.genome.json (~11.5 MB) is a derived,
base64-encoded repackaging of an npz snapshot (gen 515682 / step 5156825). The
Lane-5 backup-presence check confirmed that source snapshot is preserved in the warm
backup (UNC + K: mirror) and locally, and it is regenerable via
scripts/portable_genome.py --include-epigenetic. Ignoring the heavy derived bundle
loses nothing.

Deliberately narrow (*_epi.genome.json), verified read-only NOT to match the tracked
base genome (organism_v075_phase6c.genome.json) or the curated data/ files
(medusa_*.html, organism_genome_qr.png). Effect: git status untracked 2 -> 1
(only crates/vanguard-mcp/Cargo.lock remains). Single file: .gitignore. Deletes
nothing; untracks nothing. Fully reversible.
