### PR TITLE
frontend: ESLint enablement + evidence-backed elimination of all explicit-any (PACKAGE P, stacked on lockfile PR)

### DIFF
--- a/utilityfog_frontend/frontend/.eslintrc.cjs
+++ b/utilityfog_frontend/frontend/.eslintrc.cjs
@@ -1,0 +1,52 @@
+// Minimal ESLint 8 legacy configuration for the existing lint script
+// (`eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0`).
+// TypeScript-aware via the exact-pinned @typescript-eslint v8 pair.
+// Unused-variable checks are deliberately OFF here: the compiler owns that
+// gate (tsc --noEmit with noUnusedLocals), avoiding double-reporting.
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+  settings: {
+    react: { version: 'detect' },
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'react-refresh'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  rules: {
+    // The automatic JSX runtime makes React imports unnecessary.
+    'react/react-in-jsx-scope': 'off',
+    // Components are typed via TypeScript props interfaces.
+    'react/prop-types': 'off',
+    // tsc (noUnusedLocals) owns unused checks — see header note.
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    'react-refresh/only-export-components': 'warn',
+    '@typescript-eslint/no-explicit-any': 'error',
+  },
+  overrides: [
+    {
+      // react-three-fiber renders custom reconciler elements whose props
+      // (position/args/intensity/...) the React plugin cannot know; the
+      // rule is scoped off for the 3D scene files only.
+      files: ['src/viz3d/**/*.tsx'],
+      rules: { 'react/no-unknown-property': 'off' },
+    },
+  ],
+  ignorePatterns: [
+    'dist/',
+    'node_modules/',
+    'playwright-report/',
+    'test-results/',
+    'coverage/',
+  ],
+}

--- a/utilityfog_frontend/frontend/package-lock.json
+++ b/utilityfog_frontend/frontend/package-lock.json
@@ -21,6 +21,8 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
         "@vitejs/plugin-react": "^4.7.0",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
@@ -2135,6 +2137,301 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.63.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -6121,6 +6418,19 @@
       "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
       "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/utilityfog_frontend/frontend/package.json
+++ b/utilityfog_frontend/frontend/package.json
@@ -15,19 +15,21 @@
     "check:budget": "node scripts/check-bundle-budget.mjs"
   },
   "dependencies": {
+    "@react-three/drei": "^9.92.0",
+    "@react-three/fiber": "^8.15.0",
+    "leva": "^0.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.160.0",
-    "@react-three/fiber": "^8.15.0",
-    "@react-three/drei": "^9.92.0",
-    "zustand": "^4.4.7",
-    "leva": "^0.10.0"
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/node": "^22.0.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "8.63.0",
+    "@typescript-eslint/parser": "8.63.0",
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
@@ -37,4 +39,3 @@
     "vite": "^6.4.3"
   }
 }
-

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { useState, useEffect } from 'react'
 import NetworkView3D from './viz3d/NetworkView3D'
 import NetworkView2D from './components/NetworkView2D'
@@ -6,7 +7,7 @@ import EventFeed from './components/EventFeed'
 import { SimBridgeClient } from './ws/SimBridgeClient'
 
 // Robust WS URL computation
