### PR TITLE
policy: lock #157 whole-payload contract with mixed-text regressions

### DIFF
--- a/policy/agent_safety.rego
+++ b/policy/agent_safety.rego
@@ -61,6 +61,16 @@ is_encoded_payload(payload) {
 # 8 is the smallest meaningful base64 output length (encodes 4-6 raw bytes
 # with padding), so this floor preserves detection of genuine short base64
 # while eliminating the false-positive class of plain words and identifiers.
+#
+# CONTRACT (issue #157): base64 detection is intentionally WHOLE-PAYLOAD —
+# the regex is anchored (^…$) on purpose. A base64-form token embedded
+# inside ordinary prose is NOT an encoded payload for this policy; embedded
+# arbitrary-text substring scanning is out of scope (the false-positive
+# surface of scanning ordinary prose — plain words, identifiers, hashes
+# quoted in text — is not justified by current evidence). Do not add a
+# decoder, entropy heuristic, tokenizer, or broader payload scanner here
+# without a new recorded decision. URL-encoding detection below remains
+# deliberately unanchored; data-URI detection remains prefix-based.
 is_base64_like(payload) {
   regex.match(`^[A-Za-z0-9+/]{4,}={0,2}$`, payload)
   count(payload) >= 8

--- a/policy/agent_safety_test.rego
+++ b/policy/agent_safety_test.rego
@@ -98,11 +98,22 @@ test_encoded_payload_json if {
 	not safety.encoded_payload_detected with input as {"payload": "{\"key\": \"value\"}"} with data.agent_limits.enforce_encoded_payload as true
 }
 
-# Embedded base64 substring inside natural text — currently NOT detected by
-# the anchored regex. Whether this should be detected is a real design
-# question (false-positive risk vs catching obfuscation) tracked in
-# issue #157. Removed from the regression suite until that's decided.
-# Was: test_encoded_payload_mixed_content with input "Hello SGVsbG8gV29ybGQ= World"
+# Whole-payload contract (issue #157 — contract locked in code; the issue's
+# disposition remains a separate decision): base64 detection is INTENTIONALLY
+# whole-payload. The anchored regex means a base64-form token embedded in
+# ordinary prose is NOT treated as an encoded payload — embedded
+# arbitrary-text substring scanning is out of scope, because the
+# false-positive surface of scanning ordinary prose is not justified by
+# current evidence. No decoder, entropy heuristic, tokenizer, or broader
+# payload scanner. URL-encoding detection remains deliberately unanchored
+# (see test_encoded_payload_url_in_text); data-URI detection remains
+# prefix-based.
+
+# Regression: mixed natural text containing a harmless base64-form token is
+# NOT detected as an encoded payload, even with enforcement enabled.
+test_encoded_payload_mixed_text_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "Hello SGVsbG8gV29ybGQ= World"} with data.agent_limits.enforce_encoded_payload as true
+}
 
 # ---------------------------------------------------------------------------
 # encoded_payload_detected isolated tests — flag disabled
@@ -296,4 +307,22 @@ test_allow_base64_when_flag_disabled if {
 		"payload": "SGVsbG8gV29ybGQ=",
 		"action": "read",
 	} with data.agent_limits.enforce_encoded_payload as false
+}
+
+# Allow-level regression for the whole-payload contract (issue #157): an
+# otherwise fully valid request whose payload is ordinary prose containing a
+# base64-form token stays ALLOWED while encoded-payload enforcement is
+# enabled.
+test_allow_mixed_text_payload_with_enforcement if {
+	safety.allow with input as {
+		"pause_before_propagate": true,
+		"intent": "creative",
+		"domain": "github.com",
+		"ttl": 3,
+		"children": 5,
+		"concurrency": 2,
+		"rate": 30,
+		"payload": "Hello SGVsbG8gV29ybGQ= World",
+		"action": "read",
+	} with data.agent_limits.enforce_encoded_payload as true
 }


### PR DESCRIPTION
## Scope (PR A of Kev's three-package runway — policy false-positive regression work)

Resolves issue #157's design ambiguity **in code, without closing the issue**: the whole-payload base64 contract is now locked and regression-tested. This PR does not decode, execute, or operationalize any payload — it proves ordinary prose is *not* flagged.

**Locked decision:** no arbitrary embedded-base64 substring scanning. The existing whole-payload detector is preserved; the false-positive surface of scanning ordinary prose is not justified by current evidence.

**Changes (2 files, allowed list only):**
- `policy/agent_safety.rego` — CONTRACT comment on `is_base64_like`: anchoring is intentional; embedded arbitrary-text scanning out of scope; no decoder/entropy-heuristic/tokenizer without a new recorded decision. No logic changed.
- `policy/agent_safety_test.rego` — the temporary “decision pending / removed from suite” comment replaced by the contract statement plus two regressions:
  - `test_encoded_payload_mixed_text_not_detected` — mixed prose containing a harmless base64-form token (`Hello SGVsbG8gV29ybGQ= World`) is not detected, enforcement ON.
  - `test_allow_mixed_text_payload_with_enforcement` — an otherwise fully valid request with that payload remains **allowed**, enforcement ON.

**Preserved unchanged:** positive whole-payload base64, URL-encoded (deliberately unanchored), data-URI, flag-disabled, TTL, and resource-limit behavior — no existing test touched.

## Verification
Local OPA binary unavailable on this seat (declared) — verification lane = the Agent Safety CI job (checksum-anchored OPA v0.59.0: `fmt --diff`, `check`, `test -v --coverage`) plus required checks `agent-safety` / `verify` / `verify-python`.

## Governance
Refs #157 — **no closing keyword; issue disposition remains separately keyed.** Stays **OPEN AND UNMERGED** for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)