### PR TITLE
fix(telemetry): emit spec-compliant Prometheus histogram exposition

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -359,3 +359,43 @@ class TestSystemHookRegressions:
 
         gauge = collector.get_metric("health_status").get_value()
         assert gauge.value == 3
+
+class TestPrometheusHistogramExposition:
+    """Histogram samples must follow the text exposition format."""
+
+    @pytest.mark.asyncio
+    async def test_histogram_uses_spec_sample_names(self, tmp_path):
+        # Regression: histograms were emitted as name{le=...}/{type="sum"}
+        # with no _bucket/_sum/_count suffixes and no +Inf bucket -- a
+        # format scrapers reject and histogram_quantile() cannot use.
+        collector = TelemetryCollector()
+        hist = collector.register_histogram("req_seconds", "Request duration")
+        hist.observe(0.003)
+        hist.observe(0.2)
+
+        output_file = tmp_path / "metrics.prom"
+        exporter = PrometheusAdapter(str(output_file))
+        assert await exporter.export_metrics(collector)
+
+        content = output_file.read_text(encoding="utf-8")
+        assert 'req_seconds_bucket{le="0.005"} 1' in content
+        assert 'req_seconds_bucket{le="+Inf"} 2' in content
+        assert "req_seconds_sum 0.203" in content
+        assert "req_seconds_count 2" in content
+        assert "req_seconds{le=" not in content
+        assert '{type="sum"}' not in content
+
+    @pytest.mark.asyncio
+    async def test_label_values_are_escaped(self, tmp_path):
+        collector = TelemetryCollector()
+        counter = collector.register_counter(
+            "evil_total", "c", labels={"path": 'a"b\\c'}
+        )
+        counter.increment()
+
+        output_file = tmp_path / "metrics.prom"
+        exporter = PrometheusAdapter(str(output_file))
+        assert await exporter.export_metrics(collector)
+
+        content = output_file.read_text(encoding="utf-8")
+        assert 'path="a\\"b\\\\c"' in content

--- a/utilityfog_frontend/telemetry/exporter.py
+++ b/utilityfog_frontend/telemetry/exporter.py
@@ -123,6 +123,60 @@ class PrometheusAdapter(MetricsExporter):
             logger.error(f"Error formatting metric {name}: {e}")
             return None
 
+    @staticmethod
+    def _escape_label_value(value):
+        """Escape a label value per the Prometheus text exposition format."""
+        return (
+            str(value)
+            .replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+        )
+
+    def _format_labels(self, labels):
+        if not labels:
+            return ""
+        pairs = [
+            f'{k}="{self._escape_label_value(v)}"' for k, v in labels.items()
+        ]
+        return "{" + ",".join(pairs) + "}"
+
+    def _histogram_sample_lines(self, metric):
+        """Emit spec-compliant histogram samples: _bucket/_sum/_count + +Inf.
+
+        Histogram.observe already keeps cumulative bucket counts, and the
+        +Inf bucket equals the total observation count by definition.
+        """
+        buckets = []
+        sum_value = 0.0
+        count_value = 0
+        base_labels = {}
+        for value_data in metric.values:
+            labels = dict(value_data["labels"])
+            if "le" in labels:
+                le = labels.pop("le")
+                buckets.append((float(le), le, value_data["value"], labels))
+                base_labels = labels
+            elif labels.get("type") == "sum":
+                labels.pop("type")
+                sum_value = value_data["value"]
+                base_labels = labels
+            elif labels.get("type") == "count":
+                labels.pop("type")
+                count_value = value_data["value"]
+                base_labels = labels
+
+        lines = []
+        for _, le, bucket_count, labels in sorted(buckets, key=lambda b: b[0]):
+            labels_str = self._format_labels({**labels, "le": le})
+            lines.append(f"{metric.name}_bucket{labels_str} {bucket_count}")
+        inf_str = self._format_labels({**base_labels, "le": "+Inf"})
+        lines.append(f"{metric.name}_bucket{inf_str} {count_value}")
+        base_str = self._format_labels(base_labels)
+        lines.append(f"{metric.name}_sum{base_str} {sum_value}")
+        lines.append(f"{metric.name}_count{base_str} {count_value}")
+        return lines
+
     def _generate_prometheus_text(self, metrics: List[ExportedMetric]) -> str:
         """Generate Prometheus text format from exported metrics."""
         lines = []
@@ -135,16 +189,14 @@ class PrometheusAdapter(MetricsExporter):
             # Add TYPE line
             lines.append(f"# TYPE {metric.name} {metric.metric_type}")
 
-            # Add metric values
-            for value_data in metric.values:
-                labels_str = ""
-                if value_data["labels"]:
-                    label_pairs = [
-                        f'{k}="{v}"' for k, v in value_data["labels"].items()
-                    ]
-                    labels_str = "{" + ",".join(label_pairs) + "}"
-
-                lines.append(f"{metric.name}{labels_str} {value_data['value']}")
+            if metric.metric_type == "histogram":
+                lines.extend(self._histogram_sample_lines(metric))
+            else:
+                for value_data in metric.values:
+                    labels_str = self._format_labels(value_data["labels"])
+                    lines.append(
+                        f"{metric.name}{labels_str} {value_data['value']}"
+                    )
 
             lines.append("")  # Empty line between metrics
 


### PR DESCRIPTION
## What
`PrometheusAdapter` emitted histograms as `name{le="0.005"} 0` / `name{type="sum"}` / `name{type="count"}` — **no `_bucket`/`_sum`/`_count` sample suffixes and no mandatory `+Inf` bucket**. Prometheus' expfmt parser rejects such families (node_exporter's textfile collector drops the whole file), and `histogram_quantile()` is impossible without `_bucket` series. Since the built-in `telemetry_collection_duration_seconds` histogram is always registered, **every export was affected**.

**Fix (exposition-side only):**
- `name_bucket{le="…"}` samples (`Histogram.observe` already keeps cumulative counts — verified), plus the `+Inf` bucket (= observation count by definition), plus `name_sum`/`name_count`.
- **Label values escaped** per the text format (backslash, quote, newline) for all metric types — previously a quote in a label corrupted the format.
- `Histogram.get_value()`'s shape is deliberately unchanged: the JSON exporter and existing tests consume it; blast radius stays in `_generate_prometheus_text`.

## Verification (existing checks + new regression tests)
- New `TestPrometheusHistogramExposition`: **both tests fail pre-fix** (old sample names; unescaped labels), pass post-fix.
- Telemetry suite: **18 passed** (16 existing + 2 new; counter/gauge assertions unchanged). Full gate: **809 passed / 1 failed / 26 skipped** (807 baseline + 2; the 1 = pre-existing gated engine/CuPy defect).

## Lane
Build-seat PR under the ratified role split. **Unmerged by design.** Independent of #296 (no file overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)