### PR TITLE
fix(telemetry): use explicit UTF-8 for metrics exporter file I/O

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -255,7 +255,7 @@ class TestExporters:
 
         # Check that file was created and contains expected content
         assert output_file.exists()
-        content = output_file.read_text()
+        content = output_file.read_text(encoding="utf-8")
 
         assert "# HELP test_counter Test counter" in content
         assert "# TYPE test_counter counter" in content
@@ -280,7 +280,7 @@ class TestExporters:
         # Parse and validate JSON content
         import json
 
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             data = json.load(f)
 
         assert "timestamp" in data

--- a/utilityfog_frontend/telemetry/exporter.py
+++ b/utilityfog_frontend/telemetry/exporter.py
@@ -68,7 +68,7 @@ class PrometheusAdapter(MetricsExporter):
             prometheus_text = self._generate_prometheus_text(exported_metrics)
 
             if self.output_file:
-                with open(self.output_file, "w") as f:
+                with open(self.output_file, "w", encoding="utf-8") as f:
                     f.write(prometheus_text)
             else:
                 # Log the metrics (in production, this would be served via HTTP)
@@ -169,7 +169,7 @@ class JSONExporter(MetricsExporter):
             snapshot = collector.get_snapshot()
 
             if self.output_file:
-                with open(self.output_file, "w") as f:
+                with open(self.output_file, "w", encoding="utf-8") as f:
                     if self.pretty:
                         json.dump(snapshot, f, indent=2)
                     else:


### PR DESCRIPTION
## What
Makes the telemetry subsystem's text-mode file I/O encoding-explicit — the same latent-hazard class fixed for cli_viz in #275/#277:

- `utilityfog_frontend/telemetry/exporter.py` — `PrometheusAdapter.export_metrics` (:71) and `JSONExporter.export_metrics` (:172) wrote with the platform default encoding (cp1252 on Windows CI-less checkouts, UTF-8 on Linux CI).
- `tests/test_telemetry.py` — the two paired readback sites (:258 `read_text()`, :283 `open()`) made explicit in the same change to preserve write/read symmetry.

## Why
Prometheus text output can carry label values verbatim; non-ASCII labels would round-trip differently per platform. Content today is ASCII, so this is latent, not currently failing — identical status to the cli.py sites merged in #277. With this, telemetry joins cli_viz as fully encoding-explicit.

## Verification (existing checks only)
- Target: `pytest tests/test_telemetry.py -q` → **14 passed**.
- Full gate: `python -m pytest tests/ -q` → **788 passed / 1 failed / 26 skipped** — byte-identical to the main (`dd208bb`) baseline; the 1 failure is the pre-existing gated engine/CuPy defect (diagnosis packet with Jack).

## Lane
Build-seat PR under the ratified role split (84 codes/opens · Jack audits · Kev speaks merge/park). **Unmerged by design.** Engine, `scripts/ca` instrument, theory sandbox, `data/`+NPZ all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)