### PR TITLE
fix(api): let the results 404 through instead of remapping it to 500

### DIFF
--- a/utilityfog_frontend/backend/api.py
+++ b/utilityfog_frontend/backend/api.py
@@ -142,6 +142,10 @@ async def get_simulation_results(run_id: str):
             "timestamp": time.time()
         }
         
+    except HTTPException:
+        # Let the intended 404 (and any other HTTPException) through instead
+        # of remapping it to a 500 below.
+        raise
     except Exception as e:
         logger.error(f"Failed to get results for {run_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to get results: {str(e)}")


### PR DESCRIPTION
## What
`GET /api/sim/results/{run_id}` explicitly raises `HTTPException(404)` for unknown run ids — but the raise sits inside a `try` whose handler is `except Exception as e`, and FastAPI's `HTTPException` subclasses `Exception`, so every 404 was caught and re-raised as `500 'Failed to get results: 404: …'`. Clients could never distinguish "unknown/not-ready run" from a real server failure. Fix: `except HTTPException: raise` ahead of the generic handler.

Class-sweep done: this is the **only** endpoint in `api.py` with the pattern — `start_simulation` and `stop_simulation` correctly raise their 400s outside the `try`.

## Provenance
Defect-hunt finding, **upheld 3/3** by independent correctness/reachability/impact refuters.

## Verification limits (disclosed)
Same as #286: `fastapi` is absent locally and from CI's verify-python deps, so no executable test surface exists for this module — source-verified only; full gate unchanged (788/1/26). Independent of #286 (different file); any merge order.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)