### PR TITLE
docs: counter-indexed RNG feasibility & correctness contract (PR 1 of 2)

### DIFF
--- a/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
+++ b/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
@@ -1,0 +1,178 @@
+# Counter-Indexed RNG — Feasibility & Correctness Contract (v1)
+
+> **Status:** feasibility contract only. Nothing here changes production code, physics,
+> or the live engine. The companion laboratory (PR 2, `claude/counter-rng-lab`) is an
+> isolated experiment under `crates/uft_ca/benches/` and is **not** integrated into the
+> stepper. **Scope: the maintained CPU `uft_ca` kernel only** — nothing in this document
+> generalizes to the live Python/GPU engine, which was not read for this work.
+>
+> **Origin:** Kev-authorized runway (2026-07-11), derived from the AURA v3 architecture
+> study as corrected by its errata (recorded in the runway authorization and the
+> consolidated audit packet). This document supersedes the study's unmeasured RNG-traffic
+> claims: **all performance statements below are hypotheses until measured.**
+
+---
+
+## A. Current consumption map (`crates/uft_ca/src/stepper.rs`, one `step()` call)
+
+All vectors are drawn from **one sequential seeded Xoshiro256\*\* stream**
+(`rng_util.rs:12`, `pub type CaRng = Xoshiro256StarStar`) in fixed program order:
+`(0..n3).map(|_| rng.gen::<f32>()).collect()`. Trajectory identity is therefore defined
+by the *sequence and count* of draws — every row below is alignment-critical: any change
+to whether or when a vector is generated re-times all later draws.
+
+| Vector | Generated at | Consumed by | Conditionality | Consuming cells (evidence) | Lifetime / coexistence |
+|---|---|---|---|---|---|
+| `rng_vals` | `stepper.rs:32` | Phase 2.5 Anti-Star (`:67`); Phase 3 equanimity mask (`phase4.rs:38`) | Generation **unconditional**; Anti-Star consumption gated by `params.antistar_enabled` (default `true`, `memory.rs:179`) | VOID cells with ≥1 COMPUTE neighbor (nucleation, `:66`); COMPUTE cells (resist check, `phase4.rs:38`) | **Function-scoped** — allocated before Phase 1, last read at `:92`, freed at end of `step()`; coexists with every later vector |
+| `rng_vals2` | `:110` | Phase 5 nervous system → `apply_compassion` (`phase6c.rs:90`) | **Interval-conditional**: `signal_interval > 0 && gen % signal_interval == 0` (default interval 10, `memory.rs:177`) | Mature COMPUTE (compassion donation, `phase6c.rs:139–141`) | Block-scoped |
+| `rng_vals3` | `:123` | Phase 6 `apply_stochastic` (`:211+`) | `config.stochastic.enabled` (**default `true`**, `params.rs:26`) | Per-state stochastic transitions (e.g. STRUCTURAL→ENERGY/SENSOR probs, `params.rs:14–15`) | Block-scoped |
+| `rng_vals4` | `:129` | Phase 7 `apply_forward_contagion` (`:246+`) | `config.contagion.enabled` (**default `true`**, `params.rs:55`) | Contagion-eligible non-VOID cells (`:250`) | Block-scoped |
+| `rng_vals5` | `:135` | Phase 8 `apply_reverse_contagion` (`:282–290`) | **Unconditional** | STRUCTURAL with COMPUTE neighbors (reclaim, `:290`) | Block-scoped |
+| `rng_vals6` | `:149` | Phase 11 `apply_energy_conversion` (`:333–345`) | **Unconditional** | ENERGY/COMPUTE (biofilm leech `:340`, 5% branch `:345`) | Block-scoped |
+| `rng_vals7` | `:161` | Phase 13 `apply_decay_resistance` (`:426–472`) | **Unconditional** | Non-VOID decay candidates (`decay_prob` draw, `:472`) | Block-scoped |
+| `rng_vals8` | `:174` | Phase 15 `apply_analogue_mutation` (`:483–493`) | **Unconditional** | Non-VOID cells (`pre_mut[i] != VOID`, `:490`); the same value is reused for the replacement-state pick (`:493`) | Block-scoped |
+
+**Counts (source-exact):** 5 unconditionally generated vectors (`rng_vals`, `rng_vals5`–`rng_vals8`)
++ 2 default-enabled conditional vectors (`rng_vals3`, `rng_vals4`) = **7 per ordinary
+default-configuration generation**; **8 on signal generations** (default: every 10th).
+Disabled stochastic/contagion configurations generate fewer. Phase 10 inactivity decay
+(`:143–145`) and Phase 5's every-step `decay_cooldown` (`:119`) consume **no** RNG.
+
+**Peak coexistence:** `rng_vals` is function-scoped and outlives its last read (Rust
+frees it at end of `step()`), while each later vector is block-scoped and dropped before
+the next is generated ⇒ **at most ~2 vector payloads are simultaneously allocated**,
+not 7–8. Allocator capacity reuse and transient copies are **unmeasured**.
+
+## B. Memory arithmetic
+
+Definitions: 1 MiB = 2²⁰ bytes (binary); 1 MB = 10⁶ bytes (decimal). One f32 = 4 bytes.
+256³ is **analytical only** — nothing at that size is allocated or run by this work.
+
+| Quantity | 32³ (32,768) | 64³ (262,144) | 96³ (884,736) | 256³ (16,777,216) |
+|---|---|---|---|---|
+| One f32 vector | 128 KiB / 131.1 kB | 1 MiB / 1.049 MB | 3.375 MiB / 3.539 MB | **64 MiB / 67.11 MB** |
+| 7-vector aggregate (generated, ordinary gen) | 896 KiB / 0.918 MB | 7 MiB / 7.34 MB | 23.625 MiB / 24.77 MB | **448 MiB / 469.8 MB** |
+| 8-vector aggregate (signal gen) | 1 MiB / 1.049 MB | 8 MiB / 8.39 MB | 27 MiB / 28.31 MB | **512 MiB / 536.9 MB** |
+| Peak simultaneous RNG payload (~2 vectors) | 256 KiB / 262.1 kB | 2 MiB / 2.10 MB | 6.75 MiB / 7.08 MB | 128 MiB / 134.2 MB |
+| Memory grid (8 × f32 = 32 B/voxel) | 1 MiB / 1.049 MB | 8 MiB / 8.39 MB | 27 MiB / 28.31 MB | 512 MiB / 536.9 MB |
+| `states` (u8) | 32 KiB | 256 KiB | 864 KiB | 16 MiB / 16.78 MB |
+| `inactivity_steps` (i16) | 64 KiB | 512 KiB | 1.6875 MiB | 32 MiB / 33.55 MB |
+| `age_grid` (f32) | 128 KiB | 1 MiB | 3.375 MiB | 64 MiB / 67.11 MB |
+| `half_step_flags` (`Vec<bool>`, **1 B/element**) | 32 KiB | 256 KiB | 864 KiB | 16 MiB / 16.78 MB |
+
+**`Vec<bool>` correction (direct evidence contradicts the bit-packed assumption):** in
+Rust, `bool` is guaranteed 1 byte and `Vec<T>` stores contiguous `T`; unlike C++'s
+`std::vector<bool>`, **Rust's `Vec<bool>` is not bit-packed**. Arithmetic above uses
+1 B/element accordingly.
+
+**Other principal per-step transients** (from `step()` source): `out` state clone
+(u8, `:39`) and `pre_mut` clone (`:173`) — 16 MiB each at 256³; `neighbor_counts`
+(`[i16; 5]`/cell, `:35`) — **160 MiB at 256³, the largest single transient**;
+`nonvoid_counts` (i16, `:36`) — 32 MiB. Allocator behavior, capacity growth and
+transient-copy effects are **unmeasured** and excluded from the totals above.
+
+## C. Semantic contracts (five distinct properties — none implies the next)
+
+1. **Existing Xoshiro sequential-stream determinism.** Given (seed, initial state,
+   config), the current kernel replays exactly: draws come from one serial stream in
+   fixed program order. *Established by construction* (`stepper.rs`, `rng_util.rs`).
+2. **Dense-pre-draw / sparse-apply trajectory preservation.** If vectors continue to be
+   generated **densely, in the identical order and count**, but are *consumed* sparsely,
+   the existing trajectory is preserved bit-for-bit. Preservation lives in generation,
+   not consumption. (Design option; not implemented here.)
+3. **Counter-indexed access-order independence.** A pure function of a key tuple returns
+   the same value regardless of traversal order, thread schedule, or which other keys
+   are queried. *This is the property the laboratory demonstrates.*
+4. **Statistical similarity.** Counter output distribution ≈ Xoshiro output distribution
+   by statistical tests. **Not established by (3)** and not claimed by the laboratory.
+5. **Existing-trajectory identity.** Counter-indexed draws produce a **different random
+   stream** from sequential Xoshiro and therefore **different trajectories** — even with
+   the same seed. **(3) does not establish (4) or (5); nothing in this contract or the
+   laboratory claims the new stream preserves existing Medusa trajectories.**
+
+## D. Counter-key proposal (proposed, not canonized)
+
+Proposed key tuple:
+
+```text
+{ seed: u64, generation: u32, phase_id: u16, voxel_index: u64, draw_lane: u16 }
+```
+
+Requirements any implementation must meet:
+
+- **Domain separation:** fields folded in a fixed, documented order through a mixing
+  chain, with a stream-version constant folded first, so no two distinct tuples collapse
+  by field-boundary aliasing.
+- **Stable integer widths:** exactly the widths above; widening or reordering is a
+  stream-version change.
+- **No dependence on traversal order or thread scheduling:** output is a pure function
+  of the tuple; no global mutable state.
+- **Deterministic mapping to `[0,1)`:** upper 24 bits of the mixed u64, scaled by 2⁻²⁴ —
+  yields at most (2²⁴−1)/2²⁴ < 1.0; can never produce 1.0.
+- **Versioning:** a `LAB_STREAM_VERSION` constant participates in mixing; any algorithm
+  or constant change must bump it so replay identity cannot silently drift (golden-vector
+  tests make drift visible).
+- **No cryptographic-security claim** — the mixer is a statistical utility, never a
+  security primitive.
+- **No collision-freedom claim:** with a 64-bit output space, output coincidences across
+  large key populations are expected (birthday behavior) and acceptable for f32 use;
+  key→output determinism is what matters, and nothing more is claimed.
+
+## E. Sparse / quiescence analysis (per-phase inventory)
+
+Phases able to **create a non-VOID state**: Phase 2 transition table (VOID + dominant
+neighbor — requires a non-VOID cell in the 26-Moore shell, `:44`); Phase 2.5 Anti-Star
+(VOID with ≥1 COMPUTE neighbor, `:66`). **No other phase writes a non-VOID state into a
+VOID cell**: stochastic/contagion/energy/decay/mutation all gate on non-VOID sources
+(mutation explicitly `pre_mut[i] != VOID`, `:490`).
+
+Phases that **mutate states probabilistically**: 2.5, 6, 7, 8, 11, 13, 15 (table in §A).
+Phases that **update memory/counters in otherwise state-unchanged regions**:
+`decay_cooldown` every step (`:119`, memory-wide); memory aging (Phase 12, `:154`);
+metta warmth (Phase 9, `:140`); inactivity counters (Phase 10, `:144`); signal-generation
+nervous system (Phase 5) including mycelial signal-field iteration.
+Phases that **reach beyond the 26-neighbor Moore shell**: Phase 5 only — mindsight radius
+12, mycelial `k_iter` 3 (iterative diffusion), compassion `distance_scale` 15
+(`memory.rs:87–99`); all others are r ≤ 1.
+
+**Certification result:** an **all-VOID block whose 1-cell halo is also all-VOID cannot
+gain a non-VOID state in one tick** — state-quiescence is certifiable from the gating
+above, k ticks requiring a width-k all-VOID halo (states only, r = 1 growth). **Exact
+preconditions for full (state + memory) quiescence:**
+
+1. Block + width-k halo all-VOID for k ticks (state channel), **and**
+2. every memory channel in the block sits at a per-channel fixed point of the
+   memory-wide operations (`decay_cooldown`, aging) — zero-valued channels are fixed
+   points only if those operations are multiplicative/floor-clamped, which requires a
+   dedicated one-file verification of `phase6c::decay_cooldown` and
+   `apply_memory_aging` before any use, **and**
+3. no signal generation occurs in the window (default: gen % 10 ≠ 0), **or** the
+   signal-field/mycelial influx is separately bounded away from the halo, **and**
+4. RNG draw alignment is preserved by dense pre-draw or counter indexing (§C.2/C.3) —
+   under the current sequential stream, skipping *generation* of any vector changes the
+   trajectory globally.
+
+Nothing here implements skipping; this section only states what a future implementation
+would have to prove.
+
+## F. Experiment contract (locked questions for the PR 2 laboratory)
+
+The laboratory answers exactly these questions, on CPU toy workloads only:
+
+1. Is counter access **repeatable**? (same tuple → same output, across runs)
+2. Is it **independent of lookup order**? (forward / reverse / sparse traversals agree
+   per index)
+3. Does **dense counter materialization reproduce direct counter lookup** for the same
+   indices?
+4. What is the **CPU throughput** of: sequential Xoshiro materialization into `Vec<f32>`;
+   counter materialization into `Vec<f32>`; direct dense counter consumption (no
+   intermediate vector); sparse counter lookup?
+5. How do results vary across bounded toy sizes (32³, 64³, optionally 96³) and access
+   densities (1%, 10%, 50%)?
+
+**What the experiment cannot prove:** statistical adequacy for Medusa physics;
+trajectory equivalence with the existing Xoshiro stream (§C.5 — explicitly different);
+any GPU speedup; physics stability under a different stream; or that production
+integration is safe. Production integration is out of scope until Jack audits both PRs
+and AURA reviews the corrected semantics, and would in any case be a separate
+engine/kernel gate.

