### PR TITLE
fix(engine): coerce memory_grid to active backend in _migrate_memory_grid

### DIFF
--- a/scripts/continuous_evolution_ca.py
+++ b/scripts/continuous_evolution_ca.py
@@ -658,6 +658,7 @@ def init_memory_grid(shape: Tuple[int, int, int]):
 def _migrate_memory_grid(memory_grid, shape: Tuple[int, int, int]):
     """Auto-migrate older memory grids to 8-channel format."""
     xp = _xp
+    memory_grid = xp.asarray(memory_grid)
     if memory_grid.shape[0] == MEMORY_CHANNELS:
         return memory_grid
     if memory_grid.shape[0] == 5:

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -209,6 +209,34 @@ class TestLoader:
         assert loaded.generation == snapshot.generation
         assert loaded.ca_step == snapshot.ca_step
 
+    def test_load_npz_legacy_grid_stays_numpy(self):
+        """Legacy 3-channel NPZ: the migrated grid must be NumPy even when the
+        engine helper runs on a GPU backend (ObservatorySnapshot contract)."""
+        lattice = np.zeros((16, 16, 16), dtype=np.uint8)
+        legacy = np.random.rand(3, 16, 16, 16).astype(np.float32)
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            np.savez(
+                f.name,
+                lattice=lattice,
+                memory_grid=legacy,
+                generation=1,
+                ca_step=2,
+                best_fitness=0.5,
+            )
+            loaded = load_npz(f.name)
+        os.unlink(f.name)
+
+        assert isinstance(loaded.memory_grid, np.ndarray)
+        assert loaded.memory_grid.shape == (8, 16, 16, 16)
+        assert loaded.memory_grid.dtype == np.float32
+        # 3->8 channel mapping per _migrate_memory_grid: 0->0, 1->2, 2->4
+        assert np.allclose(loaded.memory_grid[0], legacy[0])
+        assert np.allclose(loaded.memory_grid[2], legacy[1])
+        assert np.allclose(loaded.memory_grid[4], legacy[2])
+        # downstream NumPy plotting path works on the migrated grid
+        masked = loaded.channel_masked(0, 0)
+        assert isinstance(masked, np.ndarray)
+
     def test_load_snapshot_autodetect_npz(self, snapshot):
         """load_snapshot() auto-detects .npz format."""
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -81,6 +81,9 @@ def load_npz(path: str | Path) -> ObservatorySnapshot:
         try:
             from scripts.continuous_evolution_ca import _migrate_memory_grid
             memory_grid = _migrate_memory_grid(memory_grid, lattice.shape)
+            if not isinstance(memory_grid, np.ndarray):
+                # engine helper may return a GPU device array; the snapshot contract is NumPy
+                memory_grid = memory_grid.get()
         except ImportError:
             # Fallback: zero-pad to 8 channels
             old_ch = memory_grid.shape[0]


### PR DESCRIPTION
## ⚠️ ENGINE FILE — own gate

This touches `scripts/continuous_evolution_ca.py` (the running Medusa's source). Opened **unmerged** under Kev's proceed-with-the-queue word (2026-07-08, engine one-liner = Jack's declared pack-order top). **Merge needs Jack's audit + Kev's explicit word — nothing here self-authorizes.** Governing packet: ops-dir `ENGINE_CUPY_MIGRATION_BUG_DIAGNOSIS_v1.md` (+ 07-07 addendum, Gemini-corrected, source-verified).

## What (Fix A from the packet — +1 line)

`memory_grid = xp.asarray(memory_grid)` immediately after `xp = _xp` in `_migrate_memory_grid`.

**Root cause (packet addendum, verified):** order-of-operations gap in `step()` — the memory grid is migrated (:962) *before* being coerced to GPU (:963–964), so on CuPy machines the helper allocates a CuPy `new_grid` and then assigns NumPy slices into it → `ValueError: non-scalar numpy.ndarray cannot be used for fill`. Fix A makes the helper safe for **any** caller (3→8 and 5→8 paths + normalizes the 8-channel pass-through) rather than patching one call site (packet's Fix B, considered and not chosen — call-site ordering was evidently easy to get wrong once already).

**CPU no-op by construction:** with `xp = np`, `np.asarray` on an existing ndarray returns the same object — no copy, no behavior change. The sealed replication instrument forces the NumPy backend before import and never sees the changed branch.

## Verification (packet §4 plan, executed on the GPU/Windows box that reproduces it)

- Pre-fix: `test_3_to_8_channel_migration` FAILED (0.49s, exact packet symptom).
- Post-fix target file: **29/29 passed**.
- Post-fix full gate: `python -m pytest tests/ -q` → **816 passed, 0 failed, 26 skipped, zero warnings** — the suite's first fully green run; the sole standing failure since 2026-07-06 is resolved.
- CI (CPU-only) expected unchanged by the no-op argument above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)