### PR TITLE
frontend: SimBridgeClient lifecycle — reconnect intent, idempotent connect, stale-socket guards

### DIFF
--- a/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
+++ b/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
@@ -90,47 +90,60 @@ export class SimBridgeClient {
   }
 
   private openSocket(): void {
+    let socket: WebSocket
     try {
-      const socket = new WebSocket(this.url)
-      this.ws = socket
-
-      socket.onopen = () => {
-        if (this.ws !== socket) return
-        console.log('Connected to SimBridge')
-        this.clearReconnectTimer()
-        this.emit('connected')
-      }
-
-      socket.onmessage = (event) => {
-        if (this.ws !== socket) return
-        try {
-          const data = JSON.parse(event.data)
-          this.handleMessage(data)
-        } catch (error) {
-          console.error('Error parsing message:', error)
-        }
-      }
-
-      socket.onclose = () => {
-        if (this.ws !== socket) return
-        this.ws = null
-        console.log('Disconnected from SimBridge')
-        this.emit('disconnected')
-        if (this.shouldReconnect) {
-          this.scheduleReconnect()
-        }
-      }
-
-      socket.onerror = (error) => {
-        if (this.ws !== socket) return
-        console.error('WebSocket error:', error)
-        this.emit('error', error)
-      }
+      socket = new WebSocket(this.url)
     } catch (error) {
+      // Synchronous construction failure (bad scheme, CSP, …): no socket
+      // exists, so the client must not keep pointing at a stale one.
+      // Surface the failure and retry on the normal schedule while
+      // reconnect intent holds — at most one timer, no duplicate sockets.
+      this.ws = null
       console.error('Failed to connect:', error)
+      this.emit('error', error)
       if (this.shouldReconnect) {
         this.scheduleReconnect()
       }
+      return
+    }
+    this.ws = socket
+
+    socket.onopen = () => {
+      if (this.ws !== socket) return
+      console.log('Connected to SimBridge')
+      this.clearReconnectTimer()
+      this.emit('connected')
+    }
+
+    socket.onmessage = (event) => {
+      if (this.ws !== socket) return
+      // Parse inside the catch boundary; dispatch outside it. A listener
+      // exception must surface through the page error channel, not be
+      // swallowed and mislabelled as a JSON parsing failure.
+      let data: any
+      try {
+        data = JSON.parse(event.data)
+      } catch (error) {
+        console.error('Error parsing message:', error)
+        return
+      }
+      this.handleMessage(data)
+    }
+
+    socket.onclose = () => {
+      if (this.ws !== socket) return
+      this.ws = null
+      console.log('Disconnected from SimBridge')
+      this.emit('disconnected')
+      if (this.shouldReconnect) {
+        this.scheduleReconnect()
+      }
+    }
+
+    socket.onerror = (error) => {
+      if (this.ws !== socket) return
+      console.error('WebSocket error:', error)
+      this.emit('error', error)
     }
   }
 

--- a/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
+++ b/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
@@ -18,57 +18,57 @@ interface NetworkEdge {
   strength: number
 }
 
+// Lifecycle contract (see tests/simbridge-lifecycle.spec.ts):
+//   - connect() enables reconnect intent; it is idempotent while the current
+//     socket is CONNECTING or OPEN.
+//   - Only the CURRENT socket instance may mutate connection state or
+//     schedule a reconnect — every handler checks socket identity, so late
+//     callbacks from an obsolete socket are inert.
+//   - An unexpected close emits 'disconnected' and schedules at most one
+//     reconnect. A successful open clears pending reconnect state.
+//   - disconnect() disables reconnect intent, clears any pending reconnect
+//     timer, releases the socket BEFORE closing it (so its close callback
+//     fails the identity check and can never schedule a reconnect), and
+//     emits 'disconnected' synchronously so UI state stays truthful.
+//   - A later explicit connect() starts a fresh socket.
 export class SimBridgeClient {
   private ws: WebSocket | null = null
   private url: string
   private listeners: Map<string, Set<(data?: any) => void>> = new Map()
-  private reconnectInterval = 5000
+  private reconnectInterval: number
   private reconnectTimer: number | null = null
+  private shouldReconnect = false
 
-  constructor(url: string) {
+  // reconnectIntervalMs is optional and defaults to the previous fixed
+  // 5000ms — existing `new SimBridgeClient(url)` calls are unchanged. Tests
+  // inject a short delay for deterministic reconnect timing.
+  constructor(url: string, reconnectIntervalMs: number = 5000) {
     this.url = url
+    this.reconnectInterval = reconnectIntervalMs
   }
 
   connect(): void {
-    try {
-      this.ws = new WebSocket(this.url)
-      
-      this.ws.onopen = () => {
-        console.log('Connected to SimBridge')
-        this.emit('connected')
-        this.clearReconnectTimer()
-      }
-
-      this.ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data)
-          this.handleMessage(data)
-        } catch (error) {
-          console.error('Error parsing message:', error)
-        }
-      }
-
-      this.ws.onclose = () => {
-        console.log('Disconnected from SimBridge')
-        this.emit('disconnected')
-        this.scheduleReconnect()
-      }
-
-      this.ws.onerror = (error) => {
-        console.error('WebSocket error:', error)
-        this.emit('error', error)
-      }
-    } catch (error) {
-      console.error('Failed to connect:', error)
-      this.scheduleReconnect()
+    this.shouldReconnect = true
+    if (
+      this.ws &&
+      (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)
+    ) {
+      return
     }
+    this.clearReconnectTimer()
+    this.openSocket()
   }
 
   disconnect(): void {
+    this.shouldReconnect = false
     this.clearReconnectTimer()
     if (this.ws) {
-      this.ws.close()
+      const socket = this.ws
+      // Release before closing: the socket's own close callback then fails
+      // the identity check and cannot schedule a reconnect.
       this.ws = null
+      socket.close()
+      this.emit('disconnected')
     }
   }
 
