### PR TITLE
fix(telemetry): stop system hooks re-recording their own trigger event

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -331,3 +331,31 @@ class TestIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+class TestSystemHookRegressions:
+    """Hooks react to recorded events; they must not re-record them."""
+
+    def test_one_event_records_once_and_counts_once(self):
+        # Regression: each system hook re-recorded the event that triggered
+        # it, recursing until RecursionError (swallowed) — one real event
+        # left ~331 stored events and a ~330x-inflated counter.
+        collector = TelemetryCollector()
+        setup_messaging_hooks(collector)
+
+        collector.record_event("message_sent", {"to": "node1"})
+
+        assert len(collector.get_events()) == 1
+        sent = collector.get_metric("messages_sent_total").get_value()
+        assert sent.value == 1
+
+    def test_health_status_gauge_tracks_event_payload(self):
+        # Regression: on_health_check called .get on the TelemetryEvent
+        # object (hooks receive the event, not the raw dict); the
+        # AttributeError was swallowed and the gauge never left 0.
+        collector = TelemetryCollector()
+        setup_health_hooks(collector)
+
+        collector.record_event("health_check", {"status": "UNHEALTHY"})
+
+        gauge = collector.get_metric("health_status").get_value()
+        assert gauge.value == 3

--- a/utilityfog_frontend/telemetry/collector.py
+++ b/utilityfog_frontend/telemetry/collector.py
@@ -306,7 +306,9 @@ def setup_coordination_hooks(collector: TelemetryCollector) -> None:
     )
 
     def on_coordination_message(message_data):
-        collector.record_event("coordination_message", message_data)
+        # Hooks REACT to an already-recorded event; re-recording the same
+        # event name here re-triggers this hook and recurses until
+        # RecursionError (silently swallowed by _trigger_hooks).
         if "coordination_messages_total" in collector._metrics:
             collector._metrics["coordination_messages_total"].increment()
 
@@ -325,12 +327,10 @@ def setup_messaging_hooks(collector: TelemetryCollector) -> None:
     )
 
     def on_message_sent(message_data):
-        collector.record_event("message_sent", message_data)
         if "messages_sent_total" in collector._metrics:
             collector._metrics["messages_sent_total"].increment()
 
     def on_message_received(message_data):
-        collector.record_event("message_received", message_data)
         if "messages_received_total" in collector._metrics:
             collector._metrics["messages_received_total"].increment()
 
@@ -352,13 +352,16 @@ def setup_health_hooks(collector: TelemetryCollector) -> None:
     )
 
     def on_health_check(health_data):
-        collector.record_event("health_check", health_data)
         if "health_checks_total" in collector._metrics:
             collector._metrics["health_checks_total"].increment()
 
+        # Hooks receive the TelemetryEvent; the status dict is its value.
+        payload = getattr(health_data, "value", health_data)
+        if not isinstance(payload, dict):
+            payload = {}
         # Map health status to numeric value
         status_map = {"UNKNOWN": 0, "HEALTHY": 1, "DEGRADED": 2, "UNHEALTHY": 3}
-        status_value = status_map.get(health_data.get("status", "UNKNOWN"), 0)
+        status_value = status_map.get(payload.get("status", "UNKNOWN"), 0)
         if "health_status" in collector._metrics:
             collector._metrics["health_status"].set(status_value)
 


### PR DESCRIPTION
## What (two entangled defects, one hooks subsystem)
1. **Infinite hook recursion (HIGH, 3/3 verifiers, reproduced live):** every `setup_coordination_hooks` / `setup_messaging_hooks` / `setup_health_hooks` callback called `collector.record_event(...)` with the **same event name it was hooked to**. `record_event` fires `_trigger_hooks`, so one real event recursed to Python's recursion limit — the RecursionError silently swallowed by `_trigger_hooks`' `except Exception` — leaving **~331 stored events and ~300×-inflated counters per real event**. The hooks now only update their metrics: the triggering event is already recorded by `record_event` itself (this is the contract the integration test exercises — external code records, hooks react).
2. **health_status gauge never set (MED, 2/3):** `on_health_check` called `.get()` on the `TelemetryEvent` object (hooks receive the event, not the raw dict); the AttributeError was swallowed and the gauge stayed 0 forever — monitoring built on it could never see degradation. It now reads the status from the event's `value` payload (tolerating a raw dict for direct calls).

## Verification (existing checks + new regression tests)
- New `TestSystemHookRegressions` in `tests/test_telemetry.py`: **both tests fail pre-fix** (331 events / counter ~330 / gauge 0), pass post-fix (1 event, counter 1, gauge 3).
- Telemetry suite: **16 passed** (14 existing + 2 new; existing hook tests assert registration only, unaffected). Full gate: **799 passed / 1 failed / 26 skipped** (797 baseline + 2; the 1 = pre-existing gated engine/CuPy defect).

## Not done (deliberate)
No re-entrancy guard added to `_trigger_hooks` — the confirmed defect is in the hooks, and a guard would silently suppress same-name cycles rather than surface them. If defense-in-depth is wanted, that's a separate small brick.

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Independent of #291/#292 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)