### PR TITLE
security(tuning-api): reject autonomous policy:auto commits at the write boundary (R of R/S/T)

### DIFF
--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -27,7 +27,11 @@ class Category(str, Enum):
     """How a tuning proposal for this parameter is gated."""
 
     AUTO = "auto"
-    """Small-effect, self-bounded. Agents may commit with approver='policy:auto'."""
+    """Small-effect, self-bounded. Historically committable by the autonomous
+    approver='policy:auto'; that autonomous commit path is now disabled at the
+    tuning-API write boundary (``auto_commit_disabled``), so an AUTO proposal
+    still validates and can be proposed/dry-run, but committing it requires a
+    deliberate human approver ('human:<name>'). See scripts/tuning_api.py."""
 
     HUMAN_APPROVAL = "human_approval"
     """Significant effect on dynamics. Requires approver='human:<name>'."""

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -61,10 +61,11 @@ VALID_MODES = ("dry-run", "commit-pending")
 AUTO_COMMIT_APPROVER = "policy:auto"
 """The autonomous approver identity the legacy orchestrator commits with.
 
-Commits presenting this exact approver are rejected at the boundary
-(``auto_commit_disabled``). Re-enabling autonomous commits must be a reviewed
-code change here — there is deliberately no env flag, query param, header, or
-alternate route that turns it back on."""
+Stored lowercase; the commit boundary compares against ``approver.strip()
+.casefold()`` so whitespace- and case-variant spellings of the same autonomous
+identity are all rejected (``auto_commit_disabled``). Re-enabling autonomous
+commits must be a reviewed code change here — there is deliberately no env flag,
+query param, header, or alternate route that turns it back on."""
 
 
 # -- helpers ----------------------------------------------------------------
@@ -222,6 +223,18 @@ class TuningState:
 
     def _commit_locked(self, proposal_id: str, approver: str) -> dict[str, Any]:
         with self._lock:
+            # Type guard: `approver` must be a string before any string
+            # operation (the quarantine comparison and the human-approval
+            # startswith check below both assume str). A bool/number/null/
+            # list/dict is a malformed request → stable 400 bad_request, never
+            # an AttributeError. Checked first so a bad type cannot slip past
+            # on an otherwise-valid proposal.
+            if not isinstance(approver, str):
+                raise TuningError(
+                    400, "bad_request",
+                    "approver must be a string.",
+                )
+
             proposal = self._proposals.get(proposal_id)
             if proposal is None:
                 raise TuningError(
@@ -241,7 +254,15 @@ class TuningState:
             # it shut, no LLM-facing tool call can mutate a parameter. Checked
             # before the human-approval branch so policy:auto yields one stable
             # reason. A human commit (approver="human:<name>") is unaffected.
-            if approver == AUTO_COMMIT_APPROVER:
+            #
+            # The match is stripped + case-insensitive so surface variants of
+            # the same autonomous identity — " POLICY:AUTO ", tab/newline
+            # padding, mixed case — cannot slip a mutation through. This
+            # normalization is used ONLY for the quarantine comparison; the
+            # human approver identity is never stripped or rewritten (the
+            # startswith check below and the ledger entry both keep the raw
+            # value, preserving existing human semantics exactly).
+            if approver.strip().casefold() == AUTO_COMMIT_APPROVER:
                 raise TuningError(
                     403, "auto_commit_disabled",
                     "Autonomous commits (approver='policy:auto') are disabled at "

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -16,9 +16,20 @@ For now, the pending file is an authoritative promise waiting to be picked up.
 
 Safety contract enforced here:
   - LOCKED params always rejected at `propose` (via params_schema.validate_proposal).
+  - The autonomous ``policy:auto`` commit approver is rejected at the commit
+    boundary (``AUTO_COMMIT_APPROVER`` / ``auto_commit_disabled``). This closes
+    the legacy orchestrator's only write identity: it commits with
+    ``approver="policy:auto"`` (see ``scripts/orchestrator.py`` ToolRouter),
+    so with this path shut, no LLM-facing tool call can mutate a parameter —
+    the protection lives at the server boundary, not in a prompt or tool list.
+    A deliberate human commit (``approver="human:<name>"``) is unaffected.
   - HUMAN_APPROVAL params require `approver` starting with `human:` at commit.
   - Per-parameter rate limit (MIN_GEN_BETWEEN_COMMITS_PER_PARAM generations).
   - Invalid proposals cannot be committed even if approver is otherwise sufficient.
+
+Scope note: this module does NOT authenticate callers or make the tuning API
+generally secure. It closes exactly the proven ``policy:auto`` auto-commit path;
+propose/dry-run, reads, and human-approved commits are intentionally unchanged.
 """
 
 from __future__ import annotations