-const envUrl = (import.meta as any).env?.VITE_WS_URL as string | undefined;
+const envUrl = import.meta.env.VITE_WS_URL as string | undefined;
 
 function computeDefaultWsUrl(): string {
   const origin = window.location.origin; // http(s)://host[:port]

--- a/utilityfog_frontend/frontend/src/components/NetworkView2D.tsx
+++ b/utilityfog_frontend/frontend/src/components/NetworkView2D.tsx
@@ -17,15 +17,18 @@ export default function NetworkView2D({ simClient }: NetworkView2DProps) {
     // Same ingestion boundary as the scene store (nodeValidation.ts): this
     // view keeps its own subscription, so malformed positions must be
     // reconciled here too before the draw effect indexes node.position.
-    const handleNetworkUpdate = (data: any) => {
+    const handleNetworkUpdate = (data?: unknown) => {
       if (!data || typeof data !== 'object') return
+      const d = data as { nodes?: unknown; edges?: unknown }
       // Per-side tolerance mirrors the store: malformed one side never
-      // discards the other; explicit [] clears its collection.
-      if (Array.isArray(data.nodes)) setNodes(prev => sanitizeNodeList(data.nodes, prev))
-      if (Array.isArray(data.edges)) setEdges(data.edges)
+      // discards the other; explicit [] clears its collection. Edge
+      // ELEMENT shape stays tolerated (the draw effect skips dangling
+      // references) — the array check is the documented boundary.
+      if (Array.isArray(d.nodes)) setNodes(prev => sanitizeNodeList(d.nodes, prev))
+      if (Array.isArray(d.edges)) setEdges(d.edges as NetworkEdge[])
     }
 
-    const handleNodeUpdate = (node: NetworkNode) => {
+    const handleNodeUpdate = (node?: unknown) => {
       setNodes(prev => applyNodeUpdate(prev, node))
     }
 

--- a/utilityfog_frontend/frontend/src/viz3d/adapters.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/adapters.ts
@@ -1,8 +1,28 @@
 import { NetworkNode, NetworkEdge } from '../ws/SimBridgeClient'
 
-// Adapter functions to convert between different data formats
+// Adapter functions to convert between different data formats.
+// Raw simulation payloads are an external-data boundary: elements are
+// narrowed to partial shapes and every field access keeps its runtime
+// fallback, exactly as before.
 
-export function adaptSimulationData(rawData: any): {
+interface RawAgent {
+  id?: string
+  position?: [number, number, number]
+  connections?: string[]
+  active?: boolean
+}
+
+interface RawConnection {
+  id?: string
+  source?: string
+  target?: string
+  from?: string
+  to?: string
+  strength?: number
+  weight?: number
+}
+
+export function adaptSimulationData(rawData: unknown): {
   nodes: NetworkNode[]
   edges: NetworkEdge[]
 } {
@@ -10,8 +30,15 @@ export function adaptSimulationData(rawData: any): {
   const edges: NetworkEdge[] = []
 
   // Handle different possible data structures from the simulation
-  if (rawData.agents) {
-    rawData.agents.forEach((agent: any, index: number) => {
+  const raw = (rawData ?? {}) as {
+    agents?: unknown[]
+    connections?: unknown[]
+    nodes?: unknown[]
+    edges?: unknown[]
+  }
+  if (raw.agents) {
+    raw.agents.forEach((rawAgent: unknown, index: number) => {
+      const agent = rawAgent as RawAgent
       nodes.push({
         id: agent.id || `agent_${index}`,
         position: agent.position || [
@@ -25,20 +52,25 @@ export function adaptSimulationData(rawData: any): {
     })
   }
 
-  if (rawData.connections) {
-    rawData.connections.forEach((conn: any, index: number) => {
+  if (raw.connections) {
+    raw.connections.forEach((rawConn: unknown, index: number) => {
+      const conn = rawConn as RawConnection
       edges.push({
         id: conn.id || `edge_${index}`,
-        source: conn.source || conn.from,
-        target: conn.target || conn.to,
+        // Legacy adapter tolerance preserved exactly: a connection with
+        // neither field yields undefined at runtime (as before); edge
+        // consumers skip dangling references.
+        source: (conn.source || conn.from) as string,
+        target: (conn.target || conn.to) as string,
         strength: conn.strength || conn.weight || 1
       })
     })
   }
 
   // Handle generic node/edge format
-  if (rawData.nodes) {
-    rawData.nodes.forEach((node: any) => {
+  if (raw.nodes) {
+    raw.nodes.forEach((rawNode: unknown) => {
+      const node = rawNode as Partial<NetworkNode> & { id: string }
       nodes.push({
         id: node.id,
         position: node.position || [0, 0, 0],
@@ -48,8 +80,9 @@ export function adaptSimulationData(rawData: any): {
     })
   }
 
-  if (rawData.edges) {
-    rawData.edges.forEach((edge: any) => {
+  if (raw.edges) {
+    raw.edges.forEach((rawEdge: unknown) => {
+      const edge = rawEdge as Partial<NetworkEdge> & { id: string; source: string; target: string }
       edges.push({
         id: edge.id,
         source: edge.source,

--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -35,11 +35,16 @@ export function isValidPosition(p: unknown): p is [number, number, number] {
 /// renderer. A previously unknown node with a valid position is therefore
 /// admitted as supplied — no missing fields are invented.
 export function reconcileNode(
-  incoming: NetworkNode,
+  incoming: unknown,
   existing: NetworkNode | undefined,
 ): NetworkNode | null {
-  const merged = existing ? { ...existing, ...incoming } : incoming
-  if (isValidPosition((incoming as { position?: unknown }).position)) {
+  if (!incoming || typeof incoming !== 'object') return null
+  // The candidate is only trusted after the runtime position validation
+  // below (id is checked by callers); status/connections stay tolerated
+  // per the source-verified renderer-requirements evidence.
+  const candidate = incoming as Partial<NetworkNode> & { position?: unknown }
+  const merged = (existing ? { ...existing, ...candidate } : candidate) as NetworkNode
+  if (isValidPosition(candidate.position)) {
     return merged
   }
   if (existing && isValidPosition(existing.position)) {
@@ -55,7 +60,7 @@ export function reconcileNode(
 /// always by id.
 export function applyNodeUpdate(
   previous: NetworkNode[],
-  incoming: NetworkNode,
+  incoming: unknown,
 ): NetworkNode[] {
   const id = (incoming as { id?: unknown } | null | undefined)?.id
   if (typeof id !== 'string') return previous
@@ -74,7 +79,7 @@ export function applyNodeUpdate(
 /// against the previously known nodes so a bulk update cannot smuggle
 /// invalid positions past the boundary either.
 export function sanitizeNodeList(
-  incoming: NetworkNode[],
+  incoming: unknown,
   previous: NetworkNode[],
 ): NetworkNode[] {
   if (!Array.isArray(incoming)) return previous

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -1,9 +1,9 @@
-import { useEffect, useRef } from 'react'
-import { SimBridgeClient, NetworkNode, NetworkEdge } from '../ws/SimBridgeClient'
+import { useCallback, useEffect, useRef } from 'react'
+import { SimBridgeClient } from '../ws/SimBridgeClient'
 
 interface EventQueueHandlers {
-  updateNode: (node: NetworkNode) => void
-  setNetwork: (nodes: NetworkNode[], edges: NetworkEdge[]) => void
+  updateNode: (node: unknown) => void
+  setNetwork: (nodes: unknown, edges: unknown) => void
 }
 
 export function useEventQueue(
@@ -13,7 +13,7 @@ export function useEventQueue(
   const queueRef = useRef<Array<() => void>>([])
   const processingRef = useRef(false)
 
-  const processQueue = async () => {
+  const processQueue = useCallback(async () => {
     if (processingRef.current) return
     processingRef.current = true
 
@@ -26,34 +26,38 @@ export function useEventQueue(
     }
 
     processingRef.current = false
-  }
+  }, [])
 
-  const enqueueUpdate = (updateFn: () => void) => {
-    queueRef.current.push(updateFn)
-    if (!processingRef.current) {
-      requestAnimationFrame(processQueue)
-    }
-  }
+  const enqueueUpdate = useCallback(
+    (updateFn: () => void) => {
+      queueRef.current.push(updateFn)
+      if (!processingRef.current) {
+        requestAnimationFrame(processQueue)
+      }
+    },
+    [processQueue],
+  )
 
   useEffect(() => {
     if (!simClient) return
 
-    const handleNetworkUpdate = (data: { nodes?: NetworkNode[], edges?: NetworkEdge[] } | null | undefined) => {
+    const handleNetworkUpdate = (data?: unknown) => {
       // Null/primitive payloads must not throw, and one malformed side
       // must not discard the other: forward whatever is present and let
       // the store's per-side validation decide (empty arrays stay
       // meaningful and clear their collection).
       if (!data || typeof data !== 'object') return
-      if (data.nodes !== undefined || data.edges !== undefined) {
-        enqueueUpdate(() => handlers.setNetwork(data.nodes as NetworkNode[], data.edges as NetworkEdge[]))
+      const d = data as { nodes?: unknown; edges?: unknown }
+      if (d.nodes !== undefined || d.edges !== undefined) {
+        enqueueUpdate(() => handlers.setNetwork(d.nodes, d.edges))
       }
     }
 
-    const handleNodeUpdate = (node: NetworkNode) => {
+    const handleNodeUpdate = (node?: unknown) => {
       enqueueUpdate(() => handlers.updateNode(node))
     }
 
-    const handleEdgeUpdate = (edge: NetworkEdge) => {
+    const handleEdgeUpdate = (edge?: unknown) => {
       // Handle edge updates if needed
       console.log('Edge update:', edge)
     }
@@ -67,7 +71,7 @@ export function useEventQueue(
       simClient.off('node_update', handleNodeUpdate)
       simClient.off('edge_update', handleEdgeUpdate)
     }
-  }, [simClient, handlers])
+  }, [simClient, handlers, enqueueUpdate])
 
   return {
     queueLength: queueRef.current.length,

--- a/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
@@ -5,9 +5,9 @@ import { applyNodeUpdate, sanitizeNodeList } from './nodeValidation'
 interface SceneStore {
   nodes: NetworkNode[]
   edges: NetworkEdge[]
-  updateNode: (node: NetworkNode) => void
+  updateNode: (node: unknown) => void
   updateEdge: (edge: NetworkEdge) => void
-  setNetwork: (nodes: NetworkNode[], edges: NetworkEdge[]) => void
+  setNetwork: (nodes: unknown, edges: unknown) => void
   clearNetwork: () => void
 }
 
@@ -15,7 +15,7 @@ export const useSceneStore = create<SceneStore>((set) => ({
   nodes: [],
   edges: [],
 
-  updateNode: (node: NetworkNode) =>
+  updateNode: (node: unknown) =>
     set((state) => {
       // Ingestion boundary: malformed positions never reach the renderers
       // (see nodeValidation.ts for the reconcile contract).
@@ -36,12 +36,14 @@ export const useSceneStore = create<SceneStore>((set) => ({
       }
     }),
 
-  setNetwork: (nodes: NetworkNode[], edges: NetworkEdge[]) =>
+  setNetwork: (nodes: unknown, edges: unknown) =>
     set((state) => ({
       // Per-side tolerance: a malformed side never discards the valid
       // other side; explicit empty arrays remain meaningful and clear.
+      // Edge ELEMENT shape stays tolerated (renderers skip dangling
+      // references) — the array check is the documented boundary.
       nodes: Array.isArray(nodes) ? sanitizeNodeList(nodes, state.nodes) : state.nodes,
-      edges: Array.isArray(edges) ? edges : state.edges,
+      edges: Array.isArray(edges) ? (edges as NetworkEdge[]) : state.edges,
     })),
 
   clearNetwork: () =>

--- a/utilityfog_frontend/frontend/src/viz3d/utils.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/utils.ts
@@ -1,3 +1,5 @@
+import { NetworkNode } from '../ws/SimBridgeClient'
+
 export function calculateDistance(pos1: [number, number, number], pos2: [number, number, number]): number {
   const [x1, y1, z1] = pos1
   const [x2, y2, z2] = pos2
@@ -27,8 +29,8 @@ export function clampPosition(
   ]
 }
 
-export function createSpatialGrid(nodes: any[], gridSize: number = 10) {
-  const grid: { [key: string]: any[] } = {}
+export function createSpatialGrid(nodes: NetworkNode[], gridSize: number = 10) {
+  const grid: { [key: string]: NetworkNode[] } = {}
   
   nodes.forEach(node => {
     const gridX = Math.floor(node.position[0] / gridSize)
@@ -47,9 +49,9 @@ export function createSpatialGrid(nodes: any[], gridSize: number = 10) {
 
 export function findNearbyNodes(
   targetPosition: [number, number, number],
-  nodes: any[],
+  nodes: NetworkNode[],
   radius: number
-): any[] {
+): NetworkNode[] {
   return nodes.filter(node => {
     return calculateDistance(targetPosition, node.position) <= radius
   })
@@ -88,7 +90,7 @@ export class PerformanceMonitor {
   }
 }
 
-export function throttle<T extends any[]>(
+export function throttle<T extends unknown[]>(
   func: (...args: T) => void,
   wait: number
 ): (...args: T) => void {
@@ -116,7 +118,7 @@ export function throttle<T extends any[]>(
   }
 }
 
-export function debounce<T extends any[]>(
+export function debounce<T extends unknown[]>(
   func: (...args: T) => void,
   wait: number
 ): (...args: T) => void {

--- a/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
+++ b/utilityfog_frontend/frontend/src/ws/SimBridgeClient.ts
@@ -1,7 +1,7 @@
 interface SimEvent {
   type: string
   timestamp: number
-  data: any
+  data: unknown
 }
 
 interface NetworkNode {
@@ -34,7 +34,7 @@ interface NetworkEdge {
 export class SimBridgeClient {
   private ws: WebSocket | null = null
   private url: string
-  private listeners: Map<string, Set<(data?: any) => void>> = new Map()
+  private listeners: Map<string, Set<(data?: unknown) => void>> = new Map()
   private reconnectInterval: number
   private reconnectTimer: number | null = null
   private shouldReconnect = false
@@ -72,18 +72,18 @@ export class SimBridgeClient {
     }
   }
 
-  on(event: string, callback: (data?: any) => void): void {
+  on(event: string, callback: (data?: unknown) => void): void {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set())
     }
     this.listeners.get(event)!.add(callback)
   }
 
-  off(event: string, callback: (data?: any) => void): void {
+  off(event: string, callback: (data?: unknown) => void): void {
     this.listeners.get(event)?.delete(callback)
   }
 
-  send(data: any): void {
+  send(data: unknown): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(data))
     }
@@ -120,7 +120,7 @@ export class SimBridgeClient {
       // Parse inside the catch boundary; dispatch outside it. A listener
       // exception must surface through the page error channel, not be
       // swallowed and mislabelled as a JSON parsing failure.
-      let data: any
+      let data: unknown
       try {
         data = JSON.parse(event.data)
       } catch (error) {
@@ -147,26 +147,34 @@ export class SimBridgeClient {
     }
   }
 
-  private handleMessage(data: any): void {
-    switch (data.type) {
+  private handleMessage(data: unknown): void {
+    // External-data boundary: parsed JSON is unknown until narrowed. A
+    // non-object message (null, number, string) is logged and dropped
+    // instead of dereferencing .type on it.
+    if (!data || typeof data !== 'object') {
+      console.log('Unknown message type:', data)
+      return
+    }
+    const msg = data as { type?: unknown; payload?: unknown }
+    switch (msg.type) {
       case 'simulation_event':
-        this.emit('simulation_event', data.payload)
+        this.emit('simulation_event', msg.payload)
         break
       case 'network_update':
-        this.emit('network_update', data.payload)
+        this.emit('network_update', msg.payload)
         break
       case 'node_update':
-        this.emit('node_update', data.payload)
+        this.emit('node_update', msg.payload)
         break
       case 'edge_update':
-        this.emit('edge_update', data.payload)
+        this.emit('edge_update', msg.payload)
         break
       default:
-        console.log('Unknown message type:', data.type)
+        console.log('Unknown message type:', msg.type)
     }
   }
 
-  private emit(event: string, data?: any): void {
+  private emit(event: string, data?: unknown): void {
     this.listeners.get(event)?.forEach(callback => callback(data))
   }
 

--- a/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
@@ -1,5 +1,58 @@
 import { test, expect, Page } from '@playwright/test';
 
+// ---------------------------------------------------------------------------
+// Typed test-harness surface (no `any`): the in-page fake socket and the
+// harness slots this spec pins onto window. Types are erased at runtime, so
+// page.evaluate closures may reference them freely.
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _close: () => void;
+  _message: (obj: unknown) => void;
+  _messageRaw: (raw: string) => void;
+}
+interface SimClientLike {
+  connect: () => void;
+  disconnect: () => void;
+  on: (event: string, cb: (data?: unknown) => void) => void;
+  off: (event: string, cb: (data?: unknown) => void) => void;
+  send: (data: unknown) => void;
+  readonly isConnected: boolean;
+}
+interface ExportCapture {
+  revoked: string[];
+  sequence: string[];
+  download: string;
+  href: string;
+  text: string;
+  blob?: Blob;
+}
+interface LifecycleHarness {
+  events: string[];
+  payloads: Array<{ channel: string; payload: unknown }>;
+  client: SimClientLike;
+  sockets: () => FakeSocketHarness[];
+  removable?: (p?: unknown) => void;
+}
+type HarnessWindow = Window &
+  typeof globalThis & {
+    __fakeSockets: FakeSocketHarness[];
+    __throwNextConstruction?: boolean;
+    __h: LifecycleHarness;
+    __exportCapture: ExportCapture;
+    __cap: ExportCapture;
+    __pwned?: boolean;
+    __pwned2?: boolean;
+  };
+// ---------------------------------------------------------------------------
+
+
 // ConnectionBadge accessibility + reduced-motion tests.
 //
 // A deterministic in-page FakeWebSocket replaces window.WebSocket before the
@@ -10,7 +63,7 @@ import { test, expect, Page } from '@playwright/test';
 
 async function setupPage(page: Page) {
   await page.addInitScript(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__fakeSockets = [];
     class FakeWebSocket {
       static CONNECTING = 0;
@@ -48,7 +101,7 @@ async function setupPage(page: Page) {
         if (this.onclose) this.onclose({});
       }
     }
-    w.WebSocket = FakeWebSocket;
+    w.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
@@ -56,11 +109,11 @@ async function setupPage(page: Page) {
 
 const activeSocket = (page: Page, action: '_open' | '_close') =>
   page.evaluate((act) => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     // Defensive diagnostics: tolerate a missing registry, then fail with a
     // descriptive error rather than an opaque undefined-property throw.
     const registry = Array.isArray(w.__fakeSockets) ? w.__fakeSockets : [];
-    const appSockets = registry.filter((s: any) => String(s.url).includes('/ws'));
+    const appSockets = registry.filter((s) => String(s.url).includes('/ws'));
     const active = appSockets[appSockets.length - 1];
     if (!active) {
       throw new Error(

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -1,5 +1,58 @@
 import { test, expect, Page } from '@playwright/test';
 
+// ---------------------------------------------------------------------------
+// Typed test-harness surface (no `any`): the in-page fake socket and the
+// harness slots this spec pins onto window. Types are erased at runtime, so
+// page.evaluate closures may reference them freely.
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _close: () => void;
+  _message: (obj: unknown) => void;
+  _messageRaw: (raw: string) => void;
+}
+interface SimClientLike {
+  connect: () => void;
+  disconnect: () => void;
+  on: (event: string, cb: (data?: unknown) => void) => void;
+  off: (event: string, cb: (data?: unknown) => void) => void;
+  send: (data: unknown) => void;
+  readonly isConnected: boolean;
+}
+interface ExportCapture {
+  revoked: string[];
+  sequence: string[];
+  download: string;
+  href: string;
+  text: string;
+  blob?: Blob;
+}
+interface LifecycleHarness {
+  events: string[];
+  payloads: Array<{ channel: string; payload: unknown }>;
+  client: SimClientLike;
+  sockets: () => FakeSocketHarness[];
+  removable?: (p?: unknown) => void;
+}
+type HarnessWindow = Window &
+  typeof globalThis & {
+    __fakeSockets: FakeSocketHarness[];
+    __throwNextConstruction?: boolean;
+    __h: LifecycleHarness;
+    __exportCapture: ExportCapture;
+    __cap: ExportCapture;
+    __pwned?: boolean;
+    __pwned2?: boolean;
+  };
+// ---------------------------------------------------------------------------
+
+
 // EventFeed contract tests.
 //
 // A deterministic in-page FakeWebSocket replaces window.WebSocket before the
@@ -11,7 +64,7 @@ import { test, expect, Page } from '@playwright/test';
 
 async function setupPage(page: Page) {
   await page.addInitScript(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__fakeSockets = [];
     class FakeWebSocket {
       static CONNECTING = 0;
@@ -47,7 +100,7 @@ async function setupPage(page: Page) {
         if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
       }
     }
-    w.WebSocket = FakeWebSocket;
+    w.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   });
   await page.goto('/');
   // The app's client(s) exist once the root renders; the active one is last.
@@ -57,8 +110,8 @@ async function setupPage(page: Page) {
 // Inject one already-parsed-shape message on the app's active socket.
 const inject = (page: Page, type: string, payload: unknown) =>
   page.evaluate(({ type, payload }) => {
-    const w = window as any;
-    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const appSockets = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     const active = appSockets[appSockets.length - 1];
     active._message({ type, payload });
   }, { type, payload });
@@ -108,8 +161,8 @@ test('newest event appears first', async ({ page }) => {
 
 test('exactly fifty events are retained; after fifty-five the oldest five are gone', async ({ page }) => {
   await page.evaluate(() => {
-    const w = window as any;
-    const appSockets = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const appSockets = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     const active = appSockets[appSockets.length - 1];
     for (let n = 1; n <= 55; n++) {
       active._message({ type: 'node_update', payload: { seq: `marker-${n}` } });
@@ -169,7 +222,7 @@ test('script-like payload text renders as text, never as markup', async ({ page 
   await expect(entries(page).first()).toContainText('<script>');
   // …and no element was actually created from the payload.
   expect(await feed(page).locator('script, img').count()).toBe(0);
-  expect(await page.evaluate(() => (window as any).__pwned ?? (window as any).__pwned2 ?? null)).toBeNull();
+  expect(await page.evaluate(() => (window as HarnessWindow).__pwned ?? (window as HarnessWindow).__pwned2 ?? null)).toBeNull();
 });
 
 test('StrictMode double-mount does not duplicate entries (cleanup removes listeners)', async ({ page }) => {

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -1,5 +1,58 @@
 import { test, expect, Page } from '@playwright/test';
 
+// ---------------------------------------------------------------------------
+// Typed test-harness surface (no `any`): the in-page fake socket and the
+// harness slots this spec pins onto window. Types are erased at runtime, so
+// page.evaluate closures may reference them freely.
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _close: () => void;
+  _message: (obj: unknown) => void;
+  _messageRaw: (raw: string) => void;
+}
+interface SimClientLike {
+  connect: () => void;
+  disconnect: () => void;
+  on: (event: string, cb: (data?: unknown) => void) => void;
+  off: (event: string, cb: (data?: unknown) => void) => void;
+  send: (data: unknown) => void;
+  readonly isConnected: boolean;
+}
+interface ExportCapture {
+  revoked: string[];
+  sequence: string[];
+  download: string;
+  href: string;
+  text: string;
+  blob?: Blob;
+}
+interface LifecycleHarness {
+  events: string[];
+  payloads: Array<{ channel: string; payload: unknown }>;
+  client: SimClientLike;
+  sockets: () => FakeSocketHarness[];
+  removable?: (p?: unknown) => void;
+}
+type HarnessWindow = Window &
+  typeof globalThis & {
+    __fakeSockets: FakeSocketHarness[];
+    __throwNextConstruction?: boolean;
+    __h: LifecycleHarness;
+    __exportCapture: ExportCapture;
+    __cap: ExportCapture;
+    __pwned?: boolean;
+    __pwned2?: boolean;
+  };
+// ---------------------------------------------------------------------------
+
+
 // EventFeed OPERATIONS tests (Package J — filtering, search, summary, clear,
 // JSON export). Same in-page FakeWebSocket harness as the contract spec;
 // fixed benign JSON fixtures; nothing external.
@@ -12,7 +65,7 @@ import { test, expect, Page } from '@playwright/test';
 
 async function setupPage(page: Page) {
   await page.addInitScript(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__fakeSockets = [];
     class FakeWebSocket {
       static CONNECTING = 0;
@@ -48,9 +101,9 @@ async function setupPage(page: Page) {
       construct(target, args) {
         const url = String(args[0] ?? '');
         if (url.includes('/ws')) return new target(url);
-        return new (RealWebSocket as any)(...args);
+        return new RealWebSocket(...(args as ConstructorParameters<typeof WebSocket>));
       },
-    });
+    }) as unknown as typeof WebSocket;
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
@@ -58,8 +111,8 @@ async function setupPage(page: Page) {
 
 const inject = (page: Page, type: string, payload: unknown) =>
   page.evaluate(({ type, payload }) => {
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     socks[socks.length - 1]._message({ type, payload });
   }, { type, payload });
 
@@ -83,10 +136,10 @@ const injectFour = async (page: Page) => {
 // Install export-capture stubs (blob text, anchor download/href, revocations)
 const armExportCapture = (page: Page) =>
   page.evaluate(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     // Ordered event sequence proves the download click happens BEFORE the
     // (deferred) revocation — no fixed sleeps; tests poll for 'revoke'.
-    w.__exportCapture = { revoked: [] as string[], sequence: [] as string[], download: '', href: '', text: '' };
+    w.__exportCapture = { revoked: [], sequence: [], download: '', href: '', text: '' };
     URL.createObjectURL = ((blob: Blob) => {
       w.__exportCapture.blob = blob;
       w.__exportCapture.sequence.push('create');
@@ -104,15 +157,15 @@ const armExportCapture = (page: Page) =>
   });
 const awaitRevocation = async (page: Page) => {
   await expect
-    .poll(async () => page.evaluate(() => (window as any).__exportCapture.revoked.length))
+    .poll(async () => page.evaluate(() => (window as HarnessWindow).__exportCapture.revoked.length))
     .toBe(1);
-  const seq: string[] = await page.evaluate(() => (window as any).__exportCapture.sequence);
+  const seq = await page.evaluate(() => (window as HarnessWindow).__exportCapture.sequence);
   expect(seq.indexOf('click')).toBeGreaterThanOrEqual(0);
   expect(seq.indexOf('click')).toBeLessThan(seq.indexOf('revoke'));
 };
 const readExport = (page: Page) =>
   page.evaluate(async () => {
-    const c = (window as any).__exportCapture;
+    const c = (window as HarnessWindow).__exportCapture;
     return {
       download: c.download,
       href: c.href,
@@ -228,8 +281,8 @@ test('the 50-event retained cap holds regardless of filters', async ({ page }) =
     await chan(page, off).click();
   }
   await page.evaluate(() => {
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     const s = socks[socks.length - 1];
     for (let n = 1; n <= 55; n++) s._message({ type: 'simulation_event', payload: { seq: `m-${n}` } });
   });
@@ -262,7 +315,7 @@ test('export: visible-only, newest-first, schema/version, full payloads, revoked
   expect(result.download).toBe('event-feed-export.json');
   expect(result.href).toBe('blob:capture-1');
   await awaitRevocation(page);
-  expect(await page.evaluate(() => (window as any).__exportCapture.revoked)).toContain('blob:capture-1');
+  expect(await page.evaluate(() => (window as HarnessWindow).__exportCapture.revoked)).toContain('blob:capture-1');
   expect(result.doc.schema).toBe('utilityfog.event-feed-export');
   expect(result.doc.version).toBe(1);
   // Visible-only (edge_update excluded), newest first.
@@ -296,8 +349,8 @@ test('export composes with search + filter and is disabled at zero visible', asy
 test('export normalizes absent payloads to null and preserves falsy payloads distinctly', async ({ page }) => {
   // Injection order (oldest→newest): absent, null, false, 0, ''.
   await page.evaluate(() => {
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     const s = socks[socks.length - 1];
     s._message({ type: 'simulation_event' }); // payload property absent
     s._message({ type: 'simulation_event', payload: null });

--- a/utilityfog_frontend/frontend/tests/node-update-resilience.spec.ts
+++ b/utilityfog_frontend/frontend/tests/node-update-resilience.spec.ts
@@ -1,5 +1,58 @@
 import { test, expect, Page } from '@playwright/test';
 
+// ---------------------------------------------------------------------------
+// Typed test-harness surface (no `any`): the in-page fake socket and the
+// harness slots this spec pins onto window. Types are erased at runtime, so
+// page.evaluate closures may reference them freely.
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _close: () => void;
+  _message: (obj: unknown) => void;
+  _messageRaw: (raw: string) => void;
+}
+interface SimClientLike {
+  connect: () => void;
+  disconnect: () => void;
+  on: (event: string, cb: (data?: unknown) => void) => void;
+  off: (event: string, cb: (data?: unknown) => void) => void;
+  send: (data: unknown) => void;
+  readonly isConnected: boolean;
+}
+interface ExportCapture {
+  revoked: string[];
+  sequence: string[];
+  download: string;
+  href: string;
+  text: string;
+  blob?: Blob;
+}
+interface LifecycleHarness {
+  events: string[];
+  payloads: Array<{ channel: string; payload: unknown }>;
+  client: SimClientLike;
+  sockets: () => FakeSocketHarness[];
+  removable?: (p?: unknown) => void;
+}
+type HarnessWindow = Window &
+  typeof globalThis & {
+    __fakeSockets: FakeSocketHarness[];
+    __throwNextConstruction?: boolean;
+    __h: LifecycleHarness;
+    __exportCapture: ExportCapture;
+    __cap: ExportCapture;
+    __pwned?: boolean;
+    __pwned2?: boolean;
+  };
+// ---------------------------------------------------------------------------
+
+
 // Positionless/malformed node_update resilience (Package N).
 //
 // Reproduced defect (combined-lab, 2026-07-11): a node_update whose payload
@@ -16,7 +69,7 @@ import { test, expect, Page } from '@playwright/test';
 
 async function setupPage(page: Page) {
   await page.addInitScript(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__fakeSockets = [];
     class FakeWebSocket {
       static CONNECTING = 0;
@@ -57,23 +110,23 @@ async function setupPage(page: Page) {
       construct(target, args) {
         const url = String(args[0] ?? '');
         if (url.includes('/ws')) return new target(url);
-        return new (RealWebSocket as any)(...args);
+        return new RealWebSocket(...(args as ConstructorParameters<typeof WebSocket>));
       },
-    });
+    }) as unknown as typeof WebSocket;
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
   await page.evaluate(() => {
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     socks[socks.length - 1]._open();
   });
 }
 
 const inject = (page: Page, type: string, payload: unknown) =>
   page.evaluate(({ type, payload }) => {
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     socks[socks.length - 1]._message({ type, payload });
   }, { type, payload });
 
@@ -87,7 +140,7 @@ const inject = (page: Page, type: string, payload: unknown) =>
 const storeNodes = (page: Page) =>
   page.evaluate(async () => {
     const mod = await import('/src/viz3d/useSceneStore.ts');
-    return mod.useSceneStore.getState().nodes as Array<{ id: string; position: unknown }>;
+    return mod.useSceneStore.getState().nodes as Array<{ id: string; position: unknown; connections?: unknown; status?: unknown }>;
   });
 const storeUpdate = (page: Page, payload: unknown) =>
   page.evaluate(async (payload) => {
@@ -142,7 +195,7 @@ test('existing node + positionless update: no error, last valid position preserv
   await page.waitForTimeout(150);
   const node = (await storeNodes(page)).find(n => n.id === 'n-keep')!;
   expect(node.position).toEqual([7, 8, 9]); // last valid preserved
-  expect((node as any).status).toBe('error'); // other fields updated
+  expect(node.status).toBe('error'); // other fields updated
   await appMounted(page);
   expect(errors).toHaveLength(0);
 });
@@ -189,7 +242,7 @@ test('malformed positions never crash: null, string, wrong lengths, non-numbers'
 test('partial status-only update preserves position AND connections (merge semantics)', async ({ page }) => {
   await storeUpdate(page, { id: 'n-merge', position: [1, 2, 3], connections: ['a', 'b'], status: 'active' });
   await storeUpdate(page, { id: 'n-merge', status: 'error' }); // partial, no position/connections
-  const node = (await storeNodes(page)).find(n => n.id === 'n-merge') as any;
+  const node = (await storeNodes(page)).find(n => n.id === 'n-merge')!;
   expect(node.position).toEqual([1, 2, 3]);
   expect(node.connections).toEqual(['a', 'b']); // omitted field survives
   expect(node.status).toBe('error');
@@ -198,7 +251,7 @@ test('partial status-only update preserves position AND connections (merge seman
 test('valid-position partial update preserves omitted fields', async ({ page }) => {
   await storeUpdate(page, { id: 'n-move', position: [1, 1, 1], connections: ['x'], status: 'active' });
   await storeUpdate(page, { id: 'n-move', position: [9, 9, 9] }); // no connections/status
-  const node = (await storeNodes(page)).find(n => n.id === 'n-move') as any;
+  const node = (await storeNodes(page)).find(n => n.id === 'n-move')!;
   expect(node.position).toEqual([9, 9, 9]);
   expect(node.connections).toEqual(['x']);
   expect(node.status).toBe('active');
@@ -209,7 +262,7 @@ test('unknown node with valid position but missing connections is admitted (rend
   page.on('pageerror', (e) => errors.push(e.message));
   await storeUpdate(page, { id: 'n-min', position: [2, 2, 2] }); // no connections/status
   await page.waitForTimeout(300); // let the 3D effect render it
-  const node = (await storeNodes(page)).find(n => n.id === 'n-min') as any;
+  const node = (await storeNodes(page)).find(n => n.id === 'n-min')!;
   expect(node.position).toEqual([2, 2, 2]);
   expect(errors).toHaveLength(0); // renderers tolerate missing optional fields
   await appMounted(page);
@@ -226,7 +279,7 @@ test('bulk network_update: null/undefined/primitive payloads never throw', async
   // a NEIGHBORING fragility owned and fixed by #318/#320 (documented in
   // the PR body), not by this PR's files.
   for (const payload of [null, undefined, 42, 'garbage', { nodes: null, edges: null }]) {
-    await storeSetNetwork(page, (payload as any)?.nodes, (payload as any)?.edges);
+    await storeSetNetwork(page, (payload as { nodes?: unknown } | null | undefined)?.nodes, (payload as { edges?: unknown } | null | undefined)?.edges);
   }
   await inject(page, 'network_update', {}); // object-shaped, side-free
   await inject(page, 'network_update', { nodes: null, edges: null });
@@ -269,8 +322,8 @@ test('rapid mixed valid/invalid updates do not duplicate nodes', async ({ page }
   page.on('pageerror', (e) => errors.push(e.message));
   await page.evaluate(async () => {
     const mod = await import('/src/viz3d/useSceneStore.ts');
-    const w = window as any;
-    const socks = w.__fakeSockets.filter((s: any) => String(s.url).includes('/ws'));
+    const w = window as HarnessWindow;
+    const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));
     const s = socks[socks.length - 1];
     for (let n = 0; n < 40; n++) {
       // Alternate valid and invalid updates for the SAME node id, through
@@ -321,13 +374,13 @@ test('2D↔3D switching stays functional after malformed bursts (both ingestion 
 
 test('invalid data causes no reconnect and no duplicate socket lineage', async ({ page }) => {
   const before = await page.evaluate(() =>
-    (window as any).__fakeSockets.filter((s: any) => String(s.url).includes('/ws')).length);
+    (window as HarnessWindow).__fakeSockets.filter((s) => String(s.url).includes('/ws')).length);
   for (let i = 0; i < 10; i++) {
     await inject(page, 'node_update', { id: `spam-${i}`, position: null });
   }
   await page.waitForTimeout(400);
   const after = await page.evaluate(() =>
-    (window as any).__fakeSockets.filter((s: any) => String(s.url).includes('/ws')).length);
+    (window as HarnessWindow).__fakeSockets.filter((s) => String(s.url).includes('/ws')).length);
   expect(after).toBe(before); // transport untouched — no reconnect churn
   await appMounted(page);
 });

--- a/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
+++ b/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
@@ -1,5 +1,58 @@
 import { test, expect, Page } from '@playwright/test';
 
+// ---------------------------------------------------------------------------
+// Typed test-harness surface (no `any`): the in-page fake socket and the
+// harness slots this spec pins onto window. Types are erased at runtime, so
+// page.evaluate closures may reference them freely.
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  sent: string[];
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _close: () => void;
+  _message: (obj: unknown) => void;
+  _messageRaw: (raw: string) => void;
+}
+interface SimClientLike {
+  connect: () => void;
+  disconnect: () => void;
+  on: (event: string, cb: (data?: unknown) => void) => void;
+  off: (event: string, cb: (data?: unknown) => void) => void;
+  send: (data: unknown) => void;
+  readonly isConnected: boolean;
+}
+interface ExportCapture {
+  revoked: string[];
+  sequence: string[];
+  download: string;
+  href: string;
+  text: string;
+  blob?: Blob;
+}
+interface LifecycleHarness {
+  events: string[];
+  payloads: Array<{ channel: string; payload: unknown }>;
+  client: SimClientLike;
+  sockets: () => FakeSocketHarness[];
+  removable?: (p?: unknown) => void;
+}
+type HarnessWindow = Window &
+  typeof globalThis & {
+    __fakeSockets: FakeSocketHarness[];
+    __throwNextConstruction?: boolean;
+    __h: LifecycleHarness;
+    __exportCapture: ExportCapture;
+    __cap: ExportCapture;
+    __pwned?: boolean;
+    __pwned2?: boolean;
+  };
+// ---------------------------------------------------------------------------
+
+
 // SimBridgeClient lifecycle contract tests.
 //
 // A deterministic in-page FakeWebSocket replaces window.WebSocket before the
@@ -17,7 +70,7 @@ const AFTER_RECONNECT_MS = 4 * RECONNECT_MS;
 
 async function setupHarness(page: Page) {
   await page.addInitScript(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__fakeSockets = [];
     class FakeWebSocket {
       static CONNECTING = 0;
@@ -69,17 +122,17 @@ async function setupHarness(page: Page) {
         if (this.onmessage) this.onmessage({ data: raw });
       }
     }
-    w.WebSocket = FakeWebSocket;
+    w.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   });
   await page.goto('/');
   await page.evaluate(async ({ url, delay }) => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     const mod = await import('/src/ws/SimBridgeClient.ts');
     w.__h = {
-      events: [] as string[],
-      payloads: [] as Array<{ channel: string; payload: unknown }>,
-      client: new mod.SimBridgeClient(url, delay),
-      sockets: () => w.__fakeSockets.filter((s: any) => s.url === url),
+      events: [],
+      payloads: [],
+      client: new mod.SimBridgeClient(url, delay) as SimClientLike,
+      sockets: () => w.__fakeSockets.filter((s) => s.url === url),
     };
     w.__h.client.on('connected', () => w.__h.events.push('connected'));
     w.__h.client.on('disconnected', () => w.__h.events.push('disconnected'));
@@ -88,25 +141,25 @@ async function setupHarness(page: Page) {
 }
 
 const socketCount = (page: Page) =>
-  page.evaluate(() => (window as any).__h.sockets().length);
+  page.evaluate(() => (window as HarnessWindow).__h.sockets().length);
 const events = (page: Page) =>
-  page.evaluate(() => (window as any).__h.events as string[]);
+  page.evaluate(() => (window as HarnessWindow).__h.events as string[]);
 
 test.beforeEach(async ({ page }) => {
   await setupHarness(page);
 });
 
 test('first connect creates exactly one socket; repeats while CONNECTING/OPEN are idempotent', async ({ page }) => {
-  await page.evaluate(() => (window as any).__h.client.connect());
+  await page.evaluate(() => (window as HarnessWindow).__h.client.connect());
   expect(await socketCount(page)).toBe(1);
 
   // Repeat while CONNECTING — no second socket.
-  await page.evaluate(() => (window as any).__h.client.connect());
+  await page.evaluate(() => (window as HarnessWindow).__h.client.connect());
   expect(await socketCount(page)).toBe(1);
 
   // Open, then repeat while OPEN — still no second socket.
-  await page.evaluate(() => (window as any).__h.sockets()[0]._open());
-  await page.evaluate(() => (window as any).__h.client.connect());
+  await page.evaluate(() => (window as HarnessWindow).__h.sockets()[0]._open());
+  await page.evaluate(() => (window as HarnessWindow).__h.client.connect());
   expect(await socketCount(page)).toBe(1);
 
   // Open emitted 'connected' exactly once.
@@ -115,7 +168,7 @@ test('first connect creates exactly one socket; repeats while CONNECTING/OPEN ar
 
 test('unexpected close emits disconnected and schedules exactly one reconnect', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.sockets()[0]._open();
     h.sockets()[0]._close(); // server-side drop
@@ -130,14 +183,14 @@ test('unexpected close emits disconnected and schedules exactly one reconnect', 
   expect(await socketCount(page)).toBe(2);
 
   // Successful reopen clears pending reconnect state (no third socket).
-  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  await page.evaluate(() => (window as HarnessWindow).__h.sockets()[1]._open());
   await page.waitForTimeout(AFTER_RECONNECT_MS);
   expect(await socketCount(page)).toBe(2);
 });
 
 test('intentional disconnect never yields a replacement socket', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.sockets()[0]._open();
     h.client.disconnect(); // fake delivers its close callback async
@@ -149,7 +202,7 @@ test('intentional disconnect never yields a replacement socket', async ({ page }
 
 test('disconnect clears an already-scheduled reconnect', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.sockets()[0]._open();
     h.sockets()[0]._close(); // schedules a reconnect...
@@ -161,32 +214,32 @@ test('disconnect clears an already-scheduled reconnect', async ({ page }) => {
 
 test('explicit connect after disconnect creates a fresh working socket', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.sockets()[0]._open();
     h.client.disconnect();
   });
-  await page.evaluate(() => (window as any).__h.client.connect());
+  await page.evaluate(() => (window as HarnessWindow).__h.client.connect());
   expect(await socketCount(page)).toBe(2);
-  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  await page.evaluate(() => (window as HarnessWindow).__h.sockets()[1]._open());
   expect(await events(page)).toEqual(['connected', 'disconnected', 'connected']);
-  expect(await page.evaluate(() => (window as any).__h.client.isConnected)).toBe(true);
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.client.isConnected)).toBe(true);
 });
 
 test('late callbacks from an obsolete socket cannot affect the current connection', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.sockets()[0]._open();
     h.sockets()[0]._close(); // drop → reconnect scheduled
   });
   await page.waitForTimeout(AFTER_RECONNECT_MS);
-  await page.evaluate(() => (window as any).__h.sockets()[1]._open());
+  await page.evaluate(() => (window as HarnessWindow).__h.sockets()[1]._open());
   const before = await events(page);
 
   // Fire every callback on the OBSOLETE socket: all must be inert.
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     const stale = h.sockets()[0];
     if (stale.onopen) stale.onopen({});
     if (stale.onmessage) stale.onmessage({ data: JSON.stringify({ type: 'node_update', payload: { id: 'stale' } }) });
@@ -195,12 +248,12 @@ test('late callbacks from an obsolete socket cannot affect the current connectio
   await page.waitForTimeout(AFTER_RECONNECT_MS);
   expect(await events(page)).toEqual(before); // no new connected/disconnected
   expect(await socketCount(page)).toBe(2);    // no extra reconnect socket
-  expect(await page.evaluate(() => (window as any).__h.client.isConnected)).toBe(true);
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.client.isConnected)).toBe(true);
 });
 
 test('message routing and listener removal remain behaviorally compatible', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     for (const ch of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
       h.client.on(ch, (p: unknown) => h.payloads.push({ channel: ch, payload: p }));
     }
@@ -212,22 +265,22 @@ test('message routing and listener removal remain behaviorally compatible', asyn
     s._message({ type: 'node_update', payload: { id: 'n1' } });
     s._message({ type: 'edge_update', payload: { id: 'e1' } });
   });
-  const payloads = await page.evaluate(() => (window as any).__h.payloads);
-  expect(payloads.map((p: any) => p.channel)).toEqual([
+  const payloads = await page.evaluate(() => (window as HarnessWindow).__h.payloads);
+  expect(payloads.map((p) => p.channel)).toEqual([
     'simulation_event', 'network_update', 'node_update', 'edge_update',
   ]);
   expect(payloads[2].payload).toEqual({ id: 'n1' });
 
   // off() prevents later delivery.
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.removable = (p: unknown) => h.payloads.push({ channel: 'removable', payload: p });
     h.client.on('node_update', h.removable);
     h.client.off('node_update', h.removable);
     h.sockets()[0]._message({ type: 'node_update', payload: { id: 'n2' } });
   });
-  const after = await page.evaluate(() => (window as any).__h.payloads);
-  expect(after.filter((p: any) => p.channel === 'removable')).toHaveLength(0);
+  const after = await page.evaluate(() => (window as HarnessWindow).__h.payloads);
+  expect(after.filter((p) => p.channel === 'removable')).toHaveLength(0);
 });
 
 test('malformed JSON logs a parse error and is never routed; no page error', async ({ page }) => {
@@ -237,7 +290,7 @@ test('malformed JSON logs a parse error and is never routed; no page error', asy
   page.on('pageerror', (e) => pageErrors.push(e.message));
 
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.on('node_update', (p: unknown) => h.payloads.push({ channel: 'node_update', payload: p }));
     h.client.connect();
     h.sockets()[0]._open();
@@ -245,7 +298,7 @@ test('malformed JSON logs a parse error and is never routed; no page error', asy
   });
   await page.waitForTimeout(50);
   expect(consoleErrors.some((t) => t.includes('Error parsing message'))).toBe(true);
-  expect(await page.evaluate(() => (window as any).__h.payloads.length)).toBe(0);
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.payloads.length)).toBe(0);
   expect(pageErrors).toHaveLength(0);
 });
 
@@ -256,7 +309,7 @@ test('a throwing listener surfaces as a page error and is not mislabelled as a p
   page.on('pageerror', (e) => pageErrors.push(e.message));
 
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.on('node_update', () => { throw new Error('SENTINEL_LISTENER_FAILURE'); });
     h.client.connect();
     h.sockets()[0]._open();
@@ -272,7 +325,7 @@ test('a throwing listener surfaces as a page error and is not mislabelled as a p
 
 test('synchronous constructor failure emits one error, retries once, then connects normally', async ({ page }) => {
   await page.evaluate(() => {
-    const w = window as any;
+    const w = window as HarnessWindow;
     w.__throwNextConstruction = true;
     w.__h.client.connect();
   });
@@ -283,7 +336,7 @@ test('synchronous constructor failure emits one error, retries once, then connec
   // Exactly one scheduled replacement attempt.
   await page.waitForTimeout(AFTER_RECONNECT_MS);
   expect(await socketCount(page)).toBe(1);
-  await page.evaluate(() => (window as any).__h.sockets()[0]._open());
+  await page.evaluate(() => (window as HarnessWindow).__h.sockets()[0]._open());
   expect(await events(page)).toEqual(['error', 'connected']);
 
   // No duplicate timers or sockets after another full delay.
@@ -293,27 +346,27 @@ test('synchronous constructor failure emits one error, retries once, then connec
 
 test('send serializes only while OPEN and is a no-op otherwise', async ({ page }) => {
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.connect();
     h.client.send({ early: true }); // CONNECTING — must be a no-op
   });
-  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([]);
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.sockets()[0].sent)).toEqual([]);
 
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.sockets()[0]._open();
     h.client.send({ hello: 'world' });
   });
-  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.sockets()[0].sent)).toEqual([
     JSON.stringify({ hello: 'world' }),
   ]);
 
   await page.evaluate(() => {
-    const h = (window as any).__h;
+    const h = (window as HarnessWindow).__h;
     h.client.disconnect();
     h.client.send({ late: true }); // released socket — no-op
   });
-  expect(await page.evaluate(() => (window as any).__h.sockets()[0].sent)).toEqual([
+  expect(await page.evaluate(() => (window as HarnessWindow).__h.sockets()[0].sent)).toEqual([
     JSON.stringify({ hello: 'world' }),
   ]);
 });


### PR DESCRIPTION
## PACKAGE P — ESLint enablement + type-safety recovery (frontend quality runway, refs #6)

**Stacked PR: base is `ci/frontend-lockfile-npm-ci` (PACKAGE O). Merge order O → P → Q. Do not merge before O.**

### What
1. **`.eslintrc.cjs` (new)** — ESLint 8 legacy config serving the *existing* `lint` script (`eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0`, previously broken: no config existed). `eslint:recommended` + `@typescript-eslint/recommended` + react + react-hooks; `@typescript-eslint/no-explicit-any: error`; unused-vars checks OFF (tsc `noUnusedLocals` owns that gate — no double reporting); `react/no-unknown-property` scoped off for `src/viz3d/**/*.tsx` only (react-three-fiber reconciler props: `position`/`args`/`intensity`…).
2. **devDependencies** — `@typescript-eslint/parser` + `@typescript-eslint/eslint-plugin` pinned **exactly 8.63.0** (compatible pair for ESLint 8.57.1 + TS 5.9.3). Lockfile updated with the pinned npm 10.9.8; 17 packages added, all registry-resolved with integrity. npm cosmetically re-sorted `package.json` dependency keys; versions untouched.
3. **Lint debt eliminated with evidence, not suppressions** — initial inventory **111 problems (100 `no-explicit-any`, 10 `react/no-unknown-property`, 1 `react-hooks/exhaustive-deps`) → 0 errors, 0 warnings, 0 disable directives, 0 suppressions**.

### How the 100 anys were resolved
- **src (21)**: `any` → `unknown` at every external-data boundary, with runtime narrowing at the point of use — `SimBridgeClient` (listener maps, message parse boundary now narrows non-objects and drops them with a log), `nodeValidation` (unknown-in, position-validated-out), `useSceneStore`, `useEventQueue`, `NetworkView2D`, `adapters` (RawAgent/RawConnection with documented legacy tolerance), `utils` (generics). The one behavioral edit: `useEventQueue` callbacks wrapped in `useCallback`, fixing the pre-existing exhaustive-deps warning and making effect deps stable.
- **tests (79)**: a typed harness surface per spec — `FakeSocketHarness`, `SimClientLike`, `HarnessWindow` with **enumerated** slots (`__fakeSockets`, `__h`, `__exportCapture`, …). No broad index signatures, no `as any`; most callback annotations simply dropped because the arrays are now typed.
- **Protocol honored**: no `ts-ignore`/`ts-nocheck`, no invented wire contracts — where the backend schema is unknown, payloads stay `unknown` behind narrow validators.

### Verification (after clean `npx npm@10.9.8 ci`)
| Gate | Result |
|---|---|
| `npm run lint` | **0 errors / 0 warnings** (exit 0 under `--max-warnings 0`) |
| `npx tsc --noEmit` | clean |
| `npm run test:budget` | pass |
| `npm run build` | ok |
| `npm run check:budget` | **PASS** — js_raw 983,911 / js_gzip 274,040 (+202/+59 vs base, from the useCallback wrappers; limits unchanged) |
| Playwright | **56/56 × 3 = 168/168** |

### Non-claims / notes
- Runtime behavior preserved except the deliberate useCallback fix (suite-verified ×3).
- ESLint 8.57.1 is EOL-flagged by npm; flat-config migration is future work, deliberately out of this fence.
- Opened unmerged for Jack's audit. No closing keyword for #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)