### PR TITLE
fix(agent): guard Convergence Trace against empty energy history

### DIFF
--- a/agent/ising_tempering.py
+++ b/agent/ising_tempering.py
@@ -309,7 +309,11 @@ def format_remote_polaroid(result: GrokkingRunResult) -> str:
 
     n_hist = len(result.energy_history)
     sample_points = [0, n_hist // 4, n_hist // 2, 3 * n_hist // 4, n_hist - 1]
-    sample_points = sorted(set(max(0, min(p, n_hist - 1)) for p in sample_points))
+    if n_hist:
+        sample_points = sorted(set(max(0, min(p, n_hist - 1)) for p in sample_points))
+    else:
+        # Empty history: the clamp would yield index 0 into an empty list.
+        sample_points = []
     lines.append("  --- Convergence Trace ---")
     lines.append(f"    {'Step':>6s}  {'MinE':>10s}  {'MeanE':>10s}  {'MaxE':>10s}  {'SwapRate':>10s}")
     for idx in sample_points:

--- a/tests/test_ising_tempering.py
+++ b/tests/test_ising_tempering.py
@@ -185,3 +185,18 @@ class TestWatchdogAlignment:
         """Verify each replica targets gpu-0 on its node (matching GPU router slot IDs)."""
         for node in ParallelTempering.NODE_MAP:
             assert node["gpu"] == "gpu-0"
+
+class TestFormatRemotePolaroidEmptyHistory:
+
+    def test_empty_energy_history_does_not_raise(self):
+        # Regression: with total_exchanges=0 the energy history is empty and
+        # the Convergence Trace sample-point clamp yielded index 0 into an
+        # empty list (IndexError at agent/ising_tempering.py:316).
+        config = IsingConfig(lattice_size=8, num_replicas=4, total_exchanges=0,
+                             sweeps_per_exchange=1, seed=0)
+        pt = ParallelTempering(config)
+        result = pt.run()
+        assert result.energy_history == []
+
+        report = format_remote_polaroid(result)
+        assert "Convergence Trace" in report


### PR DESCRIPTION
## What
`format_remote_polaroid` already guards its Energy Landscape section against an empty `energy_history`, but the Convergence Trace block's sample-point clamp (`max(0, min(p, n_hist - 1))`) yields index 0 when `n_hist == 0` and indexes into the empty list — **IndexError** for any result with no exchanges (`total_exchanges=0` dry-run/smoke dispatches, or runs aborted before the first exchange), losing the report for the run. Sample points are now `[]` when the history is empty; the trace section prints its header with no rows, consistent with the Energy Landscape's empty behavior.

## Provenance
Defect-hunt finding, **upheld 2/2** (third verifier lost to the session limit), reproduced live before fixing.

## Verification (existing checks + new regression test)
- New test in `tests/test_ising_tempering.py` **fails pre-fix** (IndexError at `ising_tempering.py:316`) and passes post-fix.
- Target suite: **23 passed** (22 existing + 1 new). Full gate: **789 passed / 1 failed / 26 skipped** (788 baseline + 1 new; the 1 = pre-existing gated engine/CuPy defect).

## Not touched (routed separately)
The hunt's other ising finding — the PT ladder-scramble (`attempt_swap` migrates betas while `exchange_step` pairs by fixed index, 2/2 upheld) — is a physics-behavior fix needing more care than a guard clause; deliberately not bundled here.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)