@@ -46,6 +57,14 @@ MIN_GEN_BETWEEN_COMMITS_PER_PARAM = 1000
 Prevents an LLM in a tight loop from oscillating a tunable."""
 
 VALID_MODES = ("dry-run", "commit-pending")
+
+AUTO_COMMIT_APPROVER = "policy:auto"
+"""The autonomous approver identity the legacy orchestrator commits with.
+
+Commits presenting this exact approver are rejected at the boundary
+(``auto_commit_disabled``). Re-enabling autonomous commits must be a reviewed
+code change here — there is deliberately no env flag, query param, header, or
+alternate route that turns it back on."""
 
 
 # -- helpers ----------------------------------------------------------------
@@ -215,6 +234,20 @@ class TuningState:
                     "Proposal failed validation; cannot commit.",
                 )
             params: dict[str, Any] = proposal["params"]
+
+            # Auto-commit quarantine: the autonomous policy:auto approver is
+            # refused at the write boundary regardless of parameter category.
+            # This is the legacy orchestrator's only commit identity, so with
+            # it shut, no LLM-facing tool call can mutate a parameter. Checked
+            # before the human-approval branch so policy:auto yields one stable
+            # reason. A human commit (approver="human:<name>") is unaffected.
+            if approver == AUTO_COMMIT_APPROVER:
+                raise TuningError(
+                    403, "auto_commit_disabled",
+                    "Autonomous commits (approver='policy:auto') are disabled at "
+                    "the server boundary. A deliberate human approver "
+                    "(approver='human:<name>') is required to commit.",
+                )
 
             # Approver policy.
             if _contains_human_approval_param(params) and not approver.startswith("human:"):
@@ -462,6 +495,7 @@ def create_blueprint(state: TuningState) -> Blueprint:
 __all__ = [
     "MIN_GEN_BETWEEN_COMMITS_PER_PARAM",
     "VALID_MODES",
+    "AUTO_COMMIT_APPROVER",
     "TuningError",
     "TuningState",
     "create_blueprint",

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -215,14 +215,15 @@ def test_tuning_commit_emits_tuning_committed(tmp_path):
             justification="test",
             mode="commit-pending",
         )
-        state.commit(proposal_id=proposal["proposal_id"], approver="policy:auto")
+        # policy:auto is refused post-quarantine; a human approver commits.
+        state.commit(proposal_id=proposal["proposal_id"], approver="human:kevin")
 
         msg = sub.recv(timeout_ms=500)
         assert msg is not None
         topic, _ts, payload = msg
         assert topic == TOPIC_TUNING_COMMITTED
         assert payload["proposal_id"] == proposal["proposal_id"]
-        assert payload["approver"] == "policy:auto"
+        assert payload["approver"] == "human:kevin"
         assert payload["params"] == {"signal_interval": 14}
         assert payload["effective_after"]["signal_interval"] == 14
     finally:
@@ -243,10 +244,13 @@ def test_tuning_gate_denial_emits_tuning_rejected(tmp_path):
             justification="t",
             mode="commit-pending",
         )
-        # policy:auto is insufficient → TuningError + emit tuning.rejected
+        # A non-human approver on a HUMAN_APPROVAL param → human_approval_required
+        # + emit tuning.rejected. (Uses a neutral approver, not policy:auto, so
+        # this exercises the human-approval gate rather than the Package R
+        # auto-commit quarantine — both are 403 denials that emit tuning.rejected.)
         from scripts.tuning_api import TuningError
         with pytest.raises(TuningError):
-            state.commit(proposal_id=proposal["proposal_id"], approver="policy:auto")
+            state.commit(proposal_id=proposal["proposal_id"], approver="agent:opus")
 
         msg = sub.recv(timeout_ms=500)
         assert msg is not None
@@ -294,13 +298,13 @@ def test_rollback_emits_tuning_rolled_back(tmp_path):
             params={"signal_interval": 15},
             source="human:kevin", justification="t", mode="commit-pending",
         )
-        state.commit(proposal_id=p1["proposal_id"], approver="policy:auto")
+        state.commit(proposal_id=p1["proposal_id"], approver="human:kevin")
         gen.advance(MIN_GEN_BETWEEN_COMMITS_PER_PARAM + 1)
         p2 = state.propose(
             params={"joy_beta": 0.5},
             source="human:kevin", justification="t", mode="commit-pending",
         )
-        state.commit(proposal_id=p2["proposal_id"], approver="policy:auto")
+        state.commit(proposal_id=p2["proposal_id"], approver="human:kevin")
         # Rollback to p1's snapshot.
         state.rollback(to_proposal_id=p1["proposal_id"])
 
@@ -328,5 +332,5 @@ def test_tuning_state_without_publisher_works(tmp_path):
         params={"signal_interval": 15},
         source="human:kevin", justification="t", mode="commit-pending",
     )
-    entry = state.commit(proposal_id=prop["proposal_id"], approver="policy:auto")
+    entry = state.commit(proposal_id=prop["proposal_id"], approver="human:kevin")
     assert entry["effective_after"]["signal_interval"] == 15

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -59,6 +59,7 @@ from scripts.orchestrator import (
     ToolRouter,
 )
 from scripts.tuning_api import TuningState, create_blueprint as create_tuning_blueprint
+from scripts.params_schema import PARAMS
 
 
 if AnthropicBackend is None or OpenAICompatBackend is None:
@@ -392,29 +393,39 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     o_result = o_orch.run_one_iteration("Observe Medusa; tune if needed.")
 
     # ---- Parity assertions ----
+    #
+    # Post-quarantine (Package R): the orchestrator's commit identity
+    # (approver="policy:auto") is refused at the server boundary, so the commit
+    # tool call attempted by both scripts is rejected identically. Provider
+    # parity is preserved — both backends behave the same — but now at the
+    # *rejected* outcome: one dry-run proposal each, zero commits, state
+    # unchanged. This proves backend-equivalence of the quarantined path.
 
     # 1. Both stopped naturally.
     assert a_result.stopped_because == o_result.stopped_because == "end_turn"
 
-    # 2. Both made the same number of tool calls (propose + commit = 2).
+    # 2. Both made the same number of tool calls (propose + commit-attempt = 2).
     assert a_result.tool_calls_executed == o_result.tool_calls_executed == 2
 
-    # 3. Both proposed exactly one and committed exactly one.
+    # 3. Both proposed exactly one; neither committed (server refused policy:auto).
     assert len(a_result.proposals_created) == len(o_result.proposals_created) == 1
-    assert len(a_result.commits_applied) == len(o_result.commits_applied) == 1
+    assert len(a_result.commits_applied) == len(o_result.commits_applied) == 0
+    assert a_result.commits_applied == o_result.commits_applied
 
-    # 4. Both backends pushed the same effective param into the live state.
-    assert state_a.effective_params()["signal_interval"] == 14
-    assert state_o.effective_params()["signal_interval"] == 14
+    # 4. No mutation reached the live state; both remain at the registry default.
+    default_si = PARAMS["signal_interval"].default
+    assert state_a.effective_params()["signal_interval"] == default_si
+    assert state_o.effective_params()["signal_interval"] == default_si
 
-    # 5. Both ledgers have a propose + commit entry for the same param value.
+    # 5. Both ledgers hold only the propose entry (the refused commit is not
+    #    recorded as a commit).
     a_lines = [json.loads(ln) for ln in
                (tmp_path / "a" / "tuning_ledger.jsonl").read_text().splitlines() if ln.strip()]
     o_lines = [json.loads(ln) for ln in
                (tmp_path / "o" / "tuning_ledger.jsonl").read_text().splitlines() if ln.strip()]
-    assert len(a_lines) == len(o_lines) == 2
-    assert [e["type"] for e in a_lines] == ["propose", "commit"]
-    assert [e["type"] for e in o_lines] == ["propose", "commit"]
+    assert len(a_lines) == len(o_lines) == 1
+    assert [e["type"] for e in a_lines] == ["propose"]
+    assert [e["type"] for e in o_lines] == ["propose"]
     # Parameters and source match modulo backend-specific proposal_ids
     assert a_lines[0]["params"] == o_lines[0]["params"] == PROPOSAL_PARAMS
     assert a_lines[0]["source"] == o_lines[0]["source"] == SOURCE

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -430,7 +430,8 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     assert a_lines[0]["params"] == o_lines[0]["params"] == PROPOSAL_PARAMS
     assert a_lines[0]["source"] == o_lines[0]["source"] == SOURCE
     assert a_lines[0]["justification"] == o_lines[0]["justification"] == JUSTIFICATION
-    assert a_lines[1]["approver"] == o_lines[1]["approver"] == "policy:auto"
+    # No commit ledger entry exists on either side — the policy:auto commit was
+    # refused at the server boundary (Package R), so both ledgers stop at propose.
 
 
 def test_parity_at_response_translation_layer():

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -150,34 +150,54 @@ def _propose(client, params, source="human:kevin", mode="commit-pending"):
     return resp.get_json()["proposal_id"]
 
 
-def test_commit_auto_category_accepts_policy_auto(tuning):
+def test_commit_auto_category_via_policy_auto_is_disabled(tuning):
+    """Package R quarantine: even a valid AUTO-category proposal can no longer
+    be committed by the autonomous policy:auto approver. The rejection is at
+    the server boundary; no engine-state mutation and no pending file result."""
     client, state, gen, tmp_path = tuning
     pid = _propose(client, {"signal_interval": 15})
     code, body = _json(client.post(
         "/api/tuning/commit",
         json={"proposal_id": pid, "approver": "policy:auto"},
     ))
+    assert code == 403
+    assert body["error"] == "auto_commit_disabled"
+    # No mutation: effective params unchanged, no pending file written.
+    assert state.effective_params()["signal_interval"] == PARAMS["signal_interval"].default
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+def test_commit_auto_category_still_accepts_human_approver(tuning):
+    """The quarantine closes only the autonomous path. A deliberate human
+    approver may still commit an AUTO-category proposal (they take
+    responsibility explicitly)."""
+    client, state, gen, tmp_path = tuning
+    pid = _propose(client, {"signal_interval": 15})
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": "human:kevin"},
+    ))
     assert code == 200
     assert body["status"] == "committed"
-    assert body["applied_at_gen"] == gen.value
-    assert body["effective_after"]["signal_interval"] == 15
-    # Pending file was written.
-    pending = json.loads((tmp_path / "tuning_pending.json").read_text())
-    assert pending["effective_params"]["signal_interval"] == 15
-    assert pending["proposal_id"] == pid
-    # Effective state updated.
     assert state.effective_params()["signal_interval"] == 15
+    pending = json.loads((tmp_path / "tuning_pending.json").read_text())
+    assert pending["proposal_id"] == pid
 
 
-def test_commit_human_approval_required_rejects_policy_auto(tuning):
-    client, *_ = tuning
+def test_commit_human_approval_param_via_policy_auto_disabled(tuning):
+    """A HUMAN_APPROVAL param committed with policy:auto is refused. Post-R the
+    auto-commit quarantine fires first, so the stable reason is
+    auto_commit_disabled (still 403; still rejected; still no mutation)."""
+    client, state, *_ = tuning
     pid = _propose(client, {"magnon_coupling": 2.5})  # HUMAN_APPROVAL category
     code, body = _json(client.post(
         "/api/tuning/commit",
         json={"proposal_id": pid, "approver": "policy:auto"},
     ))
     assert code == 403
-    assert body["error"] == "human_approval_required"
+    assert body["error"] == "auto_commit_disabled"
+    assert "magnon_coupling" not in state.effective_params() or \
+        state.effective_params()["magnon_coupling"] == PARAMS["magnon_coupling"].default
 
 
 def test_commit_human_approval_accepts_human_prefix(tuning):
@@ -218,23 +238,25 @@ def test_commit_invalid_proposal_rejected_even_with_human(tuning):
 
 
 def test_commit_rate_limit_rejects_quick_repeat(tuning):
+    # Rate-limit protection is unchanged by the auto-commit quarantine; proven
+    # here via the still-available human-approver commit path.
     client, state, gen, _ = tuning
     # First commit succeeds.
     pid1 = _propose(client, {"signal_interval": 20})
     assert client.post("/api/tuning/commit",
-                       json={"proposal_id": pid1, "approver": "policy:auto"}).status_code == 200
+                       json={"proposal_id": pid1, "approver": "human:kevin"}).status_code == 200
     # Advance less than the cooldown.
     gen.advance(MIN_GEN_BETWEEN_COMMITS_PER_PARAM - 1)
     pid2 = _propose(client, {"signal_interval": 25})
     code, body = _json(client.post("/api/tuning/commit",
-                                    json={"proposal_id": pid2, "approver": "policy:auto"}))
+                                    json={"proposal_id": pid2, "approver": "human:kevin"}))
     assert code == 429
     assert body["error"] == "rate_limited"
     # Advance past the cooldown; second commit now succeeds.
     gen.advance(2)
     pid3 = _propose(client, {"signal_interval": 30})
     assert client.post("/api/tuning/commit",
-                       json={"proposal_id": pid3, "approver": "policy:auto"}).status_code == 200
+                       json={"proposal_id": pid3, "approver": "human:kevin"}).status_code == 200
 
 
 def test_commit_400_when_body_incomplete(tuning):
@@ -245,6 +267,72 @@ def test_commit_400_when_body_incomplete(tuning):
         assert body["error"] == "bad_request"
 
 
+# -- Package R: auto-commit quarantine (server boundary) --------------------
+
+
+def test_auto_commit_disabled_is_the_orchestrators_only_identity(tuning):
+    """The legacy orchestrator's ToolRouter hard-codes approver='policy:auto'
+    (see scripts/orchestrator.py) and offers the LLM no way to set it. That
+    exact identity is refused here, and the refusal does not mutate state — so
+    the orchestrator's whole write path is closed at the boundary."""
+    client, state, *_ = tuning
+    pid = _propose(client, {"signal_interval": 15})
+    code, body = _json(client.post("/api/tuning/commit",
+                                   json={"proposal_id": pid, "approver": "policy:auto"}))
+    assert code == 403
+    assert body["error"] == "auto_commit_disabled"
+    assert state.effective_params()["signal_interval"] == PARAMS["signal_interval"].default
+
+
+def test_auto_commit_rejection_emits_no_committed_event(tmp_path):
+    """A refused policy:auto commit must not fire tuning.committed on the event
+    bus (no downstream consumer should believe a commit happened)."""
+    class RecordingBus:
+        def __init__(self):
+            self.published = []
+
+        def publish(self, topic, payload):
+            self.published.append((topic, payload))
+
+    gen = FakeGen()
+    bus = RecordingBus()
+    state = TuningState(data_dir=tmp_path, gen_getter=gen, event_publisher=bus)
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint(state))
+    client = app.test_client()
+
+    pid = _propose(client, {"signal_interval": 15})
+    resp = client.post("/api/tuning/commit",
+                       json={"proposal_id": pid, "approver": "policy:auto"})
+    assert resp.status_code == 403
+    topics = [t for t, _ in bus.published]
+    assert "tuning.committed" not in topics
+    # The rejection is surfaced as a rejected event (stage=commit).
+    assert any(t == "tuning.rejected" for t in topics)
+    # No pending file was written.
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+def test_locked_and_dryrun_paths_unchanged_by_quarantine(tuning):
+    """Baseline preserved: LOCKED still rejected at propose; dry-run proposal
+    still accepted; proposal creation still returns an id."""
+    client, *_ = tuning
+    # LOCKED rejected at propose (unchanged).
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"structural_to_void_decay_prob": 0.004}},
+    ))
+    assert code == 422
+    assert body["validation"]["errors"]["structural_to_void_decay_prob"]["error"] == "locked"
+    # Dry-run proposal still accepted and recorded.
+    code, body = _json(client.post(
+        "/api/tuning/propose",
+        json={"params": {"signal_interval": 12}, "justification": "ok", "mode": "dry-run"},
+    ))
+    assert code == 200
+    assert body["proposal_id"].startswith("prop-")
+
+
 # -- POST /api/tuning/rollback ---------------------------------------------
 
 
