### PR TITLE
fix(tests): read exporter output as UTF-8 in cli_viz tests

### DIFF
--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -214,7 +214,7 @@ class TestExporters:
         assert success
         assert output_file.exists()
         
-        content = output_file.read_text()
+        content = output_file.read_text(encoding='utf-8')
         assert "<!DOCTYPE html>" in content
         assert "UtilityFog Fractal Tree Visualization" in content
         assert "Test Node" in content
@@ -229,7 +229,7 @@ class TestExporters:
         assert success
         assert output_file.exists()
         
-        content = output_file.read_text()
+        content = output_file.read_text(encoding='utf-8')
         assert "<svg" in content
         assert "width=\"400\"" in content
         assert "height=\"300\"" in content
@@ -244,7 +244,7 @@ class TestExporters:
         assert success
         assert output_file.exists()
         
-        content = output_file.read_text()
+        content = output_file.read_text(encoding='utf-8')
         assert "UTILITYFOG FRACTAL TREE VISUALIZATION REPORT" in content
         assert "TREE STRUCTURE" in content
         assert "MESSAGE FLOWS" in content
@@ -259,7 +259,7 @@ class TestExporters:
         assert success
         assert output_file.exists()
         
-        with open(output_file) as f:
+        with open(output_file, encoding='utf-8') as f:
             data = json.load(f)
         
         assert "timestamp" in data


### PR DESCRIPTION
## What

Makes the four exporter-readback sites in `tests/test_cli_viz.py` encoding-explicit (`read_text(encoding='utf-8')` at lines 217/232/247, `open(..., encoding='utf-8')` at line 262).

## Why

The exporters under test write with explicit `encoding='utf-8'` (`exporters.py` lines 35/591/746/803), but the tests read back with the platform default — cp1252 on Windows — so `test_html_exporter` and `test_text_exporter` fail with `UnicodeDecodeError` on any Windows checkout. Linux CI passes only because its default encoding is already UTF-8. The svg/json readback sites are the same latent bug, fixed in the same stroke.

## Deliberately NOT touched

The fixture write at line 334 and readback at line 415 pair with `cli.py`'s own default-encoding I/O (`cli.py:118/307`). Making only the test side UTF-8-explicit there would create a write/read asymmetry with the code under test. That sibling cleanup belongs with a `cli.py` change, if ever chosen.

## Verification (existing checks only, local Windows / Python 3.14)

- `python -m pytest tests/test_cli_viz.py -q` → **19 passed** (was 17 passed / 2 failed)
- `python -m pytest tests/ -q` (the ci.yml gate command) → **788 passed, 26 skipped, 1 failed** — the 1 failure is pre-existing and unrelated (`test_3_to_8_channel_migration`: GPU/CuPy-vs-NumPy mixing on GPU-equipped machines; fails identically before and after this branch). The 26 skips are the uft_ca-extension self-skips, expected without `pip install ./crates/uft_ca`.

Zero production code touched. No merge performed — awaiting review per house rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)