### PR TITLE
frontend: restore TypeScript/build baseline (7 diagnostics → 0) in viz3d

### DIFF
--- a/utilityfog_frontend/frontend/src/viz3d/Edges.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/Edges.tsx
@@ -8,7 +8,7 @@ interface EdgesProps {
 }
 
 export default function Edges({ edges, nodes }: EdgesProps) {
-  const { geometry, colors } = useMemo(() => {
+  const geometry = useMemo(() => {
     const positions: number[] = []
     const colors: number[] = []
     
@@ -38,7 +38,7 @@ export default function Edges({ edges, nodes }: EdgesProps) {
     geometry.setAttribute('position', new BufferAttribute(new Float32Array(positions), 3))
     geometry.setAttribute('color', new BufferAttribute(new Float32Array(colors), 3))
 
-    return { geometry, colors }
+    return geometry
   }, [edges, nodes])
 
   if (edges.length === 0) {

--- a/utilityfog_frontend/frontend/src/viz3d/InstancedNodes.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/InstancedNodes.tsx
@@ -1,6 +1,5 @@
 import { useRef, useMemo, useEffect } from 'react'
-import { useFrame } from '@react-three/fiber'
-import { InstancedMesh, Matrix4, Color, Object3D } from 'three'
+import { InstancedMesh, Color, Object3D } from 'three'
 import { NetworkNode } from '../ws/SimBridgeClient'
 
 interface InstancedNodesProps {
@@ -18,7 +17,6 @@ export default function InstancedNodes({ nodes }: InstancedNodesProps) {
     if (!meshRef.current) return
 
     const mesh = meshRef.current
-    const matrix = new Matrix4()
 
     // Update instance matrices and colors
     nodes.forEach((node, index) => {
@@ -59,14 +57,6 @@ export default function InstancedNodes({ nodes }: InstancedNodesProps) {
       mesh.instanceColor.needsUpdate = true
     }
   }, [nodes, tempObject, tempColor, maxNodes])
-
-  useFrame((state) => {
-    if (!meshRef.current) return
-
-    // Optional: Add subtle animation
-    const time = state.clock.getElapsedTime()
-    // meshRef.current.rotation.y = time * 0.1
-  })
 
   return (
     <instancedMesh ref={meshRef} args={[undefined, undefined, maxNodes]}>

--- a/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
@@ -1,3 +1,6 @@
+/// <reference types="vite/client" />
+// Vite's client type declarations (shipped with the installed vite package)
+// type import.meta.env — no compiler flags or casts needed.
 import { Suspense } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Grid, Stats } from '@react-three/drei'

--- a/utilityfog_frontend/frontend/src/viz3d/ThreeScene.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/ThreeScene.tsx
@@ -1,4 +1,3 @@
-import { useFrame } from '@react-three/fiber'
 import InstancedNodes from './InstancedNodes'
 import Edges from './Edges'
 import { useSceneStore } from './useSceneStore'
@@ -13,11 +12,6 @@ export default function ThreeScene({ simClient }: ThreeSceneProps) {
   const { nodes, edges, updateNode, setNetwork } = useSceneStore()
   
   useEventQueue(simClient, { updateNode, setNetwork })
-
-  useFrame((state, delta) => {
-    // Animation loop for any continuous updates
-    // This runs at 60fps and can be used for smooth transitions
-  })
 
   return (
     <>

--- a/utilityfog_frontend/frontend/src/viz3d/utils.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/utils.ts
@@ -1,5 +1,3 @@
-import { Vector3 } from 'three'
-
 export function calculateDistance(pos1: [number, number, number], pos2: [number, number, number]): number {
   const [x1, y1, z1] = pos1
   const [x2, y2, z2] = pos2


### PR DESCRIPTION
## Scope (PR D of Kev's continuation runway)

Removes the seven pre-existing TypeScript build failures with minimal, behavior-preserving repairs. **Files: `src/viz3d/` only** — no App, tests, package metadata, config, WebSocket code, 2D components, workflows, or dependencies.

## Before → after (all seven diagnostics, recorded verbatim from clean `main`)
| # | Diagnostic (on `main = 6f0c720`) | Cause | Repair |
|---|---|---|---|
| 1 | `Edges.tsx(11,21) TS6133 'colors' … never read` | memo returned `{geometry, colors}`; only `geometry` consumed | return `geometry` alone — inner `colors` array still builds the color `BufferAttribute`; geometry construction byte-identical |
| 2 | `InstancedNodes.tsx(21,11) TS6133 'matrix'` | `new Matrix4()` created, never used (`tempObject.matrix` is what's applied) | remove the line + now-unused `Matrix4` import |
| 3 | `InstancedNodes.tsx(67,11) TS6133 'time'` | no-op `useFrame`: only live statement computed `time`; the rotation using it was already commented out | remove the dead `useFrame` block + now-unused `useFrame` import |
| 4 | `NetworkView3D.tsx(52,22) TS2339 'env' not on ImportMeta` | `import.meta.env.VITE_DEBUG_MODE` used without Vite's client types in scope | `/// <reference types="vite/client" />` — types ship with the installed `vite` package; **no casts, no `@ts-ignore`, no tsconfig/flag changes** |
| 5 | `ThreeScene.tsx(17,13) TS6133 'state'` | empty `useFrame` callback (comment-only body) | remove the callback + its import (also prevents a would-be 8th unused-import diagnostic) |
| 6 | `ThreeScene.tsx(17,20) TS6133 'delta'` | same empty callback | same removal |
| 7 | `utils.ts(1,1) TS6133 'Vector3'` | unused import | removed |

## Behavior confirmation
No rendering, geometry, node/edge colors, WebSocket event semantics, frame scheduling (removed callbacks scheduled zero work), camera, or public component props changed. Max-node cap (1000) and instance matrix/color update behavior untouched.

## Verification receipts (local, this seat)
- `npm install --no-package-lock --no-save` (no lockfile exists in the repo — PR E's separate package)
- `npx tsc --noEmit` → **zero errors** (was 7)
- `npm run build` → **success, first green build**: `dist/assets/index-*.css` 0.91 kB · `dist/assets/index-*.js` 979.38 kB (gzip 273.21 kB) · built in 2.52s (informational chunk-size warning only)
- `npm run test:ui` → **2 passed (2.7s)** (main's suite; local build artifacts restored to HEAD, not committed)
- `npm run lint` still fails solely because no ESLint config exists (expected, untouched — Packet F's subject)

## Governance
Stays **OPEN AND UNMERGED** for Jack's audit. Independent of PR #314 (not stacked; both branch from `6f0c720`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)