@@ -252,12 +340,12 @@ def test_rollback_happy_path(tuning):
     client, state, gen, tmp_path = tuning
     # Commit A
     pid_a = _propose(client, {"signal_interval": 17})
-    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "policy:auto"})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "human:kevin"})
     # Move past rate limit for next param so we can vary state a bit
     gen.advance(MIN_GEN_BETWEEN_COMMITS_PER_PARAM + 1)
     # Commit B (different param so no rate-limit collision)
     pid_b = _propose(client, {"joy_beta": 0.5})
-    client.post("/api/tuning/commit", json={"proposal_id": pid_b, "approver": "policy:auto"})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_b, "approver": "human:kevin"})
     assert state.effective_params()["signal_interval"] == 17
     assert state.effective_params()["joy_beta"] == 0.5
     # Rollback to the snapshot after A — joy_beta should return to its default.
@@ -291,7 +379,7 @@ def test_ledger_replay_restores_state_across_restart(tuning):
     client, state, gen, tmp_path = tuning
     # Propose + commit + rollback, then build a fresh TuningState from the same dir.
     pid_a = _propose(client, {"signal_interval": 22})
-    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "policy:auto"})
+    client.post("/api/tuning/commit", json={"proposal_id": pid_a, "approver": "human:kevin"})
 
     fresh = TuningState(data_dir=tmp_path, gen_getter=gen)
     assert fresh.effective_params()["signal_interval"] == 22
