### PR TITLE
fix(cli_viz): validate demo node counts and stop load_data accumulating on reload

### DIFF
--- a/tests/test_cli_viz.py
+++ b/tests/test_cli_viz.py
@@ -347,6 +347,63 @@ class TestCLI:
         assert len(cli.data.messages) == 1
         assert len(cli.data.transitions) == 1
     
+    def test_load_data_replaces_previous_state(self, cli, sample_json_file):
+        """Reloading must not accumulate messages/transitions (regression)."""
+        assert cli.load_data(sample_json_file)
+        assert cli.load_data(sample_json_file)
+
+        assert len(cli.data.nodes) == 2
+        assert len(cli.data.messages) == 1
+        assert len(cli.data.transitions) == 1
+
+    def test_load_data_failure_preserves_existing_data(self, cli, sample_json_file, tmp_path):
+        """A failed (re)load leaves previously loaded data untouched."""
+        assert cli.load_data(sample_json_file)
+        assert not cli.load_data(str(tmp_path / "missing.json"))
+
+        assert len(cli.data.nodes) == 2
+        assert len(cli.data.messages) == 1
+        assert len(cli.data.transitions) == 1
+
+    def test_demo_zero_nodes_exits_cleanly(self, cli, tmp_path, capsys):
+        """demo with --nodes 0 must fail with a message, not a traceback (regression)."""
+        args = type('Args', (), {
+            'nodes': 0,
+            'messages': 20,
+            'transitions': 15,
+            'output': str(tmp_path / "demo.json")
+        })()
+
+        assert cli.cmd_demo(args) == 1
+        assert "at least 1" in capsys.readouterr().out
+
+    def test_demo_single_node_with_messages_exits_cleanly(self, cli, tmp_path, capsys):
+        """demo with --nodes 1 and messages requested must fail cleanly, not IndexError (regression)."""
+        out_file = tmp_path / "demo.json"
+        args = type('Args', (), {
+            'nodes': 1,
+            'messages': 5,
+            'transitions': 0,
+            'output': str(out_file)
+        })()
+
+        assert cli.cmd_demo(args) == 1
+        assert "at least 2 nodes" in capsys.readouterr().out
+        assert not out_file.exists()
+
+    def test_demo_single_node_without_messages_succeeds(self, cli, tmp_path):
+        """demo with --nodes 1 and --messages 0 is valid (transitions only need one node)."""
+        out_file = tmp_path / "demo.json"
+        args = type('Args', (), {
+            'nodes': 1,
+            'messages': 0,
+            'transitions': 3,
+            'output': str(out_file)
+        })()
+
+        assert cli.cmd_demo(args) == 0
+        assert out_file.exists()
+
     def test_tree_command(self, cli, sample_json_file, capsys):
         """Test tree command."""
         args = type('Args', (), {

--- a/utilityfog_frontend/cli_viz/cli.py
+++ b/utilityfog_frontend/cli_viz/cli.py
@@ -113,10 +113,17 @@ Examples:
         return parser
     
     def load_data(self, input_file: str) -> bool:
-        """Load visualization data from JSON file."""
+        """Load visualization data from JSON file, replacing previously loaded data.
+
+        Built into a fresh container and swapped in only on success, so a
+        failed (re)load — e.g. the interactive 'r' key, which ignores the
+        return value — leaves existing data untouched.
+        """
         try:
             with open(input_file, 'r', encoding='utf-8') as f:
                 json_data = json.load(f)
+
+            data = VisualizationData()
             
             # Load nodes
             for node_id, node_data in json_data.get('nodes', {}).items():
@@ -130,7 +137,7 @@ Examples:
                     metadata=node_data.get('metadata', {}),
                     last_updated=node_data.get('last_updated', time.time())
                 )
-                self.data.add_node(node)
+                data.add_node(node)
             
             # Load messages
             for msg_data in json_data.get('messages', []):
@@ -144,7 +151,7 @@ Examples:
                     status=msg_data['status'],
                     metadata=msg_data.get('metadata', {})
                 )
-                self.data.add_message(message)
+                data.add_message(message)
             
             # Load transitions
             for trans_data in json_data.get('transitions', []):
@@ -156,10 +163,11 @@ Examples:
                     trigger=trans_data.get('trigger', 'unknown'),
                     metadata=trans_data.get('metadata', {})
                 )
-                self.data.add_transition(transition)
+                data.add_transition(transition)
             
             # Load metadata
-            self.data.metadata = json_data.get('metadata', {})
+            data.metadata = json_data.get('metadata', {})
+            self.data = data
             
             return True
         except Exception as e:
@@ -299,6 +307,12 @@ Examples:
     
     def cmd_demo(self, args) -> int:
         """Handle demo command."""
+        if args.nodes < 1:
+            print("Error: demo requires at least 1 node (--nodes)")
+            return 1
+        if args.nodes < 2 and args.messages > 0:
+            print("Error: generating messages requires at least 2 nodes (source and target must differ)")
+            return 1
         
         # Generate demo data
         demo_data = self._generate_demo_data(args.nodes, args.messages, args.transitions)


### PR DESCRIPTION
## What

Two verifier-confirmed findings from the 07-07/08 defect hunt (ledger recovered from the surviving workflow journal `wf_9da88e26-595` after thread loss) — the two LOWs that slipped step 59's "every test-covered finding fixed" claim:

1. **`cmd_demo` IndexError on `--nodes <= 1`** (`cli.py:357`, verifier-confirmed): `random.choice([nid for nid in node_ids if nid != source_id])` picks from an empty list with one node (and `--nodes 0` crashes one line earlier), and `_generate_demo_data` is called **outside** the try/except — users get a raw traceback. Now validated up front: `--nodes < 1` → clean error; messages requested with fewer than 2 nodes → clean error, exit 1. Single-node demos **without** messages stay valid (transitions only need one node). Note: degenerate `--nodes 0 --messages 0 --transitions 0` previously "succeeded" with an empty file; it now errors — flagged as a deliberate behavior choice.

2. **`load_data` accumulates on reload** (`cli.py:115`, 3/3 verifier-confirmed): `self.data` was never reset, so the interactive `r` (reload) key re-appended every message/transition on each press (models.py caps then silently evict the oldest). Fix: parse into a **fresh** `VisualizationData`, swap on success. Since the `r` handler ignores the return value, this shape also means a failed reload preserves the existing view instead of wiping or half-loading it — locked by a dedicated test.

## Verification

Test-first: **3 of 5 new tests fail pre-fix** (both demo IndexErrors + accumulation: messages/transitions doubled); the other 2 lock existing contracts (failure-preserves-data, single-node-demo-valid).

- cli_viz suite: **26 passed** (21 existing + 5 new)
- Full gate: **814 passed / 1 failed / 26 skipped, zero warnings** (809 baseline + 5; the 1 = pre-existing gated engine/CuPy defect)

## Lane

Build-seat PR under the ratified role split. **Unmerged by design** — Jack audits, Kev speaks the merge word. Independent of everything open (no file overlap with Dependabot PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)