### PR TITLE
fix(observatory): guard diverging color scale against all-NaN slices

### DIFF
--- a/vis/observatory/animation.py
+++ b/vis/observatory/animation.py
@@ -113,7 +113,10 @@ def animate_slices(
 
             # Update normalization
             if overlay_channel == SIGNAL_FIELD_CHANNEL:
-                vmax = max(abs(np.nanmin(ch_sl)), abs(np.nanmax(ch_sl)), 0.01)
+                if np.all(np.isnan(ch_sl)):
+                    vmax = 0.01
+                else:
+                    vmax = max(abs(np.nanmin(ch_sl)), abs(np.nanmax(ch_sl)), 0.01)
                 im_overlay.set_norm(TwoSlopeNorm(vmin=-vmax, vcenter=0, vmax=vmax))
             else:
                 vmin_val = np.nanmin(ch_sl) if not np.all(np.isnan(ch_sl)) else 0

--- a/vis/observatory/dashboard.py
+++ b/vis/observatory/dashboard.py
@@ -120,7 +120,10 @@ def observatory_dashboard(
     sig_vol = snapshot.channel(SIGNAL_FIELD_CHANNEL).copy().astype(float)
     sig_vol[snapshot.lattice == VOID] = np.nan
     sig_z = sig_vol[:, :, mid_z]
-    vmax_sig = max(abs(np.nanmin(sig_z)), abs(np.nanmax(sig_z)), 0.01)
+    if np.all(np.isnan(sig_z)):
+        vmax_sig = 0.01
+    else:
+        vmax_sig = max(abs(np.nanmin(sig_z)), abs(np.nanmax(sig_z)), 0.01)
     norm_sig = TwoSlopeNorm(vmin=-vmax_sig, vcenter=0, vmax=vmax_sig)
     # Base: lattice states
     ax_sig.imshow(lattice_z.T, origin="lower", cmap=cmap, vmin=0, vmax=4,

--- a/vis/observatory/slicer.py
+++ b/vis/observatory/slicer.py
@@ -161,7 +161,10 @@ def slice_channel(
     # Bipolar normalization for signal_field
     cmap_name = CHANNEL_COLORMAPS.get(channel, "viridis")
     if channel == SIGNAL_FIELD_CHANNEL:
-        vmax = max(abs(np.nanmin(sl)), abs(np.nanmax(sl)), 0.01)
+        if np.all(np.isnan(sl)):
+            vmax = 0.01
+        else:
+            vmax = max(abs(np.nanmin(sl)), abs(np.nanmax(sl)), 0.01)
         norm = TwoSlopeNorm(vmin=-vmax, vcenter=0, vmax=vmax)
     else:
         vmin_val = np.nanmin(sl) if not np.all(np.isnan(sl)) else 0
@@ -229,7 +232,10 @@ def slice_composite(
     # Overlay: channel heatmap
     cmap_name = CHANNEL_COLORMAPS.get(overlay_channel, "viridis")
     if overlay_channel == SIGNAL_FIELD_CHANNEL:
-        vmax = max(abs(np.nanmin(ch_sl)), abs(np.nanmax(ch_sl)), 0.01)
+        if np.all(np.isnan(ch_sl)):
+            vmax = 0.01
+        else:
+            vmax = max(abs(np.nanmin(ch_sl)), abs(np.nanmax(ch_sl)), 0.01)
         norm = TwoSlopeNorm(vmin=-vmax, vcenter=0, vmax=vmax)
     else:
         vmin_val = np.nanmin(ch_sl) if not np.all(np.isnan(ch_sl)) else 0
@@ -299,7 +305,10 @@ def tri_slice(
             cmap_name = CHANNEL_COLORMAPS.get(channel, "viridis")
 
             if channel == SIGNAL_FIELD_CHANNEL:
-                vmax = max(abs(np.nanmin(sl)), abs(np.nanmax(sl)), 0.01)
+                if np.all(np.isnan(sl)):
+                    vmax = 0.01
+                else:
+                    vmax = max(abs(np.nanmin(sl)), abs(np.nanmax(sl)), 0.01)
                 norm = TwoSlopeNorm(vmin=-vmax, vcenter=0, vmax=vmax)
             else:
                 vmin_val = np.nanmin(sl) if not np.all(np.isnan(sl)) else 0


### PR DESCRIPTION
## What
The observatory's signal-field **diverging-scale** line — `vmax = max(abs(np.nanmin(x)), abs(np.nanmax(x)), 0.01)` — runs unguarded on slices that are all-NaN whenever the visible lattice region is entirely VOID (empty snapshot, void slice). That emits `RuntimeWarning: All-NaN slice encountered` and propagates NaN into `TwoSlopeNorm` limits, making the overlay's color scaling undefined.

The **sequential-scale siblings directly below every one of these sites already have the guard** (`np.nanmin(x) if not np.all(np.isnan(x)) else 0`) — this is one consistent oversight, fixed with the same in-file pattern at all five diverging-scale sites:

- `vis/observatory/dashboard.py:123` (fires today via `test_dashboard_empty_snapshot`)
- `vis/observatory/slicer.py:164, :232, :302` (latent, same defect)
- `vis/observatory/animation.py:116` (latent, same defect)

All fall back to the existing `0.01` floor → `TwoSlopeNorm(-0.01, 0, 0.01)`, well-defined. Non-empty data takes the identical code path as before.

## Verification (existing checks only)
- Target: `pytest tests/test_observatory.py -q` → **39 passed**, All-NaN RuntimeWarning gone.
- Full gate: `python -m pytest tests/ -q` → **788 passed / 1 failed / 26 skipped** — pass/fail counts byte-identical to the main (`44874e8`) baseline; the 1 failure is the pre-existing gated engine/CuPy defect. Warnings on this branch: 104, all from the unrelated `utcnow` deprecation fixed in #282. **#282 + this PR together take the gate from 105 warnings to 0.**

## Notes for the audit
- Independent of #282 (no overlapping files); either merge order works.
- `vis/observatory/` is the active visualization CLI (application-side viz per C1 orientation) — **not** the engine, not the sealed `scripts/ca` replication instrument.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)