### PR TITLE
fix(agent): pair parallel-tempering exchanges by beta ladder, not list index

### DIFF
--- a/agent/ising_tempering.py
+++ b/agent/ising_tempering.py
@@ -201,9 +201,14 @@ class ParallelTempering:
 
     def exchange_step(self, step: int, even: bool) -> int:
         accepted = 0
+        # Pair ladder neighbors by CURRENT beta, not list position:
+        # accepted swaps migrate betas between replicas, so list order
+        # stops matching the temperature ladder after the first swap.
+        order = sorted(range(len(self.replicas)),
+                       key=lambda idx: self.replicas[idx].beta)
         start = 0 if even else 1
-        for k in range(start, len(self.replicas) - 1, 2):
-            if self.attempt_swap(k, k + 1):
+        for k in range(start, len(order) - 1, 2):
+            if self.attempt_swap(order[k], order[k + 1]):
                 accepted += 1
         return accepted
 

--- a/tests/test_pt_ladder_pairing.py
+++ b/tests/test_pt_ladder_pairing.py
@@ -1,0 +1,68 @@
+"""Tests for agent/ising_tempering.py — exchange pairing follows the beta ladder.
+
+Separate file from test_ising_tempering.py so this branch shares no test-file
+region with other open PRs.
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.ising_tempering import IsingConfig, ParallelTempering
+
+
+class PairRecordingPT(ParallelTempering):
+    """Records the beta pair of every proposed swap."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.proposed_beta_pairs = []
+
+    def attempt_swap(self, i, j):
+        pair = tuple(sorted((self.replicas[i].beta, self.replicas[j].beta)))
+        self.proposed_beta_pairs.append(pair)
+        return super().attempt_swap(i, j)
+
+
+def _ladder_adjacent_pairs(betas):
+    ladder = sorted(betas)
+    return {tuple(sorted(pair)) for pair in zip(ladder, ladder[1:])}
+
+
+class TestExchangePairsLadderNeighbors:
+
+    def test_proposals_are_ladder_adjacent_after_beta_migration(self):
+        # Regression: exchange_step paired replicas by fixed list index while
+        # attempt_swap migrates betas between list slots, so after any
+        # accepted swap the proposals stopped being between neighboring
+        # temperatures (e.g. pairing the coldest with the hottest replica).
+        config = IsingConfig(lattice_size=8, num_replicas=4, total_exchanges=1,
+                             sweeps_per_exchange=1, seed=0)
+        pt = PairRecordingPT(config)
+
+        # Simulate prior accepted swaps: betas of replicas 0 and 2 migrated.
+        pt.replicas[0].beta, pt.replicas[2].beta = (
+            pt.replicas[2].beta, pt.replicas[0].beta
+        )
+        allowed = _ladder_adjacent_pairs(r.beta for r in pt.replicas)
+
+        pt.exchange_step(step=0, even=True)
+
+        assert pt.proposed_beta_pairs, "expected at least one proposed swap"
+        for pair in pt.proposed_beta_pairs:
+            assert pair in allowed, (
+                f"proposed swap between non-adjacent temperatures {pair}; "
+                f"ladder-adjacent pairs are {sorted(allowed)}"
+            )
+
+    def test_full_run_conserves_the_beta_ladder(self):
+        # Swaps exchange betas, never create or destroy them: after a full
+        # run the multiset of replica betas is the original ladder.
+        config = IsingConfig(lattice_size=8, num_replicas=4, total_exchanges=10,
+                             sweeps_per_exchange=2, seed=7)
+        pt = ParallelTempering(config)
+        original = sorted(r.beta for r in pt.replicas)
+
+        pt.run()
+
+        assert sorted(r.beta for r in pt.replicas) == original


### PR DESCRIPTION
## What
`attempt_swap` implements swaps by **migrating betas** between replicas (each replica keeps its spin configuration — a standard PT convention). But `exchange_step` pairs replicas by **fixed list index** `(k, k+1)` — correct only until the first accepted swap. After that, index adjacency no longer matches temperature adjacency: proposals can span arbitrary ladder gaps (acceptance `exp(Δβ·ΔE)`-suppressed), the even/odd alternation loses its meaning, and replica-exchange mixing — the entire point of parallel tempering — degrades toward independent tempering.

**Fix:** `exchange_step` sorts replica indices by current beta each round and pairs true ladder neighbors. Pairs within a round are disjoint, so in-round swaps cannot corrupt the pairing. At step 0 (pre-any-swap) behavior is identical to before.

## Physics note for the audit
Both "swap betas" and "swap configurations" are valid PT formulations; the defect is purely the pairing. This fix keeps the existing migrate-betas convention (per-replica swap statistics keep their meaning) and touches nothing else. This is `agent/` machinery — **not** the gated CA engine.

## Verification (existing checks + new regression tests)
- New `tests/test_pt_ladder_pairing.py`: a pair-recording subclass proves the pre-fix failure exactly (after beta migration, a proposal pairs the coldest with the hottest rung — test FAILS pre-fix, passes post-fix), plus a ladder-conservation invariant over a full run.
- All **22 existing PT tests unchanged and green** (seeded expectations only diverge after accepted swaps, which they don't pin). Full gate: **790 passed / 1 failed / 26 skipped** (788 + 2 new; the 1 = pre-existing gated engine/CuPy defect).

## Merge-order note
Shares `agent/ising_tempering.py` with #288 but in **disjoint regions** (`exchange_step` vs `format_remote_polaroid`) — git merges cleanly in either order; the regression test lives in a new file specifically to avoid test-file overlap.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)