### PR TITLE
fix(agent): delete replaced meme by dict key in infect_with_meme

### DIFF
--- a/agent/foglet_agent.py
+++ b/agent/foglet_agent.py
@@ -262,14 +262,16 @@ class FogletAgent:
             return False
         
         # Check for conflicts with existing memes
-        for existing_meme in self.active_memes.values():
+        for existing_key, existing_meme in list(self.active_memes.items()):
             if existing_meme.meme_type == meme.meme_type:
                 # Competition between memes of same type
                 if existing_meme.genes.dominance > meme.genes.dominance:
                     return False
                 else:
-                    # Replace weaker meme
-                    del self.active_memes[existing_meme.meme_id]
+                    # Replace weaker meme. Delete by dict key: stored copies
+                    # carry a regenerated meme_id (Meme.copy() assigns a new
+                    # uuid), so existing_meme.meme_id is never the key.
+                    del self.active_memes[existing_key]
                     break
         
         # Successful infection

--- a/tests/test_foglet_agent.py
+++ b/tests/test_foglet_agent.py
@@ -1,0 +1,64 @@
+"""Tests for agent/foglet_agent.py — meme infection and same-type replacement."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.foglet_agent import FogletAgent
+from agent.meme_structure import Meme, MemeGenes, MemeType
+
+
+def _agent_with_no_resistance():
+    agent = FogletAgent()
+    agent.active_memes.clear()
+    # Zero resistance + virality 1.0 makes infection_probability exactly 1.0,
+    # so random.random() > 1.0 is always False and infection is deterministic.
+    agent.meme_resistances = {meme_type: 0.0 for meme_type in MemeType}
+    return agent
+
+
+def _behavioral_meme(dominance, marker):
+    return Meme(
+        meme_type=MemeType.BEHAVIORAL,
+        payload={"marker": marker},
+        genes=MemeGenes(dominance=dominance, virality=1.0),
+    )
+
+
+class TestSameTypeMemeReplacement:
+
+    def test_stronger_meme_replaces_weaker_same_type(self):
+        agent = _agent_with_no_resistance()
+
+        assert agent.infect_with_meme(_behavioral_meme(0.2, "weak"), infection_strength=1.0)
+        assert agent.infect_with_meme(_behavioral_meme(0.9, "strong"), infection_strength=1.0)
+
+        assert len(agent.active_memes) == 1
+        (stored,) = agent.active_memes.values()
+        assert stored.payload["marker"] == "strong"
+
+    def test_weaker_meme_is_rejected_by_dominant_incumbent(self):
+        agent = _agent_with_no_resistance()
+
+        assert agent.infect_with_meme(_behavioral_meme(0.9, "strong"), infection_strength=1.0)
+        assert not agent.infect_with_meme(_behavioral_meme(0.2, "weak"), infection_strength=1.0)
+
+        assert len(agent.active_memes) == 1
+        (stored,) = agent.active_memes.values()
+        assert stored.payload["marker"] == "strong"
+
+    def test_repeated_replacement_never_raises(self):
+        # Regression: stored memes carry regenerated meme_ids (Meme.copy()
+        # assigns a new uuid), so replacement must delete by dict key —
+        # deleting by the stored meme's id raises KeyError on every
+        # same-type takeover.
+        agent = _agent_with_no_resistance()
+
+        for dominance in (0.1, 0.5, 0.9):
+            assert agent.infect_with_meme(
+                _behavioral_meme(dominance, dominance), infection_strength=1.0
+            )
+
+        assert len(agent.active_memes) == 1
+        (stored,) = agent.active_memes.values()
+        assert stored.payload["marker"] == 0.9


### PR DESCRIPTION
## What
`FogletAgent.infect_with_meme`'s same-type conflict branch **always crashed with KeyError** when a stronger meme replaced a weaker incumbent: `active_memes` stores each meme under the ORIGINAL meme's id (`active_memes[meme.meme_id] = meme.copy()`), but `Meme.copy()` assigns the stored copy a **fresh uuid** — so `del self.active_memes[existing_meme.meme_id]` (line 272) referenced an id that was never a key. Every same-type takeover, whether via `infect_with_meme` or `propagate_memes`, crashed instead of replacing.

**Fix:** iterate `items()` and delete by the actual dict key (+ a comment stating the non-obvious copy()-regenerates-id constraint). Sole deletion site in the file; `Meme.copy()`'s id-regeneration itself is intended lineage behavior (a hunt finding proposing to change it was voted down) — the call site owns the fix.

## Provenance
Surfaced by tonight's adversarially-verified defect hunt: found by the agent-core finder, **upheld 3/3** by independent correctness/reachability/impact refuters, and reproduced live with a seeded script before any fix.

## Verification (existing checks + new regression tests)
- **New `tests/test_foglet_agent.py` demonstrates the bug**: run against unfixed code → 2/3 tests FAIL with `KeyError` at `foglet_agent.py:272`; post-fix → 3/3 pass. Locks replacement + rejection semantics (fully deterministic: zero resistance + virality 1.0 → infection probability exactly 1.0).
- Full gate: `python -m pytest tests/ -q` → **791 passed / 1 failed / 26 skipped** (788 baseline + 3 new; the 1 = pre-existing gated engine/CuPy defect; zero warnings).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Engine, sealed instruments, data/ untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)