### PR TITLE
fix(vis): use explicit UTF-8 for CSV export and test readbacks

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -105,7 +105,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path)
-            with open(path, encoding="utf-8") as f:
+            with open(path, newline="", encoding="utf-8") as f:
                 reader = csv.reader(f)
                 header = next(reader)
             assert header == ["step", "void", "structural", "compute", "energy", "sensor"]
@@ -139,7 +139,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path)
-            with open(path, encoding="utf-8") as f:
+            with open(path, newline="", encoding="utf-8") as f:
                 reader = csv.reader(f)
                 next(reader)
                 first_row = next(reader)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -105,7 +105,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 reader = csv.reader(f)
                 header = next(reader)
             assert header == ["step", "void", "structural", "compute", "energy", "sensor"]
@@ -117,7 +117,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 lines = f.readlines()
             assert len(lines) == 6
         finally:
@@ -128,7 +128,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path, header=False)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 lines = f.readlines()
             assert len(lines) == 5
         finally:
@@ -139,7 +139,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv(SAMPLE_FLAT, path)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 reader = csv.reader(f)
                 next(reader)
                 first_row = next(reader)
@@ -152,7 +152,7 @@ class TestExportCSV:
             path = f.name
         try:
             to_csv([], path)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 lines = f.readlines()
             assert len(lines) == 1
         finally:

--- a/vis/export.py
+++ b/vis/export.py
@@ -18,7 +18,7 @@ def to_numpy(history):
 
 def to_csv(history, path, header=True):
     arr = to_numpy(history)
-    with open(path, "w", newline="") as f:
+    with open(path, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         if header:
             writer.writerow(["step"] + STATE_NAMES)


### PR DESCRIPTION
## What
Makes the vis timeseries CSV export encoding-explicit — same latent-hazard class as #275/#277/#280:

- `vis/export.py` — `to_csv()` (:21) wrote with the platform default encoding; now `open(path, "w", newline="", encoding="utf-8")`, the csv module's documented pattern.
- `tests/test_visualization.py` — the five paired readback sites (:108/:120/:131/:142/:155) made explicit in the same change to preserve write/read symmetry.

## Why
Content today is ASCII (state names + digits), so this is latent rather than currently failing — identical status to the sites merged in #277. `vis/export.py` is exercised by the CI gate via `tests/test_visualization.py`, so the fix has a real verification surface.

## Verification (existing checks only)
- Target: `pytest tests/test_visualization.py -q` → **50 passed**.
- Full gate: `python -m pytest tests/ -q` → **788 passed / 1 failed / 26 skipped** — byte-identical to the main (`dd208bb`) baseline; the 1 failure is the pre-existing gated engine/CuPy defect (diagnosis packet with Jack).

## Notes for the audit
- Independent of #280 (no overlapping files); either merge order works.
- Same sweep also surfaced default-encoding sites with **no** verification surface — routed as notes, deliberately not fixed here: `testing_framework/` (9 sites, zero test coverage), `src/uft_orch/ca/` (dormant lane), `UtilityFog_Agent_Package/agent/feature_flags.py` (disposition pending with Kev/Jack).

## Lane
Build-seat PR under the ratified role split (84 codes/opens · Jack audits · Kev speaks merge/park). **Unmerged by design.** Engine, `scripts/ca` instrument, theory sandbox, `data/`+NPZ all untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)