--- a/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
+++ b/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
@@ -24,7 +24,7 @@ to whether or when a vector is generated re-times all later draws.
 | Vector | Generated at | Consumed by | Conditionality | Consuming cells (evidence) | Lifetime / coexistence |
 |---|---|---|---|---|---|
 | `rng_vals` | `stepper.rs:32` | Phase 2.5 Anti-Star (`:67`); Phase 3 equanimity mask (`phase4.rs:38`) | Generation **unconditional**; Anti-Star consumption gated by `params.antistar_enabled` (default `true`, `memory.rs:179`) | VOID cells with ≥1 COMPUTE neighbor (nucleation, `:66`); COMPUTE cells (resist check, `phase4.rs:38`) | **Function-scoped** — allocated before Phase 1, last read at `:92`, freed at end of `step()`; coexists with every later vector |
-| `rng_vals2` | `:110` | Phase 5 nervous system → `apply_compassion` (`phase6c.rs:90`) | **Interval-conditional**: `signal_interval > 0 && gen % signal_interval == 0` (default interval 10, `memory.rs:177`) | Mature COMPUTE (compassion donation, `phase6c.rs:139–141`) | Block-scoped |
+| `rng_vals2` | `:110` | Phase 5 nervous system → `apply_compassion` (`phase6c.rs:90`) | **Interval-conditional**: `signal_interval > 0 && gen % signal_interval == 0` (default interval 10, `memory.rs:177`) | Mature COMPUTE only — one stochastic-activation draw per candidate (`phase6c.rs:176`); activation probability additionally depends on the **global** `compute_max_age` reduction (`stepper.rs:103–107`) | Block-scoped |
 | `rng_vals3` | `:123` | Phase 6 `apply_stochastic` (`:211+`) | `config.stochastic.enabled` (**default `true`**, `params.rs:26`) | Per-state stochastic transitions (e.g. STRUCTURAL→ENERGY/SENSOR probs, `params.rs:14–15`) | Block-scoped |
 | `rng_vals4` | `:129` | Phase 7 `apply_forward_contagion` (`:246+`) | `config.contagion.enabled` (**default `true`**, `params.rs:55`) | Contagion-eligible non-VOID cells (`:250`) | Block-scoped |
 | `rng_vals5` | `:135` | Phase 8 `apply_reverse_contagion` (`:282–290`) | **Unconditional** | STRUCTURAL with COMPUTE neighbors (reclaim, `:290`) | Block-scoped |
