### PR TITLE
fix(testing_framework): energy-only proxy for entanglement writeback (D6 Option B)

### DIFF
--- a/testing_framework/simulation_runner.py
+++ b/testing_framework/simulation_runner.py
@@ -600,9 +600,9 @@ class SimulationRunner:
                         # Create simple state objects for quantum_myelin
                         class SimpleAgent:
                             def __init__(self, agent):
-                                self.state = agent.energy_level  # the writeback below targets
-                                # energy_level alone, so the proxy must BE energy
-                                # (D6 Option B: health no longer silently taxes it)
+                                # D6 Option B: The writeback below targets energy_level alone,
+                                # so the proxy must be energy (health no longer silently taxes it).
+                                self.state = agent.energy_level
                         
                         simple_a = SimpleAgent(agent_a)
                         simple_b = SimpleAgent(agent_b)

--- a/testing_framework/simulation_runner.py
+++ b/testing_framework/simulation_runner.py
@@ -600,7 +600,9 @@ class SimulationRunner:
                         # Create simple state objects for quantum_myelin
                         class SimpleAgent:
                             def __init__(self, agent):
-                                self.state = agent.energy_level * agent.health  # Simple state metric
+                                self.state = agent.energy_level  # the writeback below targets
+                                # energy_level alone, so the proxy must BE energy
+                                # (D6 Option B: health no longer silently taxes it)
                         
                         simple_a = SimpleAgent(agent_a)
                         simple_b = SimpleAgent(agent_b)

--- a/tests/test_energy_health_writeback.py
+++ b/tests/test_energy_health_writeback.py
@@ -41,4 +41,5 @@ def test_entanglement_writeback_preserves_energy_for_unhealthy_agents(monkeypatc
     assert a.energy_level == 0.8  # pre-fix: 0.8 * 0.5 = 0.4 silently drained
     assert b.energy_level == 0.6  # pre-fix: 0.6 * 0.25 = 0.15
     # health is untouched either way
-    assert a.health == 0.5 and b.health == 0.25
+    assert a.health == 0.5
+    assert b.health == 0.25

--- a/tests/test_energy_health_writeback.py
+++ b/tests/test_energy_health_writeback.py
@@ -1,0 +1,44 @@
+"""D6 ruling implementation guard (ENERGY_HEALTH_WRITEBACK_DECISION_PACKET_v1, Option B).
+
+Entanglement must not silently tax energy by health: the quantum_myelin proxy
+state is written back into energy_level alone, so the proxy must BE energy.
+Pre-fix, an agent with health < 1.0 lost energy on every entanglement event
+(state = energy * health round-tripped into energy).
+"""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import testing_framework.simulation_runner as sr
+
+
+def _skeleton_runner():
+    runner = sr.SimulationRunner.__new__(sr.SimulationRunner)
+    runner.quantum_logger = Mock()
+    runner.simulation_logger = Mock()
+    runner.all_logs = []
+    runner._emit_event = lambda *a, **k: None
+    runner._should_form_entanglement = lambda a, b: True
+    return runner
+
+
+def _agent(aid, energy, health):
+    return SimpleNamespace(agent_id=aid, energy_level=energy, health=health)
+
+
+def test_entanglement_writeback_preserves_energy_for_unhealthy_agents(monkeypatch):
+    runner = _skeleton_runner()
+    a = _agent("a", 0.8, 0.5)
+    b = _agent("b", 0.6, 0.25)
+    runner.agents = [a, b]
+
+    # Identity myelin: any energy change must then come from the proxy
+    # round-trip itself -- which is exactly the defect under test.
+    monkeypatch.setattr(sr, "myelin_layer", lambda sa, sb, strength: None)
+    monkeypatch.setattr(sr.random, "uniform", lambda lo, hi: 0.5)
+
+    runner._process_quantum_myelin_interactions()
+
+    assert a.energy_level == 0.8  # pre-fix: 0.8 * 0.5 = 0.4 silently drained
+    assert b.energy_level == 0.6  # pre-fix: 0.6 * 0.25 = 0.15
+    # health is untouched either way
+    assert a.health == 0.5 and b.health == 0.25


### PR DESCRIPTION
## What (D6 from the decision lines — the queue's final item)

Hunt finding #29, verifier-confirmed and source re-verified: the quantum_myelin proxy state was built as a **product** (`energy_level * health`, :603) but written back into **`energy_level` alone`** (:618–619) — so every entanglement event silently multiplied an unhealthy agent's energy down by its health factor, a compounding drain never stated as design intent anywhere.

**Option B from ops-dir `ENERGY_HEALTH_WRITEBACK_DECISION_PACKET_v1.md` (the packet's recommendation, which Jack earlier called "the cleanest"):** the proxy now IS energy — if the writeback target is energy, the proxy must be energy. Health stops silently taxing entanglement; any deliberate energy-cost mechanic remains free to be designed out loud later (packet Option C, not chosen). One line + constraint comment.

## Consent interpretation, stated openly (the #302 pattern)

Kev handed back the takeover-card D6 task with "proceed" (2026-07-10). Read as: implementation opened under the packet's standing recommendation; **the ruling's human confirmation happens right here at audit/merge** — if Kev/Jack prefer Option A (invert-on-writeback) or C (declare the drain intentional), this PR parks without ceremony and the packet documents both. No merge without Jack's audit + Kev's explicit word.

## Verification (test-first, demonstrated)

New `tests/test_energy_health_writeback.py` drives the real `_process_quantum_myelin_interactions` with a skeleton runner and identity myelin, so any energy change can only come from the proxy round-trip itself. **Pre-fix: FAILED (0.8→0.4, 0.6→0.15 — the exact drain). Post-fix: passes.** (+1 = the new test; testing_framework's near-zero CI surface gains its first writeback guard.)

**Gate results, precisely labelled (Jack-audit correction, 2026-07-10):**

- **818 passed / 0 failed / 27 skipped, zero warnings** — the opening desktop seat's LOCAL gate at the original head `d070544`. Not reverified since: the current (lounge) seat has no Python toolchain and no install authorization, so the local gate has not been rerun for the closeout commit.
- Live GitHub CI `verify-python` at the audited head `d070544`: **922 passed / 10 skipped / 0 failed in 34.35s**.
- Live GitHub CI `verify-python` at the current head `de4e668` (audit-closeout commit — block-comment layout + split health assertion, non-functional): **922 passed / 10 skipped / 0 failed in 29.44s** (the pull_request-triggered PR gate; the push-triggered sibling run reports identical counts in 34.70s); `verify` and `agent-safety` also green.
- Local-vs-CI count difference is the known lane difference, not a discrepancy: CI installs the full dep set and builds the `uft_ca` extension, so modules that skip locally run there.

## Lane

Unmerged — Jack audits, Kev speaks merge/park. This closes the last line of the D1–D8 queue if accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
