### PR TITLE
fix(agent): scope convergence window to the current evolve_memes run

### DIFF
--- a/agent/evolution_engine.py
+++ b/agent/evolution_engine.py
@@ -197,6 +197,7 @@ class EvolutionEngine:
         self.agent_population: List[FogletAgent] = []
         self.current_generation: int = 0
         self.generation_history: List[GenerationStats] = []
+        self._run_start_index: int = 0
         self.best_individuals: List[Union[Meme, FogletAgent]] = []
         self.evolution_start_time: float = 0.0
         self.total_evaluations: int = 0
@@ -232,6 +233,7 @@ class EvolutionEngine:
         env_context = environment_context or {}
         
         self.evolution_start_time = time.time()
+        self._run_start_index = len(self.generation_history)
         generation_stats = []
         
         for generation in range(max_gens):
@@ -318,11 +320,12 @@ class EvolutionEngine:
         )
     
     def _check_convergence(self, stats: GenerationStats) -> bool:
-        """Check if the population has converged."""
-        if len(self.generation_history) < 10:
+        """Check if the population has converged (within the current evolve run)."""
+        run_history = self.generation_history[self._run_start_index:]
+        if len(run_history) < 10:
             return False
-        
-        recent_best = [s.best_fitness for s in self.generation_history[-10:]]
+
+        recent_best = [s.best_fitness for s in run_history[-10:]]
         improvement = max(recent_best) - min(recent_best)
         
         return improvement < self.parameters.convergence_threshold

--- a/tests/test_evolution_convergence.py
+++ b/tests/test_evolution_convergence.py
@@ -1,0 +1,56 @@
+"""Regression test: the convergence window must not leak across evolve_memes runs.
+
+_check_convergence reads generation_history, which is appended to across
+evolve_memes calls and never reset. A second run on the same engine therefore
+inherited the previous run's plateau: if the new run started at (or near) the
+old best-fitness level, the 10-generation improvement window was already flat
+and the run "converged" at generation 0 regardless of its own progress.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.evolution_engine import EvolutionEngine, EvolutionParameters
+
+
+class _ScriptedFitness:
+    """Test-driven evaluator: a flat plateau, then a steady per-generation climb."""
+
+    def __init__(self):
+        self.engine = None
+        self.climbing = False
+
+    def evaluate_meme(self, meme, environment_context):
+        if not self.climbing:
+            return 0.5
+        return min(1.0, 0.5 + 0.05 * self.engine.current_generation)
+
+
+def test_second_run_does_not_inherit_previous_convergence_window():
+    evaluator = _ScriptedFitness()
+    engine = EvolutionEngine(
+        parameters=EvolutionParameters(population_size=4, convergence_threshold=0.001),
+        fitness_evaluator=evaluator,
+        random_seed=42,
+    )
+    evaluator.engine = engine
+    engine.initialize_meme_population(population_size=4)
+
+    # Run 1: flat fitness -> genuine convergence as soon as a full
+    # 10-generation window exists (generation 9).
+    run1 = engine.evolve_memes(generations=15)
+    assert len(run1) == 10
+
+    # Run 2: fitness now climbs 0.05 per generation, starting from the old
+    # plateau value. Pre-fix, generation 0 saw a window of nine stale 0.5s
+    # from run 1 plus its own 0.5 -> zero improvement -> false convergence
+    # at generation 0.
+    evaluator.climbing = True
+    engine.initialize_meme_population(population_size=4)
+    run2 = engine.evolve_memes(generations=12)
+
+    assert len(run2) == 12
+    best = [stats.best_fitness for stats in run2]
+    assert best[-1] > best[0]

--- a/tests/test_evolution_convergence.py
+++ b/tests/test_evolution_convergence.py
@@ -12,10 +12,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from agent.evolution_engine import EvolutionEngine, EvolutionParameters
+from agent.evolution_engine import EvolutionEngine, EvolutionParameters, FitnessEvaluator
 
 
-class _ScriptedFitness:
+class _ScriptedFitness(FitnessEvaluator):
     """Test-driven evaluator: a flat plateau, then a steady per-generation climb."""
 
     def __init__(self):
@@ -26,6 +26,10 @@ class _ScriptedFitness:
         if not self.climbing:
             return 0.5
         return min(1.0, 0.5 + 0.05 * self.engine.current_generation)
+
+    def evaluate_agent(self, agent, environment_context):
+        # Interface contract only — this test never evolves agents.
+        return 0.0
 
 
 def test_second_run_does_not_inherit_previous_convergence_window():


### PR DESCRIPTION
## What

Hunt finding #12 (LOW) from the recovered `wf_9da88e26-595` journal — the one finding the hunt's verifier fleet **never reached** before the session limit; parent-seat verified today against current source.

`EvolutionEngine.generation_history` is initialized once in `__init__`, appended every generation in `evolve_memes` (`evolution_engine.py:246`), and never reset. `_check_convergence` read `generation_history[-10:]` unconditionally, so a **second** `evolve_memes` call on the same engine inherited the previous run's plateau: starting at (or near) the old best-fitness level, the improvement window was already flat and the run "converged" at generation 0 no matter what it was about to do. Pre-fix the regression test captures exactly that: `Convergence reached at generation 9` (run 1, genuine) followed by `Convergence reached at generation 0` (run 2, false).

**Fix:** `evolve_memes` records `len(generation_history)` at run start (`_run_start_index`); `_check_convergence` only considers stats appended by the current run. Single-run behavior is byte-identical (start index 0), and cross-run history is still fully retained for reporting.

## Verification

- Test-first: new `tests/test_evolution_convergence.py` **fails pre-fix** (run 2 returns 1 stat instead of 12), passes post-fix. Scripted-fitness evaluator, population 4 — no randomness in the assertion path.
- The test RUNS in CI (plain `agent.` import + numpy, same pattern as #285/#289/#290's test files — not one of the internal sub-skips).
- Full gate: **810 passed / 1 failed / 26 skipped, zero warnings** (809 baseline + 1 new; the 1 = pre-existing gated engine/CuPy defect).

## Lane

Build-seat PR under the ratified role split. **Unmerged by design** — Jack audits, Kev speaks the merge word. No file overlap with #299 or anything open. `agent/` is app-stack, not the gated CA engine (`scripts/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)