### PR TITLE
frontend: accessible 2D/3D view selection with Playwright coverage

### DIFF
--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -49,15 +49,25 @@ function App() {
       <EventFeed simClient={simClient} />
       <ConnectionBadge isConnected={isConnected} />
 
-      {/* display:contents keeps these accessibility wrappers out of the
-          .app-container flex layout — the view roots stay direct flex
-          children, so rendering/styling is unchanged. */}
+      {/* Each rendered view sits in a labelled region landmark. The wrapper
+          mirrors the flex slot the view roots already expect (a flex:1 child
+          of the column-flex .app-container) and is itself a flex container,
+          so the view root's own flex:1 fills it and child canvas sizing is
+          unchanged. minHeight/minWidth 0 keep flex overflow semantics. */}
       {view === '3d' ? (
-        <section role="region" aria-label="3D network view" style={{ display: 'contents' }}>
+        <section
+          role="region"
+          aria-label="3D network view"
+          style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
+        >
           <NetworkView3D simClient={simClient} />
         </section>
       ) : (
-        <section role="region" aria-label="2D network view" style={{ display: 'contents' }}>
+        <section
+          role="region"
+          aria-label="2D network view"
+          style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
+        >
           <NetworkView2D simClient={simClient} />
         </section>
       )}

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -42,17 +42,24 @@ function App() {
   return (
     <div className="app-container">
       <div className="controls">
-        <button onClick={() => setView('2d')}>2D View</button>
-        <button onClick={() => setView('3d')}>3D View</button>
+        <button aria-pressed={view === '2d'} onClick={() => setView('2d')}>2D View</button>
+        <button aria-pressed={view === '3d'} onClick={() => setView('3d')}>3D View</button>
       </div>
 
       <EventFeed simClient={simClient} />
       <ConnectionBadge isConnected={isConnected} />
 
+      {/* display:contents keeps these accessibility wrappers out of the
+          .app-container flex layout — the view roots stay direct flex
+          children, so rendering/styling is unchanged. */}
       {view === '3d' ? (
-        <NetworkView3D simClient={simClient} />
+        <section role="region" aria-label="3D network view" style={{ display: 'contents' }}>
+          <NetworkView3D simClient={simClient} />
+        </section>
       ) : (
-        <NetworkView2D simClient={simClient} />
+        <section role="region" aria-label="2D network view" style={{ display: 'contents' }}>
+          <NetworkView2D simClient={simClient} />
+        </section>
       )}
     </div>
   )

--- a/utilityfog_frontend/frontend/tests/smoke.spec.ts
+++ b/utilityfog_frontend/frontend/tests/smoke.spec.ts
@@ -21,17 +21,17 @@ test('view switching: default 3D, accessible toggle to 2D and back', async ({ pa
 
   const btn2d = page.getByRole('button', { name: '2D View' });
   const btn3d = page.getByRole('button', { name: '3D View' });
-  // Semantic regions (role + accessible name), not CSS selectors. The
-  // region wrappers use display:contents (no box of their own), so
-  // presence is asserted with toBeAttached/toHaveCount and visibility on
-  // the canvas each view renders inside its region.
+  // Semantic regions (role + accessible name), not CSS selectors. Each
+  // region is a real layout-preserving flex wrapper, so the region itself
+  // is asserted visibly rendered, along with the canvas its view draws
+  // inside it.
   const region2d = page.getByRole('region', { name: '2D network view' });
   const region3d = page.getByRole('region', { name: '3D network view' });
 
   // Initial state: 3D selected and rendered, 2D absent.
   await expect(btn3d).toHaveAttribute('aria-pressed', 'true');
   await expect(btn2d).toHaveAttribute('aria-pressed', 'false');
-  await expect(region3d).toBeAttached();
+  await expect(region3d).toBeVisible();
   await expect(region3d.locator('canvas')).toBeVisible();
   await expect(region2d).toHaveCount(0);
 
@@ -39,7 +39,7 @@ test('view switching: default 3D, accessible toggle to 2D and back', async ({ pa
   await btn2d.click();
   await expect(btn2d).toHaveAttribute('aria-pressed', 'true');
   await expect(btn3d).toHaveAttribute('aria-pressed', 'false');
-  await expect(region2d).toBeAttached();
+  await expect(region2d).toBeVisible();
   await expect(region2d.locator('canvas')).toBeVisible();
   await expect(region3d).toHaveCount(0);
 
@@ -47,7 +47,7 @@ test('view switching: default 3D, accessible toggle to 2D and back', async ({ pa
   await btn3d.click();
   await expect(btn3d).toHaveAttribute('aria-pressed', 'true');
   await expect(btn2d).toHaveAttribute('aria-pressed', 'false');
-  await expect(region3d).toBeAttached();
+  await expect(region3d).toBeVisible();
   await expect(region3d.locator('canvas')).toBeVisible();
   await expect(region2d).toHaveCount(0);
 

--- a/utilityfog_frontend/frontend/tests/smoke.spec.ts
+++ b/utilityfog_frontend/frontend/tests/smoke.spec.ts
@@ -13,3 +13,44 @@ test('app renders without JavaScript errors', async ({ page }) => {
   await page.waitForLoadState('networkidle');
   expect(errors).toHaveLength(0);
 });
+
+test('view switching: default 3D, accessible toggle to 2D and back', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto('/');
+
+  const btn2d = page.getByRole('button', { name: '2D View' });
+  const btn3d = page.getByRole('button', { name: '3D View' });
+  // Semantic regions (role + accessible name), not CSS selectors. The
+  // region wrappers use display:contents (no box of their own), so
+  // presence is asserted with toBeAttached/toHaveCount and visibility on
+  // the canvas each view renders inside its region.
+  const region2d = page.getByRole('region', { name: '2D network view' });
+  const region3d = page.getByRole('region', { name: '3D network view' });
+
+  // Initial state: 3D selected and rendered, 2D absent.
+  await expect(btn3d).toHaveAttribute('aria-pressed', 'true');
+  await expect(btn2d).toHaveAttribute('aria-pressed', 'false');
+  await expect(region3d).toBeAttached();
+  await expect(region3d.locator('canvas')).toBeVisible();
+  await expect(region2d).toHaveCount(0);
+
+  // Switch to 2D: selected state and rendered region both update.
+  await btn2d.click();
+  await expect(btn2d).toHaveAttribute('aria-pressed', 'true');
+  await expect(btn3d).toHaveAttribute('aria-pressed', 'false');
+  await expect(region2d).toBeAttached();
+  await expect(region2d.locator('canvas')).toBeVisible();
+  await expect(region3d).toHaveCount(0);
+
+  // Switch back to 3D: original state restored.
+  await btn3d.click();
+  await expect(btn3d).toHaveAttribute('aria-pressed', 'true');
+  await expect(btn2d).toHaveAttribute('aria-pressed', 'false');
+  await expect(region3d).toBeAttached();
+  await expect(region3d.locator('canvas')).toBeVisible();
+  await expect(region2d).toHaveCount(0);
+
+  // No page-level JavaScript errors across the whole sequence.
+  expect(errors).toHaveLength(0);
+});


### PR DESCRIPTION
## Scope (PR B of Kev's runway — amended per Jack's delta audit)

A bounded slice of issue #2's controls/testing work: accessible, testable 2D/3D view selection. **No backend, WebSocket, Three.js physics, camera, styling-system, or simulation changes.**

**Changes (2 files):**
- `src/App.tsx` — 2D/3D buttons expose `aria-pressed` selected state; each rendered view sits in a `role=region` landmark with a semantic label (`2D network view` / `3D network view`). **Amendment:** regions are real layout-preserving flex wrappers (`flex: 1`, `display: flex`, `position: relative`, `minHeight/minWidth: 0`) mirroring the flex slot the view roots already expect as `flex: 1` children of the column-flex `.app-container` — so the region itself is visibly rendered and child canvas sizing is unchanged. Default remains 3D; exactly one view mounted at a time, as before.
- `tests/smoke.spec.ts` — new spec proving: initial 3D selection · **3D region itself visible** with visible canvas and 2D region absent · switching to 2D updates `aria-pressed` + the rendered region · switching back restores the original state · zero page-level JS errors across the sequence. Selectors are semantic (`getByRole` + accessible names), not CSS.

## Verification receipts (local, this seat — amended head `139330b`)
- `npx playwright test` → **3 passed (2.8s)** on the amended branch (Chromium)
- `npx tsc --noEmit` baseline comparison: **7 pre-existing errors on main (all in untouched `viz3d/` files), 7 after this diff — byte-identical; zero new TS errors**
- `npm install --no-package-lock --no-save` (declared: `npm ci` impossible repo-wide — no `package-lock.json` exists; introducing one is PR E's separate package)
- `npm run lint` / `npm run build`: fail identically on main and this branch (pre-existing: no ESLint config; 7 `viz3d/` TS errors — PR D's separate package)

## Governance
Refs #2 — **partial progress only; no closing keyword.** Stays **OPEN AND UNMERGED** for Jack's delta audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)