### PR TITLE
fix(observability): replace deprecated datetime.utcnow() with timezone-aware now

### DIFF
--- a/UtilityFog_Agent_Package/agent/observability.py
+++ b/UtilityFog_Agent_Package/agent/observability.py
@@ -9,7 +9,7 @@ import logging
 import time
 import uuid
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Union
 from contextlib import contextmanager
 from functools import wraps
@@ -65,7 +65,7 @@ class StructuredLogger:
         class JSONFormatter(logging.Formatter):
             def format(self, record):
                 log_entry = {
-                    'timestamp': datetime.utcnow().isoformat() + 'Z',
+                    'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
                     'level': record.levelname,
                     'logger': record.name,
                     'message': record.getMessage(),


### PR DESCRIPTION
## What
One functional line (+ its import): `UtilityFog_Agent_Package/agent/observability.py:68` used `datetime.utcnow()`, which is **deprecated and scheduled for removal** — and produced **104 of the gate's 105 warnings** (via `tests/test_observability.py`, which exercises the StructuredLogger heavily).

The replacement `datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')` emits a **byte-identical timestamp format** (`...T...Z`) — same wall-clock value, same string shape — so log consumers see no change.

## ⚠ Audit flag: this touches UtilityFog_Agent_Package
The package's **disposition** (remove vs tombstone for its corrupted stubs) is a separate, still-open Kev/Jack item. This PR deliberately does **not** touch that question: `observability.py` is one of the live, gate-imported modules (per today's discovery, `test_observability.py` calls this the "canonical package"), and the fix travels with the file whatever the disposition decision ends up being. If Jack judges the package frozen pending disposition, parking this PR is the right call — flagging rather than assuming.

## Verification (existing checks only)
- Target: `pytest tests/test_observability.py -q` → **25 passed**, utcnow warnings gone.
- Full gate: `python -m pytest tests/ -q` → **788 passed / 1 failed / 26 skipped, 1 warning** (was 105 warnings) — pass/fail counts byte-identical to the main (`44874e8`) baseline; the 1 failure is the pre-existing gated engine/CuPy defect. The 1 remaining warning is an unrelated all-NaN RuntimeWarning in vis/observatory (separate PR incoming).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Engine untouched (the `utcnow` sites in `scripts/continuous_evolution.py` are engine-lane and were deliberately left alone — routed as a note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)