### PR TITLE
fix(cli_viz): use explicit UTF-8 for JSON load/demo file I/O

### DIFF
--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -331,7 +331,7 @@ class TestCLI:
         }
         
         json_file = tmp_path / "sample.json"
-        with open(json_file, 'w') as f:
+        with open(json_file, 'w', encoding='utf-8') as f:
             json.dump(data, f)
         
         return str(json_file)
@@ -412,7 +412,7 @@ class TestCLI:
         assert output_file.exists()
         
         # Verify generated data
-        with open(output_file) as f:
+        with open(output_file, encoding='utf-8') as f:
             data = json.load(f)
         
         assert len(data['nodes']) == 5

--- a/utilityfog_frontend/cli_viz/cli.py
+++ b/utilityfog_frontend/cli_viz/cli.py
@@ -115,7 +115,7 @@ Examples:
     def load_data(self, input_file: str) -> bool:
         """Load visualization data from JSON file."""
         try:
-            with open(input_file, 'r') as f:
+            with open(input_file, 'r', encoding='utf-8') as f:
                 json_data = json.load(f)
             
             # Load nodes
@@ -304,7 +304,7 @@ Examples:
         demo_data = self._generate_demo_data(args.nodes, args.messages, args.transitions)
         
         try:
-            with open(args.output, 'w') as f:
+            with open(args.output, 'w', encoding='utf-8') as f:
                 json.dump(demo_data, f, indent=2)
             
             print(f"Generated demo data with {args.nodes} nodes, {args.messages} messages, {args.transitions} transitions")


### PR DESCRIPTION
## What

Makes `cli.py`'s two JSON I/O sites encoding-explicit — `load_data()` (line 118, read) and `cmd_demo()` (line 307, write) — plus the two paired test sites (fixture write at 334, demo readback at 415).

## Why

These were the only two remaining platform-default-encoding sites in the cli_viz package; all four exporters already write `encoding='utf-8'`, and JSON's interchange encoding is UTF-8. As written, a demo file produced on Linux with non-ASCII content fails to load on Windows (cp1252), and vice versa.

## Relationship to #275

Companion, not dependency: #275 fixes the *exporter-readback* sites in the same test file; this fixes the *cli JSON I/O* sites. Disjoint hunks — no conflict in either merge order. The two cli_viz test failures visible on this branch's CI-less local run are the pre-existing ones #275 fixes (this branch is cut from main); they fail identically before and after this change. Linux CI is green either way; Windows checkouts are fully green once both merge.

## Verification (existing checks only)

- `python -m pytest tests/test_cli_viz.py -q` → 17 passed + the 2 pre-existing #275-scope failures (identical to main)
- `python -m pytest tests/ -q` → **3 failed / 786 passed / 26 skipped — byte-identical to the main baseline** recorded in tonight's C2 run (3rd failure = unrelated GPU/CuPy engine test)

No merge performed — awaiting review per house rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)