### PR TITLE
lab(uft_ca): isolated counter-RNG laboratory (LAB-CRNG-v1) — benches/tests only

### DIFF
--- a/crates/uft_ca/Cargo.toml
+++ b/crates/uft_ca/Cargo.toml
@@ -43,3 +43,7 @@ wasm = []
 [[bench]]
 name = "stepping"
 harness = false
+
+[[bench]]
+name = "counter_rng"
+harness = false

--- a/crates/uft_ca/benches/counter_rng.rs
+++ b/crates/uft_ca/benches/counter_rng.rs
@@ -3,13 +3,27 @@
 //!
 //! Groups are reported SEPARATELY and are not like-for-like proofs of a
 //! production speedup:
-//!   1. xoshiro_dense    — seeded Xoshiro256** (the engine's CaRng algorithm)
-//!                         materializing Vec<f32> via Rng::gen::<f32>().
-//!   2. counter_dense    — counter generator materializing Vec<f32>
+//!   1. xoshiro_persistent — Xoshiro256** (the engine's CaRng algorithm)
+//!                         seeded ONCE outside the timed region, then
+//!                         consumed across iterations, materializing
+//!                         Vec<f32> via Rng::gen::<f32>(). This is the
+//!                         production-representative comparison: the
+//!                         stepper keeps a persistent RNG and does not
+//!                         reseed per vector. A persistent generator means
+//!                         each Criterion iteration consumes a DIFFERENT
+//!                         stretch of the random sequence — that is
+//!                         correct for measuring generation/
+//!                         materialization throughput, which does not
+//!                         depend on which stretch is drawn.
+//!   2. xoshiro_reseed   — the previous shape (seed inside the timed
+//!                         region) retained ONLY as a measurement of
+//!                         seeding overhead. NEVER the production
+//!                         comparison.
+//!   3. counter_dense    — counter generator materializing Vec<f32>
 //!                         (generator cost + allocation cost together).
-//!   3. counter_direct   — counter generator consumed directly (checksum),
+//!   4. counter_direct   — counter generator consumed directly (checksum),
 //!                         no intermediate vector (generator cost alone).
-//!   4. counter_sparse   — counter lookups on deterministic 1%/10%/50%
+//!   5. counter_sparse   — counter lookups on deterministic 1%/10%/50%
 //!                         index sets (skipped-work shape). Index-set
 //!                         construction happens OUTSIDE the timed region.
 //!
@@ -50,8 +64,29 @@ fn checksum(values: impl IntoIterator<Item = f32>) -> f64 {
     values.into_iter().map(f64::from).sum()
 }
 
