### PR TITLE
fix(agent): pair metric collectors with their registered entity source

### DIFF
--- a/agent/simulation_metrics.py
+++ b/agent/simulation_metrics.py
@@ -19,7 +19,6 @@ import csv
 from collections import defaultdict, deque
 from abc import ABC, abstractmethod
 import numpy as np
-import pandas as pd
 
 from .meme_structure import Meme, MemeType
 from .foglet_agent import FogletAgent, AgentState

--- a/agent/simulation_metrics.py
+++ b/agent/simulation_metrics.py
@@ -216,7 +216,9 @@ class SimulationMetrics:
         total_collected = 0
         
         try:
-            for collector, source_name in zip(self.collectors, self.collector_source_names):
+            for collector, source_name in zip(
+                self.collectors, self.collector_source_names, strict=True
+            ):
                 entities = self.entity_sources.get(source_name, [])
                 
                 collected_metrics = collector.collect_metrics(entities, timestamp)

--- a/agent/simulation_metrics.py
+++ b/agent/simulation_metrics.py
@@ -179,6 +179,7 @@ class SimulationMetrics:
         self.metric_data: Dict[str, deque] = defaultdict(lambda: deque(maxlen=max_data_points))
         
         self.collectors: List[MetricCollector] = []
+        self.collector_source_names: List[str] = []
         self.entity_sources: Dict[str, List[Any]] = {}
         
         self.last_collection_time: float = 0.0
@@ -200,6 +201,7 @@ class SimulationMetrics:
     def add_collector(self, collector: MetricCollector, entity_source_name: str) -> None:
         """Add a metric collector with its associated entity source."""
         self.collectors.append(collector)
+        self.collector_source_names.append(entity_source_name)
         if entity_source_name not in self.entity_sources:
             self.entity_sources[entity_source_name] = []
     
@@ -215,16 +217,14 @@ class SimulationMetrics:
         total_collected = 0
         
         try:
-            for i, collector in enumerate(self.collectors):
-                source_names = list(self.entity_sources.keys())
-                if i < len(source_names):
-                    entities = self.entity_sources[source_names[i]]
-                    
-                    collected_metrics = collector.collect_metrics(entities, timestamp)
-                    
-                    for metric_name, data_point in collected_metrics:
-                        self._store_metric_data(metric_name, data_point)
-                        total_collected += 1
+            for collector, source_name in zip(self.collectors, self.collector_source_names):
+                entities = self.entity_sources.get(source_name, [])
+                
+                collected_metrics = collector.collect_metrics(entities, timestamp)
+                
+                for metric_name, data_point in collected_metrics:
+                    self._store_metric_data(metric_name, data_point)
+                    total_collected += 1
             
             self.last_collection_time = timestamp
             self.collection_count += 1

