### PR TITLE
frontend: ConnectionBadge status live-region + reduced-motion pulse

### DIFF
--- a/utilityfog_frontend/frontend/src/components/ConnectionBadge.tsx
+++ b/utilityfog_frontend/frontend/src/components/ConnectionBadge.tsx
@@ -5,7 +5,11 @@ interface ConnectionBadgeProps {
 export default function ConnectionBadge({ isConnected }: ConnectionBadgeProps) {
   return (
     <div className="connection-badge">
+      {/* role="status" is an implicitly polite live region; aria-atomic
+          makes each announcement the whole current state, never a diff. */}
       <div
+        role="status"
+        aria-atomic="true"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -18,13 +22,17 @@ export default function ConnectionBadge({ isConnected }: ConnectionBadgeProps) {
           fontWeight: '500',
         }}
       >
+        {/* Purely decorative indicator — hidden from accessibility APIs.
+            The pulse lives in a class so the reduced-motion media query
+            below can suppress it. */}
         <div
+          aria-hidden="true"
+          className={isConnected ? 'connection-badge-dot connection-badge-dot--pulsing' : 'connection-badge-dot'}
           style={{
             width: '8px',
             height: '8px',
             borderRadius: '50%',
             backgroundColor: 'white',
-            animation: isConnected ? 'pulse 2s infinite' : 'none',
           }}
         />
         {isConnected ? 'Connected' : 'Disconnected'}
@@ -33,6 +41,14 @@ export default function ConnectionBadge({ isConnected }: ConnectionBadgeProps) {
         @keyframes pulse {
           0%, 100% { opacity: 1; }
           50% { opacity: 0.5; }
+        }
+        .connection-badge-dot--pulsing {
+          animation: pulse 2s infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .connection-badge-dot--pulsing {
+            animation: none;
+          }
         }
       `}</style>
     </div>

--- a/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from '@playwright/test';
+
+// ConnectionBadge accessibility + reduced-motion tests.
+//
+// A deterministic in-page FakeWebSocket replaces window.WebSocket before the
+// app loads; connection transitions are driven on the app's ACTIVE socket
+// (React StrictMode mounts effects twice — the live client is the one
+// constructed last, so helpers target the LAST app-URL socket). Nothing
+// dials a real backend.
+
+async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      sent: string[] = [];
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send(data: string) {
+        this.sent.push(data);
+      }
+      close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        setTimeout(() => {
+          if (this.onclose) this.onclose({});
+        }, 0);
+      }
+      _open() {
+        this.readyState = 1;
+        if (this.onopen) this.onopen({});
+      }
+      _close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        if (this.onclose) this.onclose({});
+      }
+    }
+    w.WebSocket = FakeWebSocket;
+  });
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+}
+
+const activeSocket = (page: Page, action: '_open' | '_close') =>
+  page.evaluate((act) => {
+    const w = window as any;
+    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    appSockets[appSockets.length - 1][act]();
+  }, action);
+
+const status = (page: Page) => page.getByRole('status');
+const dot = (page: Page) => page.locator('.connection-badge [aria-hidden="true"]');
+const dotAnimation = (page: Page) =>
+  dot(page).evaluate((el) => getComputedStyle(el).animationName);
+const statusBackground = (page: Page) =>
+  status(page).evaluate((el) => getComputedStyle(el).backgroundColor);
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page);
+});
+
+test('connection state is exposed through a status live region across open/close', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+
+  // Initial: Disconnected, exposed via role=status, atomic.
+  await expect(status(page)).toHaveCount(1);
+  await expect(status(page)).toHaveText('Disconnected');
+  await expect(status(page)).toHaveAttribute('aria-atomic', 'true');
+  expect(await statusBackground(page)).toBe('rgb(239, 68, 68)');
+
+  // Simulated open → Connected (text atomic: exactly the one state string).
+  await activeSocket(page, '_open');
+  await expect(status(page)).toHaveText('Connected');
+  await expect(status(page)).toHaveCount(1);
+  expect(await statusBackground(page)).toBe('rgb(16, 185, 129)');
+
+  // Simulated close → back to Disconnected.
+  await activeSocket(page, '_close');
+  await expect(status(page)).toHaveText('Disconnected');
+  expect(await statusBackground(page)).toBe('rgb(239, 68, 68)');
+
+  expect(errors).toHaveLength(0);
+});
+
+test('decorative dot is hidden from accessibility APIs', async ({ page }) => {
+  await expect(dot(page)).toHaveCount(1);
+  await expect(dot(page)).toHaveAttribute('aria-hidden', 'true');
+  // The status text is the badge's entire accessible content.
+  await expect(status(page)).toHaveText('Disconnected');
+});
+
+test('normal motion: pulse animates only while connected', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+
+  // Disconnected: no pulse.
+  expect(await dotAnimation(page)).toBe('none');
+
+  // Connected: pulse.
+  await activeSocket(page, '_open');
+  await expect(status(page)).toHaveText('Connected');
+  expect(await dotAnimation(page)).toBe('pulse');
+
+  // Disconnected again: pulse stops.
+  await activeSocket(page, '_close');
+  await expect(status(page)).toHaveText('Disconnected');
+  expect(await dotAnimation(page)).toBe('none');
+});
+
+test('reduced motion: pulse is suppressed even while connected', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+
+  await activeSocket(page, '_open');
+  await expect(status(page)).toHaveText('Connected');
+  expect(await dotAnimation(page)).toBe('none');
+
+  // Visible wording and colour are unchanged by the media preference.
+  expect(await statusBackground(page)).toBe('rgb(16, 185, 129)');
+});

--- a/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
@@ -57,8 +57,19 @@ async function setupPage(page: Page) {
 const activeSocket = (page: Page, action: '_open' | '_close') =>
   page.evaluate((act) => {
     const w = window as any;
-    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
-    appSockets[appSockets.length - 1][act]();
+    // Defensive diagnostics: tolerate a missing registry, then fail with a
+    // descriptive error rather than an opaque undefined-property throw.
+    const registry = Array.isArray(w.__fakeSockets) ? w.__fakeSockets : [];
+    const appSockets = registry.filter((s: any) => String(s.url).includes('/ws'));
+    const active = appSockets[appSockets.length - 1];
+    if (!active) {
+      throw new Error(
+        `No active application fake socket (registry size ${registry.length}, ` +
+        `app-URL sockets ${appSockets.length}) — did the init script install ` +
+        `FakeWebSocket before the app loaded?`
+      );
+    }
+    active[act]();
   }, action);
 
 const status = (page: Page) => page.getByRole('status');


### PR DESCRIPTION
## Scope (PR I of Kev's connection-reliability runway — test-diagnostics amendment per Jack's live audit)

**Files: `src/components/ConnectionBadge.tsx` + new `tests/connection-status-a11y.spec.ts` only.** The component passed audit and is unchanged since; **the amendment (T5) touches the spec's `activeSocket` helper only**: it now tolerates an absent fake-socket registry, selects the active application socket, and throws a descriptive error naming registry/app-socket counts when none exists — diagnostics instead of an opaque undefined-property failure.

**Contract (unchanged from the audited component):**
- Textual connection state in a `role="status"` live region with `aria-atomic="true"` — polite, whole-state announcements.
- Decorative dot `aria-hidden="true"`.
- Pulse in a narrowly-scoped class inside the component's existing style block, with a `prefers-reduced-motion: reduce` query on that class only — reduced-motion users get no pulse; pulse applies only while connected.
- Visible Connected/Disconnected wording, colours (`#10b981`/`#ef4444`), position, and layout preserved.

## Test receipts (amended head; in-page fake WebSocket + `emulateMedia`; nothing external)
4 tests: status region across simulated open→close with colour receipts and a single status node · hidden decorative dot · normal-motion pulse only while connected (computed `animationName` `none`→`pulse`→`none`) · reduced-motion suppression while connected. Page-error capture in the transition test recorded none.
- **Local (amended head): `--repeat-each=3` → 12/12 (3.4s); suite on this branch 6/6 (3.0s); `tsc --noEmit` matches the 7-diagnostic main baseline with no additions.**

## Governance
Independent branch from `main = 6f0c720` (not stacked). Stays **OPEN AND UNMERGED** for Jack's audit. Review thread left unresolved for Jack; disposition in the consolidated packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)