### PR TITLE
fix(cli_viz): escape untrusted strings in HTML and SVG exporters

### DIFF
--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -510,6 +510,10 @@ class TestExporterEscaping:
         # benign 'A<B' corrupted the document.
         data = VisualizationData()
         data.add_node(TreeNode("node1", "<script>alert(1)</script>", NodeState.ACTIVE))
+        data.add_transition(StateTransition(
+            "node1", NodeState.ACTIVE, NodeState.ERROR,
+            trigger="<img src=x onerror=alert(2)>",
+        ))
         output_file = tmp_path / "report.html"
 
         assert HTMLExporter().export(data, str(output_file))
@@ -517,6 +521,8 @@ class TestExporterEscaping:
         content = output_file.read_text(encoding="utf-8")
         assert "<script>alert(1)</script>" not in content
         assert "&lt;script&gt;alert(1)&lt;/script&gt;" in content
+        assert "<img src=x onerror=alert(2)>" not in content
+        assert "&lt;img src=x onerror=alert(2)&gt;" in content
 
     def test_svg_export_is_well_formed_with_special_chars(self, tmp_path):
         # Regression: unescaped '&'/'<' in node names produced SVG that no

--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -500,3 +500,33 @@ class TestIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+class TestExporterEscaping:
+    """User-supplied strings must be escaped in HTML/SVG output."""
+
+    def test_html_export_escapes_untrusted_strings(self, tmp_path):
+        # Regression: node names/ids from the input JSON were interpolated
+        # into markup verbatim, so a hostile name became live script and a
+        # benign 'A<B' corrupted the document.
+        data = VisualizationData()
+        data.add_node(TreeNode("node1", "<script>alert(1)</script>", NodeState.ACTIVE))
+        output_file = tmp_path / "report.html"
+
+        assert HTMLExporter().export(data, str(output_file))
+
+        content = output_file.read_text(encoding="utf-8")
+        assert "<script>alert(1)</script>" not in content
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in content
+
+    def test_svg_export_is_well_formed_with_special_chars(self, tmp_path):
+        # Regression: unescaped '&'/'<' in node names produced SVG that no
+        # XML parser or viewer would accept.
+        import xml.etree.ElementTree as ET
+
+        data = VisualizationData()
+        data.add_node(TreeNode("n1", "R&D <core>", NodeState.ACTIVE))
+        output_file = tmp_path / "graph.svg"
+
+        assert SVGExporter().export(data, str(output_file))
+
+        ET.fromstring(output_file.read_text(encoding="utf-8"))  # must parse

--- a/utilityfog_frontend/cli_viz/exporters.py
+++ b/utilityfog_frontend/cli_viz/exporters.py
@@ -5,6 +5,7 @@ Export functionality for visualization artifacts.
 
 import json
 import time
+from html import escape as _escape
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
@@ -117,18 +118,18 @@ class HTMLExporter(BaseExporter):
         state_class = f"node-{node.state.value}"
         indent = "  " * depth
         
-        html.append(f'{indent}<div class="node {state_class}" data-node-id="{node.id}">')
+        html.append(f'{indent}<div class="node {state_class}" data-node-id="{_escape(str(node.id))}">')
         html.append(f'{indent}  <div class="node-header">')
         html.append(f'{indent}    <span class="node-state"></span>')
-        html.append(f'{indent}    <span class="node-name">{node.name}</span>')
-        html.append(f'{indent}    <span class="node-id">({node.id})</span>')
+        html.append(f'{indent}    <span class="node-name">{_escape(str(node.name))}</span>')
+        html.append(f'{indent}    <span class="node-id">({_escape(str(node.id))})</span>')
         html.append(f'{indent}  </div>')
         
         # Add metadata
         if node.metadata:
             html.append(f'{indent}  <div class="node-metadata">')
             for key, value in node.metadata.items():
-                html.append(f'{indent}    <span class="metadata-item">{key}: {value}</span>')
+                html.append(f'{indent}    <span class="metadata-item">{_escape(str(key))}: {_escape(str(value))}</span>')
             html.append(f'{indent}  </div>')
         
         # Add children
@@ -167,20 +168,20 @@ class HTMLExporter(BaseExporter):
             
             for msg in sorted(messages, key=lambda m: m.timestamp, reverse=True):
                 age = time.time() - msg.timestamp
