### PR TITLE
docs(ci): refresh stale verify-python scope-note comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,12 @@ jobs:
   # auto-passing without running anything. This job runs the maintained
   # Python suites so a real regression fails the build visibly.
   #
-  # Scope note: targets the two maintained nextness suites explicitly rather
-  # than bare `pytest`, because several pre-existing modules fail at
-  # collection (uft_ca / utilityfog_frontend.cli_viz imports, root-level
-  # *_test.py scripts) — tracked separately. These two files are exactly the
-  # suite verified locally for PRs #160–#164 (275 tests). Broadening coverage
-  # (fixing or excluding the broken collectors) is a follow-up under #165.
+  # Scope note: gates the full tests/ suite (pytest.ini scopes collection to
+  # tests/ and keeps the root-level legacy *_test.py scripts out). The uft_ca
+  # pyo3 extension is built below so its suites run instead of self-skipping
+  # (#165 skip-conversion + #180). Historical: this job originally targeted
+  # only the two maintained nextness suites (the set verified for
+  # PRs #160–#164) while the broken collectors were being fixed under #165.
   verify-python:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

Rewrites the stale scope-note comment above the `verify-python` job in `.github/workflows/ci.yml`. Comment-only; zero workflow behavior changed (YAML parses identically).

## Why

The comment still said the job "targets the two maintained nextness suites explicitly rather than bare `pytest`" — that description was superseded when the job was widened to gate the **full `tests/` suite** with the uft_ca pyo3 extension built (#165 skip-conversion + #180). The run step at the bottom of the file already documents the current 832-passed baseline, so the header comment contradicted the job it introduces and misled readers about CI scope. The two-suite era is kept as a one-line historical note.

## Verification

- Comment-only diff (every changed line starts with `#`)
- `yaml.safe_load` parses the file cleanly before and after

No merge performed — awaiting review per house rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)