@@ -128,29 +128,62 @@ VOID cell**: stochastic/contagion/energy/decay/mutation all gate on non-VOID sou
 
 Phases that **mutate states probabilistically**: 2.5, 6, 7, 8, 11, 13, 15 (table in §A).
 Phases that **update memory/counters in otherwise state-unchanged regions**:
-`decay_cooldown` every step (`:119`, memory-wide); memory aging (Phase 12, `:154`);
-metta warmth (Phase 9, `:140`); inactivity counters (Phase 10, `:144`); signal-generation
-nervous system (Phase 5) including mycelial signal-field iteration.
-Phases that **reach beyond the 26-neighbor Moore shell**: Phase 5 only — mindsight radius
-12, mycelial `k_iter` 3 (iterative diffusion), compassion `distance_scale` 15
-(`memory.rs:87–99`); all others are r ≤ 1.
+`decay_cooldown` every step (`:119`, memory-wide, subtract-and-clamp — 0 is a verified
+fixed point, `phase6c.rs:209–218`); memory aging (Phase 12 — the VOID branch writes
+exactly the `init_memory()` defaults, `stepper.rs:404–410` vs `memory.rs:190–195`, so
+already-reset VOID cells are an idempotent fixed point); metta warmth (Phase 9 —
+memory-wide multiplicative decay ×`metta_warmth_decay`, 0 is a fixed point,
+`phase6a.rs:26`); sympathetic joy (Phase 4 — writes only where the r≤1 max-neighbor
+COMPUTE age exceeds `equanimity_age_min`, `phase6b.rs:37–43`; no-op in all-VOID
+regions); inactivity counters (Phase 10 — writes 0 over 0 for VOID cells,
+`stepper.rs:322–324`); signal-field store on signal generations (writes the computed
+value to **every** cell, `phase6c.rs:81–82` — 0 over 0 in regions the signal cannot
+reach).
 