--- a/tests/test_simulation_metrics.py
+++ b/tests/test_simulation_metrics.py
@@ -1,0 +1,67 @@
+"""Tests for agent/simulation_metrics.py — collector/entity-source pairing."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.simulation_metrics import MetricCollector, SimulationMetrics
+
+
+class RecordingCollector(MetricCollector):
+    """Stub collector that records which entities it was handed."""
+
+    def __init__(self):
+        self.seen = None
+
+    def collect_metrics(self, entities, timestamp):
+        self.seen = list(entities)
+        return []
+
+
+class TestCollectorSourcePairing:
+
+    def test_two_collectors_on_same_source_both_run(self):
+        # Regression: pairing collectors with sources by parallel index
+        # silently skipped the trailing collector whenever two collectors
+        # registered against the same source name.
+        sm = SimulationMetrics(collection_interval=0.0)
+        first = RecordingCollector()
+        second = RecordingCollector()
+        sm.add_collector(first, "pool")
+        sm.add_collector(second, "pool")
+        sm.entity_sources["pool"] = ["m1", "m2"]
+
+        sm.collect_all_metrics(timestamp=100.0)
+
+        assert first.seen == ["m1", "m2"]
+        assert second.seen == ["m1", "m2"]
+
+    def test_collector_receives_its_registered_source(self):
+        # Regression: with reused source names, index pairing handed the
+        # second collector the WRONG source's entities and skipped the third.
+        sm = SimulationMetrics(collection_interval=0.0)
+        meme_a = RecordingCollector()
+        meme_b = RecordingCollector()
+        agents = RecordingCollector()
+        sm.add_collector(meme_a, "pool")
+        sm.add_collector(meme_b, "pool")
+        sm.add_collector(agents, "agents")
+        sm.entity_sources["pool"] = ["meme1"]
+        sm.entity_sources["agents"] = ["agent1", "agent2"]
+
+        sm.collect_all_metrics(timestamp=100.0)
+
+        assert meme_a.seen == ["meme1"]
+        assert meme_b.seen == ["meme1"]
+        assert agents.seen == ["agent1", "agent2"]
+
+    def test_unpopulated_source_yields_empty_entities(self):
+        # A collector registered before its source is populated gets an
+        # empty list, not a crash or someone else's entities.
+        sm = SimulationMetrics(collection_interval=0.0)
+        lonely = RecordingCollector()
+        sm.add_collector(lonely, "never_filled")
+
+        sm.collect_all_metrics(timestamp=100.0)
+
+        assert lonely.seen == []

--- a/tests/test_simulation_metrics.py
+++ b/tests/test_simulation_metrics.py
@@ -2,7 +2,15 @@
 
 import sys
 from pathlib import Path
+
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# simulation_metrics imports the agent package family (network_topology needs
+# networkx), which is not part of CI's dependency set. Self-skip like the
+# other optional-dep suites (#165 Tier 1 pattern).
+pytest.importorskip("networkx")
 
 from agent.simulation_metrics import MetricCollector, SimulationMetrics
 


### PR DESCRIPTION
## What
`SimulationMetrics.add_collector(collector, entity_source_name)` threw away the association — the name became only a dict key — and `collect_all_metrics` rebuilt it **by parallel index** (`source_names[i]` for collector `i`). Consequences, both reproduced:

- Two collectors registered on the **same** source: `len(collectors) > len(source_names)`, so the trailing collector was **silently never run** (metrics just missing, no error).
- Reused source names out of order: a collector receives the **wrong source's entities** (e.g. an agent collector handed Meme objects → `AttributeError` mid-collection).

**Fix:** record the source name at registration (`collector_source_names`, parallel list) and pair them in the collection loop with `zip(..., strict=True)` — any future divergence between the two lists raises a loud `ValueError` instead of silently truncating (per audit). Unpopulated sources yield `[]`.

## Provenance
Defect-hunt finding, **upheld 2/3** (dissent argued impact, not correctness; the skip was reproduced live).

## Verification — read this plainly
- **Locally** (networkx installed): the three new regression tests in `tests/test_simulation_metrics.py` **run and pass** — 2 of 3 fail pre-fix (dropped trailing collector; wrong-source pairing), all pass post-fix. Full local gate: **791 passed / 1 failed / 26 skipped** (788 baseline + 3 new; the 1 = pre-existing gated engine/CuPy defect).
- **In CI the three new tests SKIP.** The module import-chains `agent/network_topology.py`, which requires `networkx` — absent from verify-python's dependency set — so the suite self-skips via module-level `pytest.importorskip("networkx")` (the #165 Tier 1 idiom used by the matplotlib/flask/uft_ca suites). **CI therefore verifies only that nothing else broke; it does not execute these regression tests.** Promoting `networkx` into CI's pip set (the #190 skip-conversion pattern) is the follow-up brick if CI execution is wanted — flagged, not done here.

## Amendment history (audit round-trips)
1. `bc1c790` — removed a **dead** `import pandas as pd` from the module (zero uses; latent forever because nothing in the gate imported this module until these tests did; CI has no pandas).
2. `8f9a701` — added the `networkx` importorskip after CI collection surfaced the real dependency.
3. `bb74cc0` — `zip(..., strict=True)` per Jack's audit.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)