### PR TITLE
fix(sim_bridge): liveness guard + request-time start (concurrency Option A)

### DIFF
--- a/tests/test_sim_bridge_concurrency.py
+++ b/tests/test_sim_bridge_concurrency.py
@@ -1,4 +1,5 @@
-"""Concurrency contract for SimBridge (SIM_BRIDGE_CONCURRENCY_OPTIONS_v1, Option A).
+"""Concurrency contract for SimBridge (SIM_BRIDGE_CONCURRENCY_OPTIONS_v1, Option A,
+amended per #304 audit: start-blocking and stoppability are separate questions).
 
 Skips when fastapi is absent (sim_bridge imports ws_server, which needs
 fastapi) -- the same verification limit disclosed on #286/#287.
@@ -13,31 +14,59 @@ pytest.importorskip("fastapi")
 from utilityfog_frontend.backend.sim_bridge import SimBridge
 
 
-def _draining_bridge():
-    """Bridge in the post-stop state with its worker thread still alive."""
+def _bridge(status, thread_alive):
     bridge = SimBridge()
+    bridge.status = status
     release = threading.Event()
-    bridge.status = "stopped"
-    bridge.simulation_thread = threading.Thread(target=release.wait, daemon=True)
-    bridge.simulation_thread.start()
+    if thread_alive:
+        bridge.simulation_thread = threading.Thread(target=release.wait, daemon=True)
+        bridge.simulation_thread.start()
+    else:
+        dead = threading.Thread(target=lambda: None, daemon=True)
+        dead.start()
+        dead.join(timeout=5)
+        bridge.simulation_thread = dead
     return bridge, release
 
 
-def test_is_running_true_while_thread_drains():
-    bridge, release = _draining_bridge()
-    try:
-        assert bridge.is_running()
-    finally:
-        release.set()
+def _drain(bridge, release):
+    release.set()
+    if bridge.simulation_thread is not None:
         bridge.simulation_thread.join(timeout=5)
-    assert not bridge.is_running()
 
 
-def test_start_refused_while_prior_thread_alive():
-    bridge, release = _draining_bridge()
+def test_draining_thread_blocks_start():
+    bridge, release = _bridge("stopped", thread_alive=True)
     try:
+        assert not bridge.can_start()
         with pytest.raises(RuntimeError, match="already running"):
             asyncio.run(bridge.start_simulation("run-2", {"simulation_steps": 1}))
     finally:
-        release.set()
-        bridge.simulation_thread.join(timeout=5)
+        _drain(bridge, release)
+    assert bridge.can_start()
+
+
+def test_terminal_status_with_live_thread_blocks_start_but_is_not_stoppable():
+    # Codex P2: worker wrote "completed" but is still cleaning up/broadcasting.
+    bridge, release = _bridge("completed", thread_alive=True)
+    try:
+        assert not bridge.can_start()      # still draining: no new run yet
+        assert not bridge.is_running()     # not stoppable: stop must not overwrite terminal status
+    finally:
+        _drain(bridge, release)
+
+
+def test_stale_running_status_with_dead_thread_does_not_block_start():
+    # Gemini: a crashed worker that left status "running" must not block forever.
+    bridge, _ = _bridge("running", thread_alive=False)
+    assert bridge.can_start()
+    assert not bridge.is_running()
+
+
+def test_live_running_worker_is_running_and_blocks_start():
+    bridge, release = _bridge("running", thread_alive=True)
+    try:
+        assert bridge.is_running()
+        assert not bridge.can_start()
+    finally:
+        _drain(bridge, release)

--- a/tests/test_sim_bridge_concurrency.py
+++ b/tests/test_sim_bridge_concurrency.py
@@ -1,0 +1,43 @@
+"""Concurrency contract for SimBridge (SIM_BRIDGE_CONCURRENCY_OPTIONS_v1, Option A).
+
+Skips when fastapi is absent (sim_bridge imports ws_server, which needs
+fastapi) -- the same verification limit disclosed on #286/#287.
+"""
+import asyncio
+import threading
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from utilityfog_frontend.backend.sim_bridge import SimBridge
+
+
+def _draining_bridge():
+    """Bridge in the post-stop state with its worker thread still alive."""
+    bridge = SimBridge()
+    release = threading.Event()
+    bridge.status = "stopped"
+    bridge.simulation_thread = threading.Thread(target=release.wait, daemon=True)
+    bridge.simulation_thread.start()
+    return bridge, release
+
+
+def test_is_running_true_while_thread_drains():
+    bridge, release = _draining_bridge()
+    try:
+        assert bridge.is_running()
+    finally:
+        release.set()
+        bridge.simulation_thread.join(timeout=5)
+    assert not bridge.is_running()
+
+
+def test_start_refused_while_prior_thread_alive():
+    bridge, release = _draining_bridge()
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            asyncio.run(bridge.start_simulation("run-2", {"simulation_steps": 1}))
+    finally:
+        release.set()
+        bridge.simulation_thread.join(timeout=5)

--- a/utilityfog_frontend/backend/api.py
+++ b/utilityfog_frontend/backend/api.py
@@ -9,7 +9,7 @@ import asyncio
 import time
 import uuid
 from typing import Dict, Any, Optional
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import logging
 
@@ -49,10 +49,10 @@ class SimulationStatus(BaseModel):
     connected_clients: int
 
 @app.post("/api/sim/start")
-async def start_simulation(request: SimulationStartRequest, background_tasks: BackgroundTasks):
+async def start_simulation(request: SimulationStartRequest):
     """Start a new simulation run."""
     
-    if sim_bridge.is_running():
+    if not sim_bridge.can_start():
         raise HTTPException(status_code=400, detail="Simulation already running")
     
     try:

--- a/utilityfog_frontend/backend/api.py
+++ b/utilityfog_frontend/backend/api.py
@@ -75,7 +75,10 @@ async def start_simulation(request: SimulationStartRequest, background_tasks: Ba
         }
         
         # Start simulation in background
-        background_tasks.add_task(sim_bridge.start_simulation, run_id, config)
+        # Start at request time (no await between the guard above and here),
+        # so a second rapid POST gets its 400 instead of dying later in a
+        # background task; the actual work still runs on the bridge's thread.
+        await sim_bridge.start_simulation(run_id, config)
         
         logger.info(f"🚀 Starting simulation {run_id} with {request.num_agents} agents")
         

--- a/utilityfog_frontend/backend/sim_bridge.py
+++ b/utilityfog_frontend/backend/sim_bridge.py
@@ -45,8 +45,14 @@ class SimBridge:
         logger.info("🌉 SimBridge initialized")
     
     def is_running(self) -> bool:
-        """Check if simulation is currently running."""
-        return self.status == "running"
+        """Check if simulation is currently running.
+
+        True while the worker thread is alive even after a "stop": stop lets
+        the thread drain, so new starts must wait or both runs would write the
+        same shared fields (current_step/status/current_simulation).
+        """
+        thread_alive = self.simulation_thread is not None and self.simulation_thread.is_alive()
+        return thread_alive or self.status == "running"
     
     def get_status(self) -> Dict[str, Any]:
         """Get current simulation status."""

--- a/utilityfog_frontend/backend/sim_bridge.py
+++ b/utilityfog_frontend/backend/sim_bridge.py
@@ -44,15 +44,29 @@ class SimBridge:
         
         logger.info("🌉 SimBridge initialized")
     
-    def is_running(self) -> bool:
-        """Check if simulation is currently running.
+    def _worker_alive(self) -> bool:
+        """True while a background worker thread exists and is executing."""
+        return self.simulation_thread is not None and self.simulation_thread.is_alive()
 
-        True while the worker thread is alive even after a "stop": stop lets
-        the thread drain, so new starts must wait or both runs would write the
-        same shared fields (current_step/status/current_simulation).
+    def can_start(self) -> bool:
+        """A new run may start only when no worker thread is executing.
+
+        A draining worker (stopped/completed but still cleaning up) blocks new
+        starts so two threads never share current_step/status/
+        current_simulation; a dead thread never blocks, even if a crash left
+        status stale at "running".
         """
-        thread_alive = self.simulation_thread is not None and self.simulation_thread.is_alive()
-        return thread_alive or self.status == "running"
+        return not self._worker_alive()
+
+    def is_running(self) -> bool:
+        """Currently in a live, STOPPABLE run: running status AND a live worker.
+
+        Deliberately distinct from (not can_start()): a worker that already
+        wrote a terminal status (completed/error) but is still broadcasting or
+        cleaning up must not be treated as stoppable, or stop would overwrite
+        the terminal status with "stopped".
+        """
+        return self.status == "running" and self._worker_alive()
     
     def get_status(self) -> Dict[str, Any]:
         """Get current simulation status."""
@@ -77,7 +91,7 @@ class SimBridge:
     async def start_simulation(self, run_id: str, config: Dict[str, Any]):
         """Start a new simulation run."""
         
-        if self.is_running():
+        if not self.can_start():
             raise RuntimeError("Simulation already running")
         
         logger.info(f"🚀 Starting simulation {run_id}")


### PR DESCRIPTION
## What (Option A from ops-dir `SIM_BRIDGE_CONCURRENCY_OPTIONS_v1.md`, chosen under Kev's explicit delegation 2026-07-08; amended `235cad1` per Jack's audit)

Hunt-confirmed defect: `stop_simulation()` sets `status='stopped'` but lets the worker drain; the old status-only guard let a second run start while the first thread was alive — both writing `current_step`/`status`/`current_simulation`, interleaving `/api/sim/status`, and re-opening the guard for a third overlap.

## Amended semantics (start-blocking and stoppability are separate questions)

- **`_worker_alive()`** — private liveness primitive: a worker thread exists and is executing.
- **`can_start()`** — the start path (bridge guard + `/api/sim/start`): a new run may start only when no worker is alive. A draining worker blocks new starts; **a dead thread never blocks, even if a crash left `status='running'` stale** (Gemini's wedge case).
- **`is_running()`** — the stop path, now meaning *stoppable only*: `status == 'running'` AND worker alive. **A worker that already wrote `completed`/`error` but is still broadcasting/cleaning up is not stoppable, so `/api/sim/stop` cannot overwrite a terminal status** (Codex's P2).
- **`/api/sim/start`** awaits `start_simulation` at request time (no await between guard and start — the second rapid POST gets its 400 instead of a silent background death); unused `BackgroundTasks` parameter and import removed.

## Verification

**Four contract tests** (`tests/test_sim_bridge_concurrency.py`): draining-thread-blocks-start · terminal-status-with-live-thread (blocks start, NOT stoppable) · stale-running-dead-thread (start allowed) · live-running-worker (stoppable, blocks start). **Tests skip wherever fastapi is absent — currently both locally and in CI** (sim_bridge → ws_server → fastapi; same limit disclosed on #286/#287); they go live the day the packet's Q3 fastapi lane exists. Behavior change is source-verified. Full gate: **817 passed / 0 failed / 27 skipped, zero warnings** (+1 skip = this module).

## Lane

Unmerged, Jack's lane — packet Q1 answered by this choice ('stop = drain + refuse until done'); Q2 (testing_framework test surface) and Q3 (fastapi CI brick) remain his open items. Kev speaks merge/park.

🤖 Generated with [Claude Code](https://claude.com/claude-code)