### PR TITLE
fix(tools): exit nonzero when run_tests.py results contain failures

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -159,6 +159,10 @@ Examples:
             test_runner.reporter.export_results_to_csv(results, csv_filename)
         
         print(f"\n📁 Detailed results saved in: {args.output_dir}")
+        failed = [r for r in results if not r.success]
+        if failed:
+            print(f"💥 {len(failed)}/{len(results)} tests FAILED")
+            return 1
         print("🎯 Testing completed successfully!")
         
         return 0


### PR DESCRIPTION
## What
`run_tests.py` (the documented local batch entry point: `python run_tests.py --quick/--standard/--batch`) printed ❌ per failed result and then **unconditionally `return 0` + "🎯 Testing completed successfully!"** — as a command it could never fail, so any script or habit keyed on its exit code got a green light regardless of results. It now returns 1 with a `💥 N/M tests FAILED` line when any result is unsuccessful; the success path is byte-identical.

## Provenance
Defect-hunt finder report (its adversarial verifiers were lost to the session limit), **parent-seat CONFIRMED by direct read** before fixing: the `return 0` at the end of the summary block is unconditional.

## Verification limits (disclosed)
`run_tests.py` is CI-excluded by design (`pytest.ini` `testpaths = tests/`; #165 umbrella) and imports `testing_framework/`, which has no test surface — so this is source-verified only. Full gate unchanged: **797 passed / 1 failed / 26 skipped** (the 1 = pre-existing gated engine/CuPy defect).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)