### PR TITLE
fix(testing_framework): log true pre-entanglement values in state_before

### DIFF
--- a/testing_framework/simulation_runner.py
+++ b/testing_framework/simulation_runner.py
@@ -605,6 +605,11 @@ class SimulationRunner:
                         simple_a = SimpleAgent(agent_a)
                         simple_b = SimpleAgent(agent_b)
                         
+                        # Capture pre-entanglement values: the writeback below
+                        # mutates energy_level before the log dict is built.
+                        energy_a_before = agent_a.energy_level
+                        energy_b_before = agent_b.energy_level
+                        
                         # Apply quantum myelin entanglement
                         entanglement_strength = random.uniform(0.1, 0.8)
                         myelin_layer(simple_a, simple_b, entanglement_strength)
@@ -619,10 +624,10 @@ class SimulationRunner:
                             agent_b.agent_id,
                             entanglement_strength,
                             {
-                                "agent_a_state_before": agent_a.energy_level,
-                                "agent_b_state_before": agent_b.energy_level,
-                                "agent_a_state_after": simple_a.state,
-                                "agent_b_state_after": simple_b.state
+                                "agent_a_state_before": energy_a_before,
+                                "agent_b_state_before": energy_b_before,
+                                "agent_a_state_after": agent_a.energy_level,
+                                "agent_b_state_after": agent_b.energy_level
                             }
                         )
                         


### PR DESCRIPTION
## What
In `_process_quantum_myelin_interactions`, the entanglement log dict is built AFTER the writeback mutates `energy_level` — so `agent_*_state_before` recorded **post**-entanglement values (making before==after analysis of these logs meaningless), and `agent_*_state_after` recorded the raw `simple.state` product rather than the clamped value actually applied to the agent. Pre-values are now captured before `myelin_layer` runs; after-values read the agents' real post-writeback `energy_level`. Log-content-only fix.

## Deliberately out of scope
The **energy×health writeback** itself (`:613` — writes the state *product* back into `energy_level`, silently draining energy when health < 1.0) is a real confirmed defect, but its correct inverse mapping is a **simulation-semantics decision** — routed to Kev/Jack, untouched here.

## Verification limits (disclosed)
`testing_framework/` has no test surface in the CI gate (nothing in `tests/` imports it) — source-verified only, same disclosure as #291. Full gate unchanged: **807 passed / 1 failed / 26 skipped** (the 1 = pre-existing gated engine/CuPy defect).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)