### PR TITLE
test: node-validation + scene-store unit contracts — three boundary defects repaired failing-first (PACKAGE V)

### DIFF
--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -12,11 +12,14 @@ import { NetworkNode } from '../ws/SimBridgeClient'
 /// numbers. (NaN/Infinity are rejected — they draw nothing meaningful and
 /// poison instanced-matrix math.)
 export function isValidPosition(p: unknown): p is [number, number, number] {
-  return (
-    Array.isArray(p) &&
-    p.length === 3 &&
-    p.every(v => typeof v === 'number' && Number.isFinite(v))
-  )
+  if (!Array.isArray(p) || p.length !== 3) return false
+  // Indexed access, not every(): every() SKIPS holes in sparse arrays, so
+  // Array(3) — length 3, zero coordinates — would validate vacuously.
+  for (let i = 0; i < 3; i++) {
+    const v: unknown = p[i]
+    if (typeof v !== 'number' || !Number.isFinite(v)) return false
+  }
+  return true
 }
 
 /// Reconcile an incoming node-shaped payload against the previously known
@@ -42,15 +45,23 @@ export function reconcileNode(
   // The candidate is only trusted after the runtime position validation
   // below (id is checked by callers); status/connections stay tolerated
   // per the source-verified renderer-requirements evidence.
-  const candidate = incoming as Partial<NetworkNode> & { position?: unknown }
-  const merged = (existing ? { ...existing, ...candidate } : candidate) as NetworkNode
-  if (isValidPosition(candidate.position)) {
-    return merged
+  try {
+    const candidate = incoming as Partial<NetworkNode> & { position?: unknown }
+    const merged = (existing ? { ...existing, ...candidate } : candidate) as NetworkNode
+    if (isValidPosition(candidate.position)) {
+      return merged
+    }
+    if (existing && isValidPosition(existing.position)) {
+      return { ...merged, position: existing.position }
+    }
+    return null
+  } catch {
+    // Hostile payload shapes (throwing getters, poisoned proxies) are
+    // contained at the boundary exactly like any other malformed input —
+    // property access and the merge spread both evaluate getters, and an
+    // exception here must not cross into store/render code.
+    return null
   }
-  if (existing && isValidPosition(existing.position)) {
-    return { ...merged, position: existing.position }
-  }
-  return null
 }
 
 /// Apply one incoming node to a node list (update-or-append by id),
@@ -62,7 +73,13 @@ export function applyNodeUpdate(
   previous: NetworkNode[],
   incoming: unknown,
 ): NetworkNode[] {
-  const id = (incoming as { id?: unknown } | null | undefined)?.id
+  let id: unknown
+  try {
+    id = (incoming as { id?: unknown } | null | undefined)?.id
+  } catch {
+    // A throwing id getter identifies nothing — same outcome as no id.
+    return previous
+  }
   if (typeof id !== 'string') return previous
   const index = previous.findIndex(n => n.id === id)
   const next = reconcileNode(incoming, index >= 0 ? previous[index] : undefined)
@@ -87,7 +104,13 @@ export function sanitizeNodeList(
   const result: NetworkNode[] = []
   const seen = new Set<string>()
   for (const candidate of incoming) {
-    const id = (candidate as { id?: unknown } | null | undefined)?.id
+    let id: unknown
+    try {
+      id = (candidate as { id?: unknown } | null | undefined)?.id
+    } catch {
+      // A hostile entry is skipped without losing the rest of the batch.
+      continue
+    }
     if (typeof id !== 'string' || seen.has(id)) continue
     const next = reconcileNode(candidate, byId.get(id))
     if (next !== null) {

--- a/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
@@ -40,10 +40,14 @@ export const useSceneStore = create<SceneStore>((set) => ({
     set((state) => ({
       // Per-side tolerance: a malformed side never discards the valid
       // other side; explicit empty arrays remain meaningful and clear.
-      // Edge ELEMENT shape stays tolerated (renderers skip dangling
-      // references) — the array check is the documented boundary.
+      // Edge elements must at least be non-null objects — renderers index
+      // edge.source/edge.target, so a null/primitive element throws in
+      // render code. Dangling REFERENCES on real edge objects stay
+      // tolerated (renderers skip unmatched ids).
       nodes: Array.isArray(nodes) ? sanitizeNodeList(nodes, state.nodes) : state.nodes,
-      edges: Array.isArray(edges) ? (edges as NetworkEdge[]) : state.edges,
+      edges: Array.isArray(edges)
+        ? edges.filter((e): e is NetworkEdge => !!e && typeof e === 'object')
+        : state.edges,
     })),
 
   clearNetwork: () =>

--- a/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
@@ -1,0 +1,282 @@
+// Package V, part 1: the nodeValidation ingestion-boundary contract,
+// tested directly at its exported seams (isValidPosition, reconcileNode,
+// applyNodeUpdate, sanitizeNodeList).
+//
+// External payloads are `unknown` until the module narrows them — these
+// tests feed genuinely hostile shapes (sparse arrays, throwing getters,
+// prototype-less objects) as well as the documented boundary values.
+import { describe, it, expect } from 'vitest'
+import {
+  isValidPosition,
+  reconcileNode,
+  applyNodeUpdate,
+  sanitizeNodeList,
+} from '../src/viz3d/nodeValidation'
+import type { NetworkNode } from '../src/ws/SimBridgeClient'
+
+const node = (
+  id: string,
+  position: [number, number, number],
+  rest: Partial<NetworkNode> = {},
+): NetworkNode => ({
+  id,
+  position,
+  connections: [],
+  status: 'active',
+  ...rest,
+})
+
+describe('isValidPosition', () => {
+  it.each([
+    { label: 'origin', value: [0, 0, 0], valid: true },
+    { label: 'floats and negatives', value: [1.5, -2, 3e10], valid: true },
+    { label: 'negative zero', value: [-0, 0, 0], valid: true },
+    { label: 'null', value: null, valid: false },
+    { label: 'undefined', value: undefined, valid: false },
+    { label: 'string', value: 'up-and-left', valid: false },
+    { label: 'number', value: 42, valid: false },
+    { label: 'plain object', value: { 0: 1, 1: 2, 2: 3, length: 3 }, valid: false },
+    { label: 'empty array', value: [], valid: false },
+    { label: 'length 2', value: [1, 2], valid: false },
+    { label: 'length 4', value: [1, 2, 3, 4], valid: false },
+    { label: 'string coordinate', value: [1, 'two', 3], valid: false },
+    { label: 'NaN coordinate', value: [1, 2, Number.NaN], valid: false },
+    { label: '+Infinity coordinate', value: [1, 2, Number.POSITIVE_INFINITY], valid: false },
+    { label: '-Infinity coordinate', value: [Number.NEGATIVE_INFINITY, 0, 0], valid: false },
+    { label: 'null coordinate', value: [1, null, 3], valid: false },
+  ])('$label → $valid', ({ value, valid }) => {
+    expect(isValidPosition(value)).toBe(valid)
+  })
+
+  it('rejects fully sparse arrays (Array(3) has length 3 but no coordinates)', () => {
+    // every() skips holes, so a naive implementation is vacuously true here.
+    expect(isValidPosition(new Array(3))).toBe(false)
+  })
+
+  it('rejects a length-3 array with a hole', () => {
+    // Built by index assignment: [1, <hole>, 3] without sparse-literal syntax.
+    const holed: unknown[] = new Array(3)
+    holed[0] = 1
+    holed[2] = 3
+    expect(isValidPosition(holed)).toBe(false)
+  })
+})
+
+describe('reconcileNode', () => {
+  it('admits an unknown node with a valid position, as supplied', () => {
+    const incoming = { id: 'n1', position: [1, 2, 3], connections: [], status: 'active' }
+    expect(reconcileNode(incoming, undefined)).toEqual(node('n1', [1, 2, 3]))
+  })
+
+  it('merges a partial update over the existing record ({...existing, ...incoming})', () => {
+    const existing = node('n1', [1, 2, 3])
+    const result = reconcileNode({ id: 'n1', position: [4, 5, 6], status: 'error' }, existing)
+    expect(result).toEqual(node('n1', [4, 5, 6], { status: 'error' }))
+  })
+
+  it('preserves the LAST VALID position when the update has no usable position', () => {
+    const existing = node('n1', [7, 8, 9])
+    const result = reconcileNode({ id: 'n1', status: 'error' }, existing)
+    expect(result).toEqual(node('n1', [7, 8, 9], { status: 'error' }))
+  })
+
+  it.each([
+    { label: 'missing position', incoming: { id: 'g' } },
+    { label: 'null position', incoming: { id: 'g', position: null } },
+    { label: 'NaN position', incoming: { id: 'g', position: [1, 2, Number.NaN] } },
+  ])('returns null for an unknown node with $label (no [0,0,0] invented)', ({ incoming }) => {
+    expect(reconcileNode(incoming, undefined)).toBeNull()
+  })
+
+  it.each([
+    { label: 'null', incoming: null },
+    { label: 'undefined', incoming: undefined },
+    { label: 'string', incoming: 'not-a-node' },
+    { label: 'number', incoming: 12 },
+  ])('returns null for non-object payload: $label', ({ incoming }) => {
+    expect(reconcileNode(incoming, node('n1', [1, 2, 3]))).toBeNull()
+  })
+
+  it('admits a prototype-less object carrying a valid position', () => {
+    const incoming = Object.create(null) as Record<string, unknown>
+    incoming.id = 'proto-free'
+    incoming.position = [1, 2, 3]
+    incoming.connections = []
+    incoming.status = 'active'
+    expect(reconcileNode(incoming, undefined)).toEqual(node('proto-free', [1, 2, 3]))
+  })
+
+  it('contains a throwing position getter instead of letting it cross the boundary', () => {
+    const hostile = {
+      id: 'h1',
+      get position(): unknown {
+        throw new Error('hostile getter')
+      },
+    }
+    expect(reconcileNode(hostile, undefined)).toBeNull()
+  })
+
+  it('contains a throwing getter on a non-position field (triggered by merge spread)', () => {
+    const hostile = {
+      id: 'h2',
+      position: [1, 2, 3],
+      get status(): unknown {
+        throw new Error('hostile getter')
+      },
+    }
+    expect(reconcileNode(hostile, node('h2', [9, 9, 9]))).toBeNull()
+  })
+
+  it('does not mutate the existing record or the incoming payload', () => {
+    const existing = Object.freeze(node('n1', Object.freeze([1, 2, 3]) as unknown as [number, number, number]))
+    const incoming = Object.freeze({ id: 'n1', status: 'error' as const })
+    const result = reconcileNode(incoming, existing)
+    expect(result).toEqual(node('n1', [1, 2, 3], { status: 'error' }))
+    expect(existing).toEqual(node('n1', [1, 2, 3]))
+    expect(incoming).toEqual({ id: 'n1', status: 'error' })
+  })
+})
+
+describe('applyNodeUpdate', () => {
+  it.each([
+    { label: 'missing id', incoming: { position: [1, 2, 3] } },
+    { label: 'numeric id', incoming: { id: 7, position: [1, 2, 3] } },
+    { label: 'null payload', incoming: null },
+    { label: 'string payload', incoming: 'nope' },
+  ])('returns the previous list unchanged (same reference) for $label', ({ incoming }) => {
+    const previous = [node('a', [1, 2, 3])]
+    expect(applyNodeUpdate(previous, incoming)).toBe(previous)
+  })
+
+  it('appends a new valid node and updates an existing one in place (never duplicates)', () => {
+    const step1 = applyNodeUpdate([], { id: 'a', position: [1, 2, 3], connections: [], status: 'active' })
+    const step2 = applyNodeUpdate(step1, { id: 'b', position: [4, 5, 6], connections: [], status: 'active' })
+    const step3 = applyNodeUpdate(step2, { id: 'a', position: [9, 9, 9] })
+    expect(step3.map(n => n.id)).toEqual(['a', 'b'])
+    expect(step3[0].position).toEqual([9, 9, 9])
+  })
+
+  it('returns the previous list (same reference) when reconcile rejects an unknown ghost', () => {
+    const previous = [node('a', [1, 2, 3])]
+    expect(applyNodeUpdate(previous, { id: 'ghost', status: 'active' })).toBe(previous)
+  })
+
+  it('survives a throwing id getter, preserving the previous list', () => {
+    const previous = [node('a', [1, 2, 3])]
+    const hostile = {
+      get id(): unknown {
+        throw new Error('hostile id')
+      },
+    }
+    expect(applyNodeUpdate(previous, hostile)).toBe(previous)
+  })
+
+  it('does not mutate the previous list on update', () => {
+    const original = node('a', [1, 2, 3])
+    const previous = Object.freeze([original]) as unknown as NetworkNode[]
+    const next = applyNodeUpdate(previous, { id: 'a', status: 'error' })
+    expect(next).not.toBe(previous)
+    expect(previous[0]).toBe(original)
+    expect(original.status).toBe('active')
+  })
+
+  it('deterministic sequence: interleaved valid/invalid updates land in a reproducible order', () => {
+    // The promised ordering: existing nodes keep their slot, new valid
+    // nodes append in arrival order, rejected updates change nothing.
+    let list: NetworkNode[] = []
+    const feed: unknown[] = [
+      { id: 'a', position: [1, 1, 1], connections: [], status: 'active' },
+      { id: 'ghost', status: 'active' },                      // rejected: unknown, positionless
+      { id: 'b', position: [2, 2, 2], connections: [], status: 'active' },
+      { id: 'a', status: 'error' },                           // merge, keeps [1,1,1], keeps slot 0
+      { id: 'b', position: [8, 8, 8] },                       // position update in place
+      { id: 'c', position: [3, 3, 3], connections: [], status: 'inactive' },
+      { id: 'a', position: [1, 2, Number.NaN] },              // rejected: invalid position, 'a' keeps last valid
+    ]
+    for (const payload of feed) list = applyNodeUpdate(list, payload)
+    expect(list.map(n => ({ id: n.id, position: n.position, status: n.status }))).toEqual([
+      { id: 'a', position: [1, 1, 1], status: 'error' },
+      { id: 'b', position: [8, 8, 8], status: 'active' },
+      { id: 'c', position: [3, 3, 3], status: 'inactive' },
+    ])
+  })
+})
+
+describe('sanitizeNodeList', () => {
+  it.each([
+    { label: 'null', incoming: null },
+    { label: 'object', incoming: { length: 1 } },
+    { label: 'string', incoming: 'nodes' },
+  ])('returns the previous list unchanged (same reference) for non-array: $label', ({ incoming }) => {
+    const previous = [node('a', [1, 2, 3])]
+    expect(sanitizeNodeList(incoming, previous)).toBe(previous)
+  })
+
+  it('is wholesale: nodes absent from the incoming list are dropped', () => {
+    const previous = [node('a', [1, 2, 3]), node('b', [4, 5, 6])]
+    const result = sanitizeNodeList([{ id: 'b', position: [7, 7, 7], connections: [], status: 'active' }], previous)
+    expect(result.map(n => n.id)).toEqual(['b'])
+  })
+
+  it('preserves incoming order, keeps first occurrence of duplicate ids', () => {
+    const result = sanitizeNodeList(
+      [
+        { id: 'x', position: [1, 1, 1], connections: [], status: 'active' },
+        { id: 'y', position: [2, 2, 2], connections: [], status: 'active' },
+        { id: 'x', position: [9, 9, 9] }, // duplicate: first wins
+      ],
+      [],
+    )
+    expect(result.map(n => ({ id: n.id, position: n.position }))).toEqual([
+      { id: 'x', position: [1, 1, 1] },
+      { id: 'y', position: [2, 2, 2] },
+    ])
+  })
+
+  it('reconciles against previous state: positionless entries keep last valid position', () => {
+    const previous = [node('keep', [7, 8, 9])]
+    const result = sanitizeNodeList([{ id: 'keep', status: 'error' }], previous)
+    expect(result).toEqual([node('keep', [7, 8, 9], { status: 'error' })])
+  })
+
+  it('excludes malformed entries while admitting valid neighbours', () => {
+    const result = sanitizeNodeList(
+      [
+        null,
+        'junk',
+        { id: 'ok', position: [1, 2, 3], connections: [], status: 'active' },
+        { id: 42, position: [1, 2, 3] },
+        { id: 'ghost' },
+        { id: 'holed', position: new Array(3) },
+      ],
+      [],
+    )
+    expect(result.map(n => n.id)).toEqual(['ok'])
+  })
+
+  it('skips entries with throwing getters without losing the rest of the batch', () => {
+    const hostileId = {
+      get id(): unknown {
+        throw new Error('hostile id')
+      },
+    }
+    const hostilePosition = {
+      id: 'hp',
+      get position(): unknown {
+        throw new Error('hostile position')
+      },
+    }
+    const result = sanitizeNodeList(
+      [hostileId, { id: 'ok', position: [1, 2, 3], connections: [], status: 'active' }, hostilePosition],
+      [],
+    )
+    expect(result.map(n => n.id)).toEqual(['ok'])
+  })
+
+  it('does not mutate the previous list', () => {
+    const previous = Object.freeze([node('a', [1, 2, 3])]) as unknown as NetworkNode[]
+    const result = sanitizeNodeList([{ id: 'b', position: [1, 1, 1], connections: [], status: 'active' }], previous)
+    expect(result.map(n => n.id)).toEqual(['b'])
+    expect(previous.map(n => n.id)).toEqual(['a'])
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
@@ -1,0 +1,166 @@
+// Package V, part 2: the scene-store public contract (useSceneStore).
+//
+// The store is a module-level zustand singleton; each test starts from an
+// explicitly reset state so ordering can never matter. External payloads
+// enter as `unknown` exactly as they do from the transport handlers.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSceneStore } from '../src/viz3d/useSceneStore'
+import type { NetworkNode, NetworkEdge } from '../src/ws/SimBridgeClient'
+
+const node = (
+  id: string,
+  position: [number, number, number],
+  rest: Partial<NetworkNode> = {},
+): NetworkNode => ({
+  id,
+  position,
+  connections: [],
+  status: 'active',
+  ...rest,
+})
+
+const edge = (id: string, source: string, target: string): NetworkEdge => ({
+  id,
+  source,
+  target,
+  strength: 1,
+})
+
+beforeEach(() => {
+  useSceneStore.setState({ nodes: [], edges: [] })
+})
+
+describe('useSceneStore.updateNode', () => {
+  it('admits a valid node and merges partial updates by id', () => {
+    const s = useSceneStore.getState()
+    s.updateNode({ id: 'a', position: [1, 2, 3], connections: [], status: 'active' })
+    s.updateNode({ id: 'a', status: 'error' })
+    expect(useSceneStore.getState().nodes).toEqual([node('a', [1, 2, 3], { status: 'error' })])
+  })
+
+  it('rejected updates keep the nodes array reference unchanged (no spurious rerenders)', () => {
+    useSceneStore.getState().updateNode({ id: 'a', position: [1, 2, 3], connections: [], status: 'active' })
+    const before = useSceneStore.getState().nodes
+    useSceneStore.getState().updateNode({ id: 'ghost', status: 'active' }) // unknown, positionless
+    useSceneStore.getState().updateNode('not-a-node')
+    useSceneStore.getState().updateNode(null)
+    expect(useSceneStore.getState().nodes).toBe(before)
+  })
+
+  it('survives a hostile payload with a throwing getter; state is unaffected', () => {
+    useSceneStore.getState().updateNode({ id: 'a', position: [1, 2, 3], connections: [], status: 'active' })
+    const before = useSceneStore.getState().nodes
+    const hostile = {
+      get id(): unknown {
+        throw new Error('hostile id getter')
+      },
+    }
+    expect(() => useSceneStore.getState().updateNode(hostile)).not.toThrow()
+    expect(useSceneStore.getState().nodes).toBe(before)
+  })
+
+  it('later-valid recovery: a ghost rejected earlier is admitted once it gains a position', () => {
+    const s = useSceneStore.getState()
+    s.updateNode({ id: 'g', status: 'active' })                 // rejected
+    expect(useSceneStore.getState().nodes).toEqual([])
+    s.updateNode({ id: 'g', position: [4, 5, 6], connections: [], status: 'active' })
+    expect(useSceneStore.getState().nodes.map(n => n.id)).toEqual(['g'])
+  })
+})
+
+describe('useSceneStore.setNetwork', () => {
+  it('replaces both sides wholesale with sanitized input', () => {
+    useSceneStore.getState().updateNode({ id: 'old', position: [0, 0, 0], connections: [], status: 'active' })
+    useSceneStore.getState().setNetwork(
+      [{ id: 'a', position: [1, 1, 1], connections: [], status: 'active' }, { id: 'bad' }],
+      [edge('e1', 'a', 'a')],
+    )
+    const state = useSceneStore.getState()
+    expect(state.nodes.map(n => n.id)).toEqual(['a'])
+    expect(state.edges).toEqual([edge('e1', 'a', 'a')])
+  })
+
+  it('per-side tolerance: a malformed side never discards the valid other side', () => {
+    useSceneStore.getState().setNetwork(
+      [{ id: 'a', position: [1, 1, 1], connections: [], status: 'active' }],
+      [edge('e1', 'a', 'a')],
+    )
+    useSceneStore.getState().setNetwork(null, [edge('e2', 'a', 'a')])
+    expect(useSceneStore.getState().nodes.map(n => n.id)).toEqual(['a'])
+    expect(useSceneStore.getState().edges).toEqual([edge('e2', 'a', 'a')])
+    useSceneStore.getState().setNetwork([], 'not-edges')
+    expect(useSceneStore.getState().nodes).toEqual([])
+    expect(useSceneStore.getState().edges).toEqual([edge('e2', 'a', 'a')])
+  })
+
+  it('explicit empty arrays remain meaningful and clear both sides', () => {
+    useSceneStore.getState().setNetwork(
+      [{ id: 'a', position: [1, 1, 1], connections: [], status: 'active' }],
+      [edge('e1', 'a', 'a')],
+    )
+    useSceneStore.getState().setNetwork([], [])
+    expect(useSceneStore.getState().nodes).toEqual([])
+    expect(useSceneStore.getState().edges).toEqual([])
+  })
+
+  it('filters non-object elements out of the edges array (null/string/undefined cannot reach renderers)', () => {
+    useSceneStore.getState().setNetwork([], [edge('e1', 'a', 'b'), null, 'junk', undefined, edge('e2', 'b', 'c')])
+    expect(useSceneStore.getState().edges).toEqual([edge('e1', 'a', 'b'), edge('e2', 'b', 'c')])
+  })
+
+  it('edge OBJECTS with dangling references stay tolerated (renderers skip them)', () => {
+    const dangling = { id: 'e-dangling', source: 'nowhere', target: 'nothing', strength: 1 }
+    useSceneStore.getState().setNetwork([], [dangling])
+    expect(useSceneStore.getState().edges).toEqual([dangling])
+  })
+})
+
+describe('useSceneStore.updateEdge / clearNetwork', () => {
+  it('updateEdge appends new ids and replaces matching ids in place', () => {
+    const s = useSceneStore.getState()
+    s.updateEdge(edge('e1', 'a', 'b'))
+    s.updateEdge(edge('e2', 'b', 'c'))
+    s.updateEdge({ ...edge('e1', 'a', 'b'), strength: 9 })
+    expect(useSceneStore.getState().edges).toEqual([
+      { ...edge('e1', 'a', 'b'), strength: 9 },
+      edge('e2', 'b', 'c'),
+    ])
+  })
+
+  it('clearNetwork empties both sides', () => {
+    useSceneStore.getState().setNetwork(
+      [{ id: 'a', position: [1, 1, 1], connections: [], status: 'active' }],
+      [edge('e1', 'a', 'a')],
+    )
+    useSceneStore.getState().clearNetwork()
+    expect(useSceneStore.getState().nodes).toEqual([])
+    expect(useSceneStore.getState().edges).toEqual([])
+  })
+})
+
+describe('deterministic sequence through the store boundary', () => {
+  it('a mixed stream of updates produces one reproducible final state', () => {
+    const s = useSceneStore.getState()
+    const stream: Array<() => void> = [
+      () => s.updateNode({ id: 'a', position: [1, 1, 1], connections: [], status: 'active' }),
+      () => s.updateNode({ id: 'b', position: [2, 2, 2], connections: [], status: 'active' }),
+      () => s.setNetwork(
+        [
+          { id: 'b', status: 'error' },                                  // keeps last valid [2,2,2]
+          { id: 'c', position: [3, 3, 3], connections: [], status: 'active' },
+          { id: 'ghost' },                                               // excluded
+        ],
+        [edge('e1', 'b', 'c'), null],                                    // null filtered
+      ),
+      () => s.updateNode({ id: 'c', position: [9, 9, 9] }),
+      () => s.updateNode({ id: 'b', position: [0, 0, Number.NaN] }),     // rejected, keeps [2,2,2]
+    ]
+    stream.forEach(step => step())
+    const state = useSceneStore.getState()
+    expect(state.nodes.map(n => ({ id: n.id, position: n.position, status: n.status }))).toEqual([
+      { id: 'b', position: [2, 2, 2], status: 'error' },
+      { id: 'c', position: [9, 9, 9], status: 'active' },
+    ])
+    expect(state.edges).toEqual([edge('e1', 'b', 'c')])
+  })
+})


### PR DESCRIPTION
## PACKAGE V — domain unit contracts (frontend unit-test runway, refs #6 — partial progress, no closing keyword)

**Stacked PR: base is `test/frontend-vitest-foundation` (U → Q → P → O → main). Merge order O → P → Q → U → V.**

### What
**62 new unit tests** (corpus 15 → **77**) locking the nodeValidation and scene-store contracts at their exported seams, exactly per the runway list: position-validity boundary table (finite 3-number, NaN/±Infinity, wrong lengths, non-arrays, null coordinates) · merge semantics `{...existing, ...incoming}` · last-valid-position preservation on malformed partials · positionless-ghost exclusion (no invented [0,0,0]) · later-valid recovery · duplicate-id rules (update-in-place; bulk first-occurrence-wins) · wholesale `setNetwork` semantics · per-side tolerance · explicit-empty clears · **immutability under frozen inputs** · **prototype-less payloads** · reference-identity no-op on rejection (no spurious rerenders) · one deterministic mixed-stream **sequence test**.

### Three genuine defects — reproduced failing-first (10 failing tests captured), then repaired narrowly
1. **Sparse arrays validated as positions.** `every()` skips holes, so `Array(3)` — length 3, zero coordinates — passed `isValidPosition` vacuously and a coordinate-free position could reach renderer matrix math. → indexed per-slot check.
2. **Throwing getters crossed the boundary.** Property access and the merge spread evaluate getters; a hostile payload threw inside `reconcileNode`/`applyNodeUpdate`/`sanitizeNodeList` and up through `store.set` into caller code. → containment `try/catch` at each seam; hostile input now behaves exactly like malformed input (update ignored / entry skipped, previous state preserved, batch neighbours survive).
3. **`setNetwork` admitted non-object edge elements** — only the *array* was checked; a `null`/primitive element crashes renderers that index `edge.source`/`edge.target`. → element-level non-null-object filter; dangling *references* on real edge objects stay tolerated (renderers skip unmatched ids). *This is the store-side concern the automated review raised on #326, now landed in its proper scope with failing-first evidence.*

### Protocol
Payloads stay `unknown` until narrowed; **no as-any, no ts-ignore, zero suppressions** (the sparse-array fixture is built by index assignment specifically to avoid a lint-disable). Transport and renderers untouched.

### Documented residual (not silently dropped)
`NetworkView2D`'s own subscription retains the pre-existing edges pass-through — same class as defect (3), but component-internal (not unit-testable without rendering a canvas surface jsdom can't provide) and rendering-fenced for this package. Recorded for the audit seam.

### Verification
unit **77/77 ×5** · lint 0/0 · tsc clean · budget-unit 11/11 · build ok · BUNDLE_BUDGET **PASS** 984,056/274,094 (+145 raw — the containment code ships; limits unchanged) · Playwright **56/56** (the E2E resilience suite holds under the stricter boundary).

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)