-**Certification result:** an **all-VOID block whose 1-cell halo is also all-VOID cannot
-gain a non-VOID state in one tick** — state-quiescence is certifiable from the gating
-above, k ticks requiring a width-k all-VOID halo (states only, r = 1 growth). **Exact
-preconditions for full (state + memory) quiescence:**
+**Interaction-support classification (evidence-corrected):**
 
-1. Block + width-k halo all-VOID for k ticks (state channel), **and**
-2. every memory channel in the block sits at a per-channel fixed point of the
-   memory-wide operations (`decay_cooldown`, aging) — zero-valued channels are fixed
-   points only if those operations are multiplicative/floor-clamped, which requires a
-   dedicated one-file verification of `phase6c::decay_cooldown` and
-   `apply_memory_aging` before any use, **and**
-3. no signal generation occurs in the window (default: gen % 10 ≠ 0), **or** the
-   signal-field/mycelial influx is separately bounded away from the halo, **and**
+- `mindsight_radius` (default 12) **is a genuine configured hard radius**: a separable
+  periodic box filter of exactly that radius (`filters.rs:79–133`) smooths SENSOR
+  density. It affects signal *values computed at SENSOR cells*; it does not by itself
+  write state or memory at distance.
+- `mycelial_k_iter` (default 3) is **iterative r=1 diffusion through ENERGY-masked
+  cells** (`filters.rs:143–186`); with the two r=1 delivery steps around it
+  (`phase6c.rs:53`, `:77`), the signal chain's hard support is ≤ `k_iter + 2` cells
+  from source SENSOR/ENERGY structures — and it propagates only *through* non-VOID
+  masks.
+- `compassion_distance_scale` **is defined but never consumed in this kernel**
+  (`memory.rs:97`, `:173`; no other reference in `src/` — verified by search). It must
+  not be treated as an interaction radius *or* a distance weighting here. Compassion's
+  actual shape: activation is stochastic per mature COMPUTE cell (`phase6c.rs:176`)
+  with a **global input** (the `compute_max_age` max-reduction over all COMPUTE cells,
+  `stepper.rs:103–107`); its remote-buff *writes* go to the 26-Moore shell only
+  (`phase6c.rs:188–199`).
+- All state-creating writes into VOID cells originate from sources within **r ≤ 1**
+  (transition `:44`, Anti-Star `:66`); all memory writes into VOID cells are either
+  fixed-point self-writes (above) or r ≤ 1 deliveries (compassion buff `:198`,
+  signal delivery `filters.rs` ±1 kernels). **Corrected halo law: the non-VOID front
+  advances at most 1 cell per tick.** The earlier working assumption that
+  mindsight/mycelial/compassion imply a 12–15-cell interaction halo is withdrawn.
+
+**Certification result (state channel):** an all-VOID block whose width-k halo is
+all-VOID (periodic distance — boundaries wrap, `voxel_lattice.rs:56–62`) cannot gain a
+non-VOID state within k ticks. **Exact preconditions for full (state + memory)
+quiescence:**
+
+1. Block + width-k all-VOID halo, measured in periodic (toroidal) distance, **and**
+2. every memory channel in the block at its per-channel fixed point — all six
+   memory-writing operations above are now source-verified as fixed-point-preserving
+   on reset-valued VOID cells (multiplicative-to-zero, subtract-and-clamp-to-zero, or
+   idempotent reset), **and**
+3. on signal generations (default: every 10th), the signal chain's ≤ `k_iter + 2`
+   masked support cannot reach the block interior — guaranteed when the halo itself is
+   all-VOID, since the chain propagates only through SENSOR/ENERGY cells, **and**
 4. RNG draw alignment is preserved by dense pre-draw or counter indexing (§C.2/C.3) —
    under the current sequential stream, skipping *generation* of any vector changes the
-   trajectory globally.
+   trajectory globally, **and**
+5. global read-only reductions (`compute_max_age`, metrics, census) are still executed
+   — they read non-VOID cells elsewhere and do not wake VOID blocks, but a scheduler
+   that skips *reading* active blocks would corrupt them.
 
 Nothing here implements skipping; this section only states what a future implementation
 would have to prove.
@@ -170,9 +203,28 @@ The laboratory answers exactly these questions, on CPU toy workloads only:
 5. How do results vary across bounded toy sizes (32³, 64³, optionally 96³) and access
    densities (1%, 10%, 50%)?
 
+**Golden-vector independence (binding on the laboratory):** golden vectors must NOT be
+generated solely by the Rust implementation under test. The fixtures must be:
+
+- derived from **independently expressed calculations** — at least two genuinely
+  separate formulations (different languages/expression forms of the locked spec), or
+  one independent exact-integer oracle plus manually derived boundary cases (zero,
+  maximum-width, wrapping, and domain-separation adjacency);
+- computed against an **exactly locked specification**: all arithmetic is unsigned
+  64-bit with wrapping (mod 2⁶⁴) semantics; narrower fields are zero-extended to u64
+  before mixing; fields fold in a fixed documented order with a version constant first
+  (domain separation); **byte order is not applicable** — the algorithm consumes
+  integers, never serialized bytes; float conversion is locked as
+  `f32 = (u64_output >> 40) × 2⁻²⁴` (top 24 bits; cannot produce 1.0);
+- compared against implementation output, with any mismatch treated as
+  specification-or-implementation defect, never "close enough";
+- never used to claim statistical quality — a short vector table demonstrates
+  *identity to specification only*.
+
 **What the experiment cannot prove:** statistical adequacy for Medusa physics;
