### PR TITLE
frontend: EventFeed operations — filters, search, summary, clear, JSON export (stacked on #318)

### DIFF
--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -1,37 +1,74 @@
-import { useState, useEffect } from 'react'
-import { SimBridgeClient, SimEvent } from '../ws/SimBridgeClient'
+import { useState, useEffect, useRef } from 'react'
+import { SimBridgeClient } from '../ws/SimBridgeClient'
 
 interface EventFeedProps {
   simClient: SimBridgeClient | null
 }
 
+// The four subscription channels this feed renders. The channel is captured
+// at subscription time and displayed as the event's type — a payload's own
+// `type` field can never spoof the channel label.
+const FEED_CHANNELS = [
+  'simulation_event',
+  'network_update',
+  'node_update',
+  'edge_update',
+] as const
+type FeedChannel = (typeof FEED_CHANNELS)[number]
+
+interface FeedEntry {
+  // Stable local identifier (monotonic per mounted feed) — the React key.
+  // Never the rendered array index, which shifts as entries prepend/expire.
+  id: number
+  channel: FeedChannel
+  timestamp: number
+  // Serialized exactly once, at insert time, through the bounded helper.
+  preview: string
+}
+
+const MAX_EVENTS = 50
+const PREVIEW_CHARS = 100
+
+// Bounded preview: pretty-printed JSON truncated to PREVIEW_CHARS with a
+// trailing ellipsis (length measured on the same string that is sliced — a
+// narrow consistency improvement over the previous compact-length check).
+// Every payload enters through JSON.parse in SimBridgeClient, so circular
+// structures cannot occur; the catch is a bounded last resort and never
+// hides ordinary valid payloads.
+function formatPreview(data: unknown): string {
+  try {
+    const full = JSON.stringify(data, null, 1)
+    if (full === undefined) return String(data)
+    return full.length > PREVIEW_CHARS ? `${full.slice(0, PREVIEW_CHARS)}...` : full
+  } catch {
+    return '[unserializable payload]'
+  }
+}
+
 export default function EventFeed({ simClient }: EventFeedProps) {
-  const [events, setEvents] = useState<SimEvent[]>([])
-  const maxEvents = 50
+  const [events, setEvents] = useState<FeedEntry[]>([])
+  const nextIdRef = useRef(0)
 
   useEffect(() => {
     if (!simClient) return
 
-    const handleEvent = (eventData: any) => {
-      const event: SimEvent = {
-        type: eventData.type || 'unknown',
-        timestamp: Date.now(),
-        data: eventData
+    const subscriptions = FEED_CHANNELS.map((channel) => {
+      const handler = (payload?: unknown) => {
+        const entry: FeedEntry = {
+          id: nextIdRef.current++,
+          channel,
+          timestamp: Date.now(),
+          preview: formatPreview(payload),
+        }
+        // Newest first; hold at most MAX_EVENTS.
+        setEvents(prev => [entry, ...prev.slice(0, MAX_EVENTS - 1)])
       }
-
-      setEvents(prev => [event, ...prev.slice(0, maxEvents - 1)])
-    }
-
-    simClient.on('simulation_event', handleEvent)
-    simClient.on('network_update', handleEvent)
-    simClient.on('node_update', handleEvent)
-    simClient.on('edge_update', handleEvent)
+      simClient.on(channel, handler)
+      return { channel, handler }
+    })
 
     return () => {
-      simClient.off('simulation_event', handleEvent)
-      simClient.off('network_update', handleEvent)
-      simClient.off('node_update', handleEvent)
-      simClient.off('edge_update', handleEvent)
+      subscriptions.forEach(({ channel, handler }) => simClient.off(channel, handler))
     }
   }, [simClient])
 
@@ -39,13 +76,12 @@ export default function EventFeed({ simClient }: EventFeedProps) {
     return new Date(timestamp).toLocaleTimeString()
   }
 
-  const getEventColor = (type: string) => {
-    switch (type) {
+  const getEventColor = (channel: FeedChannel) => {
+    switch (channel) {
       case 'node_update': return '#3b82f6'
       case 'edge_update': return '#10b981'
       case 'network_update': return '#f59e0b'
       case 'simulation_event': return '#8b5cf6'
-      default: return '#6b7280'
     }
   }
 
@@ -54,21 +90,24 @@ export default function EventFeed({ simClient }: EventFeedProps) {
       <h3 style={{ margin: '0 0 10px 0', color: 'white', fontSize: '16px' }}>
         Event Feed
       </h3>
-      <div style={{ maxHeight: '350px', overflowY: 'auto' }}>
+      {/* role="log" (implicitly polite live region): newly inserted events
+          are announced without turning the whole app into a live region. */}
+      <div role="log" aria-label="Event feed" style={{ maxHeight: '350px', overflowY: 'auto' }}>
         {events.length === 0 ? (
           <div style={{ color: '#9ca3af', fontStyle: 'italic' }}>
             No events yet...
           </div>
         ) : (
-          events.map((event, index) => (
+          events.map((event) => (
             <div
-              key={index}
+              key={event.id}
+              data-event-channel={event.channel}
               style={{
                 padding: '8px',
                 marginBottom: '6px',
                 backgroundColor: 'rgba(255, 255, 255, 0.1)',
                 borderRadius: '4px',
-                borderLeft: `3px solid ${getEventColor(event.type)}`,
+                borderLeft: `3px solid ${getEventColor(event.channel)}`,
               }}
             >
               <div
@@ -81,20 +120,21 @@ export default function EventFeed({ simClient }: EventFeedProps) {
               >
                 <span
                   style={{
-                    color: getEventColor(event.type),
+                    color: getEventColor(event.channel),
                     fontSize: '12px',
                     fontWeight: '600',
                   }}
                 >
-                  {event.type}
+                  {event.channel}
                 </span>
                 <span style={{ color: '#9ca3af', fontSize: '10px' }}>
                   {formatTime(event.timestamp)}
                 </span>
               </div>
+              {/* React renders this as text — payload content is never
+                  interpreted as markup. */}
               <div style={{ color: 'white', fontSize: '11px' }}>
-                {JSON.stringify(event.data, null, 1).slice(0, 100)}
-                {JSON.stringify(event.data).length > 100 ? '...' : ''}
+                {event.preview}
               </div>
             </div>
           ))

--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -131,11 +131,14 @@ export default function EventFeed({ simClient }: EventFeedProps) {
         schema: EXPORT_SCHEMA,
         version: EXPORT_VERSION,
         // Visible (filtered + searched) results only, newest first, carrying
-        // the original parsed payloads — never the truncated previews.
+        // the original parsed payloads — never the truncated previews. An
+        // omitted payload normalizes to explicit null so JSON.stringify
+        // cannot drop the property: every exported record carries channel,
+        // timestamp AND payload. (Preview contract separate and unchanged.)
         events: visible.map(e => ({
           channel: e.channel,
           timestamp: e.timestamp,
-          payload: e.payload,
+          payload: e.payload === undefined ? null : e.payload,
         })),
       }
       const json = JSON.stringify(doc, null, 2)
@@ -144,8 +147,13 @@ export default function EventFeed({ simClient }: EventFeedProps) {
       const anchor = document.createElement('a')
       anchor.href = url
       anchor.download = EXPORT_FILENAME
+      document.body.appendChild(anchor)
       anchor.click()
-      URL.revokeObjectURL(url)
+      anchor.remove()
+      // Deferred revocation: a synchronous revoke can race the browser's
+      // resolution of the download. Exactly one revocation per successful
+      // export; on serialization failure no URL exists, so nothing leaks.
+      setTimeout(() => URL.revokeObjectURL(url), 0)
       setExportError(null)
     } catch {
       // Unreachable through the message path (payloads arrive via

--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
+import type { CSSProperties } from 'react'
 import { SimBridgeClient } from '../ws/SimBridgeClient'
 
 interface EventFeedProps {
@@ -24,10 +25,17 @@ interface FeedEntry {
   timestamp: number
   // Serialized exactly once, at insert time, through the bounded helper.
   preview: string
+  // The original parsed payload is retained alongside the preview so JSON
+  // export never reconstructs data from the truncated preview.
+  payload: unknown
 }
 
 const MAX_EVENTS = 50
 const PREVIEW_CHARS = 100
+const EXPORT_SCHEMA = 'utilityfog.event-feed-export'
+const EXPORT_VERSION = 1
+// Deterministic, path-safe filename (no separators or unsafe characters).
+const EXPORT_FILENAME = 'event-feed-export.json'
 
 // Bounded, serialize-once preview: COMPACT JSON. The rendering div collapses
 // whitespace, so pretty-printing spent part of the 100-character budget on
@@ -50,6 +58,11 @@ function formatPreview(data: unknown): string {
 
 export default function EventFeed({ simClient }: EventFeedProps) {
   const [events, setEvents] = useState<FeedEntry[]>([])
+  const [activeChannels, setActiveChannels] = useState<ReadonlySet<FeedChannel>>(
+    () => new Set(FEED_CHANNELS),
+  )
+  const [search, setSearch] = useState('')
+  const [exportError, setExportError] = useState<string | null>(null)
   const nextIdRef = useRef(0)
 
   useEffect(() => {
@@ -62,6 +75,7 @@ export default function EventFeed({ simClient }: EventFeedProps) {
           channel,
           timestamp: Date.now(),
           preview: formatPreview(payload),
+          payload,
         }
         // Newest first; hold at most MAX_EVENTS.
         setEvents(prev => [entry, ...prev.slice(0, MAX_EVENTS - 1)])
@@ -74,6 +88,72 @@ export default function EventFeed({ simClient }: EventFeedProps) {
       subscriptions.forEach(({ channel, handler }) => simClient.off(channel, handler))
     }
   }, [simClient])
+
+  const toggleChannel = (channel: FeedChannel) => {
+    setActiveChannels(prev => {
+      const next = new Set(prev)
+      if (next.has(channel)) {
+        next.delete(channel)
+      } else {
+        next.add(channel)
+      }
+      return next
+    })
+  }
+
+  // Filtering and search change PRESENTATION only — the bounded queue in
+  // `events` is untouched. Search is trimmed and case-insensitive over the
+  // channel name and the exact rendered preview; the query is treated as a
+  // plain string (never markup, a regular expression, or code).
+  const query = search.trim().toLowerCase()
+  const visible = useMemo(
+    () =>
+      events.filter(
+        e =>
+          activeChannels.has(e.channel) &&
+          (query === '' || `${e.channel} ${e.preview}`.toLowerCase().includes(query)),
+      ),
+    [events, activeChannels, query],
+  )
+
+  // Deliberate, documented decision: clearing does NOT reset the monotonic
+  // id counter — ids only need uniqueness for React keys, and continuing
+  // guarantees that across clears. Subscriptions are untouched, so later
+  // events still arrive normally.
+  const handleClear = () => {
+    setEvents([])
+    setExportError(null)
+  }
+
+  const handleExport = () => {
+    try {
+      const doc = {
+        schema: EXPORT_SCHEMA,
+        version: EXPORT_VERSION,
+        // Visible (filtered + searched) results only, newest first, carrying
+        // the original parsed payloads — never the truncated previews.
+        events: visible.map(e => ({
+          channel: e.channel,
+          timestamp: e.timestamp,
+          payload: e.payload,
+        })),
+      }
+      const json = JSON.stringify(doc, null, 2)
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = EXPORT_FILENAME
+      anchor.click()
+      URL.revokeObjectURL(url)
+      setExportError(null)
+    } catch {
+      // Unreachable through the message path (payloads arrive via
+      // JSON.parse), but the guard keeps any failure bounded and visible
+      // instead of producing a broken download.
+      setExportError('Export failed: the visible events could not be serialized.')
+    }
+  }
 
   const formatTime = (timestamp: number) => {
     return new Date(timestamp).toLocaleTimeString()
@@ -88,11 +168,87 @@ export default function EventFeed({ simClient }: EventFeedProps) {
     }
   }
 
+  const controlButtonStyle: CSSProperties = {
+    fontSize: '10px',
+    padding: '2px 6px',
+    borderRadius: '4px',
+    border: '1px solid rgba(255, 255, 255, 0.3)',
+    color: 'white',
+    cursor: 'pointer',
+  }
+
   return (
     <div className="event-feed">
       <h3 style={{ margin: '0 0 10px 0', color: 'white', fontSize: '16px' }}>
         Event Feed
       </h3>
+
+      {/* Operations rows: channel filters, search, clear, export. Plain
+          controls — deliberately NOT a live region, so the feed's only live
+          region remains the role=log list below. */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '6px' }}>
+        {FEED_CHANNELS.map(channel => (
+          <button
+            key={channel}
+            aria-pressed={activeChannels.has(channel)}
+            onClick={() => toggleChannel(channel)}
+            style={{
+              ...controlButtonStyle,
+              backgroundColor: activeChannels.has(channel)
+                ? getEventColor(channel)
+                : 'rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            {channel}
+          </button>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: '4px', marginBottom: '6px' }}>
+        <input
+          aria-label="Search events"
+          placeholder="Search events"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{
+            flex: 1,
+            fontSize: '11px',
+            padding: '3px 6px',
+            borderRadius: '4px',
+            border: '1px solid rgba(255, 255, 255, 0.3)',
+            backgroundColor: 'rgba(255, 255, 255, 0.1)',
+            color: 'white',
+          }}
+        />
+        <button
+          onClick={handleClear}
+          disabled={events.length === 0}
+          style={{ ...controlButtonStyle, backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
+        >
+          Clear
+        </button>
+        <button
+          onClick={handleExport}
+          disabled={visible.length === 0}
+          style={{ ...controlButtonStyle, backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
+        >
+          Export visible JSON
+        </button>
+      </div>
+
+      {/* Result summary — plain text, deliberately not a live region (no
+          second/assertive region nested beside the log). Distinct truthful
+          wording for empty feed vs filtered-empty vs populated states. */}
+      <div data-testid="feed-summary" style={{ color: '#9ca3af', fontSize: '10px', marginBottom: '6px' }}>
+        {events.length === 0
+          ? 'No events retained.'
+          : `Showing ${visible.length} of ${events.length} events`}
+      </div>
+      {exportError && (
+        <div data-testid="export-error" style={{ color: '#ef4444', fontSize: '10px', marginBottom: '6px' }}>
+          {exportError}
+        </div>
+      )}
+
       {/* role="log" (implicitly polite live region): newly inserted events
           are announced without turning the whole app into a live region. */}
       <div role="log" aria-label="Event feed" style={{ maxHeight: '350px', overflowY: 'auto' }}>
@@ -100,8 +256,12 @@ export default function EventFeed({ simClient }: EventFeedProps) {
           <div style={{ color: '#9ca3af', fontStyle: 'italic' }}>
             No events yet...
           </div>
+        ) : visible.length === 0 ? (
+          <div style={{ color: '#9ca3af', fontStyle: 'italic' }}>
+            No events match the current filters.
+          </div>
         ) : (
-          events.map((event) => (
+          visible.map((event) => (
             <div
               key={event.id}
               data-event-channel={event.channel}

--- a/utilityfog_frontend/frontend/src/components/EventFeed.tsx
+++ b/utilityfog_frontend/frontend/src/components/EventFeed.tsx
@@ -29,15 +29,18 @@ interface FeedEntry {
 const MAX_EVENTS = 50
 const PREVIEW_CHARS = 100
 
-// Bounded preview: pretty-printed JSON truncated to PREVIEW_CHARS with a
-// trailing ellipsis (length measured on the same string that is sliced — a
-// narrow consistency improvement over the previous compact-length check).
-// Every payload enters through JSON.parse in SimBridgeClient, so circular
-// structures cannot occur; the catch is a bounded last resort and never
-// hides ordinary valid payloads.
+// Bounded, serialize-once preview: COMPACT JSON. The rendering div collapses
+// whitespace, so pretty-printing spent part of the 100-character budget on
+// formatting the user never saw — the cap now applies to the exact string
+// rendered, with the ellipsis appended only when truncated. String payloads
+// stay JSON-quoted (deliberate, test-locked): the preview shows the JSON
+// value, so "5" and 5 stay distinguishable and behavior matches the feed's
+// historical stringify-everything contract. Every payload enters through
+// JSON.parse in SimBridgeClient, so circular structures cannot occur; the
+// catch is a bounded last resort and never hides ordinary valid payloads.
 function formatPreview(data: unknown): string {
   try {
-    const full = JSON.stringify(data, null, 1)
+    const full = JSON.stringify(data)
     if (full === undefined) return String(data)
     return full.length > PREVIEW_CHARS ? `${full.slice(0, PREVIEW_CHARS)}...` : full
   } catch {

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, Page } from '@playwright/test';
+
+// EventFeed contract tests.
+//
+// A deterministic in-page FakeWebSocket replaces window.WebSocket before the
+// app loads, so the app's own SimBridgeClient connects to a fake and the
+// tests drive the feed by injecting messages on the app's ACTIVE socket.
+// (React StrictMode mounts effects twice — the app's live client is the one
+// constructed last, so helpers always target the LAST app-URL socket.)
+// Fixed benign JSON fixtures only; nothing dials a real backend.
+
+async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      sent: string[] = [];
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send(data: string) {
+        this.sent.push(data);
+      }
+      close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        setTimeout(() => {
+          if (this.onclose) this.onclose({});
+        }, 0);
+      }
+      _open() {
+        this.readyState = 1;
+        if (this.onopen) this.onopen({});
+      }
+      _message(obj: unknown) {
+        if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
+      }
+    }
+    w.WebSocket = FakeWebSocket;
+  });
+  await page.goto('/');
+  // The app's client(s) exist once the root renders; the active one is last.
+  await expect(page.locator('#root')).toBeVisible();
+}
+
+// Inject one already-parsed-shape message on the app's active socket.
+const inject = (page: Page, type: string, payload: unknown) =>
+  page.evaluate(({ type, payload }) => {
+    const w = window as any;
+    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const active = appSockets[appSockets.length - 1];
+    active._message({ type, payload });
+  }, { type, payload });
+
+const feed = (page: Page) => page.getByRole('log', { name: 'Event feed' });
+const entries = (page: Page) => feed(page).locator('[data-event-channel]');
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page);
+});
+
+test('initial state shows the empty-feed message and an accessible log', async ({ page }) => {
+  await expect(feed(page)).toBeAttached();
+  await expect(feed(page)).toContainText('No events yet');
+  await expect(entries(page)).toHaveCount(0);
+});
+
+test('each channel is labelled by its subscription channel even when the payload has no type', async ({ page }) => {
+  await inject(page, 'simulation_event', { kind: 'tick' });
+  await inject(page, 'network_update', { nodes: [] });
+  await inject(page, 'node_update', { id: 'n1' });
+  await inject(page, 'edge_update', { id: 'e1' });
+
+  await expect(entries(page)).toHaveCount(4);
+  for (const channel of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+    await expect(feed(page).locator(`[data-event-channel="${channel}"]`)).toHaveCount(1);
+    await expect(feed(page).locator(`[data-event-channel="${channel}"]`)).toContainText(channel);
+  }
+});
+
+test('a payload-provided type cannot spoof the subscribed channel label', async ({ page }) => {
+  await inject(page, 'node_update', { type: 'simulation_event', id: 'sneaky' });
+  await expect(entries(page)).toHaveCount(1);
+  const entry = entries(page).first();
+  await expect(entry).toHaveAttribute('data-event-channel', 'node_update');
+  // The label span shows the channel, not the payload's claimed type.
+  await expect(entry.locator('span').first()).toHaveText('node_update');
+});
+
+test('newest event appears first', async ({ page }) => {
+  await inject(page, 'node_update', { marker: 'older' });
+  await inject(page, 'edge_update', { marker: 'newer' });
+  await expect(entries(page)).toHaveCount(2);
+  await expect(entries(page).first()).toHaveAttribute('data-event-channel', 'edge_update');
+  await expect(entries(page).last()).toHaveAttribute('data-event-channel', 'node_update');
+});
+
+test('exactly fifty events are retained; after fifty-five the oldest five are gone', async ({ page }) => {
+  await page.evaluate(() => {
+    const w = window as any;
+    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const active = appSockets[appSockets.length - 1];
+    for (let n = 1; n <= 55; n++) {
+      active._message({ type: 'node_update', payload: { seq: `marker-${n}` } });
+    }
+  });
+  await expect(entries(page)).toHaveCount(50);
+  // Newest first…
+  await expect(entries(page).first()).toContainText('marker-55');
+  // …oldest retained is #6; #1–#5 expired.
+  await expect(entries(page).last()).toContainText('marker-6');
+  for (const gone of [1, 2, 3, 4, 5]) {
+    await expect(feed(page).getByText(`marker-${gone}"`, { exact: false })).toHaveCount(0);
+  }
+});
+
+test('payload preview is bounded with an ellipsis', async ({ page }) => {
+  await inject(page, 'simulation_event', { blob: 'x'.repeat(500) });
+  const preview = entries(page).first().locator('div').last();
+  const text = (await preview.textContent()) ?? '';
+  expect(text.endsWith('...')).toBe(true);
+  expect(text.length).toBeLessThanOrEqual(103); // 100 chars + '...'
+});
+
+test('script-like payload text renders as text, never as markup', async ({ page }) => {
+  await inject(page, 'simulation_event', { msg: '<script>window.__pwned = true<' + '/script><img src=x onerror="window.__pwned2=true">' });
+  await expect(entries(page)).toHaveCount(1);
+  // Rendered as text: the literal tag text is present…
+  await expect(entries(page).first()).toContainText('<script>');
+  // …and no element was actually created from the payload.
+  expect(await feed(page).locator('script, img').count()).toBe(0);
+  expect(await page.evaluate(() => (window as any).__pwned ?? (window as any).__pwned2 ?? null)).toBeNull();
+});
+
+test('StrictMode double-mount does not duplicate entries (cleanup removes listeners)', async ({ page }) => {
+  // main.tsx renders in React.StrictMode: effects run setup→cleanup→setup.
+  // If unsubscription were broken, one injected message would render twice.
+  await inject(page, 'node_update', { once: true });
+  await expect(entries(page)).toHaveCount(1);
+});
+
+test('no page-level JavaScript errors during a mixed sequence', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await inject(page, 'simulation_event', { kind: 'tick' });
+  await inject(page, 'node_update', { type: 'spoof' });
+  await inject(page, 'edge_update', { id: 'e9' });
+  await expect(entries(page)).toHaveCount(3);
+  expect(errors).toHaveLength(0);
+});

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -130,7 +130,36 @@ test('payload preview is bounded with an ellipsis', async ({ page }) => {
   const preview = entries(page).first().locator('div').last();
   const text = (await preview.textContent()) ?? '';
   expect(text.endsWith('...')).toBe(true);
-  expect(text.length).toBeLessThanOrEqual(103); // 100 chars + '...'
+  expect(text.length).toBe(103); // exactly 100 rendered chars + '...'
+});
+
+test('nested objects serialize compactly — no whitespace spent on formatting', async ({ page }) => {
+  await inject(page, 'simulation_event', { a: { b: [1, 2] } });
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text).toBe('{"a":{"b":[1,2]}}');
+});
+
+test('a compact serialization of exactly 100 characters is shown whole, no ellipsis', async ({ page }) => {
+  // {"s":"…"} wrapper is 8 chars; 92 x's → exactly 100.
+  await inject(page, 'simulation_event', { s: 'x'.repeat(92) });
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text.length).toBe(100);
+  expect(text.endsWith('...')).toBe(false);
+  expect(text).toBe(`{"s":"${'x'.repeat(92)}"}`);
+});
+
+test('101 characters truncates to 100 plus exactly one ellipsis', async ({ page }) => {
+  await inject(page, 'simulation_event', { s: 'x'.repeat(93) }); // 101 compact chars
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text.length).toBe(103);
+  expect(text.endsWith('...')).toBe(true);
+  expect(text.endsWith('....')).toBe(false);
+});
+
+test('string payloads remain JSON-quoted (locked contract)', async ({ page }) => {
+  await inject(page, 'node_update', 'plain-string');
+  const text = (await entries(page).first().locator('div').last().textContent()) ?? '';
+  expect(text).toBe('"plain-string"');
 });
 
 test('script-like payload text renders as text, never as markup', async ({ page }) => {

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -39,7 +39,18 @@ async function setupPage(page: Page) {
       _open() { this.readyState = 1; if (this.onopen) this.onopen({}); }
       _message(obj: unknown) { if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) }); }
     }
-    w.WebSocket = FakeWebSocket;
+    // Only the app's SimBridge socket (/ws path) is faked; everything else
+    // (notably Vite's HMR client socket) keeps the real WebSocket, so the
+    // dev-server connection stays healthy and never triggers the client's
+    // lost-connection page reload mid-test.
+    const RealWebSocket = w.WebSocket;
+    w.WebSocket = new Proxy(FakeWebSocket, {
+      construct(target, args) {
+        const url = String(args[0] ?? '');
+        if (url.includes('/ws')) return new target(url);
+        return new (RealWebSocket as any)(...args);
+      },
+    });
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
@@ -64,7 +75,7 @@ const exportBtn = (page: Page) => feed(page).getByRole('button', { name: 'Export
 const injectFour = async (page: Page) => {
   await inject(page, 'simulation_event', { kind: 'tick' });
   await inject(page, 'network_update', { nodes: [] });
-  await inject(page, 'node_update', { id: 'n1' });
+  await inject(page, 'node_update', { id: 'n1', position: [0, 0, 0], connections: [], status: 'active' });
   await inject(page, 'edge_update', { id: 'e1' });
   await expect(entries(page)).toHaveCount(4);
 };
@@ -219,9 +230,9 @@ test('the 50-event retained cap holds regardless of filters', async ({ page }) =
 test('export: visible-only, newest-first, schema/version, full payloads, revoked URL, deterministic filename', async ({ page }) => {
   test.slow(); // stub installation + blob readback under contention
   const longText = 'y'.repeat(300);
-  await inject(page, 'node_update', { seq: 1, blob: longText });
+  await inject(page, 'node_update', { seq: 1, id: 'x1', position: [0, 0, 0], connections: [], status: 'active', blob: longText });
   await inject(page, 'edge_update', { seq: 2 });
-  await inject(page, 'node_update', { seq: 3 });
+  await inject(page, 'node_update', { seq: 3, id: 'x3', position: [0, 0, 0], connections: [], status: 'active' });
   await expect(entries(page)).toHaveCount(3);
 
   // Filter to node_update + search that matches both node entries.
@@ -271,12 +282,12 @@ test('StrictMode single delivery holds with operations present; no page errors a
   const errors: string[] = [];
   page.on('pageerror', (e) => errors.push(e.message));
 
-  await inject(page, 'node_update', { once: true });
+  await inject(page, 'node_update', { id: 'once-1', position: [0, 0, 0], connections: [], status: 'active' });
   await expect(entries(page)).toHaveCount(1); // one delivery per message
 
   await chan(page, 'node_update').click();
   await chan(page, 'node_update').click();
-  await searchBox(page).fill('once');
+  await searchBox(page).fill('once-1');
   await expect(entries(page)).toHaveCount(1);
   await searchBox(page).fill('');
   await clearBtn(page).click();

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -1,0 +1,287 @@
+import { test, expect, Page } from '@playwright/test';
+
+// EventFeed OPERATIONS tests (Package J — filtering, search, summary, clear,
+// JSON export). Same in-page FakeWebSocket harness as the contract spec;
+// fixed benign JSON fixtures; nothing external.
+//
+// Serialization-failure note (declared): every payload enters through
+// JSON.parse in SimBridgeClient, so no in-page fixture can deliver an
+// unserializable payload through the message path — the component's bounded
+// export-error guard is therefore untestable from here and is covered by
+// code inspection only.
+
+async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as any;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      sent: string[] = [];
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send(data: string) { this.sent.push(data); }
+      close() {
+        if (this.readyState === 3) return;
+        this.readyState = 3;
+        setTimeout(() => { if (this.onclose) this.onclose({}); }, 0);
+      }
+      _open() { this.readyState = 1; if (this.onopen) this.onopen({}); }
+      _message(obj: unknown) { if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) }); }
+    }
+    w.WebSocket = FakeWebSocket;
+  });
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+}
+
+const inject = (page: Page, type: string, payload: unknown) =>
+  page.evaluate(({ type, payload }) => {
+    const w = window as any;
+    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    socks[socks.length - 1]._message({ type, payload });
+  }, { type, payload });
+
+const feed = (page: Page) => page.locator('.event-feed');
+const log = (page: Page) => page.getByRole('log', { name: 'Event feed' });
+const entries = (page: Page) => log(page).locator('[data-event-channel]');
+const summary = (page: Page) => page.getByTestId('feed-summary');
+const chan = (page: Page, name: string) => feed(page).getByRole('button', { name, exact: true });
+const searchBox = (page: Page) => feed(page).getByLabel('Search events');
+const clearBtn = (page: Page) => feed(page).getByRole('button', { name: 'Clear' });
+const exportBtn = (page: Page) => feed(page).getByRole('button', { name: 'Export visible JSON' });
+
+const injectFour = async (page: Page) => {
+  await inject(page, 'simulation_event', { kind: 'tick' });
+  await inject(page, 'network_update', { nodes: [] });
+  await inject(page, 'node_update', { id: 'n1' });
+  await inject(page, 'edge_update', { id: 'e1' });
+  await expect(entries(page)).toHaveCount(4);
+};
+
+// Install export-capture stubs (blob text, anchor download/href, revocations)
+const armExportCapture = (page: Page) =>
+  page.evaluate(() => {
+    const w = window as any;
+    w.__exportCapture = { revoked: [] as string[], download: '', href: '', text: '' };
+    URL.createObjectURL = ((blob: Blob) => {
+      w.__exportCapture.blob = blob;
+      return 'blob:capture-1';
+    }) as typeof URL.createObjectURL;
+    URL.revokeObjectURL = ((u: string) => {
+      w.__exportCapture.revoked.push(u);
+    }) as typeof URL.revokeObjectURL;
+    HTMLAnchorElement.prototype.click = function () {
+      w.__exportCapture.download = (this as HTMLAnchorElement).download;
+      w.__exportCapture.href = (this as HTMLAnchorElement).href;
+    };
+  });
+const readExport = (page: Page) =>
+  page.evaluate(async () => {
+    const c = (window as any).__exportCapture;
+    return {
+      download: c.download,
+      href: c.href,
+      revoked: c.revoked,
+      doc: JSON.parse(await c.blob.text()),
+    };
+  });
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page);
+});
+
+test('initial state: all four channels selected, clear/export disabled, truthful empty summary', async ({ page }) => {
+  for (const c of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+    await expect(chan(page, c)).toHaveAttribute('aria-pressed', 'true');
+  }
+  await expect(summary(page)).toHaveText('No events retained.');
+  await expect(clearBtn(page)).toBeDisabled();
+  await expect(exportBtn(page)).toBeDisabled();
+  await expect(log(page)).toContainText('No events yet');
+});
+
+test('single- and multi-channel filtering changes presentation only', async ({ page }) => {
+  await injectFour(page);
+
+  // Single channel: node_update only.
+  for (const off of ['simulation_event', 'network_update', 'edge_update']) {
+    await chan(page, off).click();
+    await expect(chan(page, off)).toHaveAttribute('aria-pressed', 'false');
+  }
+  await expect(entries(page)).toHaveCount(1);
+  await expect(entries(page).first()).toHaveAttribute('data-event-channel', 'node_update');
+  await expect(summary(page)).toHaveText('Showing 1 of 4 events');
+
+  // Multi-channel: add edge_update back.
+  await chan(page, 'edge_update').click();
+  await expect(entries(page)).toHaveCount(2);
+  await expect(summary(page)).toHaveText('Showing 2 of 4 events');
+
+  // Hidden events remained retained: re-enable all → all four reappear.
+  await chan(page, 'simulation_event').click();
+  await chan(page, 'network_update').click();
+  await expect(entries(page)).toHaveCount(4);
+  await expect(summary(page)).toHaveText('Showing 4 of 4 events');
+});
+
+test('every channel disabled: clear empty-filter wording, queue intact', async ({ page }) => {
+  await injectFour(page);
+  for (const c of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+    await chan(page, c).click();
+  }
+  await expect(entries(page)).toHaveCount(0);
+  await expect(log(page)).toContainText('No events match the current filters.');
+  await expect(summary(page)).toHaveText('Showing 0 of 4 events');
+  await expect(exportBtn(page)).toBeDisabled(); // zero visible
+  // Queue intact: re-enable one channel and its event returns.
+  await chan(page, 'node_update').click();
+  await expect(entries(page)).toHaveCount(1);
+});
+
+test('search: trimmed, case-insensitive, composes with filters, whitespace is a no-op', async ({ page }) => {
+  await injectFour(page);
+
+  await searchBox(page).fill('  NODE_UPD  '); // trimmed + case-insensitive
+  await expect(entries(page)).toHaveCount(1);
+  await expect(entries(page).first()).toHaveAttribute('data-event-channel', 'node_update');
+
+  await searchBox(page).fill('   '); // whitespace-only → no filtering
+  await expect(entries(page)).toHaveCount(4);
+
+  // Composition: search matches two entries' previews, filter removes one.
+  await searchBox(page).fill('id');
+  await expect(entries(page)).toHaveCount(2); // node n1 + edge e1 previews contain "id"
+  await chan(page, 'edge_update').click();
+  await expect(entries(page)).toHaveCount(1);
+  await expect(entries(page).first()).toHaveAttribute('data-event-channel', 'node_update');
+  await expect(summary(page)).toHaveText('Showing 1 of 4 events');
+
+  // Clearing search restores the filter-only view.
+  await searchBox(page).fill('');
+  await expect(entries(page)).toHaveCount(3); // edge_update still filtered off
+});
+
+test('search input treats markup-like queries as plain text', async ({ page }) => {
+  await injectFour(page);
+  await searchBox(page).fill('<script>alert(1)</script>');
+  await expect(entries(page)).toHaveCount(0);
+  await expect(log(page)).toContainText('No events match the current filters.');
+  expect(await feed(page).locator('script').count()).toBe(0);
+});
+
+test('clear empties retained events without breaking later delivery', async ({ page }) => {
+  await injectFour(page);
+  await expect(clearBtn(page)).toBeEnabled();
+  await clearBtn(page).click();
+  await expect(summary(page)).toHaveText('No events retained.');
+  await expect(log(page)).toContainText('No events yet');
+  await expect(clearBtn(page)).toBeDisabled();
+
+  // Subscriptions untouched: a later event still arrives.
+  await inject(page, 'edge_update', { id: 'after-clear' });
+  await expect(entries(page)).toHaveCount(1);
+  await expect(summary(page)).toHaveText('Showing 1 of 1 events');
+});
+
+test('the 50-event retained cap holds regardless of filters', async ({ page }) => {
+  test.slow(); // 50-entry render under parallel-worker contention
+  // Fixture hygiene: the flood uses simulation_event, which the 3D scene
+  // store does not consume — bursts of structurally-minimal node_update
+  // payloads (no position) can crash the untouched viz3d lane (pre-existing
+  // app fragility, reported separately; outside this PR's allowed files).
+  for (const off of ['network_update', 'node_update', 'edge_update']) {
+    await chan(page, off).click();
+  }
+  await page.evaluate(() => {
+    const w = window as any;
+    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const s = socks[socks.length - 1];
+    for (let n = 1; n <= 55; n++) s._message({ type: 'simulation_event', payload: { seq: `m-${n}` } });
+  });
+  // Retained queue capped at 50 even though visibility never changed it.
+  await expect(summary(page)).toHaveText('Showing 50 of 50 events');
+  await expect(entries(page)).toHaveCount(50);
+  await expect(entries(page).first()).toContainText('m-55');
+  await expect(entries(page).last()).toContainText('m-6');
+});
+
+test('export: visible-only, newest-first, schema/version, full payloads, revoked URL, deterministic filename', async ({ page }) => {
+  test.slow(); // stub installation + blob readback under contention
+  const longText = 'y'.repeat(300);
+  await inject(page, 'node_update', { seq: 1, blob: longText });
+  await inject(page, 'edge_update', { seq: 2 });
+  await inject(page, 'node_update', { seq: 3 });
+  await expect(entries(page)).toHaveCount(3);
+
+  // Filter to node_update + search that matches both node entries.
+  for (const off of ['simulation_event', 'network_update', 'edge_update']) {
+    await chan(page, off).click();
+  }
+  await expect(entries(page)).toHaveCount(2);
+
+  await armExportCapture(page);
+  await expect(exportBtn(page)).toBeEnabled();
+  await exportBtn(page).click();
+  const result = await readExport(page);
+
+  expect(result.download).toBe('event-feed-export.json');
+  expect(result.href).toBe('blob:capture-1');
+  expect(result.revoked).toContain('blob:capture-1');
+  expect(result.doc.schema).toBe('utilityfog.event-feed-export');
+  expect(result.doc.version).toBe(1);
+  // Visible-only (edge_update excluded), newest first.
+  expect(result.doc.events).toHaveLength(2);
+  expect(result.doc.events[0].channel).toBe('node_update');
+  expect(result.doc.events[0].payload.seq).toBe(3);
+  expect(result.doc.events[1].payload.seq).toBe(1);
+  // Full untruncated payload — not the 100-char preview.
+  expect(result.doc.events[1].payload.blob).toBe(longText);
+  expect(result.doc.events[1].payload.blob.length).toBe(300);
+  // Timestamps present on every record.
+  expect(typeof result.doc.events[0].timestamp).toBe('number');
+});
+
+test('export composes with search + filter and is disabled at zero visible', async ({ page }) => {
+  await injectFour(page);
+  await searchBox(page).fill('no-such-token-xyz');
+  await expect(entries(page)).toHaveCount(0);
+  await expect(exportBtn(page)).toBeDisabled();
+
+  await searchBox(page).fill('e1'); // edge preview only
+  await expect(entries(page)).toHaveCount(1);
+  await armExportCapture(page);
+  await exportBtn(page).click();
+  const result = await readExport(page);
+  expect(result.doc.events).toHaveLength(1);
+  expect(result.doc.events[0].channel).toBe('edge_update');
+});
+
+test('StrictMode single delivery holds with operations present; no page errors across a mixed sequence', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+
+  await inject(page, 'node_update', { once: true });
+  await expect(entries(page)).toHaveCount(1); // one delivery per message
+
+  await chan(page, 'node_update').click();
+  await chan(page, 'node_update').click();
+  await searchBox(page).fill('once');
+  await expect(entries(page)).toHaveCount(1);
+  await searchBox(page).fill('');
+  await clearBtn(page).click();
+  await inject(page, 'simulation_event', { later: true });
+  await expect(entries(page)).toHaveCount(1);
+
+  expect(errors).toHaveLength(0);
+});

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -84,19 +84,32 @@ const injectFour = async (page: Page) => {
 const armExportCapture = (page: Page) =>
   page.evaluate(() => {
     const w = window as any;
-    w.__exportCapture = { revoked: [] as string[], download: '', href: '', text: '' };
+    // Ordered event sequence proves the download click happens BEFORE the
+    // (deferred) revocation — no fixed sleeps; tests poll for 'revoke'.
+    w.__exportCapture = { revoked: [] as string[], sequence: [] as string[], download: '', href: '', text: '' };
     URL.createObjectURL = ((blob: Blob) => {
       w.__exportCapture.blob = blob;
+      w.__exportCapture.sequence.push('create');
       return 'blob:capture-1';
     }) as typeof URL.createObjectURL;
     URL.revokeObjectURL = ((u: string) => {
       w.__exportCapture.revoked.push(u);
+      w.__exportCapture.sequence.push('revoke');
     }) as typeof URL.revokeObjectURL;
     HTMLAnchorElement.prototype.click = function () {
       w.__exportCapture.download = (this as HTMLAnchorElement).download;
       w.__exportCapture.href = (this as HTMLAnchorElement).href;
+      w.__exportCapture.sequence.push('click');
     };
   });
+const awaitRevocation = async (page: Page) => {
+  await expect
+    .poll(async () => page.evaluate(() => (window as any).__exportCapture.revoked.length))
+    .toBe(1);
+  const seq: string[] = await page.evaluate(() => (window as any).__exportCapture.sequence);
+  expect(seq.indexOf('click')).toBeGreaterThanOrEqual(0);
+  expect(seq.indexOf('click')).toBeLessThan(seq.indexOf('revoke'));
+};
 const readExport = (page: Page) =>
   page.evaluate(async () => {
     const c = (window as any).__exportCapture;
@@ -248,7 +261,8 @@ test('export: visible-only, newest-first, schema/version, full payloads, revoked
 
   expect(result.download).toBe('event-feed-export.json');
   expect(result.href).toBe('blob:capture-1');
-  expect(result.revoked).toContain('blob:capture-1');
+  await awaitRevocation(page);
+  expect(await page.evaluate(() => (window as any).__exportCapture.revoked)).toContain('blob:capture-1');
   expect(result.doc.schema).toBe('utilityfog.event-feed-export');
   expect(result.doc.version).toBe(1);
   // Visible-only (edge_update excluded), newest first.
@@ -276,6 +290,36 @@ test('export composes with search + filter and is disabled at zero visible', asy
   const result = await readExport(page);
   expect(result.doc.events).toHaveLength(1);
   expect(result.doc.events[0].channel).toBe('edge_update');
+  await awaitRevocation(page); // exactly one revocation here too
+});
+
+test('export normalizes absent payloads to null and preserves falsy payloads distinctly', async ({ page }) => {
+  // Injection order (oldest→newest): absent, null, false, 0, ''.
+  await page.evaluate(() => {
+    const w = window as any;
+    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const s = socks[socks.length - 1];
+    s._message({ type: 'simulation_event' }); // payload property absent
+    s._message({ type: 'simulation_event', payload: null });
+    s._message({ type: 'simulation_event', payload: false });
+    s._message({ type: 'simulation_event', payload: 0 });
+    s._message({ type: 'simulation_event', payload: '' });
+  });
+  await expect(entries(page)).toHaveCount(5);
+  await armExportCapture(page);
+  await exportBtn(page).click();
+  const result = await readExport(page);
+  expect(result.doc.events).toHaveLength(5);
+  // Every record carries channel, timestamp AND payload — even when the
+  // original payload was absent (normalized to explicit null).
+  for (const rec of result.doc.events) {
+    expect(Object.prototype.hasOwnProperty.call(rec, 'payload')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(rec, 'channel')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(rec, 'timestamp')).toBe(true);
+  }
+  // Newest first: '', 0, false, null (explicit), null (normalized absent).
+  expect(result.doc.events.map((r: { payload: unknown }) => r.payload)).toEqual(['', 0, false, null, null]);
+  await awaitRevocation(page);
 });
 
 test('StrictMode single delivery holds with operations present; no page errors across a mixed sequence', async ({ page }) => {


### PR DESCRIPTION
## Scope (Package J of Kev's runway — STACKED PR)

**Base: `claude/event-feed-contract` (#318), not main — this PR depends on #318 and is NOT independently mergeable to main.** Displayed diff = Package J only. **Files: `src/components/EventFeed.tsx` + new `tests/event-feed-operations.spec.ts` only** (no helper file needed).

**Delivered (bounded issue-#2 timeline slice):** channel filtering (four `aria-pressed` toggles, all on initially, multi-select, truthful all-off state, presentation-only — retention untouched) · labelled trimmed case-insensitive search over channel + rendered preview (plain string; composes with filters; clearing restores filter-only view) · plain-text result summary (not a live region; the `role=log` list stays the feed's only live region) with distinct empty/filtered-empty/populated wording · Clear (disabled when empty; **documented: monotonic id counter not reset**; subscriptions untouched, later delivery proven) · **Export visible JSON** (visible results newest-first; schema `utilityfog.event-feed-export` v1 with channel/timestamp/payload; **entries retain the original parsed payload** so export never reconstructs from truncated previews; Blob → object URL → download → revoke; deterministic `event-feed-export.json`; bounded visible error guard — unreachable via the JSON.parse message path, declared; no server/telemetry/clipboard/storage; no `dangerouslySetInnerHTML`) · parent #318 contracts preserved and its inherited spec passes on this branch.

## Receipts (amended head `0deab13`)
- Targeted spec: **parallel `--repeat-each=3`: 30/30 (7.7s) and 30/30 (7.2s, consecutive runs)**; earlier serialized ×3: 30/30. Full suite on branch: **25/25 (4.5s)**. `tsc --noEmit`: matches the 7-diagnostic main baseline with no additions.
- Combined-stack lab (uncommitted 7-head worktree): amended spec **10/10 serialized**; cross-feature adversarial journey (reconnect with filters+search live, clear-while-down, export-after-reconnect, cap under churn) green.
- **Two harness findings surfaced by the lab and fixed in this spec (test-only):** (1) the fake WebSocket had also captured **Vite's HMR socket**, whose lost-connection restart ping reloads the page mid-test — the source of earlier intermittent parallel expect-timeouts; the fake now proxies construction and fakes only the app's `/ws` socket. (2) **Positionless `node_update` fixtures can crash-loop the untouched viz3d lane** when features are integrated (`node.position is not iterable`) — fixtures now carry valid node shapes; fragility reported separately as a product finding (outside this PR's files).

## Governance
Stacked child of #318 — do not merge before its parent; **stays OPEN AND UNMERGED** for Jack's audit. Refs #2, no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## AMENDMENT (Jack's three findings; head `30913ad5c822d0749f63be361b255caf66ebfa95`)
1. **Deferred URL revocation** — `setTimeout(…, 0)` after append→click→remove of the anchor; exactly one revocation per successful export; no URL exists on serialization failure, so nothing leaks. 2. **Async receipt** — ordered stub sequence + `expect.poll`: click provably precedes revoke; no fixed sleeps. 3. **Absent payloads export as explicit `null`** — every record carries channel/timestamp/payload; falsy matrix (absent/null/false/0/'') proves no conflation; preview contract unchanged. **Receipts: targeted ×3 twice = 33/33 both; branch suite 26/26; remaining-stack lab (new main +316+321+318+320+324): 56/56, ×3 = 168/168, adversarial journey 2/2 incl. download-before-revocation and falsy-payload export. CI green.** Threads left unresolved for Jack.