### PR TITLE
test: component/hook/a11y unit contracts + derived coverage gate — rAF-after-unmount defect repaired (PACKAGE X)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,11 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
-      - name: Unit tests (Vitest, jsdom — Playwright E2E stays in ui-smoke)
-        run: npm run test:unit
+      - name: Unit tests + coverage contract (Vitest, jsdom — Playwright E2E stays in ui-smoke)
+        # Coverage thresholds gate only the explicitly unit-owned modules
+        # (see vitest.config.ts coverage block); measured stable across
+        # repeated runs, adds ~2s over the plain unit run.
+        run: npm run test:unit:coverage
 
       - name: Budget-script unit tests
         run: npm run test:budget

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -12,15 +12,30 @@ export function useEventQueue(
 ) {
   const queueRef = useRef<Array<() => void>>([])
   const processingRef = useRef(false)
+  // Lifetime guard: rAF callbacks scheduled while mounted can fire AFTER
+  // unmount, and queued work must never invoke handlers then. Armed on
+  // mount, disarmed (and the queue released) in cleanup; StrictMode's
+  // mount→cleanup→mount cycle re-arms correctly.
+  const activeRef = useRef(false)
+
+  useEffect(() => {
+    activeRef.current = true
+    return () => {
+      activeRef.current = false
+      queueRef.current = []
+    }
+  }, [])
 
   const processQueue = useCallback(async () => {
     if (processingRef.current) return
     processingRef.current = true
 
-    while (queueRef.current.length > 0) {
+    // Re-checked after every awaited frame: an unmount mid-drain stops the
+    // loop at the batch boundary.
+    while (activeRef.current && queueRef.current.length > 0) {
       const batch = queueRef.current.splice(0, 10) // Process in batches of 10
       batch.forEach(fn => fn())
-      
+
       // Allow browser to render
       await new Promise(resolve => requestAnimationFrame(resolve))
     }
@@ -30,6 +45,7 @@ export function useEventQueue(
 
   const enqueueUpdate = useCallback(
     (updateFn: () => void) => {
+      if (!activeRef.current) return
       queueRef.current.push(updateFn)
       if (!processingRef.current) {
         requestAnimationFrame(processQueue)

--- a/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
@@ -1,0 +1,125 @@
+// Package X: App view-switching contracts.
+//
+// The WebGL-heavy view boundaries are MOCKED — jsdom does not render WebGL
+// or canvas, so NetworkView3D/NetworkView2D are replaced with typed markers
+// at the module seam (exactly the boundary the views own). App's real
+// SimBridgeClient wiring stays live against a typed fake WebSocket, so
+// connection state and feed delivery are exercised genuinely.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StrictMode } from 'react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import App from '../src/App'
+
+vi.mock('../src/viz3d/NetworkView3D', () => ({
+  default: () => <div data-testid="view-3d" />,
+}))
+vi.mock('../src/components/NetworkView2D', () => ({
+  default: () => <div data-testid="view-2d" />,
+}))
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+  serverOpen() {
+    this.readyState = 1
+    this.onopen?.({})
+  }
+  serverMessage(obj: unknown) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+}
+
+const live = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  FakeWebSocket.instances = []
+})
+
+describe('App view switching', () => {
+  it('defaults to the 3D view with semantic pressed state and a labelled region', () => {
+    render(<App />)
+    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
+    expect(screen.queryByTestId('view-2d')).not.toBeInTheDocument()
+    expect(screen.getByRole('region', { name: '3D network view' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '3D View' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: '2D View' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('switching shows exactly one active view and swaps pressed state + region label', () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
+    expect(screen.queryByTestId('view-3d')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('region')).toHaveLength(1)
+    expect(screen.getByRole('region', { name: '2D network view' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '2D View' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: '3D View' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('switching preserves the persistent connection/status surfaces and feed content', () => {
+    render(<App />)
+    act(() => live().serverOpen())
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+
+    act(() => live().serverMessage({ type: 'node_update', payload: { id: 'n1' } }))
+    const feed = screen.getByRole('log', { name: 'Event feed' })
+    expect(feed.querySelectorAll('[data-event-channel]')).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    // One status region, one log region — same content, nothing remounted.
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+    expect(screen.getAllByRole('log')).toHaveLength(1)
+    expect(
+      screen.getByRole('log', { name: 'Event feed' }).querySelectorAll('[data-event-channel]'),
+    ).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+    expect(
+      screen.getByRole('log', { name: 'Event feed' }).querySelectorAll('[data-event-channel]'),
+    ).toHaveLength(1)
+  })
+
+  it('StrictMode: one live socket lineage, single status region, no duplicated feed entries', () => {
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    )
+    // Development StrictMode mounts effects twice: the first client is
+    // disconnected by its own cleanup; the LAST socket is the live one.
+    expect(FakeWebSocket.instances.length).toBe(2)
+    act(() => live().serverOpen())
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+
+    act(() => live().serverMessage({ type: 'node_update', payload: { id: 'once' } }))
+    expect(
+      screen.getByRole('log', { name: 'Event feed' }).querySelectorAll('[data-event-channel]'),
+    ).toHaveLength(1)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/connection-badge-contract.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/connection-badge-contract.test.tsx
@@ -1,0 +1,67 @@
+// Package X: the full ConnectionBadge accessibility contract (the U
+// foundation slice covered only the basics).
+//
+// The pulsing class is queried BY CLASS NAME deliberately: the class is
+// itself the contract — the prefers-reduced-motion stylesheet keys off
+// `.connection-badge-dot--pulsing`, so its presence/absence is the
+// observable API for motion behavior in jsdom (which computes no CSS
+// animations).
+import { describe, it, expect } from 'vitest'
+import { StrictMode } from 'react'
+import { render, screen } from '@testing-library/react'
+import ConnectionBadge from '../src/components/ConnectionBadge'
+
+const dot = (container: HTMLElement) =>
+  container.querySelector('.connection-badge [aria-hidden="true"]')
+
+describe('ConnectionBadge contract', () => {
+  it('exposes exactly one atomic status region whose text is the whole announcement', () => {
+    render(<ConnectionBadge isConnected={false} />)
+    const regions = screen.getAllByRole('status')
+    expect(regions).toHaveLength(1)
+    expect(regions[0]).toHaveAttribute('aria-atomic', 'true')
+    expect(regions[0]).toHaveTextContent(/^Disconnected$/)
+  })
+
+  it('rerenders update the SAME live region — no duplicates across state flips', () => {
+    const { rerender } = render(<ConnectionBadge isConnected={false} />)
+    const region = screen.getByRole('status')
+    for (const state of [true, false, true, false, true]) {
+      rerender(<ConnectionBadge isConnected={state} />)
+      const regions = screen.getAllByRole('status')
+      expect(regions).toHaveLength(1)
+      expect(regions[0]).toBe(region) // identity preserved: announcements, not replacements
+      expect(regions[0]).toHaveTextContent(state ? /^Connected$/ : /^Disconnected$/)
+    }
+  })
+
+  it('StrictMode renders a single region', () => {
+    render(
+      <StrictMode>
+        <ConnectionBadge isConnected={true} />
+      </StrictMode>,
+    )
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+  })
+
+  it('the decorative dot stays hidden and pulses only while connected', () => {
+    const { container, rerender } = render(<ConnectionBadge isConnected={false} />)
+    const disconnectedDot = dot(container)
+    expect(disconnectedDot).not.toBeNull()
+    expect(disconnectedDot).toHaveAttribute('aria-hidden', 'true')
+    expect(disconnectedDot).not.toHaveClass('connection-badge-dot--pulsing')
+
+    rerender(<ConnectionBadge isConnected={true} />)
+    expect(dot(container)).toHaveClass('connection-badge-dot--pulsing')
+
+    rerender(<ConnectionBadge isConnected={false} />)
+    expect(dot(container)).not.toHaveClass('connection-badge-dot--pulsing')
+  })
+
+  it('the status text is the badge\'s entire accessible content (dot contributes nothing)', () => {
+    render(<ConnectionBadge isConnected={true} />)
+    const region = screen.getByRole('status')
+    expect(region.textContent).toBe('Connected')
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/event-feed.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/event-feed.test.tsx
@@ -1,0 +1,267 @@
+// Package X: EventFeed contracts — meaningful behavior, no snapshots.
+//
+// The component consumes only the on/off surface of SimBridgeClient, so a
+// typed stub provides it (the cast below is unknown-mediated at the test
+// boundary; the class's private fields make structural assignment
+// impossible, and no `as any` is used). Emissions are wrapped in act()
+// because they drive React state.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StrictMode } from 'react'
+import { render, screen, within, act, fireEvent } from '@testing-library/react'
+import EventFeed from '../src/components/EventFeed'
+import type { SimBridgeClient } from '../src/ws/SimBridgeClient'
+
+class StubSimClient {
+  listeners = new Map<string, Set<(data?: unknown) => void>>()
+  on(event: string, cb: (data?: unknown) => void) {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set())
+    this.listeners.get(event)!.add(cb)
+  }
+  off(event: string, cb: (data?: unknown) => void) {
+    this.listeners.get(event)?.delete(cb)
+  }
+  emit(event: string, data?: unknown) {
+    this.listeners.get(event)?.forEach(cb => cb(data))
+  }
+  countFor(event: string) {
+    return this.listeners.get(event)?.size ?? 0
+  }
+  totalListeners() {
+    let n = 0
+    this.listeners.forEach(set => (n += set.size))
+    return n
+  }
+}
+
+let stub: StubSimClient
+const asClient = () => stub as unknown as SimBridgeClient
+
+const log = () => screen.getByRole('log', { name: 'Event feed' })
+const entries = () => Array.from(log().querySelectorAll('[data-event-channel]'))
+const summary = () => screen.getByTestId('feed-summary')
+
+const emit = (channel: string, payload?: unknown) => {
+  act(() => stub.emit(channel, payload))
+}
+
+beforeEach(() => {
+  stub = new StubSimClient()
+})
+
+describe('EventFeed subscription lifecycle', () => {
+  it('subscribes exactly once per channel and unsubscribes all on unmount', () => {
+    const { unmount } = render(<EventFeed simClient={asClient()} />)
+    for (const ch of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+      expect(stub.countFor(ch)).toBe(1)
+    }
+    unmount()
+    expect(stub.totalListeners()).toBe(0)
+  })
+
+  it('StrictMode double-mount leaves exactly one subscription per channel and no duplicate entries', () => {
+    render(
+      <StrictMode>
+        <EventFeed simClient={asClient()} />
+      </StrictMode>,
+    )
+    for (const ch of ['simulation_event', 'network_update', 'node_update', 'edge_update']) {
+      expect(stub.countFor(ch)).toBe(1)
+    }
+    emit('node_update', { id: 'once' })
+    expect(entries()).toHaveLength(1)
+  })
+
+  it('renders the empty state without a client', () => {
+    render(<EventFeed simClient={null} />)
+    expect(summary()).toHaveTextContent('No events retained.')
+    expect(log()).toHaveTextContent('No events yet...')
+  })
+})
+
+describe('EventFeed rendering contracts', () => {
+  beforeEach(() => {
+    render(<EventFeed simClient={asClient()} />)
+  })
+
+  it('channel label comes from the subscription, never from a payload `type` field', () => {
+    emit('node_update', { type: 'edge_update', id: 'spoof' })
+    const [entry] = entries()
+    expect(entry).toHaveAttribute('data-event-channel', 'node_update')
+    expect(within(entry as HTMLElement).getByText('node_update')).toBeInTheDocument()
+    expect(within(entry as HTMLElement).queryByText('edge_update')).not.toBeInTheDocument()
+  })
+
+  it('string payloads keep the locked JSON-quoted representation', () => {
+    emit('simulation_event', 'hello')
+    expect(within(log()).getByText('"hello"')).toBeInTheDocument()
+  })
+
+  it('preview truncation boundary is exact: 100 stays whole, 101 truncates to 100 + ellipsis', () => {
+    // JSON.stringify adds two quote characters: 98 a's -> exactly 100.
+    emit('node_update', 'a'.repeat(98))
+    // 99 a's -> 101 serialized -> sliced to 100 + '...'.
+    emit('node_update', 'a'.repeat(99))
+    const previews = entries().map(e => (e as HTMLElement).lastElementChild!.textContent!)
+    // Newest first: the 101-char payload is previews[0].
+    expect(previews[1]).toBe(`"${'a'.repeat(98)}"`)
+    expect(previews[1]).toHaveLength(100)
+    expect(previews[0]).toBe(`"${'a'.repeat(99)}"`.slice(0, 100) + '...')
+    expect(previews[0]).toHaveLength(103)
+  })
+
+  it('orders newest first', () => {
+    emit('simulation_event', { seq: 1 })
+    emit('node_update', { seq: 2 })
+    emit('edge_update', { seq: 3 })
+    expect(entries().map(e => e.getAttribute('data-event-channel'))).toEqual([
+      'edge_update',
+      'node_update',
+      'simulation_event',
+    ])
+  })
+
+  it('caps retention at exactly 50, dropping the oldest', () => {
+    for (let i = 1; i <= 55; i++) emit('node_update', { seq: i })
+    const list = entries()
+    expect(list).toHaveLength(50)
+    expect(list[0]).toHaveTextContent('{"seq":55}')
+    expect(list[49]).toHaveTextContent('{"seq":6}')
+    expect(summary()).toHaveTextContent('Showing 50 of 50 events')
+  })
+
+  it('renders malicious HTML as inert text', () => {
+    emit('simulation_event', '<img src=x onerror="window.__pwned=true">')
+    expect(log().querySelector('img')).toBeNull()
+    expect(within(log()).getByText('"<img src=x onerror=\\"window.__pwned=true\\">"')).toBeInTheDocument()
+    expect((window as Window & { __pwned?: boolean }).__pwned).toBeUndefined()
+  })
+})
+
+describe('EventFeed operations', () => {
+  beforeEach(() => {
+    render(<EventFeed simClient={asClient()} />)
+  })
+
+  it('channel filter buttons expose semantic pressed state and hide without dropping', () => {
+    emit('node_update', { seq: 1 })
+    emit('edge_update', { seq: 2 })
+    const nodeButton = screen.getByRole('button', { name: 'node_update' })
+    expect(nodeButton).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(nodeButton)
+    expect(nodeButton).toHaveAttribute('aria-pressed', 'false')
+    expect(entries().map(e => e.getAttribute('data-event-channel'))).toEqual(['edge_update'])
+    expect(summary()).toHaveTextContent('Showing 1 of 2 events')
+
+    fireEvent.click(nodeButton) // re-enable: nothing was lost
+    expect(entries()).toHaveLength(2)
+    expect(summary()).toHaveTextContent('Showing 2 of 2 events')
+  })
+
+  it('search is trimmed and case-insensitive over channel and preview; plain string only', () => {
+    emit('node_update', { name: 'Alpha' })
+    emit('edge_update', { name: 'beta' })
+    const box = screen.getByLabelText('Search events')
+
+    fireEvent.change(box, { target: { value: '  ALPHA  ' } })
+    expect(entries().map(e => e.getAttribute('data-event-channel'))).toEqual(['node_update'])
+
+    // Regex metacharacters match literally (or nothing) — never as patterns.
+    fireEvent.change(box, { target: { value: '.*' } })
+    expect(entries()).toHaveLength(0)
+    expect(log()).toHaveTextContent('No events match the current filters.')
+
+    fireEvent.change(box, { target: { value: '' } })
+    expect(entries()).toHaveLength(2)
+  })
+
+  it('Clear is disabled when empty, empties the feed, and later events still arrive', () => {
+    const clear = screen.getByRole('button', { name: 'Clear' })
+    expect(clear).toBeDisabled()
+
+    emit('node_update', { seq: 1 })
+    expect(clear).toBeEnabled()
+    fireEvent.click(clear)
+    expect(entries()).toHaveLength(0)
+    expect(summary()).toHaveTextContent('No events retained.')
+
+    emit('node_update', { seq: 2 })
+    expect(entries()).toHaveLength(1)
+  })
+})
+
+describe('EventFeed export', () => {
+  // jsdom leaves the blob-URL store unimplemented; deterministic fakes are
+  // installed per test and the original property state restored afterwards.
+  let createSpy: ReturnType<typeof vi.fn>
+  let revokeSpy: ReturnType<typeof vi.fn>
+  let originalCreate: PropertyDescriptor | undefined
+  let originalRevoke: PropertyDescriptor | undefined
+  let clicked: Array<{ href: string; download: string }>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    createSpy = vi.fn(() => 'blob:unit-test')
+    revokeSpy = vi.fn()
+    originalCreate = Object.getOwnPropertyDescriptor(URL, 'createObjectURL')
+    originalRevoke = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL')
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, writable: true, value: createSpy })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, writable: true, value: revokeSpy })
+    clicked = []
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      clicked.push({ href: this.href, download: this.download })
+    })
+    render(<EventFeed simClient={asClient()} />)
+  })
+
+  afterEach(() => {
+    const urlRecord = URL as unknown as Record<string, unknown>
+    if (originalCreate) Object.defineProperty(URL, 'createObjectURL', originalCreate)
+    else delete urlRecord.createObjectURL
+    if (originalRevoke) Object.defineProperty(URL, 'revokeObjectURL', originalRevoke)
+    else delete urlRecord.revokeObjectURL
+    vi.useRealTimers()
+  })
+
+  it('is disabled with nothing visible (empty feed or filtered-empty)', () => {
+    const exportButton = screen.getByRole('button', { name: 'Export visible JSON' })
+    expect(exportButton).toBeDisabled()
+    emit('node_update', { seq: 1 })
+    expect(exportButton).toBeEnabled()
+    fireEvent.click(screen.getByRole('button', { name: 'node_update' })) // filter it out
+    expect(exportButton).toBeDisabled()
+  })
+
+  it('exports visible events newest-first with ORIGINAL payloads (never truncated previews), null-normalized', async () => {
+    const long = 'x'.repeat(500)
+    emit('node_update', { blob: long })   // preview truncates; export must not
+    emit('edge_update')                    // omitted payload -> explicit null
+    emit('simulation_event', { keep: 1 })
+    fireEvent.click(screen.getByRole('button', { name: 'simulation_event' })) // hide channel
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export visible JSON' }))
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(clicked).toEqual([{ href: 'blob:unit-test', download: 'event-feed-export.json' }])
+
+    const blob = createSpy.mock.calls[0][0] as Blob
+    expect(blob.type).toBe('application/json')
+    const doc = JSON.parse(await blob.text()) as {
+      schema: string
+      version: number
+      events: Array<{ channel: string; timestamp: number; payload: unknown }>
+    }
+    expect(doc.schema).toBe('utilityfog.event-feed-export')
+    expect(doc.version).toBe(1)
+    // Visible only (simulation_event filtered out), newest first.
+    expect(doc.events.map(e => e.channel)).toEqual(['edge_update', 'node_update'])
+    expect(doc.events[0].payload).toBeNull()
+    expect(doc.events[1].payload).toEqual({ blob: long })
+
+    // Deferred revocation: not synchronous, exactly once after the macrotask.
+    expect(revokeSpy).not.toHaveBeenCalled()
+    vi.runAllTimers()
+    expect(revokeSpy).toHaveBeenCalledTimes(1)
+    expect(revokeSpy).toHaveBeenCalledWith('blob:unit-test')
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -1,0 +1,188 @@
+// Package X: useEventQueue hook contracts — subscription identity, cleanup,
+// rAF batching, and the no-update-after-unmount guarantee.
+//
+// The hook is driven through the REAL SimBridgeClient against a typed fake
+// WebSocket, so wire → queue → handler is exercised end to end. Fake timers
+// make the rAF pipeline fully deterministic (the async advance variants
+// interleave the microtasks the processing loop awaits).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useEventQueue } from '../src/viz3d/useEventQueue'
+import { SimBridgeClient } from '../src/ws/SimBridgeClient'
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+  serverOpen() {
+    this.readyState = 1
+    this.onopen?.({})
+  }
+  serverMessage(obj: unknown) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+}
+
+let client: SimBridgeClient
+let handlers: {
+  updateNode: ReturnType<typeof vi.fn<(node: unknown) => void>>
+  setNetwork: ReturnType<typeof vi.fn<(nodes: unknown, edges: unknown) => void>>
+}
+
+const socket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  client = new SimBridgeClient('ws://hook-test', 1000)
+  client.connect()
+  socket().serverOpen()
+  handlers = {
+    updateNode: vi.fn<(node: unknown) => void>(),
+    setNetwork: vi.fn<(nodes: unknown, edges: unknown) => void>(),
+  }
+})
+
+afterEach(() => {
+  client.disconnect()
+  vi.runAllTimers()
+  expect(vi.getTimerCount()).toBe(0)
+  FakeWebSocket.instances = []
+  vi.useRealTimers()
+})
+
+describe('useEventQueue subscriptions', () => {
+  it('subscribes once per channel; rerenders with identical inputs do not resubscribe', () => {
+    const onSpy = vi.spyOn(client, 'on')
+    const { rerender } = renderHook(() => useEventQueue(client, handlers))
+    const initialCalls = onSpy.mock.calls.length
+    expect(initialCalls).toBe(3) // network_update, node_update, edge_update
+
+    rerender()
+    rerender()
+    expect(onSpy.mock.calls.length).toBe(initialCalls) // listener identity stable
+  })
+
+  it('unsubscribes the SAME handler references on unmount', () => {
+    const onSpy = vi.spyOn(client, 'on')
+    const offSpy = vi.spyOn(client, 'off')
+    const { unmount } = renderHook(() => useEventQueue(client, handlers))
+    unmount()
+    expect(offSpy.mock.calls.length).toBe(3)
+    // Every off() must pass exactly the function that on() registered.
+    for (const [channel, handler] of offSpy.mock.calls) {
+      expect(onSpy.mock.calls.some(([ch, h]) => ch === channel && h === handler)).toBe(true)
+    }
+  })
+
+  it('a null client subscribes to nothing', () => {
+    renderHook(() => useEventQueue(null, handlers))
+    socket().serverMessage({ type: 'node_update', payload: { id: 'n' } })
+    vi.runAllTimers()
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEventQueue delivery', () => {
+  it('delivers node_update payloads to updateNode through the rAF batch', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    socket().serverMessage({ type: 'node_update', payload: { id: 'n1' } })
+    expect(handlers.updateNode).not.toHaveBeenCalled() // queued, not synchronous
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    expect(handlers.updateNode).toHaveBeenCalledWith({ id: 'n1' })
+  })
+
+  it('forwards network_update sides as-received (store owns per-side validation)', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    socket().serverMessage({ type: 'network_update', payload: { nodes: [], edges: [{ id: 'e' }] } })
+    socket().serverMessage({ type: 'network_update', payload: { nodes: [] } }) // one side absent
+    await vi.runAllTimersAsync()
+    expect(handlers.setNetwork).toHaveBeenCalledTimes(2)
+    expect(handlers.setNetwork).toHaveBeenNthCalledWith(1, [], [{ id: 'e' }])
+    expect(handlers.setNetwork).toHaveBeenNthCalledWith(2, [], undefined)
+  })
+
+  it.each([
+    { label: 'null payload', payload: null },
+    { label: 'string payload', payload: 'junk' },
+    { label: 'numeric payload', payload: 7 },
+    { label: 'empty object (no nodes/edges keys)', payload: {} },
+  ])('network_update with $label enqueues nothing', async ({ payload }) => {
+    renderHook(() => useEventQueue(client, handlers))
+    socket().serverMessage({ type: 'network_update', payload })
+    await vi.runAllTimersAsync()
+    expect(handlers.setNetwork).not.toHaveBeenCalled()
+  })
+
+  it('node_update payloads pass through opaquely — null and hostile shapes reach the validating store', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    socket().serverMessage({ type: 'node_update', payload: null })
+    socket().serverMessage({ type: 'node_update', payload: 'not-a-node' })
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(1, null)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, 'not-a-node')
+  })
+
+  it('processes a burst in batches, preserving order', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    for (let i = 1; i <= 25; i++) {
+      socket().serverMessage({ type: 'node_update', payload: { seq: i } })
+    }
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(25)
+    expect(handlers.updateNode.mock.calls.map(args => (args[0] as { seq: number }).seq)).toEqual(
+      Array.from({ length: 25 }, (_, i) => i + 1),
+    )
+  })
+})
+
+describe('useEventQueue unmount safety', () => {
+  it('queued rAF work cannot invoke handlers after unmount', async () => {
+    const { unmount } = renderHook(() => useEventQueue(client, handlers))
+    // Enqueue while mounted — the rAF that will process it is now pending.
+    socket().serverMessage({ type: 'node_update', payload: { id: 'late' } })
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+
+    unmount()
+    await vi.runAllTimersAsync() // the pending rAF fires after unmount
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+    expect(handlers.setNetwork).not.toHaveBeenCalled()
+  })
+
+  it('a queue mid-processing stops at the unmount boundary', async () => {
+    const { unmount } = renderHook(() => useEventQueue(client, handlers))
+    // Two batches' worth: the loop must yield to rAF between batches of 10.
+    for (let i = 1; i <= 15; i++) {
+      socket().serverMessage({ type: 'node_update', payload: { seq: i } })
+    }
+    // Fire ONLY the first pending rAF: batch 1 (10 items) processes, then
+    // the loop awaits the next frame.
+    await vi.advanceTimersByTimeAsync(20)
+    expect(handlers.updateNode.mock.calls.length).toBeGreaterThanOrEqual(10)
+    const deliveredBeforeUnmount = handlers.updateNode.mock.calls.length
+
+    unmount()
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode.mock.calls.length).toBe(deliveredBeforeUnmount)
+  })
+})

--- a/utilityfog_frontend/frontend/vitest.config.ts
+++ b/utilityfog_frontend/frontend/vitest.config.ts
@@ -27,11 +27,39 @@ export default defineConfig({
     unstubEnvs: true,
     coverage: {
       provider: 'v8',
-      // Package U reports coverage WITHOUT thresholds: thresholds are
-      // derived from the measured baseline only after the complete unit
-      // corpus exists (Package X), never chosen aspirationally.
-      reporter: ['text', 'text-summary'],
-      include: ['src/**/*.{ts,tsx}'],
+      // Reporter note: vitest 4.1.10's text table omits 100%-covered files;
+      // json-summary carries every file (verified against this corpus).
+      reporter: ['text', 'text-summary', 'json-summary'],
+      // COVERAGE CONTRACT (Package X): only explicitly unit-owned modules
+      // are measured and gated. Documented exclusions —
+      //   NetworkView2D/NetworkView3D/Edges/InstancedNodes/ThreeScene:
+      //     WebGL/canvas surfaces, owned by the Playwright E2E suite
+      //     (ui-smoke); jsdom cannot render them meaningfully.
+      //   adapters.ts: legacy format adapter, not yet unit-owned.
+      //   utils.ts: only the foundation slice is covered so far; joins the
+      //     contract when the corpus owns the rest of it.
+      //   main.tsx: bootstrap entry point.
+      include: [
+        'src/App.tsx',
+        'src/components/ConnectionBadge.tsx',
+        'src/components/EventFeed.tsx',
+        'src/viz3d/nodeValidation.ts',
+        'src/viz3d/useEventQueue.ts',
+        'src/viz3d/useSceneStore.ts',
+        'src/ws/SimBridgeClient.ts',
+      ],
+      // Thresholds are derived BELOW the measured stable baseline of the
+      // final corpus (aggregate over the include set: statements 97.01%,
+      // branches 93.10%, functions 97.50%, lines 97.38% — identical across
+      // repeated runs), with a small margin for future environment
+      // variance. Never raise these to aspirational values and never
+      // lower them merely to make CI green.
+      thresholds: {
+        statements: 93,
+        branches: 85,
+        functions: 92,
+        lines: 93,
+      },
     },
   },
 })


### PR DESCRIPTION
## PACKAGE X — component, hook and accessibility unit contracts (frontend unit-test runway, refs #6 — partial progress, no closing keyword)

**Stacked PR: base is `test/simbridge-unit-contracts` (W → V → U → Q → P → O → main). Merge order O → P → Q → U → V → W → X.**

### What
**36 new unit tests (corpus 99 → 135)** across four suites, plus the runway's coverage contract.

**EventFeed** — subscription lifecycle (once per channel; unmount unsubscribes all; **StrictMode leaves exactly one subscription, no duplicate entries**) · channel label **unspoofable** by payload `type` · strings keep the locked JSON-quoted form · **exact 100/101 truncation boundary** · newest-first · **exact 50-cap** · malicious HTML inert · aria-pressed filters that hide without dropping · trimmed case-insensitive plain-string search (regex metacharacters literal) · Clear disabled-when-empty with later events still arriving · export: visible-only newest-first with **original payloads (never truncated previews)**, null-normalized omissions, schema/version, **exactly one deferred URL revocation** (fake timers; jsdom's unimplemented blob-URL store faked per-test with descriptor-restoring cleanup).

**ConnectionBadge (full contract)** — single atomic status region whose **DOM identity is preserved across state flips** (announcements, not replacements) · StrictMode single region · decorative dot hidden; pulsing class only while connected (class queried deliberately — the reduced-motion stylesheet keys off it, so the class **is** the contract) · status text is the entire accessible content.

**App view switching** — WebGL-heavy view boundaries **mocked at the module seam** (jsdom renders no WebGL — per the runway, no pretending); real `SimBridgeClient` against a typed fake socket. Default 3D with semantic pressed state + labelled region · exactly one active view after switching · badge + feed surfaces preserved across switches · StrictMode: two constructed sockets (documented dev-mode artifact), single live lineage, single status region, no duplicated entries.

**useEventQueue** — subscribes once per channel; rerenders don't resubscribe (**listener identity stable**) · unmount `off()`s the **same** handler references · null client subscribes to nothing · rAF-batched delivery preserving order across 25-message bursts · null/primitive/empty `network_update` payloads enqueue nothing · `node_update` passes through opaquely to the validating store.

### Genuine defect — failing-first (2 failing tests captured), then repaired narrowly
**rAF work fired after unmount**: callbacks scheduled while mounted invoked handlers from a dead subscription after unmount, and a mid-drain loop kept processing. Repair in `useEventQueue.ts` only: a lifetime guard (`activeRef`) armed on mount, disarmed in cleanup (queue released); `enqueueUpdate` drops post-unmount work; the drain loop re-checks the guard after every awaited frame. StrictMode re-arms correctly. Playwright 56/56 confirms E2E behavior preserved.

### Coverage contract (measured → derived, never aspirational)
- **Include restricted to the seven explicitly unit-owned modules**: App, ConnectionBadge, EventFeed, nodeValidation, useEventQueue, useSceneStore, SimBridgeClient.
- **Documented exclusions**: the five WebGL/canvas view surfaces (E2E-owned via ui-smoke), adapters.ts (not yet unit-owned), utils.ts (foundation slice only), main.tsx (bootstrap).
- **Measured stable baseline** (identical across 3 runs): statements **97.01** / branches **93.10** / functions **97.50** / lines **97.38**.
- **Thresholds below baseline** with variance margin: **93 / 85 / 92 / 93**.
- Reporter quirk documented: vitest 4.1.10's text table omits 100%-covered files; `json-summary` added and verified carrying every file.
- `frontend-quality` now runs `test:unit:coverage` (stable ×3, ~2s over the plain run — bounded).

### Verification
unit **135/135** — serial · parallel ×3 · **shuffle seeds 1/42/1337/271828/314159** · coverage ×3 identical · lint 0/0 · tsc clean · budget-unit 11/11 · build ok · BUNDLE_BUDGET PASS 984,170/274,131 (+114 raw — the lifetime guard ships; limits unchanged) · Playwright 56/56.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)