-trajectory equivalence with the existing Xoshiro stream (§C.5 — explicitly different);
-any GPU speedup; physics stability under a different stream; or that production
-integration is safe. Production integration is out of scope until Jack audits both PRs
-and AURA reviews the corrected semantics, and would in any case be a separate
-engine/kernel gate.
+trajectory equivalence with the existing Xoshiro stream (§C.5 — explicitly different:
+a counter generator defines a **new deterministic stream**, and no claim of live-engine
+equivalence is made or implied anywhere in this contract); any GPU speedup; physics
+stability under a different stream; or that production integration is safe. Production
+integration is out of scope until Jack audits both PRs and AURA reviews the corrected
+semantics, and would in any case be a separate engine/kernel gate.

--- a/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
+++ b/docs/COUNTER_INDEXED_RNG_FEASIBILITY.md
@@ -28,7 +28,7 @@ to whether or when a vector is generated re-times all later draws.
 | `rng_vals3` | `:123` | Phase 6 `apply_stochastic` (`:211+`) | `config.stochastic.enabled` (**default `true`**, `params.rs:26`) | Per-state stochastic transitions (e.g. STRUCTURAL→ENERGY/SENSOR probs, `params.rs:14–15`) | Block-scoped |
 | `rng_vals4` | `:129` | Phase 7 `apply_forward_contagion` (`:246+`) | `config.contagion.enabled` (**default `true`**, `params.rs:55`) | Contagion-eligible non-VOID cells (`:250`) | Block-scoped |
 | `rng_vals5` | `:135` | Phase 8 `apply_reverse_contagion` (`:282–290`) | **Unconditional** | STRUCTURAL with COMPUTE neighbors (reclaim, `:290`) | Block-scoped |
-| `rng_vals6` | `:149` | Phase 11 `apply_energy_conversion` (`:333–345`) | **Unconditional** | ENERGY/COMPUTE (biofilm leech `:340`, 5% branch `:345`) | Block-scoped |
+| `rng_vals6` | `:149` | Phase 11 `apply_energy_conversion` (`:333–345`) | **Unconditional** | **ENERGY cells only** — `rng_vals[i]` is consulted solely inside the `states[i] == ENERGY` branch (`:337–345`: biofilm leech `:340`, super-pod 5% branch `:345`). COMPUTE cells are counted as *neighbors* for the biofilm condition but never consume this phase's draw. Vector generation remains dense and unconditional; this distinction concerns sparse consumption only | Block-scoped |
 | `rng_vals7` | `:161` | Phase 13 `apply_decay_resistance` (`:426–472`) | **Unconditional** | Non-VOID decay candidates (`decay_prob` draw, `:472`) | Block-scoped |
 | `rng_vals8` | `:174` | Phase 15 `apply_analogue_mutation` (`:483–493`) | **Unconditional** | Non-VOID cells (`pre_mut[i] != VOID`, `:490`); the same value is reused for the replacement-state pick (`:493`) | Block-scoped |
 
@@ -65,6 +65,22 @@ Rust, `bool` is guaranteed 1 byte and `Vec<T>` stores contiguous `T`; unlike C++
 `std::vector<bool>`, **Rust's `Vec<bool>` is not bit-packed**. Arithmetic above uses
 1 B/element accordingly.
 
+**`Vec<bool>` allocations, distinguished:**
+
+- `half_step_flags` — a **persistent, lattice-resident field** of `VoxelLattice`
+  (`voxel_lattice.rs:23–24`), allocated at n³ for the lattice's lifetime. (An automated
+  review suggestion claimed this field does not exist; that claim is **contradicted by
+  the live source** at `voxel_lattice.rs:23–24` — the review thread is left untouched
+  for the auditor.)
+- `equanimity_mask` — a **separate per-step transient** `Vec<bool>` returned by
+  `compute_equanimity_mask` (`stepper.rs:92`, `phase4.rs`), dropped within `step()`.
+- `sensor_mask` / `energy_mask` — **additional per-signal-generation transients**
+  (`phase6c.rs:52`, `:56`), allocated only when the nervous system runs.
+
+The table above is **payload arithmetic** (logical bytes of the named arrays), not a
+complete peak-resident-memory measurement; allocator capacity, metadata, and exact peak
+residency remain **unmeasured**.
+
 **Other principal per-step transients** (from `step()` source): `out` state clone
 (u8, `:39`) and `pre_mut` clone (`:173`) — 16 MiB each at 256³; `neighbor_counts`
 (`[i16; 5]`/cell, `:35`) — **160 MiB at 256³, the largest single transient**;
@@ -85,10 +101,21 @@ transient-copy effects are **unmeasured** and excluded from the totals above.
    are queried. *This is the property the laboratory demonstrates.*
 4. **Statistical similarity.** Counter output distribution ≈ Xoshiro output distribution
    by statistical tests. **Not established by (3)** and not claimed by the laboratory.
