### PR TITLE
fix(calibration): deterministic row metadata for Chapters 1+2 (#151)

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -483,9 +483,10 @@ def check_determinism(
                 run_metadata={
                     "content_fingerprint_sha256_16": fp[:16],
                     "snapshot_byte_identical_across_repeats": snapshot_byte_identical,
-                    "elapsed_seconds": entry.get("budget", {}).get(
-                        "elapsed_seconds"
-                    ),
+                    # patches_processed is deterministic; elapsed_seconds
+                    # is wallclock-derived and would break byte-identical
+                    # re-run. Timing is available in process_snapshot's
+                    # own log entry, joinable on snapshot_file.
                     "patches_processed": entry.get("budget", {}).get(
                         "patches_processed"
                     ),
@@ -815,9 +816,10 @@ def shuffle_test(
                         "cci": cci_value,
                     },
                     run_metadata={
-                        "elapsed_seconds": entry.get("budget", {}).get(
-                            "elapsed_seconds"
-                        ),
+                        # patches_processed is deterministic; elapsed_seconds
+                        # is wallclock-derived and would break byte-identical
+                        # re-run. Timing is available in process_snapshot's
+                        # own log entry, joinable on snapshot_file.
                         "patches_processed": entry.get("budget", {}).get(
                             "patches_processed"
                         ),

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -597,6 +597,24 @@ def test_check_determinism_emits_no_generated_at_field(tmp_path):
     assert "generated_at" not in content
 
 
+def test_check_determinism_byte_identical_on_rerun(tmp_path):
+    """Determinism — re-running on the same input produces byte-identical output.
+
+    Issue #151: per-row run_metadata.elapsed_seconds was wallclock-derived
+    and broke byte-identical re-run (the Chapter 4 pattern from PR #148).
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snaps = [
+        _make_snapshot(snaps_dir / f"v070_gen{i}_step{i}_test.npz", generation=i)
+        for i in (1, 2)
+    ]
+    out_a = log_path.parent / "calibration_determinism_a.jsonl"
+    out_b = log_path.parent / "calibration_determinism_b.jsonl"
+    check_determinism(snaps, out_a, log_path, "short", config, repeats=2)
+    check_determinism(snaps, out_b, log_path, "short", config, repeats=2)
+    assert out_a.read_bytes() == out_b.read_bytes()
+
+
 def test_check_determinism_calibration_set_field_propagates(tmp_path):
     """Every row (per-snapshot AND aggregate) carries the calibration_set tag."""
     snaps_dir, log_path, config = _calibration_setup(tmp_path)
@@ -1011,6 +1029,23 @@ def test_shuffle_test_no_generated_at_field(tmp_path):
     shuffle_test([snap], out, log_path, "short", config)
     content = out.read_text()
     assert "generated_at" not in content
+
+
+def test_shuffle_test_byte_identical_on_rerun(tmp_path):
+    """Determinism — re-running on the same input produces byte-identical output.
+
+    Issue #151: per-row run_metadata.elapsed_seconds was wallclock-derived
+    and broke byte-identical re-run (the Chapter 4 pattern from PR #148).
+    Shuffle permutations are seed-derived, so identical default seeds
+    produce identical rows.
+    """
+    snaps_dir, log_path, config = _calibration_setup(tmp_path)
+    snap = _make_snapshot(snaps_dir / "v070_gen1_step1_test.npz", generation=1)
+    out_a = log_path.parent / "calibration_shuffle_a.jsonl"
+    out_b = log_path.parent / "calibration_shuffle_b.jsonl"
+    shuffle_test([snap], out_a, log_path, "short", config)
+    shuffle_test([snap], out_b, log_path, "short", config)
+    assert out_a.read_bytes() == out_b.read_bytes()
 
 
 def test_shuffle_test_subset_of_modes_marks_aggregate_incomplete(tmp_path):


### PR DESCRIPTION
## What (issue #151 — Kev-authorized weekend brick #1)

Closes #151. Chapters 1+2 of the calibration harness get the same determinism cleanup Chapters 4+5 received in #148/#149: `check_determinism()` and `shuffle_test()` no longer emit wallclock-derived `elapsed_seconds` in per-row `run_metadata`, so re-running either function on the same input now produces byte-identical output.

**Pre-implementation verification on live `main` (`a5721ef`):** both emission sites confirmed present (`scripts/nextness_calibration.py:486` and `:818` emitted `entry["budget"]["elapsed_seconds"]`), and neither promised rerun test existed — exactly as Jack's discovery audit stated.

## Changes (2 files, +43/−6)

- `scripts/nextness_calibration.py` — `elapsed_seconds` removed from the per-row `run_metadata` of `check_determinism()` (Chapter 1) and `shuffle_test()` (Chapter 2), replaced with the identical four-line comment the already-fixed chapters carry ("patches_processed is deterministic; elapsed_seconds is wallclock-derived… joinable on snapshot_file"). Deterministic fields preserved: `content_fingerprint_sha256_16`, `snapshot_byte_identical_across_repeats`, `patches_processed`. No other wallclock-derived fields were found in either function's rows.
- `tests/test_nextness_calibration.py` — the two regression fences promised in #151, following the `test_sweep_stride_byte_identical_on_rerun` pattern verbatim (run twice into `_a`/`_b` outputs, `assert read_bytes() ==`): `test_check_determinism_byte_identical_on_rerun` (2 synthetic snapshots × 2 repeats) and `test_shuffle_test_byte_identical_on_rerun` (1 synthetic snapshot, default seed set — permutations are seed-derived, so identical seeds ⇒ identical rows). Synthetic fixtures only (`_calibration_setup` + `_make_snapshot`), placed beside each chapter's existing `no_generated_at_field` determinism-contract test.

Note: the module-level fingerprint scrub (`VOLATILE` fields, `_scrub_volatile_fields`) is untouched — `elapsed_seconds` remains rightly listed there for scrubbing the `budget` block of `process_snapshot` entries; this PR only stops *re-emitting* it into calibration rows.

## Verification lane, disclosed precisely

This seat (lounge machine) has **no Python toolchain and no install authorization**, so the local gate was not run here. GitHub CI is the single verification lane for this PR, per the task packet.

**Live CI at head `feab66b` — all checks green:**

- `verify-python` (pull_request-triggered PR gate): **924 passed / 10 skipped / 0 failed in 35.64s** — exactly **+2** over `main = a5721ef`'s 922, i.e. the two new regression fences collected and passing. (Push-triggered sibling run: identical counts in 36.18s.)
- `verify`, `agent-safety`, `Analyze Python` / CodeQL: all pass.

## Fences (all held)

No engine files · no `data/`/NPZ access · no observer-semantics change (row *metadata* only — classifier cascade, metrics, and aggregates untouched) · no canonical claims · no dependencies or installs · no unrelated cleanup · one PR, left **unmerged** for Jack's audit · Kev retains the merge word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