@@ -305,7 +393,7 @@ def test_ledger_replay_restores_state_across_restart(tuning):
 def test_ledger_survives_corrupt_line(tuning):
     client, state, gen, tmp_path = tuning
     pid = _propose(client, {"signal_interval": 14})
-    client.post("/api/tuning/commit", json={"proposal_id": pid, "approver": "policy:auto"})
+    client.post("/api/tuning/commit", json={"proposal_id": pid, "approver": "human:kevin"})
     # Corrupt the ledger with a bad line in the middle.
     with (tmp_path / "tuning_ledger.jsonl").open("a", encoding="utf-8") as f:
         f.write("this-is-not-json\n")

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -333,6 +333,102 @@ def test_locked_and_dryrun_paths_unchanged_by_quarantine(tuning):
     assert body["proposal_id"].startswith("prop-")
 
 
+# -- Package R amendment (Jack audit): type-guard + normalized match --------
+
+
+class _RecordingBus:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, topic, payload):
+        self.published.append((topic, payload))
+
+
+def _committed_ledger_entries(tmp_path):
+    p = tmp_path / "tuning_ledger.jsonl"
+    if not p.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in p.read_text(encoding="utf-8").splitlines()
+        if line.strip() and json.loads(line).get("type") == "commit"
+    ]
+
+
+_BLOCKED_APPROVER_VARIANTS = [
+    "policy:auto",
+    " policy:auto ",
+    "POLICY:AUTO",
+    " POLICY:AUTO ",
+    "\tPolicy:Auto\n",
+    "policy:auto\n",
+]
+
+
+@pytest.mark.parametrize("approver", _BLOCKED_APPROVER_VARIANTS)
+def test_commit_normalized_policy_auto_variants_all_disabled(tmp_path, approver):
+    """Every whitespace/case variant of the autonomous identity is refused with
+    the same stable 403 auto_commit_disabled, and none of them touches any of
+    the four write surfaces: effective params, pending file, commit ledger, or
+    the tuning.committed event."""
+    gen = FakeGen()
+    bus = _RecordingBus()
+    state = TuningState(data_dir=tmp_path, gen_getter=gen, event_publisher=bus)
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint(state))
+    client = app.test_client()
+
+    pid = _propose(client, {"signal_interval": 15})
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": approver},
+    ))
+    assert code == 403
+    assert body["error"] == "auto_commit_disabled"
+    assert state.effective_params()["signal_interval"] == PARAMS["signal_interval"].default
+    assert not (tmp_path / "tuning_pending.json").exists()
+    assert _committed_ledger_entries(tmp_path) == []
+    assert "tuning.committed" not in [t for t, _ in bus.published]
+
+
+@pytest.mark.parametrize("approver", [True, 123, 1.5, ["human:kevin"], {"who": "human:kevin"}])
+def test_commit_non_string_approver_is_bad_request(tmp_path, approver):
+    """A non-string approver (bool/number/list/object) is a malformed request:
+    stable 400 bad_request checked before any string operation, never an
+    AttributeError, and no state mutation."""
+    gen = FakeGen()
+    state = TuningState(data_dir=tmp_path, gen_getter=gen)
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint(state))
+    client = app.test_client()
+
+    pid = _propose(client, {"signal_interval": 15})
+    code, body = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": approver},
+    ))
+    assert code == 400
+    assert body["error"] == "bad_request"
+    assert state.effective_params()["signal_interval"] == PARAMS["signal_interval"].default
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+def test_commit_preserves_raw_human_approver_identity(tuning):
+    """The quarantine normalization is comparison-only. A human approver's raw
+    identity — mixed case and trailing whitespace — is stored verbatim in the
+    committed ledger entry, never stripped or lowercased."""
+    client, state, gen, tmp_path = tuning
+    pid = _propose(client, {"signal_interval": 15})
+    raw = "human:Kevin "  # valid human prefix; capitalised name; trailing space
+    code, _ = _json(client.post(
+        "/api/tuning/commit",
+        json={"proposal_id": pid, "approver": raw},
+    ))
+    assert code == 200
+    commits = _committed_ledger_entries(tmp_path)
+    assert commits and commits[-1]["approver"] == raw
+
+
 # -- POST /api/tuning/rollback ---------------------------------------------
 
 


