### PR TITLE
docs: tombstone marker for UtilityFog_Agent_Package (D7 disposition)

### DIFF
--- a/UtilityFog_Agent_Package/PACKAGE_STATUS.md
+++ b/UtilityFog_Agent_Package/PACKAGE_STATUS.md
@@ -1,0 +1,34 @@
+# PACKAGE STATUS — read before importing or editing anything here
+
+**Tombstone marker (D7 disposition, chosen 2026-07-08, implemented 2026-07-09).**
+This package is a MIXED zone: three live, gate-imported modules sitting beside five
+corrupted stub files that duplicate — and could be mistaken for — the real code.
+
+## LIVE — gate-imported, maintained (edit here when fixing these modules)
+| Module | Why it is live |
+|---|---|
+| `agent/feature_flags.py` | imported by CI-gated `tests/test_feature_flags.py` (sys.path append; "canonical package" per its comment) |
+| `agent/observability.py` | imported by CI-gated `tests/test_observability.py`; fixed in place by PR #282 (utcnow deprecation) |
+| `agent/telemetry_collector.py` | imported by `tests/test_observability.py` alongside observability |
+
+The root-level `agent/` package does NOT contain these three modules — this package is
+their only source. Plain removal of this directory breaks the pytest gate.
+
+## CORRUPTED STUBS — DO NOT USE, DO NOT "FIX" IN PLACE
+`evolution_engine.py` · `foglet_agent.py` · `meme_structure.py` · `network_topology.py` ·
+`simulation_metrics.py` — padding files of repeated `class X: pass` lines. **The real
+implementations live in the ROOT `agent/` package** (e.g. PR #300 fixed
+`agent/evolution_engine.py` at the root; PRs #285/#290 likewise landed at the root).
+Tests that import these names resolve to the root package, so the stubs are
+import-shadowed in CI — harmless there, hazardous to anyone reading or editing this
+directory directly.
+
+## UNVERIFIED
+`agent/main_simulation.py` (1001 lines, not stub-patterned, not gate-imported) and
+`config.yaml` — status not audited; treat as unknown, not as live.
+
+## Disposition history
+Remove / tombstone / relocate was decision line D7 (`OPEN_DECISION_LINES_2026-07-08.md`,
+ops-dir): **tombstone chosen** — removal breaks the gate; relocating the three live
+modules is possible future work behind its own decision. This marker changes no code
+and no behavior; it exists so nobody mistakes the stubs for the project again.

--- a/UtilityFog_Agent_Package/PACKAGE_STATUS.md
+++ b/UtilityFog_Agent_Package/PACKAGE_STATUS.md
@@ -15,8 +15,8 @@ The root-level `agent/` package does NOT contain these three modules — this pa
 their only source. Plain removal of this directory breaks the pytest gate.
 
 ## CORRUPTED STUBS — DO NOT USE, DO NOT "FIX" IN PLACE
-`evolution_engine.py` · `foglet_agent.py` · `meme_structure.py` · `network_topology.py` ·
-`simulation_metrics.py` — padding files of repeated `class X: pass` lines. **The real
+`agent/evolution_engine.py` · `agent/foglet_agent.py` · `agent/meme_structure.py` ·
+`agent/network_topology.py` · `agent/simulation_metrics.py` — padding files of repeated `class X: pass` lines. **The real
 implementations live in the ROOT `agent/` package** (e.g. PR #300 fixed
 `agent/evolution_engine.py` at the root; PRs #285/#290 likewise landed at the root).
 Tests that import these names resolve to the root package, so the stubs are


### PR DESCRIPTION
## What (D7 from the decision lines — tombstone chosen 2026-07-08 under Kev's delegation; this is the implementation)

One new file, `UtilityFog_Agent_Package/PACKAGE_STATUS.md`, zero code changes. It marks the package's true mixed status, established by source inspection this round:

- **LIVE + gate-imported (this package is their ONLY source):** `agent/feature_flags.py`, `agent/observability.py` (fixed in place by #282), `agent/telemetry_collector.py` — imported by CI-gated `tests/test_feature_flags.py` / `tests/test_observability.py`. Plain removal of the directory breaks the gate.
- **CORRUPTED STUBS, do-not-use / do-not-fix-in-place:** `evolution_engine.py`, `foglet_agent.py`, `meme_structure.py`, `network_topology.py`, `simulation_metrics.py` — literal repeated `class X: pass` padding that **shadow-duplicates the real root-level `agent/` package** (where #285/#290/#300 actually landed). Import-shadowed in CI, hazardous to a human reader.
- **UNVERIFIED, honestly marked:** `main_simulation.py` + `config.yaml`.

This sharpens the C1 §4 / AGENT_HANDOFF "legacy snapshot" caveat: the package is not uniformly legacy — it is three live modules beside five decoys. Relocating the live trio remains possible future work behind its own decision.

## Verification

Full gate after adding the marker: **817 passed / 0 failed / 27 skipped, zero warnings** — byte-identical to main's baseline (docs-only, nothing importable changed).

## Lane

Unmerged — Jack audits, Kev speaks merge/park.

🤖 Generated with [Claude Code](https://claude.com/claude-code)