-5. **Existing-trajectory identity.** Counter-indexed draws produce a **different random
-   stream** from sequential Xoshiro and therefore **different trajectories** — even with
-   the same seed. **(3) does not establish (4) or (5); nothing in this contract or the
-   laboratory claims the new stream preserves existing Medusa trajectories.**
+5. **Existing-trajectory identity.** LAB-CRNG-v1 deliberately defines a **new
+   deterministic stream**: its draws differ from sequential Xoshiro and therefore
+   produce **different trajectories** — even with the same seed. **(3) does not
+   establish (4) or (5); nothing in this contract or the laboratory claims the new
+   stream preserves existing trajectories.**
+
+6. **Scope of the incompatibility statement.** Point 5 is a property of *this proposed
+   mixer*, not a universal impossibility: a random-access **jump-ahead/offset mapping**
+   from `(generation, phase, index)` to the current Xoshiro serial offset is
+   theoretically possible in principle (Xoshiro supports jump functions; a full mapping
+   would additionally have to reproduce the **conditional whole-vector generation**
+   predicates of §A — enabled/interval flags decide whether a vector exists at all).
+   Such a design may be complex or uneconomic, **was not proven impossible, and is not
+   proposed, designed, or benchmarked here**. Dense pre-draw (point 2) remains the
+   direct way to preserve today's stream.
 
 ## D. Counter-key proposal (proposed, not canonized)
 
@@ -114,9 +141,25 @@ Requirements any implementation must meet:
   tests make drift visible).
 - **No cryptographic-security claim** — the mixer is a statistical utility, never a
   security primitive.
-- **No collision-freedom claim:** with a 64-bit output space, output coincidences across
-  large key populations are expected (birthday behavior) and acceptable for f32 use;
-  key→output determinism is what matters, and nothing more is claimed.
+- **No collision-freedom claim:** the key space is larger than the 64-bit output space,
+  so the mapping cannot be injective; fixed-width field boundaries prevent
+  *structural concatenation ambiguity* between tuples, but they do not prevent two
+  distinct tuples from mixing to the same output. By birthday reasoning, u64 output
+  coincidences become plausible around ~2³² samples, and the 24-bit f32 projection
+  necessarily repeats far sooner (birthday scale ~2¹² ≈ 4,096 samples). **Neither kind
+  of repeat is, by itself, evidence of a defect**, and no cryptographic or
+  statistical-suitability claim follows. Key→output determinism is what matters.
+
+**Generation width and overflow (source truth, `[SRC]`):** `VoxelLattice.generation`
+is `u32` (`voxel_lattice.rs:22`) and stepping performs `lattice.generation += 1`
+(`stepper.rs:192`). Ordinary Rust **debug** builds panic on overflow while **release**
+builds wrap (unless overflow checks are configured otherwise), so cross-profile
+production behavior at 2³²−1 is **not presently a locked deterministic contract**. For
+the isolated laboratory: `CounterKey.generation` accepts the full u32 domain **as
+data**; max-u32 golden vectors are valid *algorithm fixtures* and do **not** prove the
+current stepper reaches or wraps through that generation identically across build
+profiles. A future production integration must explicitly choose checked, saturating,
+or wrapping semantics — that engine decision is not made here.
 
 ## E. Sparse / quiescence analysis (per-phase inventory)
 
@@ -228,3 +271,103 @@ equivalence is made or implied anywhere in this contract); any GPU speedup; phys
 stability under a different stream; or that production integration is safe. Production
 integration is out of scope until Jack audits both PRs and AURA reviews the corrected
 semantics, and would in any case be a separate engine/kernel gate.