@@ -86,6 +86,51 @@ export class SimBridgeClient {
   send(data: any): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(data))
+    }
+  }
+
+  private openSocket(): void {
+    try {
+      const socket = new WebSocket(this.url)
+      this.ws = socket
+
+      socket.onopen = () => {
+        if (this.ws !== socket) return
+        console.log('Connected to SimBridge')
+        this.clearReconnectTimer()
+        this.emit('connected')
+      }
+
+      socket.onmessage = (event) => {
+        if (this.ws !== socket) return
+        try {
+          const data = JSON.parse(event.data)
+          this.handleMessage(data)
+        } catch (error) {
+          console.error('Error parsing message:', error)
+        }
+      }
+
+      socket.onclose = () => {
+        if (this.ws !== socket) return
+        this.ws = null
+        console.log('Disconnected from SimBridge')
+        this.emit('disconnected')
+        if (this.shouldReconnect) {
+          this.scheduleReconnect()
+        }
+      }
+
+      socket.onerror = (error) => {
+        if (this.ws !== socket) return
+        console.error('WebSocket error:', error)
+        this.emit('error', error)
+      }
+    } catch (error) {
+      console.error('Failed to connect:', error)
+      if (this.shouldReconnect) {
+        this.scheduleReconnect()
+      }
     }
   }
 
@@ -113,15 +158,19 @@ export class SimBridgeClient {
   }
 
   private scheduleReconnect(): void {
-    this.clearReconnectTimer()
+    if (this.reconnectTimer !== null) {
+      return
+    }
     this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.shouldReconnect) return
       console.log('Attempting to reconnect...')
