### PR TITLE
ci: always-present frontend-quality gate in ci.yml (PACKAGE Q, stacked on ESLint PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,44 @@ jobs:
           # 0 errors). pytest.ini scopes collection to tests/ and keeps
           # root-level legacy scripts out.
           python -m pytest tests/ -q
+
+  # Frontend quality gate (issue #6). The Node `verify` job above is inert
+  # for this repo layout (no root package.json), so frontend regressions
+  # never failed CI here. This job runs the real gates from the app
+  # directory on every push/PR — deliberately NO path filter, so the check
+  # is always present and branch protection can require it without wedging
+  # non-frontend PRs. Fork-compatible: read-only permissions, no secrets.
+  # The Playwright E2E suite is deliberately excluded (no browser
+  # downloads); ui-smoke.yml owns that.
+  frontend-quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: utilityfog_frontend/frontend
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: utilityfog_frontend/frontend/package-lock.json
+
+      - name: Install (deterministic, from committed lockfile)
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Budget-script unit tests
+        run: npm run test:budget
+
+      - name: Build
+        run: npm run build
+
+      - name: Bundle budget
+        run: npm run check:budget


### PR DESCRIPTION
## PACKAGE Q — frontend-quality CI job (frontend quality runway, refs #6)

**Stacked PR: base is `ci/frontend-eslint-types` (PACKAGE P → PACKAGE O → main). Merge order O → P → Q. Do not merge before P.**

### What
One new job in `.github/workflows/ci.yml` — `frontend-quality` — closing the gap where the Node `verify` job is inert for this repo layout (no root `package.json`; every step skips), so frontend regressions never failed CI.

### Design
- **Always present** — deliberately NO path filter, so the check exists on every push/PR and branch protection can require it without wedging non-frontend PRs.
- **Node 20**, setup-node npm cache keyed to `utilityfog_frontend/frontend/package-lock.json` (the lockfile PACKAGE O commits).
- **Steps** (working-directory `utilityfog_frontend/frontend`): `npm ci` → `npm run lint` → `npx tsc --noEmit` → `npm run test:budget` → `npm run build` → `npm run check:budget`.
- **SHA-pinned GitHub-owned actions only** — the exact same `actions/checkout` (v7.0.0) and `actions/setup-node` (v6.4.0) pins already in this workflow, so the repo's selected-actions + SHA-pinning policy is already satisfied; no settings change needed.
- **Fork-compatible**: workflow-level `permissions: contents: read`, no secrets, no Playwright browser downloads (ui-smoke.yml owns E2E).
- The inert `verify` job is **untouched** — its removal is a separate post-merge decision recorded in the issue-#6 packet.

### Verification
- YAML parses; jobs = `verify`, `verify-python`, `frontend-quality`.
- Live Actions run on this PR's own head demonstrates the job end-to-end (lint 0/0, tsc clean, budget tests, build, BUNDLE_BUDGET PASS) — see checks below.

### Non-claims
- Requiring `frontend-quality` in branch protection is NOT done here — a DRAFT-only candidate lives in the issue-#6 decision packet, Kev-gated.
- Opened unmerged for Jack's audit. No closing keyword for #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)