+
+---
+
+## Appendix — LAB-CRNG-v1 normative specification and golden vectors
+
+This appendix is **self-sufficient**: a third party can reproduce every golden vector
+from this text alone, without access to any scratch script.
+
+### A.1 Algorithm (proposed laboratory specification, normative)
+
+```text
+All operations are unsigned 64-bit (u64) modulo 2^64 (wrapping).
+">>" is a logical (zero-filling) right shift. "xor" is bitwise exclusive-or.
+Narrower input fields are zero-extended to u64 before use.
+Byte order is not applicable: the algorithm consumes integers, never serialized bytes.
+
+Constants:
+    DOMAIN  = 0x243F6A8885A308D3      (first 64 fractional bits of pi)
+    VERSION = 0x0000000000000001      (LAB_STREAM_VERSION = 1)
+    M1      = 0xBF58476D1CE4E5B9      (Stafford variant-13 multiplier 1)
+    M2      = 0x94D049BB133111EB      (Stafford variant-13 multiplier 2)
+
+mix64(z):
+    z = (z xor (z >> 30)) * M1        (wrapping multiply)
+    z = (z xor (z >> 27)) * M2        (wrapping multiply)
+    return z xor (z >> 31)
+
+counter_u64(seed: u64, generation: u32, phase_id: u16, voxel_index: u64, draw_lane: u16):
+    g   = zero_extend_u64(generation)                     (high 32 bits zero)
+    pl  = (zero_extend_u64(phase_id) << 16)
+          or zero_extend_u64(draw_lane)                   (disjoint u16 fields packed)
+    acc = mix64(DOMAIN xor VERSION)                       (initial accumulator)
+    acc = mix64(acc xor seed)                             (fold 1: seed)
+    acc = mix64(acc xor g)                                (fold 2: generation)
+    acc = mix64(acc xor pl)                               (fold 3: phase/lane pack)
+    acc = mix64(acc xor voxel_index)                      (fold 4: voxel index)
+    return acc                                            (final output point)
+
+counter_f32(...) :
+    top24 = counter_u64(...) >> 40                        (top 24 bits, integer)
+    return f32(top24) * 2^-24                             (exactly representable;
+                                                           result in [0, 1), never 1.0)
+```
+
+`voxel_index` is the row-major flat index `z·N² + y·N + x` (`voxel_lattice.rs:56–62`).
+Phase registry (append-only): 0 pre-step block · 1 nervous system · 2 stochastic ·
+3 forward contagion · 4 reverse contagion · 5 energy conversion · 6 decay resistance ·
+7 analogue mutation · 8+ reserved. Fixed-width field boundaries prevent structural
+concatenation ambiguity between tuples, but they do **not** make the larger key space
+injective into 64 output bits (see §D collision discussion).
+
+**Portability boundaries:** these integer operations are *expressible* on common GPU
+programming models; 64-bit multiplication cost and exact backend behavior remain
+**unmeasured**, Philox-style 32-bit arithmetic remains a future comparison candidate,
+and **no GPU compilation, execution, portability, or speedup was tested**. The PR 2
+laboratory is CPU-only.
+
+### A.2 Golden vectors (independently calculated, dual-formulation verified)
+
+Inputs are (seed, generation, phase_id, voxel_index, draw_lane). `top24 = u64 >> 40`.
+The f32 value `top24 × 2⁻²⁴` is exactly representable; laboratories must compare the
+**u64 outputs first**, then f32 by **exact/bit equality** (IEEE-754 bits given below) —
+never by floating tolerance. Decimal is supplementary display only.
+
+| ID | seed | gen | phase | index | lane | u64 output | top24 | f32 bits | f32 (display) |
+|---|---|---|---|---|---|---|---|---|---|
+| T1 zero | 0 | 0 | 0 | 0 | 0 | `0x966C920FE8E9DA97` | 9,858,194 | `0x3F166C92` | 0.58759415 |
+| T2 max seed | 2⁶⁴−1 | 0 | 0 | 0 | 0 | `0x9BBCF84A6EBF14FD` | 10,206,456 | `0x3F1BBCF8` | 0.60835218 |
+| T3 all max | 2⁶⁴−1 | 2³²−1 | 2¹⁶−1 | 2⁶⁴−1 | 2¹⁶−1 | `0x88D72CB6D8EE6248` | 8,967,980 | `0x3F08D72C` | 0.53453326 |
+| T4 gen boundary | 42 | 2³²−1 | 6 | 137 | 0 | `0x9E747B6304BBFFF3` | 10,384,507 | `0x3F1E747B` | 0.61896485 |
+| T5 base | 42 | 1000 | 6 | 137 | 0 | `0xAF3800A697FA60B3` | 11,483,136 | `0x3F2F3800` | 0.68444824 |
+| T6 adjacent index | 42 | 1000 | 6 | 138 | 0 | `0x5371121AAAE80CA2` | 5,468,434 | `0x3EA6E224` | 0.32594407 |
+| T7 adjacent phase | 42 | 1000 | 7 | 137 | 0 | `0x38BD0EC22AA02C6C` | 3,718,414 | `0x3E62F438` | 0.22163475 |
+| T8 adjacent lane | 42 | 1000 | 6 | 137 | 1 | `0x98A8A9BCD1C826C9` | 10,004,649 | `0x3F18A8A9` | 0.59632355 |
+| T9 realistic | 424,242 | 1,000,000 | 6 | 8,421,376 | 0 | `0xA76D5375031595F3` | 10,972,499 | `0x3F276D53` | 0.65401191 |
+| T10 wrap boundary | 2⁶³ | 2³¹ | 2¹⁵ | 2⁶³ | 2¹⁵ | `0x43AFED7293593EAF` | 4,435,949 | `0x3E875FDA` | 0.26440316 |
+
+T9 is a realistic tuple from the live phase map: registry phase 6 (decay resistance,
+the unconditional per-cell stochastic phase), a Medusa-scale generation, and a
+mid-lattice 256³ row-major index. T4/T10 are **algorithm fixtures** for the u32
+boundary — they do not prove stepper overflow behavior (§D generation note).
+
+### A.3 Provenance
+
+- **Formulation 1:** Node v22.19.0, `BigInt` with `BigInt.asUintN(64, ·)` wrapping.
+- **Formulation 2:** Windows PowerShell 5.1 / .NET `System.Numerics.BigInteger` with
+  explicit mod-2⁶⁴ masking — a genuinely separate engine, parser, and operator set.
+- **Defect caught by independence:** the first PowerShell run diverged on the three
+  tuples whose `generation` had bit 31 set, because PowerShell parses hex literals such
+  as `0xFFFFFFFF` as *signed* int32 (−1) and BigInteger sign-extends. The specification
+  was unambiguous; that formulation's *expression* was wrong. It was corrected by
+  enforcing the spec's explicit field-width masks (zero-extension) inside the function,
+  after which **all ten tuples agree exactly across both formulations**. This episode
+  is retained as evidence for the dual-oracle requirement in §F.
+- f32 bit patterns were derived mechanically (IEEE-754 encoding of exactly-representable
+  values) in the Node formulation; the PowerShell formulation cross-confirms the decimal
+  values.
+- Scratch scripts were **not committed** anywhere; this appendix supersedes them.
+- These vectors prove **conformity to the proposed laboratory specification only** —
+  no statistical or cryptographic property is claimed from them.


### PR DESCRIPTION
## What (Kev-authorized runway — PR 1 of 2, design companion to the isolated laboratory PR)

One new file: `docs/COUNTER_INDEXED_RNG_FEASIBILITY.md`. Feasibility contract only — no code, no physics change, no engine claims; scope limited to the maintained CPU `uft_ca` kernel.

