### PR TITLE
fix(observatory): load snapshot series in true chronological order

### DIFF
--- a/tests/test_observatory_loader_order.py
+++ b/tests/test_observatory_loader_order.py
@@ -1,0 +1,44 @@
+"""Tests for vis/observatory/loader.py — chronological snapshot series order."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import vis.observatory.loader as loader_mod
+from vis.observatory.loader import load_snapshot_series
+
+
+def test_load_snapshot_series_is_chronological(tmp_path, monkeypatch):
+    # Regression: sorted(glob(...)) is lexicographic, so gen9 loaded AFTER
+    # gen10/gen100 despite the docstring's chronological promise (the
+    # AGENT_HANDOFF snapshot-listing caveat, inside the loader itself).
+    for name in ("v070_gen100.npz", "v070_gen9.npz", "v070_gen10.npz"):
+        (tmp_path / name).touch()
+
+    loaded = []
+    monkeypatch.setattr(
+        loader_mod, "load_npz", lambda p: (loaded.append(Path(p).name), p)[1]
+    )
+
+    load_snapshot_series(tmp_path)
+
+    assert loaded == ["v070_gen9.npz", "v070_gen10.npz", "v070_gen100.npz"]
+
+
+def test_natural_key_handles_mixed_tokens():
+    from vis.observatory.loader import _natural_key
+
+    names = [
+        "v070_gen10_step2.npz",
+        "v070_gen9_step10.npz",
+        "v070_gen9_step2.npz",
+        "v070_gen2.npz",
+    ]
+    ordered = sorted(names, key=lambda n: _natural_key(Path(n)))
+    assert ordered == [
+        "v070_gen2.npz",
+        "v070_gen9_step2.npz",
+        "v070_gen9_step10.npz",
+        "v070_gen10_step2.npz",
+    ]

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -152,10 +152,13 @@ def _natural_key(path: Path):
     Plain lexicographic sorting breaks chronological order across digit-width
     boundaries (the AGENT_HANDOFF snapshot-listing caveat, applied here).
     """
-    return [
-        (0, int(token)) if token.isdigit() else (1, token)
-        for token in _DIGIT_RUNS.split(Path(path).name)
-    ]
+    return (
+        [
+            (0, int(token)) if token.isdigit() else (1, token)
+            for token in _DIGIT_RUNS.split(path.name)
+        ],
+        path.name,
+    )
 
 
 def load_snapshot_series(

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -7,6 +7,7 @@ Provides ObservatorySnapshot (frozen dataclass) consumed by all rendering module
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -142,6 +143,21 @@ def load_snapshot(path: str | Path) -> ObservatorySnapshot:
         raise ValueError(f"Unknown file format: {path.suffix}. Expected .npz or .json")
 
 
+_DIGIT_RUNS = re.compile(r"(\d+)")
+
+
+def _natural_key(path: Path):
+    """Numeric-aware filename key: gen9 sorts before gen10.
+
+    Plain lexicographic sorting breaks chronological order across digit-width
+    boundaries (the AGENT_HANDOFF snapshot-listing caveat, applied here).
+    """
+    return [
+        (0, int(token)) if token.isdigit() else (1, token)
+        for token in _DIGIT_RUNS.split(Path(path).name)
+    ]
+
+
 def load_snapshot_series(
     directory: str | Path,
     pattern: str = "v070_*.npz",
@@ -153,7 +169,7 @@ def load_snapshot_series(
     chronological order.
     """
     directory = Path(directory)
-    files = sorted(directory.glob(pattern))
+    files = sorted(directory.glob(pattern), key=_natural_key)
     if max_count is not None:
         files = files[:max_count]
     if not files:


### PR DESCRIPTION
## What
`load_snapshot_series` sorted `glob` results **lexicographically** while its own docstring promises chronological order — so `gen9` loaded after `gen10`/`gen100`. This is the exact snapshot-listing hazard AGENT_HANDOFF's header warns about ("plain `ls … | tail` mis-sorts lexically"), living inside the loader that animations depend on. Files are now sorted with a numeric-aware `_natural_key` (digit runs compare as integers; tokens are type-tagged so mixed digit/text names can never raise a str/int comparison).

## Provenance
Defect-hunt finder report (verifiers lost to the session limit), **parent-seat CONFIRMED by direct read** before fixing.

## Verification (existing checks + new regression tests)
- New `tests/test_observatory_loader_order.py`: **both tests fail pre-fix** (monkeypatched `load_npz` records load order → lexicographic `gen10, gen100, gen9`), pass post-fix. **No `data/` or real NPZ content involved** — empty touched files + a stubbed loader only.
- Observatory suite: **41 passed** (39 existing + 2 new). Full gate: **799 passed / 1 failed / 26 skipped** (797 baseline + 2; the 1 = pre-existing gated engine/CuPy defect).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Independent of #291 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)