-      this.connect()
+      this.openSocket()
     }, this.reconnectInterval)
   }
 
   private clearReconnectTimer(): void {
-    if (this.reconnectTimer) {
+    if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }

--- a/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
+++ b/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
@@ -1,0 +1,248 @@
+import { test, expect, Page } from '@playwright/test';
+
+// SimBridgeClient lifecycle contract tests.
+//
+// A deterministic in-page FakeWebSocket replaces window.WebSocket before the
+// app loads (so nothing ever dials a real backend), and the client module is
+// imported through the Vite dev server inside the browser. The fake fires
+// its close callback asynchronously, exactly like real browsers — that async
+// gap is what produced the original zombie-reconnect defect, so the fake
+// must reproduce it. Reconnect delay is injected (25ms) for determinism; no
+// long sleeps.
+
+const TEST_URL = 'ws://lifecycle-test';
+const RECONNECT_MS = 25;
+// Comfortably past one reconnect delay, far below two app-default delays.
+const AFTER_RECONNECT_MS = 4 * RECONNECT_MS;
+
+async function setupHarness(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      sent: string[] = [];
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send(data: string) {
+        this.sent.push(data);
+      }
+      close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        // Real browsers deliver onclose asynchronously after close().
+        setTimeout(() => {
+          if (this.onclose) this.onclose({});
+        }, 0);
+      }
+      // Test-side helpers (server-driven transitions are synchronous).
+      _open() {
+        this.readyState = 1;
+        if (this.onopen) this.onopen({});
+      }
+      _close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        if (this.onclose) this.onclose({});
+      }
+      _message(obj: unknown) {
+        if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
+      }
+    }
+    w.WebSocket = FakeWebSocket;
+  });
+  await page.goto('/');
+  await page.evaluate(async ({ url, delay }) => {
+    const w = window as any;
+    const mod = await import('/src/ws/SimBridgeClient.ts');
+    w.__h = {
+      events: [] as string[],
+      payloads: [] as Array<{ channel: string; payload: unknown }>,
+      client: new mod.SimBridgeClient(url, delay),
+      sockets: () => w.__fakeSockets.filter((s: any) => s.url === url),
+    };
+    w.__h.client.on('connected', () => w.__h.events.push('connected'));
+    w.__h.client.on('disconnected', () => w.__h.events.push('disconnected'));
+  }, { url: TEST_URL, delay: RECONNECT_MS });
+}
+
+const socketCount = (page: Page) =>
+  page.evaluate(() => (window as any).__h.sockets().length);
+const events = (page: Page) =>
+  page.evaluate(() => (window as any).__h.events as string[]);
+
+test.beforeEach(async ({ page }) => {
+  await setupHarness(page);
+});
+
+test('first connect creates exactly one socket; repeats while CONNECTING/OPEN are idempotent', async ({ page }) => {
+  await page.evaluate(() => (window as any).__h.client.connect());
+  expect(await socketCount(page)).toBe(1);
+
+  // Repeat while CONNECTING — no second socket.
+  await page.evaluate(() => (window as any).__h.client.connect());
+  expect(await socketCount(page)).toBe(1);
+
+  // Open, then repeat while OPEN — still no second socket.
+  await page.evaluate(() => (window as any).__h.sockets()[0]._open());
+  await page.evaluate(() => (window as any).__h.client.connect());
+  expect(await socketCount(page)).toBe(1);
+
+  // Open emitted 'connected' exactly once.
+  expect(await events(page)).toEqual(['connected']);
+});
+
+test('unexpected close emits disconnected and schedules exactly one reconnect', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.sockets()[0]._close(); // server-side drop
+  });
+  expect(await events(page)).toEqual(['connected', 'disconnected']);
+
+  // Exactly one replacement socket after the injected delay — and still
+  // exactly one after another full delay (at most one reconnect per close).
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(2);
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(2);
+
+  // Successful reopen clears pending reconnect state (no third socket).
+  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(2);
+});
+
+test('intentional disconnect never yields a replacement socket', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.client.disconnect(); // fake delivers its close callback async
+  });
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(1);
+  expect(await events(page)).toEqual(['connected', 'disconnected']);
+});
+
+test('disconnect clears an already-scheduled reconnect', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.sockets()[0]._close(); // schedules a reconnect...
+    h.client.disconnect();   // ...which this must cancel
+  });
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(1);
+});
+
+test('explicit connect after disconnect creates a fresh working socket', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.client.disconnect();
+  });
+  await page.evaluate(() => (window as any).__h.client.connect());
+  expect(await socketCount(page)).toBe(2);
+  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  expect(await events(page)).toEqual(['connected', 'disconnected', 'connected']);
+  expect(await page.evaluate(() => (window as any).__h.client.isConnected)).toBe(true);
+});
+
+test('late callbacks from an obsolete socket cannot affect the current connection', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.sockets()[0]._close(); // drop → reconnect scheduled
+  });
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  const before = await events(page);
+
+  // Fire every callback on the OBSOLETE socket: all must be inert.
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    const stale = h.sockets()[0];
+    if (stale.onopen) stale.onopen({});
+    if (stale.onmessage) stale.onmessage({ data: JSON.stringify({ type: 'node_update', payload: { id: 'stale' } }) });
+    if (stale.onclose) stale.onclose({});
+  });
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await events(page)).toEqual(before); // no new connected/disconnected
+  expect(await socketCount(page)).toBe(2);    // no extra reconnect socket
+  expect(await page.evaluate(() => (window as any).__h.client.isConnected)).toBe(true);
+});
+
+test('message routing and listener removal remain behaviorally compatible', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    for (const ch of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+      h.client.on(ch, (p: unknown) => h.payloads.push({ channel: ch, payload: p }));
+    }
+    h.client.connect();
+    h.sockets()[0]._open();
+    const s = h.sockets()[0];
+    s._message({ type: 'simulation_event', payload: { kind: 'tick' } });
+    s._message({ type: 'network_update', payload: { nodes: [] } });
+    s._message({ type: 'node_update', payload: { id: 'n1' } });
+    s._message({ type: 'edge_update', payload: { id: 'e1' } });
+  });
+  const payloads = await page.evaluate(() => (window as any).__h.payloads);
+  expect(payloads.map((p: any) => p.channel)).toEqual([
+    'simulation_event', 'network_update', 'node_update', 'edge_update',
+  ]);
+  expect(payloads[2].payload).toEqual({ id: 'n1' });
+
+  // off() prevents later delivery.
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.removable = (p: unknown) => h.payloads.push({ channel: 'removable', payload: p });
+    h.client.on('node_update', h.removable);
+    h.client.off('node_update', h.removable);
+    h.sockets()[0]._message({ type: 'node_update', payload: { id: 'n2' } });
+  });
+  const after = await page.evaluate(() => (window as any).__h.payloads);
+  expect(after.filter((p: any) => p.channel === 'removable')).toHaveLength(0);
+});
+
+test('send serializes only while OPEN and is a no-op otherwise', async ({ page }) => {
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.connect();
+    h.client.send({ early: true }); // CONNECTING — must be a no-op
+  });
+  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([]);
+
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.sockets()[0]._open();
+    h.client.send({ hello: 'world' });
+  });
+  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([
+    JSON.stringify({ hello: 'world' }),
+  ]);
+
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.disconnect();
+    h.client.send({ late: true }); // released socket — no-op
+  });
+  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([
+    JSON.stringify({ hello: 'world' }),
+  ]);
+});