**Contents (all sections evidence-anchored to exact paths/lines):**
- **A. Consumption map** — the true stepper RNG shape: 5 unconditional vectors + 2 default-enabled conditionals (`stochastic`/`contagion`, `params.rs:26/:55`) + 1 signal-interval vector = **7 ordinary / 8 signal generations**, all from one sequential Xoshiro stream; peak coexistence **~2 vectors**, not 7–8 (function-scoped initial vector vs block-scoped rest).
- **B. Memory arithmetic** — 32³/64³/96³ calculated logical payload sizes + 256³ analytical (nothing allocated or profiled), MiB and MB distinguished; **corrected `Vec<bool>` assumption (Rust does NOT bit-pack; 1 B/element)**; principal transients incl. the 160 MiB `neighbor_counts` at 256³; allocator effects marked unmeasured.
- **C. Five semantic contracts** — sequential-stream determinism · dense-pre-draw/sparse-apply trajectory preservation · counter access-order independence · statistical similarity · existing-trajectory identity — with the explicit statement that (3) establishes neither (4) nor (5): **counter indexing is a different stream and different trajectories**.
- **D. Counter-key proposal** (not canonized): `{seed u64, generation u32, phase_id u16, voxel_index u64, draw_lane u16}`, domain separation, stable widths, order/schedule independence, [0,1) mapping that cannot yield 1.0, stream versioning, no crypto/collision-freedom claims.
- **E. Quiescence analysis** — per-phase inventory: only Phase 2 (dominant-neighbor) and Phase 2.5 (Anti-Star) create non-VOID from VOID, both requiring r≤1 non-VOID neighbors ⇒ all-VOID block + width-k all-VOID halo is state-quiescent for k ticks; full quiescence preconditions (memory fixed-points, signal-generation exclusion, draw-alignment preservation) stated, not implemented.
- **F. Locked experiment contract** for PR 2, including the explicit cannot-prove list (no statistical adequacy, no trajectory equivalence, no GPU claims, no production integration).

## Verification
Docs-only: markdown/path review done; all arithmetic recalculated independently (powers of two by hand, decimal separately); phase counts checked against `stepper.rs` source line-by-line; no benchmark numbers appear anywhere in this PR by design. CI required checks expected green (docs-only diff).

## Lane
Unmerged — Jack audits. Companion laboratory arrives as PR 2 on an independent branch from the same base (`6f0c720`). No merge, no bypass, no settings, no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment (Jack audit, evidence-tightening pass — commit `ddbd863`)

**Head after amendment:** `ddbd863f97e3640cac28c2fc72055339d332eb69` (+79/−27, one file, docs-only).

1. **Interaction-support corrections (§E):** `mindsight_radius` confirmed as a genuine configured hard radius (separable periodic box filter, `filters.rs:79–133`); mycelial support = `k_iter + 2` through r=1 masked kernels; **`compassion_distance_scale` is defined but never consumed in this kernel** (`memory.rs:97`/`173`, no other `src/` reference) — it is neither a radius nor an active weighting here, and compassion's activation instead carries a **global** `compute_max_age` coupling (`stepper.rs:103–107`) while its writes are Moore r≤1 (`phase6c.rs:188–199`).
2. **Corrected halo law (§E):** all writes into VOID cells originate within r≤1 ⇒ the non-VOID front advances ≤1 cell/tick; the prior 12–15-cell interaction-halo assumption is withdrawn. All six memory-writing operations are now source-verified as fixed-point-preserving on reset-valued VOID cells; periodic (toroidal) halo distance made explicit; global-reduction scheduler caveat added.
3. **Golden-vector independence (§F):** fixtures must come from independently expressed calculations (two formulations or one oracle + manual boundary cases) against the locked spec — u64 wrapping, zero-extension of narrow fields, fixed fold order with version constant, byte order N/A (integer-only), `f32 = (u64 >> 40) × 2⁻²⁴`; vector tables prove specification identity only, never statistical quality.
4. **Stream-semantics hygiene (§C/§F):** explicit language that a counter generator defines a *new deterministic stream*; no live-engine equivalence is claimed anywhere in this contract.

Checks on `ddbd863`: `verify` ×2, `verify-python` ×2 (924/10/0), `agent-safety`, `tripwire` (quiet) — all green. Still **unmerged**; merge word remains withheld.

---

## Amendment 2 (Jack audit, eight-stage evidence pass — commit `ee88158`)

**Head:** `ee88158e8012d9e1fab84f45b3c133999ffbf7db` (+151/−8; cumulative vs main: one file, +373).

1. **Phase 11 consumer set corrected to ENERGY-only** (`apply_energy_conversion` consults `rng_vals[i]` solely inside `states[i] == ENERGY`, `stepper.rs:337–345`; COMPUTE cells are neighbor-counted, never consumers; generation stays dense/unconditional).
2. **`Vec<bool>` allocations distinguished:** persistent `half_step_flags` (`voxel_lattice.rs:23–24` — the automated review claim that this field does not exist is contradicted by live source; thread left untouched for the auditor) vs the per-step `equanimity_mask` transient vs signal-generation sensor/energy masks; §B relabelled **calculated logical payload arithmetic**, not peak-residency measurement.
3. **Durable Appendix added:** complete numeric LAB-CRNG-v1 algorithm (DOMAIN `0x243F6A8885A308D3`, VERSION 1, full Stafford-13 `mix64`, exact fold order, zero-extension, `(phase<<16)|lane` packing, `f32 = (u64>>40)×2⁻²⁴`) — third-party reproducible with no scratch-script access; **hardened golden table** (u64 + top-24 integer + exact IEEE-754 f32 bits per tuple; u64 compared first, f32 by bit equality, no tolerances; T9 recomputed with registry-valid phase 6 through both oracles).
4. **Xoshiro-compatibility claim narrowed** (§C.6): LAB-CRNG-v1 defines a new stream; a jump-ahead/offset mapping to the current serial stream was not proven impossible — it is out of scope, and any such map must include the conditional whole-vector predicates.
5. **Generation overflow contract recorded:** `generation: u32`, `+= 1` at `stepper.rs:192`; debug-panic vs release-wrap divergence means production wrap semantics are not presently locked; max-u32 goldens are algorithm fixtures only.
6. **Collision language corrected** (u64 birthday ≈2³²; 24-bit f32 projection birthday ≈2¹²; repeats ≠ defect) and **GPU wording bounded** (expressible on common GPU models; nothing compiled, executed, or measured on GPU; lab stays CPU-only).

Dual-oracle provenance (Node v22.19.0 BigInt + PowerShell/.NET BigInteger, the signed-hex parsing defect the independence rule caught, explicit field-width masking) is recorded in Appendix A.3. Scratch scripts uncommitted. Still **unmerged**; review threads untouched for Jack.