### PR DESCRIPTION
## Package R — server-side auto-commit quarantine

Closes the legacy Phase 18 tuning orchestrator's only write identity at the **server boundary**, not in a prompt or client tool list. Design evidence: [#322](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/322) (which uncovered `scripts/orchestrator.py` — self-described "the Swarm Hunter's brain" — committing with a hard-coded `approver="policy:auto"`).

**Change (2 files, +139/−17):** `scripts/tuning_api.py` `TuningState._commit_locked` now raises **403 `auto_commit_disabled`** when `approver == AUTO_COMMIT_APPROVER` (`"policy:auto"`), checked *before* the human-approval branch so the autonomous identity is refused regardless of parameter category. No LLM-facing tool call can mutate a parameter once this lands.

**Exact rejection contract:** `POST /api/tuning/commit` with `approver="policy:auto"` → `403 {"error": "auto_commit_disabled", "message": "..."}`, no ledger apply, no `tuning_pending.json` write, no `tuning.committed` event (a `tuning.rejected` stage=commit event is emitted instead).

**No re-enable switch:** deliberately no env flag, secret toggle, query parameter, alternate header, or hidden route re-enables autonomous commits — re-enablement requires a reviewed code change here.

**Preserved exactly:** read endpoints; dry-run validation; proposal creation; LOCKED rejection at propose; human-approval behavior; the per-parameter generation rate limit. AUTO-category params can still be committed by a deliberate **human** approver (`approver="human:<name>"`) — the quarantine closes only the autonomous path.

**Non-claim:** this does **not** authenticate callers or make the tuning API generally secure. It closes exactly the proven `policy:auto` auto-commit path.

**Tests (in `tests/test_tuning_api.py`):** policy:auto refused for AUTO and HUMAN_APPROVAL params with no mutation and no committed event; the orchestrator's sole identity is the refused one; AUTO still commits via a human approver; LOCKED/dry-run/rate-limit baselines preserved (successful commits re-pointed from `policy:auto` to `human:kevin`, which proves the rate limit is unchanged).

**Verification lane:** this seat has no local Python toolchain; the maintained suite runs in GitHub CI (`verify-python`) on this push — counts recorded once green.

Part 1 of a 3-PR stack (R → S → T). Open and **unmerged** for Jack; keeps `swarm-hunter`; no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