-fn bench_xoshiro_dense(c: &mut Criterion) {
-    let mut group = c.benchmark_group("xoshiro_dense_vec_f32");
+fn bench_xoshiro_persistent_dense(c: &mut Criterion) {
+    let mut group = c.benchmark_group("xoshiro_persistent_dense_vec_f32");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+    for (label, n) in SIZES {
+        group.bench_function(label, |b| {
+            // Production-representative: seeded ONCE outside the timed
+            // region; the persistent generator is consumed across
+            // iterations (throughput is sequence-position independent).
+            let mut rng = Xoshiro256StarStar::seed_from_u64(SEED);
+            b.iter(|| {
+                let v: Vec<f32> = (0..n).map(|_| rng.gen::<f32>()).collect();
+                black_box(checksum(v))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_xoshiro_reseed_dense(c: &mut Criterion) {
+    // Seeding-overhead measurement ONLY — never the production comparison.
+    let mut group = c.benchmark_group("xoshiro_reseed_and_dense_vec_f32");
     group.sample_size(20);
     group.warm_up_time(std::time::Duration::from_secs(1));
     group.measurement_time(std::time::Duration::from_secs(2));
@@ -136,7 +171,8 @@ fn bench_counter_sparse(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_xoshiro_dense,
+    bench_xoshiro_persistent_dense,
+    bench_xoshiro_reseed_dense,
     bench_counter_dense,
     bench_counter_direct,
     bench_counter_sparse

--- a/crates/uft_ca/benches/counter_rng.rs
+++ b/crates/uft_ca/benches/counter_rng.rs
@@ -1,0 +1,144 @@
+//! Bounded Criterion comparison for the ISOLATED counter-RNG laboratory
+//! (LAB-CRNG-v1; PR #315 Appendix A). CPU-only; no GPU claim anywhere.
+//!
+//! Groups are reported SEPARATELY and are not like-for-like proofs of a
+//! production speedup:
+//!   1. xoshiro_dense    — seeded Xoshiro256** (the engine's CaRng algorithm)
+//!                         materializing Vec<f32> via Rng::gen::<f32>().
+//!   2. counter_dense    — counter generator materializing Vec<f32>
+//!                         (generator cost + allocation cost together).
+//!   3. counter_direct   — counter generator consumed directly (checksum),
+//!                         no intermediate vector (generator cost alone).
+//!   4. counter_sparse   — counter lookups on deterministic 1%/10%/50%
+//!                         index sets (skipped-work shape). Index-set
+//!                         construction happens OUTSIDE the timed region.
+//!
+//! Memory statements are analytical, not measured: a dense Vec<f32> holds
+//! len × 4 bytes; direct/sparse consumption allocates no intermediate RNG
+//! vector. Allocator peak, cache behavior, memory traffic and energy are
+//! unmeasured here.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256StarStar;
+
+#[path = "support/counter_rng.rs"]
+mod counter_rng;
+use counter_rng::{counter_f32, materialize_dense, CounterKey};
+
+const SEED: u64 = 424_242;
+const GENERATION: u32 = 1_000_000;
+const PHASE: u16 = 6;
+const LANE: u16 = 0;
+
+// 32^3, 64^3, 96^3 — bounded; no 256^3 allocation anywhere.
+const SIZES: [(&str, usize); 3] = [("32c", 32_768), ("64c", 262_144), ("96c", 884_736)];
+
+fn base_key() -> CounterKey {
+    CounterKey {
+        seed: SEED,
+        generation: GENERATION,
+        phase_id: PHASE,
+        voxel_index: 0,
+        draw_lane: LANE,
+    }
+}
+
+fn checksum(values: impl IntoIterator<Item = f32>) -> f64 {
+    values.into_iter().map(f64::from).sum()
+}
+
+fn bench_xoshiro_dense(c: &mut Criterion) {
+    let mut group = c.benchmark_group("xoshiro_dense_vec_f32");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+    for (label, n) in SIZES {
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let mut rng = Xoshiro256StarStar::seed_from_u64(black_box(SEED));
+                let v: Vec<f32> = (0..n).map(|_| rng.gen::<f32>()).collect();
+                black_box(checksum(v))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_counter_dense(c: &mut Criterion) {
+    let mut group = c.benchmark_group("counter_dense_vec_f32");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+    for (label, n) in SIZES {
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let v = materialize_dense(black_box(base_key()), n);
+                black_box(checksum(v))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_counter_direct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("counter_direct_no_vec");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+    for (label, n) in SIZES {
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let base = black_box(base_key());
+                let mut sum = 0.0f64;
+                for i in 0..n as u64 {
+                    sum += f64::from(counter_f32(CounterKey {
+                        voxel_index: i,
+                        ..base
+                    }));
+                }
+                black_box(sum)
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_counter_sparse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("counter_sparse_lookup");
+    group.sample_size(20);
+    group.warm_up_time(std::time::Duration::from_secs(1));
+    group.measurement_time(std::time::Duration::from_secs(2));
+    for (label, n) in SIZES {
+        for (pct, step) in [("1pct", 100usize), ("10pct", 10), ("50pct", 2)] {
+            // Deterministic index set, built OUTSIDE the timed region
+            // (skipped-work construction reported separately from lookup).
+            let indices: Vec<u64> = (0..n as u64).step_by(step).collect();
+            group.bench_function(format!("{label}_{pct}"), |b| {
+                b.iter(|| {
+                    let base = black_box(base_key());
+                    let mut sum = 0.0f64;
+                    for &i in &indices {
+                        sum += f64::from(counter_f32(CounterKey {
+                            voxel_index: i,
+                            ..base
+                        }));
+                    }
+                    black_box(sum)
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_xoshiro_dense,
+    bench_counter_dense,
+    bench_counter_direct,
+    bench_counter_sparse
+);
+criterion_main!(benches);

--- a/crates/uft_ca/benches/support/counter_rng.rs
+++ b/crates/uft_ca/benches/support/counter_rng.rs
@@ -37,13 +37,20 @@ pub struct CounterKey {
 }
 
 /// Spec A.1 `mix64` — all arithmetic u64 mod 2^64, explicit wrapping
-/// multiplication, logical right shifts.
+/// multiplication, logical right shifts. `const fn`: evaluable at compile
+/// time (audit M-T2); output for any input is locked by the golden vectors.
 #[inline]
-pub fn mix64(mut z: u64) -> u64 {
+pub const fn mix64(mut z: u64) -> u64 {
     z = (z ^ (z >> 30)).wrapping_mul(M1);
     z = (z ^ (z >> 27)).wrapping_mul(M2);
     z ^ (z >> 31)
 }
+
+/// The spec's fixed initial accumulator `mix64(DOMAIN xor VERSION)`,
+/// hoisted to a compile-time constant (audit M-T3). Its exact value is
+/// locked by an independently calculated test fixture — this fold is pure
+/// algebraic hoisting and changes no output.
+pub const INITIAL_ACC: u64 = mix64(DOMAIN ^ LAB_STREAM_VERSION);
 
 /// Spec A.1 `counter_u64` — fixed fold order: version-domain, seed,
 /// generation, phase/lane pack, voxel index. Narrow fields zero-extend.
@@ -51,8 +58,7 @@ pub fn mix64(mut z: u64) -> u64 {
 pub fn counter_u64(key: CounterKey) -> u64 {
     let g = u64::from(key.generation);
     let pl = (u64::from(key.phase_id) << 16) | u64::from(key.draw_lane);
-    let mut acc = mix64(DOMAIN ^ LAB_STREAM_VERSION);
-    acc = mix64(acc ^ key.seed);
+    let mut acc = mix64(INITIAL_ACC ^ key.seed);
     acc = mix64(acc ^ g);
     acc = mix64(acc ^ pl);
     acc = mix64(acc ^ key.voxel_index);
@@ -60,10 +66,14 @@ pub fn counter_u64(key: CounterKey) -> u64 {
 }
 
 /// Spec A.1 `counter_f32` — top 24 bits scaled by exactly 2^-24; the result
-/// lies in [0, 1) and can never equal 1.0.
+/// lies in [0, 1) and can never equal 1.0. The intermediate narrows to u32
+/// before the float conversion (audit M-T4): top24 always fits in 24 bits,
+/// so the narrowing is lossless and is DESIGNED TO PERMIT a narrower
+/// integer-to-float conversion — no instruction-selection claim is made
+/// without inspecting generated assembly.
 #[inline]
 pub fn counter_f32(key: CounterKey) -> f32 {
-    let top24 = counter_u64(key) >> 40;
+    let top24 = (counter_u64(key) >> 40) as u32;
     (top24 as f32) * F32_SCALE
 }
 

--- a/crates/uft_ca/benches/support/counter_rng.rs
+++ b/crates/uft_ca/benches/support/counter_rng.rs
@@ -1,0 +1,81 @@
+//! LAB-CRNG-v1 — ISOLATED LABORATORY implementation of the counter-indexed
+//! RNG specified in `docs/COUNTER_INDEXED_RNG_FEASIBILITY.md` (PR #315),
+//! Appendix A.1, implemented verbatim.
+//!
+//! LABORATORY-ONLY: non-cryptographic, carries no statistical-quality claim,
+//! and is NOT approved for production physics. Nothing under `src/` consumes
+//! this module. Any algorithm or constant change must bump
+//! `LAB_STREAM_VERSION` so replay identity cannot silently drift.
+//!
+//! This module is shared by the golden/correctness test target and the
+//! Criterion benchmark; it lives under `benches/support/` deliberately so
+//! Cargo target auto-discovery does not treat it as an independent
+//! benchmark target.
+#![allow(dead_code)]
+
+/// Version constant folded into the stream (spec: VERSION = 1).
+pub const LAB_STREAM_VERSION: u64 = 1;
+
+/// First 64 fractional bits of pi (spec: DOMAIN).
+pub const DOMAIN: u64 = 0x243F_6A88_85A3_08D3;
+
+/// Stafford variant-13 multipliers (spec: M1, M2).
+const M1: u64 = 0xBF58_476D_1CE4_E5B9;
+const M2: u64 = 0x94D0_49BB_1331_11EB;
+
+/// Exact 2^-24 as f32 (power of two — exactly representable).
+const F32_SCALE: f32 = 1.0 / ((1u32 << 24) as f32);
+
+/// The full deterministic draw coordinate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CounterKey {
+    pub seed: u64,
+    pub generation: u32,
+    pub phase_id: u16,
+    pub voxel_index: u64,
+    pub draw_lane: u16,
+}
+
+/// Spec A.1 `mix64` — all arithmetic u64 mod 2^64, explicit wrapping
+/// multiplication, logical right shifts.
+#[inline]
+pub fn mix64(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(M1);
+    z = (z ^ (z >> 27)).wrapping_mul(M2);
+    z ^ (z >> 31)
+}
+
+/// Spec A.1 `counter_u64` — fixed fold order: version-domain, seed,
+/// generation, phase/lane pack, voxel index. Narrow fields zero-extend.
+#[inline]
+pub fn counter_u64(key: CounterKey) -> u64 {
+    let g = u64::from(key.generation);
+    let pl = (u64::from(key.phase_id) << 16) | u64::from(key.draw_lane);
+    let mut acc = mix64(DOMAIN ^ LAB_STREAM_VERSION);
+    acc = mix64(acc ^ key.seed);
+    acc = mix64(acc ^ g);
+    acc = mix64(acc ^ pl);
+    acc = mix64(acc ^ key.voxel_index);
+    acc
+}
+
+/// Spec A.1 `counter_f32` — top 24 bits scaled by exactly 2^-24; the result
+/// lies in [0, 1) and can never equal 1.0.
+#[inline]
+pub fn counter_f32(key: CounterKey) -> f32 {
+    let top24 = counter_u64(key) >> 40;
+    (top24 as f32) * F32_SCALE
+}
+
+/// Dense materialization: element `i` equals `counter_f32` of `base` with
+/// `voxel_index = i` (row-major flat index semantics; other fields fixed).
+pub fn materialize_dense(base: CounterKey, len: usize) -> Vec<f32> {
+    (0..len as u64)
+        .map(|i| {
+            counter_f32(CounterKey {
+                voxel_index: i,
+                ..base
+            })
+        })
+        .collect()
+}

--- a/crates/uft_ca/tests/counter_rng_lab.rs
+++ b/crates/uft_ca/tests/counter_rng_lab.rs
@@ -15,8 +15,13 @@
 mod counter_rng;
 
 use counter_rng::{
-    counter_f32, counter_u64, materialize_dense, mix64, CounterKey, LAB_STREAM_VERSION,
+    counter_f32, counter_u64, materialize_dense, mix64, CounterKey, INITIAL_ACC, LAB_STREAM_VERSION,
 };
+
+// Compile-time const-evaluation lock (audit M-T2): `mix64` must be usable
+// in const context. The expected value is from the INDEPENDENT Python
+// big-int oracle (mod-2^64 masking), not from the Rust implementation.
+const MIX64_OF_42_CONST: u64 = mix64(42);
 
 /// (id, seed, generation, phase_id, voxel_index, draw_lane, u64, top24, f32_bits)
 const GOLDENS: [(&str, u64, u32, u16, u64, u16, u64, u64, u32); 10] = [
@@ -182,6 +187,21 @@ fn same_key_repeats_identically() {
 #[test]
 fn version_constant_is_locked() {
     assert_eq!(LAB_STREAM_VERSION, 1);
+}
+
+#[test]
+fn initial_acc_matches_independent_oracle() {
+    // mix64(DOMAIN xor VERSION) computed independently (Python big-int with
+    // explicit mod-2^64 masking) — NOT generated from this implementation.
+    assert_eq!(INITIAL_ACC, 0x8204_7734_2D9C_40C0);
+}
+
+#[test]
+fn mix64_const_evaluation_matches_independent_oracle() {
+    // Value computed by the same independent oracle; the constant itself
+    // proves const-context evaluation compiled.
+    assert_eq!(MIX64_OF_42_CONST, 0xA759_EA27_D472_7622);
+    assert_eq!(mix64(42), MIX64_OF_42_CONST);
 }
 
 #[test]

--- a/crates/uft_ca/tests/counter_rng_lab.rs
+++ b/crates/uft_ca/tests/counter_rng_lab.rs
@@ -1,0 +1,359 @@
+//! Golden-vector and correctness suite for the ISOLATED counter-RNG
+//! laboratory (LAB-CRNG-v1; docs/COUNTER_INDEXED_RNG_FEASIBILITY.md, PR #315
+//! Appendix A). Golden fixtures below are the ten AUDITED vectors from that
+//! appendix — independently dual-formulation derived (Node BigInt + .NET
+//! BigInteger); they were NOT regenerated from this Rust implementation.
+//!
+//! Scope note (binding): this laboratory proves the integer generator and
+//! its f32 projection against the locked specification. It does NOT prove
+//! cross-platform full-physics trajectory identity — the production kernel
+//! contains floating-point operations, so full replay remains
+//! target/build-sensitive. No injectivity is claimed: distinct keys may
+//! legitimately collide in 64 (and especially 24) output bits.
+
+#[path = "../benches/support/counter_rng.rs"]
+mod counter_rng;
+
+use counter_rng::{
+    counter_f32, counter_u64, materialize_dense, mix64, CounterKey, LAB_STREAM_VERSION,
+};
+
+/// (id, seed, generation, phase_id, voxel_index, draw_lane, u64, top24, f32_bits)
+const GOLDENS: [(&str, u64, u32, u16, u64, u16, u64, u64, u32); 10] = [
+    (
+        "T1 zero",
+        0,
+        0,
+        0,
+        0,
+        0,
+        0x966C_920F_E8E9_DA97,
+        9_858_194,
+        0x3F16_6C92,
+    ),
+    (
+        "T2 max seed",
+        u64::MAX,
+        0,
+        0,
+        0,
+        0,
+        0x9BBC_F84A_6EBF_14FD,
+        10_206_456,
+        0x3F1B_BCF8,
+    ),
+    (
+        "T3 all max",
+        u64::MAX,
+        u32::MAX,
+        u16::MAX,
+        u64::MAX,
+        u16::MAX,
+        0x88D7_2CB6_D8EE_6248,
+        8_967_980,
+        0x3F08_D72C,
+    ),
+    (
+        "T4 gen boundary",
+        42,
+        u32::MAX,
+        6,
+        137,
+        0,
+        0x9E74_7B63_04BB_FFF3,
+        10_384_507,
+        0x3F1E_747B,
+    ),
+    (
+        "T5 base",
+        42,
+        1000,
+        6,
+        137,
+        0,
+        0xAF38_00A6_97FA_60B3,
+        11_483_136,
+        0x3F2F_3800,
+    ),
+    (
+        "T6 adjacent index",
+        42,
+        1000,
+        6,
+        138,
+        0,
+        0x5371_121A_AAE8_0CA2,
+        5_468_434,
+        0x3EA6_E224,
+    ),
+    (
+        "T7 adjacent phase",
+        42,
+        1000,
+        7,
+        137,
+        0,
+        0x38BD_0EC2_2AA0_2C6C,
+        3_718_414,
+        0x3E62_F438,
+    ),
+    (
+        "T8 adjacent lane",
+        42,
+        1000,
+        6,
+        137,
+        1,
+        0x98A8_A9BC_D1C8_26C9,
+        10_004_649,
+        0x3F18_A8A9,
+    ),
+    (
+        "T9 realistic",
+        424_242,
+        1_000_000,
+        6,
+        8_421_376,
+        0,
+        0xA76D_5375_0315_95F3,
+        10_972_499,
+        0x3F27_6D53,
+    ),
+    (
+        "T10 wrap boundary",
+        1 << 63,
+        1 << 31,
+        1 << 15,
+        1 << 63,
+        1 << 15,
+        0x43AF_ED72_9359_3EAF,
+        4_435_949,
+        0x3E87_5FDA,
+    ),
+];
+
+fn key(seed: u64, generation: u32, phase_id: u16, voxel_index: u64, draw_lane: u16) -> CounterKey {
+    CounterKey {
+        seed,
+        generation,
+        phase_id,
+        voxel_index,
+        draw_lane,
+    }
+}
+
+/// FAIL-CLOSED GOLDEN LADDER — checked strictly in the audited order:
+/// (1) exact u64 equality, (2) exact top-24 equality, (3) exact
+/// f32::to_bits equality. Any mismatch is a specification-or-implementation
+/// defect and stops the laboratory; never "close enough".
+#[test]
+fn t00_golden_vectors_fail_closed() {
+    // Step 1: exact u64 equality for all ten.
+    for (id, s, g, p, i, l, u, _, _) in GOLDENS {
+        assert_eq!(counter_u64(key(s, g, p, i, l)), u, "u64 mismatch at {id}");
+    }
+    // Step 2: exact top-24 equality for all ten.
+    for (id, s, g, p, i, l, _, top24, _) in GOLDENS {
+        assert_eq!(
+            counter_u64(key(s, g, p, i, l)) >> 40,
+            top24,
+            "top24 mismatch at {id}"
+        );
+    }
+    // Step 3: exact f32 bit-pattern equality for all ten.
+    for (id, s, g, p, i, l, _, _, bits) in GOLDENS {
+        assert_eq!(
+            counter_f32(key(s, g, p, i, l)).to_bits(),
+            bits,
+            "f32 bits mismatch at {id}"
+        );
+    }
+}
+
+#[test]
+fn same_key_repeats_identically() {
+    let k = key(424_242, 1_000_000, 6, 8_421_376, 0);
+    for _ in 0..8 {
+        assert_eq!(counter_u64(k), 0xA76D_5375_0315_95F3);
+        assert_eq!(counter_f32(k).to_bits(), 0x3F27_6D53);
+    }
+}
+
+#[test]
+fn version_constant_is_locked() {
+    assert_eq!(LAB_STREAM_VERSION, 1);
+}
+
+#[test]
+fn mix64_zero_is_spec_initial_state_component() {
+    // mix64 is deterministic and total; boundary inputs must not panic.
+    let _ = mix64(0);
+    let _ = mix64(u64::MAX);
+    let _ = mix64(1 << 63);
+}
+
+#[test]
+fn boundary_keys_do_not_panic_and_map_to_unit_interval() {
+    let boundary = [
+        key(0, 0, 0, 0, 0),
+        key(u64::MAX, u32::MAX, u16::MAX, u64::MAX, u16::MAX),
+        key(1 << 63, 1 << 31, 1 << 15, 1 << 63, 1 << 15),
+        key(u64::MAX, 0, u16::MAX, 0, u16::MAX),
+        key(0, u32::MAX, 0, u64::MAX, 0),
+    ];
+    for k in boundary {
+        let v = counter_f32(k);
+        assert!((0.0..1.0).contains(&v), "out of [0,1) at {k:?}: {v}");
+    }
+}
+
+#[test]
+fn outputs_always_in_unit_interval_across_a_sweep() {
+    for n in 0..10_000u64 {
+        let v = counter_f32(key(
+            n.wrapping_mul(0x9E37_79B9),
+            (n as u32) << 7,
+            (n % 9) as u16,
+            n * 31,
+            (n % 3) as u16,
+        ));
+        assert!((0.0..1.0).contains(&v));
+    }
+}
+
+#[test]
+fn dense_materialization_empty_singleton_ordinary() {
+    let base = key(42, 1000, 6, 0, 0);
+    assert!(materialize_dense(base, 0).is_empty());
+
+    let one = materialize_dense(base, 1);
+    assert_eq!(one.len(), 1);
+    assert_eq!(
+        one[0].to_bits(),
+        counter_f32(key(42, 1000, 6, 0, 0)).to_bits()
+    );
+
+    let n = 4096;
+    let dense = materialize_dense(base, n);
+    assert_eq!(dense.len(), n);
+    for (i, v) in dense.iter().enumerate() {
+        assert_eq!(
+            v.to_bits(),
+            counter_f32(key(42, 1000, 6, i as u64, 0)).to_bits(),
+            "dense[{i}] != counter_f32(key with index {i})"
+        );
+    }
+}
+
+#[test]
+fn forward_and_reverse_lookup_agree() {
+    let base = key(7, 77, 2, 0, 1);
+    let dense = materialize_dense(base, 1024);
+    for i in (0..1024usize).rev() {
+        assert_eq!(
+            dense[i].to_bits(),
+            counter_f32(key(7, 77, 2, i as u64, 1)).to_bits()
+        );
+    }
+}
+
+#[test]
+fn stride_7_traversal_is_deterministic() {
+    let base = key(99, 5, 3, 0, 0);
+    let pass = |()| -> Vec<u32> {
+        (0..4096u64)
+            .step_by(7)
+            .map(|i| counter_f32(key(99, 5, 3, i, 0)).to_bits())
+            .collect()
+    };
+    assert_eq!(pass(()), pass(()));
+    // And each strided element agrees with dense materialization.
+    let dense = materialize_dense(base, 4096);
+    for i in (0..4096usize).step_by(7) {
+        assert_eq!(
+            dense[i].to_bits(),
+            counter_f32(key(99, 5, 3, i as u64, 0)).to_bits()
+        );
+    }
+}
+
+#[test]
+fn fixed_permutation_lookup_matches_direct() {
+    // One fixed permutation of 0..16 (hardcoded; not generated at runtime).
+    let perm: [u64; 16] = [9, 3, 15, 0, 12, 7, 1, 14, 5, 11, 2, 8, 13, 4, 10, 6];
+    let dense = materialize_dense(key(1234, 9, 4, 0, 0), 16);
+    for &i in &perm {
+        assert_eq!(
+            dense[i as usize].to_bits(),
+            counter_f32(key(1234, 9, 4, i, 0)).to_bits()
+        );
+    }
+}
+
+#[test]
+fn sparse_sets_match_dense_at_1_10_50_percent() {
+    let base = key(55, 123, 6, 0, 0);
+    let n = 10_000usize;
+    let dense = materialize_dense(base, n);
+    for step in [100usize, 10, 2] {
+        // Deterministic sparse index sets: every `step`-th index.
+        for i in (0..n).step_by(step) {
+            assert_eq!(
+                dense[i].to_bits(),
+                counter_f32(key(55, 123, 6, i as u64, 0)).to_bits(),
+                "sparse(step {step}) mismatch at {i}"
+            );
+        }
+    }
+}
+
+#[test]
+fn field_adjacency_smoke_only() {
+    // SMOKE ONLY: the audited adjacent fixtures (T5-T8) differ from each
+    // other. No injectivity claim — distinct keys MAY collide in general.
+    let t5 = counter_u64(key(42, 1000, 6, 137, 0));
+    let t6 = counter_u64(key(42, 1000, 6, 138, 0));
+    let t7 = counter_u64(key(42, 1000, 7, 137, 0));
+    let t8 = counter_u64(key(42, 1000, 6, 137, 1));
+    assert_ne!(t5, t6);
+    assert_ne!(t5, t7);
+    assert_ne!(t5, t8);
+}
+
+#[test]
+fn no_global_mutable_state_interleaving() {
+    // Interleaving two logical "streams" cannot perturb either: the
+    // generator is a pure function of its key (no statics, no RNG state).
+    let a = key(1, 1, 1, 0, 0);
+    let b = key(2, 2, 2, 0, 1);
+    let a_alone: Vec<u64> = (0..64)
+        .map(|i| {
+            counter_u64(CounterKey {
+                voxel_index: i,
+                ..a
+            })
+        })
+        .collect();
+    let b_alone: Vec<u64> = (0..64)
+        .map(|i| {
+            counter_u64(CounterKey {
+                voxel_index: i,
+                ..b
+            })
+        })
+        .collect();
+    let mut a_mixed = Vec::new();
+    let mut b_mixed = Vec::new();
+    for i in 0..64 {
+        a_mixed.push(counter_u64(CounterKey {
+            voxel_index: i,
+            ..a
+        }));
+        b_mixed.push(counter_u64(CounterKey {
+            voxel_index: i,
+            ..b
+        }));
+    }
+    assert_eq!(a_alone, a_mixed);
+    assert_eq!(b_alone, b_mixed);
+}


### PR DESCRIPTION
## Scope (Kev-authorized PR 2 — ISOLATED LABORATORY; amended per Jack's four review threads)

Implements #315 Appendix A.1 **verbatim** (constants, fold order, wrapping multiplies, top-24 projection). Four-file fence: `Cargo.toml` ([[bench]] only) + `benches/support/counter_rng.rs` + `benches/counter_rng.rs` + `tests/counter_rng_lab.rs`. No `src/`, dependency, lockfile, or algorithm-spec change. Laboratory-only: non-cryptographic, no statistical-quality claim, NOT approved for production physics.

## Amendment (audit threads T1–T4)
- **T1 (bench fairness):** the previous production comparison reseeded Xoshiro inside every timed iteration; the stepper keeps a persistent RNG — **that comparison is WITHDRAWN as methodologically biased.** `xoshiro_persistent_dense_vec_f32` now seeds once outside `b.iter` and consumes the generator across iterations (each iteration draws a different sequence stretch — correct for throughput, which is sequence-position independent). The reseed shape survives only as `xoshiro_reseed_and_dense_vec_f32`, a seeding-overhead measurement, never the comparison.
- **T2/T3 (hot path):** `mix64` is `const fn`; `INITIAL_ACC = mix64(DOMAIN ^ LAB_STREAM_VERSION)` is a module const; `counter_u64` starts from it (pure algebraic hoist). **T4:** `counter_f32` narrows `(>>40)` to `u32` before the float conversion — lossless (top24 fits 24 bits), *designed to permit* a narrower conversion; **no instruction-selection claim** (assembly not inspected).
- **New oracle locks (independent Python big-int, mod-2⁶⁴ masking — not generated from the Rust):** `INITIAL_ACC == 0x820477342D9C40C0`; const-context `mix64(42) == 0xA759EA27D4727622`.
- **Golden receipt: all ten audited vectors remain EXACTLY unchanged** (fail-closed ladder re-run first: u64 → top24 → f32 bits). Lab suite now **15/15**; full `cargo test` 86 lib + 15 lab, 0 failures; Cargo.lock diff **0 lines**.

## Corrected benchmark table (amended head; 75s wall; same bounded config: sample 20, ~1s/~2s, 32³/64³/96³, black_box + consumed checksums, CPU-only, no 256³)
| Group | 32³ | 64³ | 96³ |
|---|---|---|---|
| xoshiro_persistent_dense (production-representative) | 62.5 µs | 520.6 µs | 1.777 ms |
| xoshiro_reseed_and_dense (seeding-overhead only) | 48.4 µs | 541.1 µs | 1.936 ms |
| counter_dense_vec_f32 | 49.1 µs | 533.0 µs | 1.695 ms |
| counter_direct_no_vec | 20.9 µs | 156.7 µs | 580.0 µs |
| counter_sparse 1/10/50% | 0.25/2.3/12.0 µs | 1.9/18.2/93.4 µs | 6.6/64.3/319.2 µs |
**Honest reading:** under the fair persistent comparison, counter dense materialization is **roughly on par** with persistent Xoshiro at these shapes (the original ~1.5× dense-vs-dense advantage was substantially the reseeding bias — withdrawn). Cross-run variance is visible at these scales (counter_dense 64³ measured 446 µs in the original run vs 533 µs here on identical code), so microsecond-scale group differences should not be over-read. The structurally distinct results are **counter_direct** (no intermediate vector) and **sparse lookup** (pay only for consumed draws) — shapes a persistent sequential stream cannot offer. Memory statements remain analytical only.

## Prior receipts (unchanged from the original head)
Golden T9 `0xA76D5375031595F3 / 10972499 / 0x3F276D53` · target auto-discovery = `['counter_rng','stepping']` (support/ not a target) · crate-wide `fmt --check` fails on pre-existing out-of-fence files (untouched; lab files rustfmt-clean) · two pre-existing lib warnings not introduced here.

## Explicit non-claims
No production integration · no universal Xoshiro-impossibility · no GPU compilation/measurement · no statistical/cryptographic quality · no cross-platform trajectory identity.

## Governance
Refs #315 — no closing keyword. Label `theory-to-architecture` retained; `tripwire-reviewed` is Jack's. **OPEN AND UNMERGED.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)