--- a/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
+++ b/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
@@ -32,6 +32,12 @@ async function setupHarness(page: Page) {
       onclose: ((ev: unknown) => void) | null = null;
       onerror: ((ev: unknown) => void) | null = null;
       constructor(url: string) {
+        // Synchronous construction-failure injection (one-shot): throws
+        // BEFORE registration, so no instance exists for a failed attempt.
+        if (w.__throwNextConstruction) {
+          w.__throwNextConstruction = false;
+          throw new Error('synthetic construction failure');
+        }
         this.url = url;
         w.__fakeSockets.push(this);
       }
@@ -59,6 +65,9 @@ async function setupHarness(page: Page) {
       _message(obj: unknown) {
         if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
       }
+      _messageRaw(raw: string) {
+        if (this.onmessage) this.onmessage({ data: raw });
+      }
     }
     w.WebSocket = FakeWebSocket;
   });
@@ -74,6 +83,7 @@ async function setupHarness(page: Page) {
     };
     w.__h.client.on('connected', () => w.__h.events.push('connected'));
     w.__h.client.on('disconnected', () => w.__h.events.push('disconnected'));
+    w.__h.client.on('error', () => w.__h.events.push('error'));
   }, { url: TEST_URL, delay: RECONNECT_MS });
 }
 
@@ -218,6 +228,67 @@ test('message routing and listener removal remain behaviorally compatible', asyn
   });
   const after = await page.evaluate(() => (window as any).__h.payloads);
   expect(after.filter((p: any) => p.channel === 'removable')).toHaveLength(0);
