### PR TITLE
test: assert info command output instead of smoke-running it (D8 finding)

### DIFF
--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -417,8 +417,8 @@ class TestScatter3D:
 # ---------------------------------------------------------------------------
 
 class TestCLI:
-    def test_info_command(self, snapshot):
-        """Test the info CLI command."""
+    def test_info_command(self, snapshot, capsys):
+        """Test the info CLI command actually reports the snapshot's metadata."""
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
             np.savez(
                 f.name,
@@ -431,6 +431,12 @@ class TestCLI:
             from vis.observatory.cli import main
             main(["info", f.name])
         os.unlink(f.name)
+
+        out = capsys.readouterr().out
+        assert f"Generation: {snapshot.generation:,}" in out
+        assert f"CA Step:    {snapshot.ca_step:,}" in out
+        assert f"Fitness:    {snapshot.best_fitness:.4f}" in out
+        assert f"Non-void:   {snapshot.non_void_count:,}" in out
 
     def test_slice_command(self, snapshot):
         import matplotlib.pyplot as plt


### PR DESCRIPTION
## What (the ONE confirmed finding from the bounded D8 tests-quality pass, per Jack's shape)

`TestCLI::test_info_command` ran `main(['info', file])` and asserted **nothing** — the info command could print wrong numbers or nothing at all and the test would still pass. Now it captures stdout (`capsys`) and asserts the four load-bearing metadata lines against the fixture's own values: Generation (with the `:,` formatting), CA Step, Fitness (`:.4f`), Non-void count.

## The D8 pass itself (parent-seat, deterministic AST finder — no agents)

Scanned all 34 test files for: assertion-free test functions · `assert True` literals · self-comparison tautologies · whole-test exception swallowing. **9 raw hits → verified by reading each site → 1 confirmed defect (this PR)**. The rest, honestly: 3 finder false-positives (2 nested inner defs named like tests; 1 call-comparison — `one_run(3) == one_run(3)` is two real runs, correct determinism testing) · 5 intentional "must not raise" contract smokes with in-comment rationale (weak-but-deliberate pattern; routed as a note, not defects). Finder script + full verification detail in the session log.

## Verification

Strengthened test passes against current code (the command's output is correct — the *test* was the defect). `tests/test_observatory.py` **40/40**; full gate **817 passed / 0 failed / 27 skipped, zero warnings** — baseline-identical.

## Lane

Unmerged — Jack audits, Kev speaks merge/park. Stopping at the seam per the ration shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)