### PR TITLE
frontend: EventFeed channel fidelity, stable keys, bounded previews, log semantics

### DIFF
--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -1,37 +1,74 @@
-import { useState, useEffect } from 'react'
-import { SimBridgeClient, SimEvent } from '../ws/SimBridgeClient'
+import { useState, useEffect, useRef } from 'react'
+import { SimBridgeClient } from '../ws/SimBridgeClient'
 
 interface EventFeedProps {
   simClient: SimBridgeClient | null
 }
 
+// The four subscription channels this feed renders. The channel is captured
+// at subscription time and displayed as the event's type — a payload's own
+// `type` field can never spoof the channel label.
+const FEED_CHANNELS = [
+  'simulation_event',
+  'network_update',
+  'node_update',
+  'edge_update',
+] as const
+type FeedChannel = (typeof FEED_CHANNELS)[number]
+
+interface FeedEntry {
+  // Stable local identifier (monotonic per mounted feed) — the React key.
+  // Never the rendered array index, which shifts as entries prepend/expire.
+  id: number
+  channel: FeedChannel
+  timestamp: number
+  // Serialized exactly once, at insert time, through the bounded helper.
+  preview: string
+}
+
+const MAX_EVENTS = 50
+const PREVIEW_CHARS = 100
+
+// Bounded preview: pretty-printed JSON truncated to PREVIEW_CHARS with a
+// trailing ellipsis (length measured on the same string that is sliced — a
+// narrow consistency improvement over the previous compact-length check).
+// Every payload enters through JSON.parse in SimBridgeClient, so circular
+// structures cannot occur; the catch is a bounded last resort and never
+// hides ordinary valid payloads.
+function formatPreview(data: unknown): string {
+  try {
+    const full = JSON.stringify(data, null, 1)
+    if (full === undefined) return String(data)
+    return full.length > PREVIEW_CHARS ? `${full.slice(0, PREVIEW_CHARS)}...` : full
+  } catch {
+    return '[unserializable payload]'
+  }
+}
+
 export default function EventFeed({ simClient }: EventFeedProps) {
-  const [events, setEvents] = useState<SimEvent[]>([])
-  const maxEvents = 50
+  const [events, setEvents] = useState<FeedEntry[]>([])
+  const nextIdRef = useRef(0)
 
   useEffect(() => {
     if (!simClient) return
 
-    const handleEvent = (eventData: any) => {
-      const event: SimEvent = {
-        type: eventData.type || 'unknown',
-        timestamp: Date.now(),
-        data: eventData
+    const subscriptions = FEED_CHANNELS.map((channel) => {
+      const handler = (payload?: unknown) => {
+        const entry: FeedEntry = {
+          id: nextIdRef.current++,
+          channel,
+          timestamp: Date.now(),
+          preview: formatPreview(payload),
+        }
+        // Newest first; hold at most MAX_EVENTS.
+        setEvents(prev => [entry, ...prev.slice(0, MAX_EVENTS - 1)])
       }
-
-      setEvents(prev => [event, ...prev.slice(0, maxEvents - 1)])
-    }
-
-    simClient.on('simulation_event', handleEvent)
-    simClient.on('network_update', handleEvent)
-    simClient.on('node_update', handleEvent)
-    simClient.on('edge_update', handleEvent)
+      simClient.on(channel, handler)
+      return { channel, handler }
+    })
 
     return () => {
-      simClient.off('simulation_event', handleEvent)
-      simClient.off('network_update', handleEvent)
-      simClient.off('node_update', handleEvent)
-      simClient.off('edge_update', handleEvent)
+      subscriptions.forEach(({ channel, handler }) => simClient.off(channel, handler))
     }
   }, [simClient])
 
@@ -39,13 +76,12 @@ export default function EventFeed({ simClient }: EventFeedProps) {
     return new Date(timestamp).toLocaleTimeString()
   }
 
-  const getEventColor = (type: string) => {
-    switch (type) {
+  const getEventColor = (channel: FeedChannel) => {
+    switch (channel) {
       case 'node_update': return '#3b82f6'
       case 'edge_update': return '#10b981'
       case 'network_update': return '#f59e0b'
       case 'simulation_event': return '#8b5cf6'
-      default: return '#6b7280'
     }
   }
 
@@ -54,21 +90,24 @@ export default function EventFeed({ simClient }: EventFeedProps) {
       <h3 style={{ margin: '0 0 10px 0', color: 'white', fontSize: '16px' }}>
         Event Feed
       </h3>
-      <div style={{ maxHeight: '350px', overflowY: 'auto' }}>
+      {/* role="log" (implicitly polite live region): newly inserted events
+          are announced without turning the whole app into a live region. */}
+      <div role="log" aria-label="Event feed" style={{ maxHeight: '350px', overflowY: 'auto' }}>
         {events.length === 0 ? (
           <div style={{ color: '#9ca3af', fontStyle: 'italic' }}>
             No events yet...
           </div>
         ) : (
-          events.map((event, index) => (
+          events.map((event) => (
             <div
-              key={index}
+              key={event.id}
+              data-event-channel={event.channel}
               style={{
                 padding: '8px',
                 marginBottom: '6px',
                 backgroundColor: 'rgba(255, 255, 255, 0.1)',
                 borderRadius: '4px',
-                borderLeft: `3px solid ${getEventColor(event.type)}`,
+                borderLeft: `3px solid ${getEventColor(event.channel)}`,
               }}
             >
               <div
@@ -81,20 +120,21 @@ export default function EventFeed({ simClient }: EventFeedProps) {
               >
                 <span
                   style={{
-                    color: getEventColor(event.type),
+                    color: getEventColor(event.channel),
                     fontSize: '12px',
                     fontWeight: '600',
                   }}
                 >
-                  {event.type}
+                  {event.channel}
                 </span>
                 <span style={{ color: '#9ca3af', fontSize: '10px' }}>
                   {formatTime(event.timestamp)}
                 </span>
               </div>
+              {/* React renders this as text — payload content is never
+                  interpreted as markup. */}
               <div style={{ color: 'white', fontSize: '11px' }}>
-                {JSON.stringify(event.data, null, 1).slice(0, 100)}
-                {JSON.stringify(event.data).length > 100 ? '...' : ''}
+                {event.preview}
               </div>
             </div>
           ))

--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -29,15 +29,18 @@ interface FeedEntry {
 const MAX_EVENTS = 50
 const PREVIEW_CHARS = 100
 
-// Bounded preview: pretty-printed JSON truncated to PREVIEW_CHARS with a
-// trailing ellipsis (length measured on the same string that is sliced — a
-// narrow consistency improvement over the previous compact-length check).
-// Every payload enters through JSON.parse in SimBridgeClient, so circular
-// structures cannot occur; the catch is a bounded last resort and never
-// hides ordinary valid payloads.
+// Bounded, serialize-once preview: COMPACT JSON. The rendering div collapses
+// whitespace, so pretty-printing spent part of the 100-character budget on
+// formatting the user never saw — the cap now applies to the exact string
+// rendered, with the ellipsis appended only when truncated. String payloads
+// stay JSON-quoted (deliberate, test-locked): the preview shows the JSON
+// value, so "5" and 5 stay distinguishable and behavior matches the feed's
+// historical stringify-everything contract. Every payload enters through
+// JSON.parse in SimBridgeClient, so circular structures cannot occur; the
+// catch is a bounded last resort and never hides ordinary valid payloads.
 function formatPreview(data: unknown): string {
   try {
-    const full = JSON.stringify(data, null, 1)
+    const full = JSON.stringify(data)
     if (full === undefined) return String(data)
     return full.length > PREVIEW_CHARS ? `${full.slice(0, PREVIEW_CHARS)}...` : full
   } catch {

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, Page } from '@playwright/test';
+
+// EventFeed contract tests.
+//
+// A deterministic in-page FakeWebSocket replaces window.WebSocket before the
+// app loads, so the app's own SimBridgeClient connects to a fake and the
+// tests drive the feed by injecting messages on the app's ACTIVE socket.
+// (React StrictMode mounts effects twice — the app's live client is the one
+// constructed last, so helpers always target the LAST app-URL socket.)
+// Fixed benign JSON fixtures only; nothing dials a real backend.
+
+async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      sent: string[] = [];
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send(data: string) {
+        this.sent.push(data);
+      }
+      close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        setTimeout(() => {
+          if (this.onclose) this.onclose({});
+        }, 0);
+      }
+      _open() {
+        this.readyState = 1;
+        if (this.onopen) this.onopen({});
+      }
+      _message(obj: unknown) {
+        if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
+      }
+    }
+    w.WebSocket = FakeWebSocket;
+  });
+  await page.goto('/');
+  // The app's client(s) exist once the root renders; the active one is last.
+  await expect(page.locator('#root')).toBeVisible();
+}
+
+// Inject one already-parsed-shape message on the app's active socket.
+const inject = (page: Page, type: string, payload: unknown) =>
+  page.evaluate(({ type, payload }) => {
+    const w = window as any;
+    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const active = appSockets[appSockets.length - 1];
+    active._message({ type, payload });
+  }, { type, payload });
+
+const feed = (page: Page) => page.getByRole('log', { name: 'Event feed' });
+const entries = (page: Page) => feed(page).locator('[data-event-channel]');
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page);
+});
+
+test('initial state shows the empty-feed message and an accessible log', async ({ page }) => {
+  await expect(feed(page)).toBeAttached();
+  await expect(feed(page)).toContainText('No events yet');
+  await expect(entries(page)).toHaveCount(0);
+});
+
+test('each channel is labelled by its subscription channel even when the payload has no type', async ({ page }) => {
+  await inject(page, 'simulation_event', { kind: 'tick' });
+  await inject(page, 'network_update', { nodes: [] });
+  await inject(page, 'node_update', { id: 'n1' });
+  await inject(page, 'edge_update', { id: 'e1' });
+
+  await expect(entries(page)).toHaveCount(4);
+  for (const channel of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+    await expect(feed(page).locator(`[data-event-channel="${channel}"]`)).toHaveCount(1);
+    await expect(feed(page).locator(`[data-event-channel="${channel}"]`)).toContainText(channel);
+  }
+});
+
+test('a payload-provided type cannot spoof the subscribed channel label', async ({ page }) => {
+  await inject(page, 'node_update', { type: 'simulation_event', id: 'sneaky' });
+  await expect(entries(page)).toHaveCount(1);
+  const entry = entries(page).first();
+  await expect(entry).toHaveAttribute('data-event-channel', 'node_update');
+  // The label span shows the channel, not the payload's claimed type.
+  await expect(entry.locator('span').first()).toHaveText('node_update');
+});
+
+test('newest event appears first', async ({ page }) => {
+  await inject(page, 'node_update', { marker: 'older' });
+  await inject(page, 'edge_update', { marker: 'newer' });
+  await expect(entries(page)).toHaveCount(2);
+  await expect(entries(page).first()).toHaveAttribute('data-event-channel', 'edge_update');
+  await expect(entries(page).last()).toHaveAttribute('data-event-channel', 'node_update');
+});
+
+test('exactly fifty events are retained; after fifty-five the oldest five are gone', async ({ page }) => {
+  await page.evaluate(() => {
+    const w = window as any;
+    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const active = appSockets[appSockets.length - 1];
+    for (let n = 1; n <= 55; n++) {
+      active._message({ type: 'node_update', payload: { seq: `marker-${n}` } });
+    }
+  });
+  await expect(entries(page)).toHaveCount(50);
+  // Newest first…
+  await expect(entries(page).first()).toContainText('marker-55');
+  // …oldest retained is #6; #1–#5 expired.
+  await expect(entries(page).last()).toContainText('marker-6');
+  for (const gone of [1, 2, 3, 4, 5]) {
+    await expect(feed(page).getByText(`marker-${gone}"`, { exact: false })).toHaveCount(0);
+  }
+});
+
+test('payload preview is bounded with an ellipsis', async ({ page }) => {
+  await inject(page, 'simulation_event', { blob: 'x'.repeat(500) });
+  const preview = entries(page).first().locator('div').last();
+  const text = (await preview.textContent()) ?? '';
+  expect(text.endsWith('...')).toBe(true);
+  expect(text.length).toBeLessThanOrEqual(103); // 100 chars + '...'
+});
+
+test('script-like payload text renders as text, never as markup', async ({ page }) => {
+  await inject(page, 'simulation_event', { msg: '<script>window.__pwned = true<' + '/script><img src=x onerror="window.__pwned2=true">' });
+  await expect(entries(page)).toHaveCount(1);
+  // Rendered as text: the literal tag text is present…
+  await expect(entries(page).first()).toContainText('<script>');
+  // …and no element was actually created from the payload.
+  expect(await feed(page).locator('script, img').count()).toBe(0);
+  expect(await page.evaluate(() => (window as any).__pwned ?? (window as any).__pwned2 ?? null)).toBeNull();
+});
+
+test('StrictMode double-mount does not duplicate entries (cleanup removes listeners)', async ({ page }) => {
+  // main.tsx renders in React.StrictMode: effects run setup→cleanup→setup.
+  // If unsubscription were broken, one injected message would render twice.
+  await inject(page, 'node_update', { once: true });
+  await expect(entries(page)).toHaveCount(1);
+});
+
+test('no page-level JavaScript errors during a mixed sequence', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await inject(page, 'simulation_event', { kind: 'tick' });
+  await inject(page, 'node_update', { type: 'spoof' });
+  await inject(page, 'edge_update', { id: 'e9' });
+  await expect(entries(page)).toHaveCount(3);
+  expect(errors).toHaveLength(0);
+});

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -130,7 +130,36 @@ test('payload preview is bounded with an ellipsis', async ({ page }) => {
   const preview = entries(page).first().locator('div').last();
   const text = (await preview.textContent()) ?? '';
   expect(text.endsWith('...')).toBe(true);
-  expect(text.length).toBeLessThanOrEqual(103); // 100 chars + '...'
+  expect(text.length).toBe(103); // exactly 100 rendered chars + '...'
+});
+
+test('nested objects serialize compactly — no whitespace spent on formatting', async ({ page }) => {
+  await inject(page, 'simulation_event', { a: { b: [1, 2] } });
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text).toBe('{"a":{"b":[1,2]}}');
+});
+
+test('a compact serialization of exactly 100 characters is shown whole, no ellipsis', async ({ page }) => {
+  // {"s":"…"} wrapper is 8 chars; 92 x's → exactly 100.
+  await inject(page, 'simulation_event', { s: 'x'.repeat(92) });
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text.length).toBe(100);
+  expect(text.endsWith('...')).toBe(false);
+  expect(text).toBe(`{"s":"${'x'.repeat(92)}"}`);
+});
+
+test('101 characters truncates to 100 plus exactly one ellipsis', async ({ page }) => {
+  await inject(page, 'simulation_event', { s: 'x'.repeat(93) }); // 101 compact chars
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text.length).toBe(103);
+  expect(text.endsWith('...')).toBe(true);
+  expect(text.endsWith('....')).toBe(false);
+});
+
+test('string payloads remain JSON-quoted (locked contract)', async ({ page }) => {
+  await inject(page, 'node_update', 'plain-string');
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text).toBe('"plain-string"');
 });
 
 test('script-like payload text renders as text, never as markup', async ({ page }) => {


### PR DESCRIPTION
## Scope (PR H of Kev's connection-reliability runway — amended per Jack's live audit)

**Files: `src/components/EventFeed.tsx` + new `tests/event-feed-contract.spec.ts` only.** SimBridgeClient, App, WebSocket URLs, and backend message formats untouched.

**Defects fixed:** one generic handler across four channels displayed `unknown` for payloads without a `type` field; array-index React keys; repeated serialization per render; **(audit T3/T4)** the preview pretty-printed with newlines/indentation that the rendering div collapses — part of the 100-character budget bought formatting the user never saw, and string payloads' quoting was undocumented.

**Contract now (amended):**
- Four typed handlers capture the subscription channel — the channel is the displayed type, and a payload-provided `type` cannot spoof it.
- Stable monotonic per-feed id as the React key.
- **Compact serialize-once preview**: `JSON.stringify(data)` at insert time; **the 100-character cap applies to the exact string rendered**; ellipsis appended only when truncated; `undefined` keeps the documented `String(data)` fallback. **Locked decision (T3): string payloads remain JSON-quoted** — the preview shows the JSON value (`"5"` vs `5` stay distinguishable), matching the feed's historical stringify-everything behavior.
- Newest-first ordering and the 50-event cap preserved (55 in → 50 retained, oldest five absent — receipt below).
- `role="log"` (`aria-label="Event feed"`, implicitly polite) scoped to the feed.
- Colors, layout, subscriptions/cleanup preserved; payload content renders as text only. Boundary: payloads arrive via `JSON.parse` in SimBridgeClient, so circular structures cannot occur; the formatter's catch is a bounded last resort.

## Test receipts (in-page fake WebSocket; fixed benign JSON fixtures; nothing external)
13 tests: empty state · four channel labels with type-less payloads · spoof-type blocked · newest-first · **55 → 50 retained (markers 1–5 absent; 55 first, 6 last)** · bounded preview (103-char receipt) · **compact nested-object `{"a":{"b":[1,2]}}`** · **boundary: 100-char serialization shown whole, no ellipsis** · **101 chars → 100 + one ellipsis (and not two)** · **string payload renders `"plain-string"` (locked)** · script/img payload as text with no elements created · StrictMode single-delivery · no page errors in a mixed sequence.
- **Local (amended head): `--repeat-each=3` → 39/39 (6.6s); suite 15/15 (4.0s); `tsc --noEmit` matches the 7-diagnostic main baseline with no additions.**

## Governance
Independent branch from `main = 6f0c720` (not stacked). Stays **OPEN AND UNMERGED** for Jack's audit. Review threads left unresolved for Jack; dispositions in the consolidated packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)