-                status_class = f"status-{msg.status}"
+                status_class = f"status-{_escape(str(msg.status))}"
                 
                 source_name = self._get_node_name(msg.source_id, data.nodes)
                 target_name = self._get_node_name(msg.target_id, data.nodes)
                 
                 html.append(f"<div class='message-item {status_class}'>")
                 html.append("  <div class='message-flow'>")
-                html.append(f"    <span class='source'>{source_name}</span>")
+                html.append(f"    <span class='source'>{_escape(str(source_name))}</span>")
                 html.append("    <span class='arrow'>→</span>")
-                html.append(f"    <span class='target'>{target_name}</span>")
+                html.append(f"    <span class='target'>{_escape(str(target_name))}</span>")
                 html.append("  </div>")
                 html.append("  <div class='message-meta'>")
                 html.append(f"    <span class='age'>{age:.1f}s ago</span>")
-                html.append(f"    <span class='status'>{msg.status}</span>")
+                html.append(f"    <span class='status'>{_escape(str(msg.status))}</span>")
                 html.append("  </div>")
                 html.append("</div>")
             
@@ -211,7 +212,7 @@ class HTMLExporter(BaseExporter):
             
             html.append("<div class='transition-item'>")
             html.append("  <div class='transition-header'>")
-            html.append(f"    <span class='node-name'>{node_name}</span>")
+            html.append(f"    <span class='node-name'>{_escape(str(node_name))}</span>")
             html.append(f"    <span class='age'>{age:.1f}s ago</span>")
             html.append("  </div>")
             html.append("  <div class='transition-flow'>")
@@ -683,7 +684,7 @@ class SVGExporter(BaseExporter):
         
         elements = []
         elements.append(f'<circle cx="{x}" cy="{y}" r="20" fill="{color}" class="node" />')
-        elements.append(f'<text x="{x}" y="{y + 35}" text-anchor="middle" class="node-label">{node.name}</text>')
+        elements.append(f'<text x="{x}" y="{y + 35}" text-anchor="middle" class="node-label">{_escape(str(node.name))}</text>')
         
         return '\n'.join(elements)
     

--- a/utilityfog_frontend/cli_viz/exporters.py
+++ b/utilityfog_frontend/cli_viz/exporters.py
@@ -221,7 +221,7 @@ class HTMLExporter(BaseExporter):
             html.append(f"    <span class='state {to_class}'>{trans.to_state.value}</span>")
             html.append("  </div>")
             if trans.trigger != "unknown":
-                html.append(f"  <div class='trigger'>Trigger: {trans.trigger}</div>")
+                html.append(f"  <div class='trigger'>Trigger: {_escape(str(trans.trigger))}</div>")
             html.append("</div>")
         
         html.append("</div>")


### PR DESCRIPTION
## What (one concern: user data reaching markup unescaped, both exporters)
- **HTML (3/3 verifiers):** node names/ids, metadata keys/values, message source/target/status from the user-supplied input JSON were f-string-interpolated straight into the report — `<script>…` in a node name executes in whoever opens the report; a benign `A<B` corrupts the tree markup; a quote in a node id escapes its attribute.
- **SVG (3/3 verifiers):** `_create_node_svg` wrote `{node.name}` into a `<text>` element raw — any `&`/`<` yields not-well-formed XML that every parser and viewer rejects (whole file blank).

**Fix:** all **eleven** user-data emission sites (enumerated by sweep) now pass through `html.escape` (imported as `_escape` — the methods use `html` as a local list name; default `quote=True` covers the two attribute contexts: `data-node-id` and the `status-` class). Enum-derived state/type class names are compile-time-controlled and unchanged.

## Verification (existing checks + new regression tests)
- New `TestExporterEscaping` in `tests/test_cli_viz.py`: **both tests fail pre-fix** (raw `<script>` present in HTML; `xml.etree` ParseError on the SVG), pass post-fix.
- cli_viz suite: **21 passed** (19 existing + 2 new). Full gate: **799 passed / 1 failed / 26 skipped** (797 baseline + 2; the 1 = pre-existing gated engine/CuPy defect).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Independent of #291/#292/#293 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)