+});
+
+test('malformed JSON logs a parse error and is never routed; no page error', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+  page.on('pageerror', (e) => pageErrors.push(e.message));
+
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.on('node_update', (p: unknown) => h.payloads.push({ channel: 'node_update', payload: p }));
+    h.client.connect();
+    h.sockets()[0]._open();
+    h.sockets()[0]._messageRaw('{this is not json');
+  });
+  await page.waitForTimeout(50);
+  expect(consoleErrors.some((t) => t.includes('Error parsing message'))).toBe(true);
+  expect(await page.evaluate(() => (window as any).__h.payloads.length)).toBe(0);
+  expect(pageErrors).toHaveLength(0);
+});
+
+test('a throwing listener surfaces as a page error and is not mislabelled as a parse error', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+  page.on('pageerror', (e) => pageErrors.push(e.message));
+
+  await page.evaluate(() => {
+    const h = (window as any).__h;
+    h.client.on('node_update', () => { throw new Error('SENTINEL_LISTENER_FAILURE'); });
+    h.client.connect();
+    h.sockets()[0]._open();
+    // Deliver from a timer so the throw leaves the test's own call stack
+    // and reaches the page's uncaught-error channel, as it would from a
+    // real socket event.
+    setTimeout(() => h.sockets()[0]._message({ type: 'node_update', payload: { id: 'n1' } }), 0);
+  });
+  await page.waitForTimeout(80);
+  expect(pageErrors.some((t) => t.includes('SENTINEL_LISTENER_FAILURE'))).toBe(true);
+  expect(consoleErrors.filter((t) => t.includes('Error parsing message'))).toHaveLength(0);
+});
+
+test('synchronous constructor failure emits one error, retries once, then connects normally', async ({ page }) => {
+  await page.evaluate(() => {
+    const w = window as any;
+    w.__throwNextConstruction = true;
+    w.__h.client.connect();
+  });
+  // The throwing construction registered no instance.
+  expect(await socketCount(page)).toBe(0);
+  expect(await events(page)).toEqual(['error']);
+
+  // Exactly one scheduled replacement attempt.
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(1);
+  await page.evaluate(() => (window as any).__h.sockets()[0]._open());
+  expect(await events(page)).toEqual(['error', 'connected']);
+
+  // No duplicate timers or sockets after another full delay.
+  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  expect(await socketCount(page)).toBe(1);
 });
 
 test('send serializes only while OPEN and is a no-op otherwise', async ({ page }) => {


### PR DESCRIPTION
## Scope (PR G of Kev's connection-reliability runway — amended per Jack's live audit)

**Files: `src/ws/SimBridgeClient.ts` + new `tests/simbridge-lifecycle.spec.ts` only.**

**Defects fixed:** (1) `disconnect()` closed the socket, but browsers deliver close callbacks asynchronously, so the close handler could still schedule a reconnect afterwards — an intentional disconnect could leave an unwanted reconnect. **React development StrictMode's mount/cleanup cycle reliably exposes this defect** (evidence-bounded claim; no assertion about production builds). (2) Repeated `connect()` created overlapping CONNECTING/OPEN sockets with no identity guards. (3, audit T1) The `onmessage` try/catch wrapped both `JSON.parse` and `handleMessage`, so a listener exception was swallowed and mislabelled as a parsing failure — parsing now sits inside the catch boundary and dispatch outside it; listener failures surface through the page error channel. (4, audit T2) A synchronous `new WebSocket()` throw now leaves `this.ws` null, emits the client's `error` event, retains reconnect intent, and schedules at most one retry.

## Lifecycle transition table
| State | Event | Next state | Effects |
|---|---|---|---|
| idle (no socket, no intent) | `connect()` | CONNECTING, intent=on | one socket created; pending timer cleared |
| CONNECTING / OPEN | `connect()` | unchanged | idempotent — no second socket |
| construction throws | — | idle-with-intent | `ws` left null; `error` emitted; at most one retry scheduled |
| CONNECTING | `onopen` (current socket) | OPEN | clears pending reconnect state; emits `connected` |
| OPEN | unexpected `onclose` (current) | waiting-reconnect (if intent) | emits `disconnected`; schedules at most one reconnect |
| waiting-reconnect | timer fires (intent on) | CONNECTING | one replacement socket |
| waiting-reconnect | `disconnect()` | idle, intent=off | timer cleared — no replacement |
| any (socket held) | `disconnect()` | idle, intent=off | socket released before close (its close callback fails the identity check); emits `disconnected` synchronously |
| idle after disconnect | `connect()` | CONNECTING, intent=on | fresh socket |
| any | callback from obsolete socket | unchanged | inert — identity check |
| OPEN | malformed JSON message | unchanged | logged as parse error; not routed |
| OPEN | listener throws during dispatch | unchanged | propagates to the page error channel; not logged as a parse error |

**Compatibility:** message routing, `on`/`off`, `send()` (serializes only while OPEN, no-op otherwise), `isConnected`, and existing `new SimBridgeClient(url)` calls unchanged. Optional `reconnectIntervalMs` arg (default 5000) exists solely for deterministic tests. No framework, no singleton, no swallowed listener exceptions.

## Test receipts (in-page deterministic fake WebSocket with async close; module via Vite dev server; 25ms injected delay; nothing external)
11 tests: the 8 original lifecycle behaviors + 3 audit regressions (malformed-JSON attribution and non-routing · sentinel listener exception via pageerror with no parse-error log · one-shot constructor failure → one `error`, one scheduled retry, then normal connect).
- **Local (amended head): `--repeat-each=3` → 33/33 (6.6s); suite 13/13 (4.0s); `tsc --noEmit` matches the 7-diagnostic main baseline with no additions.**

## Governance
Independent branch from `main = 6f0c720` (not stacked). Stays **OPEN AND UNMERGED** for Jack's audit. Review threads left unresolved for Jack; dispositions reported in the consolidated packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)