### PR TITLE
security(orchestrator): observe-by-default capability model (S of R/S/T, stacked on #328)

### DIFF
--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -69,11 +69,11 @@ def resolve_mode(raw: Optional[str]) -> OrchestratorMode:
     resolve to the safe `observe` mode; only the exact tokens "observe" and
     "propose" (case-insensitive, trimmed) are honored. `propose` — the only
     mode that exposes any write-adjacent tool — must be opted into explicitly."""
-    if not isinstance(raw, str):
-        return MODE_OBSERVE
-    token = raw.strip().lower()
-    if token in VALID_MODES:
-        return token  # type: ignore[return-value]
+    # Only a normalized "propose" enables proposal mode; absent, malformed,
+    # unknown, or any other value fails closed to observe. Returning the
+    # module-level Literal constants keeps this typed with no cast/ignore.
+    if isinstance(raw, str) and raw.strip().lower() == MODE_PROPOSE:
+        return MODE_PROPOSE
     return MODE_OBSERVE
 
 
@@ -296,14 +296,14 @@ class ToolRouter:
         *,
         mode: OrchestratorMode = MODE_OBSERVE,
         orchestrator_source: str = "agent:orchestrator",
-        commit_approver: str = "policy:auto",
     ) -> None:
         self.client = client
         self.mode = mode
         self.source = orchestrator_source
-        # Retained for the non-LLM-facing client.commit_tuning primitive only;
-        # the router never calls commit on the LLM's behalf.
-        self.approver = commit_approver
+        # The router holds no commit approver: committing is not an LLM-facing
+        # capability, so it never calls commit on the model's behalf. The
+        # low-level `client.commit_tuning` primitive takes its approver as an
+        # explicit argument and needs no router state.
         handlers: dict[str, ToolHandler] = {
             "get_medusa_census": self._h_census,
             "get_medusa_equanimity": self._h_equanimity,

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -1,31 +1,37 @@
-"""Phase 18 PR 6 — Orchestrator: the Swarm Hunter's brain.
+"""Phase 18 PR 6 — Legacy tuning orchestrator (quarantined).
 
-Ties the three halves of the Phase 18 bus into one propose→commit loop:
+Historically described as "the Swarm Hunter's brain," this module is the
+Phase 18 tuning orchestrator. It is distinct from the offline
+candidate-structure detector proposed in `docs/SWARM_HUNTER_V1_PREFLIGHT.md`
+(PR #322) — do not conflate the two.
+
+It ties the Phase 18 bus into one observe→decide loop:
 
   1. Observation (Phase 16 REST GET endpoints + Phase 18 PR 2 /api/params):
      read Medusa's current state via HTTP.
-  2. Decision (Phase 18 PR 4 AgentBackend, e.g. PR 5 AnthropicBackend):
-     hand the LLM the current state + a bounded tool set, let it propose.
-  3. Action (Phase 18 PR 2 tuning API + PR 3 event bus):
-     execute approved tool calls by POSTing to /api/tuning/*.
+  2. Decision (Phase 18 PR 4 AgentBackend): hand the LLM the current state +
+     a bounded tool set, let it observe and (in `propose` mode only) validate a
+     dry-run proposal.
 
 This module is **pure library code** — no threading, no long-running loop.
-One call to `Orchestrator.run_one_iteration()` does the full observe-decide-
-act cycle once and returns an `IterationResult`. A separate runner script
-(future PR or simple cron) is responsible for cadence. That split keeps the
-unit tests deterministic: we run one iteration with scripted `MockBackend`
-responses and assert on the effects.
+One call to `Orchestrator.run_one_iteration()` does one cycle and returns an
+`IterationResult`.
 
-Safety philosophy (defense in depth, layered on top of the API's own rails):
-  - `Orchestrator` only ever commits with `approver="policy:auto"`. If the
-    proposal touches a HUMAN_APPROVAL parameter, the API returns 403, the
-    tool_result carries that error back to the LLM on the next turn, and
-    the LLM can choose to escalate or back off — the orchestrator never
-    tries to bypass the gate.
-  - Per-iteration `max_tool_depth` cap prevents a confused LLM from looping
-    forever.
-  - Every LLM call's usage is returned in `IterationResult.usage_total` so
-    operators can audit token spend.
+Capability quarantine (Package S):
+  - The LLM-facing surface is **observe by default**. There is **no supported
+    LLM-facing commit tool**: `commit_tuning` is never registered in the tool
+    router, so no model turn can commit a parameter.
+  - Capability modes (`OrchestratorMode`): `observe` (observation tools only)
+    and `propose` (observation + a proposal tool that is **forced to
+    `mode="dry-run"`** at the router boundary; `commit-pending` is rejected,
+    not silently downgraded).
+  - The low-level `OrchestratorClient.commit_tuning` / `rollback_tuning`
+    methods are retained as **non-LLM-facing** primitives for existing direct
+    callers (e.g. provider-parity tests); they cannot enter the tool registry.
+  - Defense in depth: even if a proposal were somehow committed, the server
+    boundary (Package R) refuses the orchestrator's `policy:auto` approver.
+  - Per-iteration `max_tool_depth` caps a confused LLM; usage is returned in
+    `IterationResult.usage_total` for cost audit.
 """
 
 from __future__ import annotations
@@ -35,7 +41,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Literal, Optional
 
 from scripts.agent_backends import (
     AgentBackend,
@@ -44,6 +50,31 @@ from scripts.agent_backends import (
     ToolResultBlock,
     ToolSpec,
 )
+
+
+# -- capability modes --------------------------------------------------------
+
+OrchestratorMode = Literal["observe", "propose"]
+"""LLM-facing capability level. `observe` = observation tools only (default);
+`propose` = observation + a dry-run-forced proposal tool. There is deliberately
+no `commit` mode: committing is not an LLM-facing capability."""
+
+MODE_OBSERVE: OrchestratorMode = "observe"
+MODE_PROPOSE: OrchestratorMode = "propose"
+VALID_MODES: tuple[OrchestratorMode, ...] = (MODE_OBSERVE, MODE_PROPOSE)
+
+
+def resolve_mode(raw: Optional[str]) -> OrchestratorMode:
+    """Fail-closed mode resolution. Absent, malformed, or unknown values all
+    resolve to the safe `observe` mode; only the exact tokens "observe" and
+    "propose" (case-insensitive, trimmed) are honored. `propose` — the only
+    mode that exposes any write-adjacent tool — must be opted into explicitly."""
+    if not isinstance(raw, str):
+        return MODE_OBSERVE
+    token = raw.strip().lower()
+    if token in VALID_MODES:
+        return token  # type: ignore[return-value]
+    return MODE_OBSERVE
 
 
 # -- HTTP wrapper ------------------------------------------------------------
@@ -193,17 +224,21 @@ def observation_tools() -> list[ToolSpec]:
     ]
 
 
-def tuning_tools() -> list[ToolSpec]:
-    """Write tools exposed to the LLM. Every proposal requires a justification."""
+def proposal_tools() -> list[ToolSpec]:
+    """The single write-adjacent tool exposed to the LLM in `propose` mode.
+
+    Only `propose_tuning` is offered, and the router forces it to dry-run.
+    There is deliberately **no** `commit_tuning` tool — committing is not an
+    LLM-facing capability."""
     return [
         ToolSpec(
             name="propose_tuning",
             description=(
-                "Propose a parameter tuning. Validates against the schema. "
-                "Pass mode='dry-run' to test without committing; mode='commit-pending' "
-                "to flag for a follow-up commit. REQUIRES a justification explaining "
-                "why this change is being proposed — proposals without justification "
-                "will be rejected."
+                "Validate a parameter tuning as a DRY RUN. The tuning is checked "
+                "against the schema but never committed — this orchestrator has no "
+                "commit capability. REQUIRES a justification explaining why this "
+                "change is being proposed; proposals without justification are "
+                "rejected."
             ),
             input_schema={
                 "type": "object",
@@ -223,35 +258,21 @@ def tuning_tools() -> list[ToolSpec]:
                             "Human-readable rationale for this tuning. Required."
                         ),
                     },
-                    "mode": {
-                        "type": "string",
-                        "enum": ["dry-run", "commit-pending"],
-                        "description": "dry-run for validation only; commit-pending to mark as ready for commit.",
-                    },
                 },
                 "required": ["params", "justification"],
             },
         ),
-        ToolSpec(
-            name="commit_tuning",
-            description=(
-                "Commit a previously-proposed tuning. This orchestrator commits "
-                "with approver='policy:auto', which only works for AUTO-category "
-                "proposals. HUMAN_APPROVAL proposals will return 403; don't attempt "
-                "to commit them — explain what you'd want a human to approve instead."
-            ),
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "proposal_id": {
-                        "type": "string",
-                        "description": "The prop-XXXXXXXX id returned by a prior propose_tuning call.",
-                    },
-                },
-                "required": ["proposal_id"],
-            },
-        ),
     ]
+
+
+def tools_for_mode(mode: OrchestratorMode) -> list[ToolSpec]:
+    """The LLM-facing tool set for a capability mode. `observe` → observation
+    only; `propose` → observation + the dry-run proposal tool. No mode exposes
+    a commit tool."""
+    tools = observation_tools()
+    if mode == MODE_PROPOSE:
+        tools = tools + proposal_tools()
+    return tools
 
 
 # -- tool router -------------------------------------------------------------
@@ -262,27 +283,38 @@ ToolHandler = Callable[[dict], dict]
 
 class ToolRouter:
     """Maps tool-call names to handler functions. One place that knows the
-    connection between the LLM's tool vocabulary and the HTTP client."""
+    connection between the LLM's tool vocabulary and the HTTP client.
+
+    Capability-gated (Package S): observation handlers are always registered;
+    `propose_tuning` is registered ONLY in `propose` mode (and forced to
+    dry-run). `commit_tuning` is **never** registered as an LLM-facing handler,
+    so no model turn can reach the commit endpoint through the router."""
 
     def __init__(
         self,
         client: OrchestratorClient,
         *,
+        mode: OrchestratorMode = MODE_OBSERVE,
         orchestrator_source: str = "agent:orchestrator",
         commit_approver: str = "policy:auto",
     ) -> None:
         self.client = client
+        self.mode = mode
         self.source = orchestrator_source
+        # Retained for the non-LLM-facing client.commit_tuning primitive only;
+        # the router never calls commit on the LLM's behalf.
         self.approver = commit_approver
-        self._handlers: dict[str, ToolHandler] = {
+        handlers: dict[str, ToolHandler] = {
             "get_medusa_census": self._h_census,
             "get_medusa_equanimity": self._h_equanimity,
             "get_acoustic_map": self._h_acoustic,
             "get_params": self._h_params,
             "get_params_schema": self._h_schema,
-            "propose_tuning": self._h_propose,
-            "commit_tuning": self._h_commit,
         }
+        if mode == MODE_PROPOSE:
+            handlers["propose_tuning"] = self._h_propose
+        # commit_tuning is intentionally absent from every mode's registry.
+        self._handlers: dict[str, ToolHandler] = handlers
 
     def execute(self, name: str, arguments: dict) -> tuple[dict, bool]:
         """Run a tool call. Returns `(result_payload, is_error)`."""
@@ -328,25 +360,27 @@ class ToolRouter:
     def _h_propose(self, args: dict) -> dict:
         params = args.get("params") or {}
         justification = args.get("justification") or ""
-        mode = args.get("mode", "dry-run")
+        requested_mode = args.get("mode", "dry-run")
         if not justification.strip():
             return {"error": "bad_request",
                     "message": "justification is required and must be non-empty"}
+        # commit-pending is rejected outright (not silently downgraded) so the
+        # caller sees that only dry-run is available in this quarantined path.
+        if requested_mode == "commit-pending":
+            return {"error": "commit_pending_forbidden",
+                    "message": "This orchestrator validates dry-run only; "
+                               "commit-pending is not permitted."}
+        # Any other requested mode is forced to dry-run at the boundary.
         return self._unwrap(self.client.propose_tuning(
             params=params,
             source=self.source,
             justification=justification,
-            mode=mode,
+            mode="dry-run",
         ))
 
-    def _h_commit(self, args: dict) -> dict:
-        proposal_id = args.get("proposal_id")
-        if not proposal_id:
-            return {"error": "bad_request", "message": "proposal_id is required"}
-        return self._unwrap(self.client.commit_tuning(
-            proposal_id=proposal_id,
-            approver=self.approver,  # "policy:auto" — never a human prefix from the orchestrator
-        ))
+    # NOTE: there is deliberately no _h_commit handler. Committing is not an
+    # LLM-facing capability; the low-level client.commit_tuning primitive is
+    # retained for direct non-LLM callers but never wired into the router.
 
 
 # -- orchestrator ------------------------------------------------------------
@@ -394,6 +428,7 @@ class Orchestrator:
         client: OrchestratorClient,
         *,
         system_prompt: str,
+        mode: OrchestratorMode = MODE_OBSERVE,
         tools: Optional[list[ToolSpec]] = None,
         router: Optional[ToolRouter] = None,
         max_tool_depth: int = 8,
@@ -403,8 +438,12 @@ class Orchestrator:
         self.backend = backend
         self.client = client
         self.system_prompt = system_prompt
-        self.tools = tools or (observation_tools() + tuning_tools())
-        self.router = router or ToolRouter(client)
+        self.mode = mode
+        # Fail-safe defaults: the tool set and router both derive from `mode`,
+        # which defaults to observe. An explicit `tools`/`router` overrides,
+        # but a bare Orchestrator is observation-only.
+        self.tools = tools if tools is not None else tools_for_mode(mode)
+        self.router = router or ToolRouter(client, mode=mode)
         self.max_tool_depth = max_tool_depth
         self.max_tokens_per_call = max_tokens_per_call
         self.temperature = temperature
@@ -492,6 +531,12 @@ __all__ = [
     "ToolRouter",
     "Orchestrator",
     "IterationResult",
+    "OrchestratorMode",
+    "MODE_OBSERVE",
+    "MODE_PROPOSE",
+    "VALID_MODES",
+    "resolve_mode",
     "observation_tools",
-    "tuning_tools",
+    "proposal_tools",
+    "tools_for_mode",
 ]

--- a/scripts/orchestrator_config.py
+++ b/scripts/orchestrator_config.py
@@ -79,8 +79,11 @@ DEFAULT_BASE_URL = "http://127.0.0.1:8080"
 # Crafted to work with Phase 18's tool surface. Not model-specific.
 # Describes the quarantined surface accurately: observation is always
 # available; in `propose` mode a dry-run-only proposal tool is added; there is
-# no LLM-facing commit tool. Tool errors are structured (is_error result
-# blocks), not "[ERROR]"-prefixed strings.
+# no LLM-facing commit tool. Tool errors are surfaced two ways depending on
+# transport: native backends expose an `is_error` result flag; the
+# OpenAI-compatible backend marks the same condition with a leading "[ERROR]"
+# in the tool-result text (it has no native error flag). The prompt names both
+# so the model recognises an error regardless of backend.
 DEFAULT_SYSTEM_PROMPT = """\
 You are the Medusa legacy tuning orchestrator. Your job is to observe the
 Medusa cellular-automata engine and report what you see. In `propose` mode you
@@ -99,8 +102,11 @@ Rules:
   4. LOCKED params are off-limits entirely. Don't propose changes to them.
      HUMAN_APPROVAL params may be proposed as dry-run for a human to review.
   5. If the matrix looks healthy, say so and stop. No tuning is correct.
-  6. A tool result may be flagged as an error (is_error). Read it, then decide
-     whether to retry, choose a different tool, or stop and report.
+  6. A tool result may be reported as an error. Native backends flag it with
+     `is_error`; the OpenAI-compatible backend marks the same condition with a
+     leading `[ERROR]` in the result text. Either form means the call failed —
+     read it, then decide whether to retry, choose a different tool, or stop
+     and report.
 
 Be concise. Observation first, then at most one dry-run proposal per iteration."""
 
@@ -115,7 +121,6 @@ class OrchestratorConfig:
     max_tokens: int = 2048
     temperature: float = 0.0
     orchestrator_source: str = "agent:orchestrator"
-    commit_approver: str = "policy:auto"
     # Used only when backend_name == "openai-compat":
     openai_base_url: Optional[str] = None
     openai_model: Optional[str] = None
@@ -222,7 +227,6 @@ def create_orchestrator(
         client,
         mode=config.mode,
         orchestrator_source=config.orchestrator_source,
-        commit_approver=config.commit_approver,
     )
     return Orchestrator(
         backend=backend,

--- a/scripts/orchestrator_config.py
+++ b/scripts/orchestrator_config.py
@@ -1,4 +1,4 @@
-"""Phase 18 PR 6 + 7a — Orchestrator configuration.
+"""Phase 18 PR 6 + 7a — Legacy tuning orchestrator configuration.
 
 Centralises the knobs an operator will realistically want to change between
 environments (local dev vs. live Medusa) without having to edit the
@@ -9,6 +9,9 @@ Reads the following env vars, all optional:
   Core:
     MEDUSA_API_BASE_URL        Medusa REST endpoint (default: http://127.0.0.1:8080)
     MEDUSA_AGENT_BACKEND       "mock" | "anthropic" | "openai-compat"  (default: "mock")
+    MEDUSA_ORCHESTRATOR_MODE   "observe" | "propose"  (default: "observe"; any
+                               absent/malformed/unknown value fails closed to
+                               "observe" — see scripts/orchestrator.resolve_mode)
     MEDUSA_MAX_TOOL_DEPTH      int (default: 8)
     MEDUSA_MAX_TOKENS          int (default: 2048)
 
@@ -61,38 +64,45 @@ from scripts.agent_backends import (
     OpenAICompatBackend,
 )
 from scripts.orchestrator import (
+    MODE_OBSERVE,
     Orchestrator,
     OrchestratorClient,
+    OrchestratorMode,
     ToolRouter,
+    resolve_mode,
+    tools_for_mode,
 )
 
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8080"
 
 # Crafted to work with Phase 18's tool surface. Not model-specific.
+# Describes the quarantined surface accurately: observation is always
+# available; in `propose` mode a dry-run-only proposal tool is added; there is
+# no LLM-facing commit tool. Tool errors are structured (is_error result
+# blocks), not "[ERROR]"-prefixed strings.
 DEFAULT_SYSTEM_PROMPT = """\
-You are the Medusa Swarm Hunter orchestrator. Your job is to observe the
-Medusa cellular-automata engine and, when warranted, propose small
-parameter tunings to keep the matrix healthy.
+You are the Medusa legacy tuning orchestrator. Your job is to observe the
+Medusa cellular-automata engine and report what you see. In `propose` mode you
+may additionally validate a small parameter tuning as a DRY RUN for a human to
+review later.
 
 Rules:
-  1. ALWAYS inspect the current state before proposing. Use get_params,
+  1. ALWAYS inspect the current state first. Use get_params,
      get_params_schema, get_medusa_census, get_medusa_equanimity, and
      get_acoustic_map to gather context.
-  2. Every propose_tuning call MUST include a `justification` string
-     explaining what concerning signal you saw and why this change helps.
+  2. If a `propose_tuning` tool is available, every call MUST include a
+     `justification` string explaining what concerning signal you saw and why
+     this change would help. Proposals are validated as dry-run only — this
+     orchestrator cannot commit any change.
   3. Prefer SMALL adjustments. Change at most 1–2 params per proposal.
-  4. Only commit AUTO-category parameters. HUMAN_APPROVAL params can be
-     proposed as dry-run for human review, but don't attempt to commit
-     them — the API will return 403 and you should stop and explain
-     what a human should check.
-  5. LOCKED params are off-limits entirely. Don't propose changes to them.
-  6. If the matrix looks healthy, say so and stop. No tuning is correct.
-  7. Tool results that begin with "[ERROR]" indicate the tool execution
-     failed. Read the rest of the message, decide whether to retry, choose
-     a different tool, or stop and report.
+  4. LOCKED params are off-limits entirely. Don't propose changes to them.
+     HUMAN_APPROVAL params may be proposed as dry-run for a human to review.
+  5. If the matrix looks healthy, say so and stop. No tuning is correct.
+  6. A tool result may be flagged as an error (is_error). Read it, then decide
+     whether to retry, choose a different tool, or stop and report.
 
-Be concise. Observation first, then at most one proposal per iteration."""
+Be concise. Observation first, then at most one dry-run proposal per iteration."""
 
 
 @dataclass
@@ -100,6 +110,7 @@ class OrchestratorConfig:
     base_url: str = DEFAULT_BASE_URL
     backend_name: str = "mock"
     system_prompt: str = DEFAULT_SYSTEM_PROMPT
+    mode: OrchestratorMode = MODE_OBSERVE
     max_tool_depth: int = 8
     max_tokens: int = 2048
     temperature: float = 0.0
@@ -126,6 +137,8 @@ class OrchestratorConfig:
         return cls(
             base_url=os.environ.get("MEDUSA_API_BASE_URL", DEFAULT_BASE_URL),
             backend_name=os.environ.get("MEDUSA_AGENT_BACKEND", "mock").lower(),
+            # Fail-closed: absent/malformed/unknown → observe (resolve_mode).
+            mode=resolve_mode(os.environ.get("MEDUSA_ORCHESTRATOR_MODE")),
             max_tool_depth=int(os.environ.get("MEDUSA_MAX_TOOL_DEPTH", "8")),
             max_tokens=int(os.environ.get("MEDUSA_MAX_TOKENS", "2048")),
             openai_base_url=os.environ.get("MEDUSA_OPENAI_BASE_URL") or None,
@@ -207,6 +220,7 @@ def create_orchestrator(
     client = client or OrchestratorClient(config.base_url)
     router = ToolRouter(
         client,
+        mode=config.mode,
         orchestrator_source=config.orchestrator_source,
         commit_approver=config.commit_approver,
     )
@@ -214,6 +228,8 @@ def create_orchestrator(
         backend=backend,
         client=client,
         system_prompt=config.system_prompt,
+        mode=config.mode,
+        tools=tools_for_mode(config.mode),
         router=router,
         max_tool_depth=config.max_tool_depth,
         max_tokens_per_call=config.max_tokens,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -456,7 +456,7 @@ def test_config_defaults_sensibly():
     cfg = OrchestratorConfig()
     assert cfg.base_url == DEFAULT_BASE_URL
     assert cfg.backend_name == "mock"
-    assert cfg.commit_approver == "policy:auto"  # never accidentally human:
+    assert cfg.mode == "observe"  # fail-closed default; no LLM-facing write surface
 
 
 def test_config_from_env(monkeypatch):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -37,11 +37,15 @@ from scripts.agent_backends import (
 )
 from scripts.orchestrator import (
     IterationResult,
+    MODE_OBSERVE,
+    MODE_PROPOSE,
     Orchestrator,
     OrchestratorClient,
     ToolRouter,
     observation_tools,
-    tuning_tools,
+    proposal_tools,
+    resolve_mode,
+    tools_for_mode,
 )
 from scripts.orchestrator_config import (
     DEFAULT_BASE_URL,
@@ -166,7 +170,7 @@ def test_router_routes_get_census_through_client():
 
 def test_router_propose_requires_nonempty_justification():
     client, _ = _client_with_fake()
-    router = ToolRouter(client)
+    router = ToolRouter(client, mode=MODE_PROPOSE)
     payload, is_error = router.execute(
         "propose_tuning",
         {"params": {"signal_interval": 12}, "justification": "   "},
@@ -179,25 +183,29 @@ def test_router_propose_requires_nonempty_justification():
 def test_router_propose_calls_client_with_orchestrator_source():
     client, http = _client_with_fake()
     http.set("POST", "/api/tuning/propose", 200, {"proposal_id": "prop-x"})
-    router = ToolRouter(client, orchestrator_source="agent:swarm-hunter")
+    router = ToolRouter(client, mode=MODE_PROPOSE, orchestrator_source="agent:legacy-tuner")
     router.execute(
         "propose_tuning",
         {"params": {"signal_interval": 14}, "justification": "reason"},
     )
     sent = http.calls[0]["json"]
-    assert sent["source"] == "agent:swarm-hunter"
+    assert sent["source"] == "agent:legacy-tuner"
+    # Package S: the router forces dry-run at the boundary.
+    assert sent["mode"] == "dry-run"
 
 
-def test_router_commit_always_uses_configured_approver_never_human():
-    """Safety: the orchestrator's router hard-codes the approver. No
-    mechanism exists for the LLM to spoof a human approver."""
-    client, http = _client_with_fake()
-    http.set("POST", "/api/tuning/commit", 200, {"status": "committed"})
-    router = ToolRouter(client, commit_approver="policy:auto")
-    router.execute("commit_tuning", {"proposal_id": "prop-x", "approver": "human:evil"})
-    sent = http.calls[0]["json"]
-    # The human:evil from LLM input is IGNORED — router uses its configured value.
-    assert sent["approver"] == "policy:auto"
+def test_router_never_registers_commit_tool_in_any_mode():
+    """Package S: commit_tuning is not an LLM-facing tool in observe OR propose
+    mode. A call to it returns unknown_tool and makes no HTTP request — the LLM
+    has no path to the commit endpoint through the router."""
+    for mode in (MODE_OBSERVE, MODE_PROPOSE):
+        client, http = _client_with_fake()
+        router = ToolRouter(client, mode=mode)
+        payload, is_error = router.execute(
+            "commit_tuning", {"proposal_id": "prop-x", "approver": "human:evil"})
+        assert is_error is True
+        assert payload["error"] == "unknown_tool"
+        assert http.calls == []  # no POST attempted
 
 
 def test_router_commit_empty_proposal_id_rejected_client_side():
@@ -262,13 +270,14 @@ def _tool_use_response(
     )
 
 
-def _make_orchestrator(backend: MockBackend) -> tuple[Orchestrator, FakeHttp]:
+def _make_orchestrator(backend: MockBackend, *, mode: str = MODE_OBSERVE) -> tuple[Orchestrator, FakeHttp]:
     http = FakeHttp()
     client = OrchestratorClient("http://test:8080", http_do=http)
     orch = Orchestrator(
         backend=backend,
         client=client,
         system_prompt="test system",
+        mode=mode,
         max_tool_depth=4,
     )
     return orch, http
@@ -295,7 +304,7 @@ def test_iteration_propose_then_end():
         }, text="I'll propose reducing signal_interval."),
         _text_response("proposal submitted"),
     ])
-    orch, http = _make_orchestrator(backend)
+    orch, http = _make_orchestrator(backend, mode=MODE_PROPOSE)
     http.set("POST", "/api/tuning/propose", 200,
              {"proposal_id": "prop-newid", "status": "accepted"})
     result = orch.run_one_iteration("observe")
@@ -309,23 +318,39 @@ def test_iteration_propose_then_end():
     assert result.usage_total["output_tokens"] == 25 + 20
 
 
-def test_iteration_propose_then_commit_then_end():
+def test_iteration_commit_tool_call_is_unknown_and_uncommitted():
+    """Package S: even if a model emits a commit_tuning tool call, there is no
+    such tool — it resolves to unknown_tool, no POST is made, and nothing is
+    committed. (No LLM-facing commit path exists in any mode.)"""
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_1", "commit_tuning", {"proposal_id": "prop-xyz"}),
+        _text_response("nothing to commit with"),
+    ])
+    orch, http = _make_orchestrator(backend, mode=MODE_PROPOSE)
+    result = orch.run_one_iteration("observe")
+    assert result.stopped_because == "end_turn"
+    assert result.commits_applied == []
+    # The commit tool call was executed as unknown_tool; no commit POST made.
+    assert all(c["path"] != "/api/tuning/commit" for c in http.calls)
+
+
+def test_iteration_commit_pending_proposal_is_rejected():
+    """propose mode forces dry-run: a commit-pending request is refused with a
+    deterministic error, not silently downgraded."""
     backend = MockBackend(responses=[
         _tool_use_response("tu_1", "propose_tuning", {
             "params": {"signal_interval": 12},
             "justification": "reduce overhead",
             "mode": "commit-pending",
         }),
-        _tool_use_response("tu_2", "commit_tuning", {"proposal_id": "prop-xyz"}),
-        _text_response("committed"),
+        _text_response("ok, dry-run only"),
     ])
-    orch, http = _make_orchestrator(backend)
-    http.set("POST", "/api/tuning/propose", 200, {"proposal_id": "prop-xyz", "status": "accepted"})
-    http.set("POST", "/api/tuning/commit", 200, {"proposal_id": "prop-xyz", "status": "committed"})
+    orch, http = _make_orchestrator(backend, mode=MODE_PROPOSE)
     result = orch.run_one_iteration("observe")
     assert result.stopped_because == "end_turn"
-    assert result.proposals_created == ["prop-xyz"]
-    assert result.commits_applied == ["prop-xyz"]
+    # No proposal was created (the router refused commit-pending before POSTing).
+    assert result.proposals_created == []
+    assert http.calls == []  # no POST — rejected at the router boundary
 
 
 def test_iteration_hits_max_depth():
@@ -393,33 +418,42 @@ def test_iteration_system_prompt_is_forwarded():
     assert backend.calls[0].system == "custom system"
 
 
-def test_iteration_tools_default_to_observation_plus_tuning():
+def test_iteration_tools_default_to_observation_only():
+    """Package S: a default (observe) orchestrator advertises observation tools
+    only — no propose, no commit."""
     backend = MockBackend(responses=[_text_response("ok")])
-    orch, _ = _make_orchestrator(backend)
+    orch, _ = _make_orchestrator(backend)  # default mode = observe
     orch.run_one_iteration("go")
     tool_names = [t.name for t in backend.calls[0].tools]
     for expected in (
         "get_medusa_census", "get_medusa_equanimity", "get_acoustic_map",
         "get_params", "get_params_schema",
-        "propose_tuning", "commit_tuning",
     ):
         assert expected in tool_names
+    assert "propose_tuning" not in tool_names
+    assert "commit_tuning" not in tool_names
+
+
+def test_iteration_propose_mode_adds_proposal_tool_only():
+    backend = MockBackend(responses=[_text_response("ok")])
+    orch, _ = _make_orchestrator(backend, mode=MODE_PROPOSE)
+    orch.run_one_iteration("go")
+    tool_names = [t.name for t in backend.calls[0].tools]
+    assert "propose_tuning" in tool_names
+    assert "commit_tuning" not in tool_names
 
 
 # -- tool spec shape ---------------------------------------------------------
 
 
-def test_propose_tuning_tool_requires_justification():
-    specs = {t.name: t for t in tuning_tools()}
+def test_proposal_tool_requires_justification_and_has_no_commit_mode():
+    specs = {t.name: t for t in proposal_tools()}
+    assert "commit_tuning" not in specs  # no commit tool exists
     propose = specs["propose_tuning"]
     assert "justification" in propose.input_schema["required"]
     assert "params" in propose.input_schema["required"]
-
-
-def test_commit_tuning_tool_requires_proposal_id():
-    specs = {t.name: t for t in tuning_tools()}
-    commit = specs["commit_tuning"]
-    assert commit.input_schema["required"] == ["proposal_id"]
+    # The dry-run-only surface no longer advertises a mode enum toggle.
+    assert "mode" not in propose.input_schema["properties"]
 
 
 # -- orchestrator_config ----------------------------------------------------
@@ -534,3 +568,76 @@ def test_create_orchestrator_smoke():
     assert orch.backend is backend
     assert orch.system_prompt == DEFAULT_SYSTEM_PROMPT
     assert orch.max_tool_depth == 8
+
+
+# -- Package S: observe-by-default capability model -------------------------
+
+
+def test_config_default_mode_is_observe():
+    assert OrchestratorConfig().mode == MODE_OBSERVE
+
+
+def test_resolve_mode_fail_closed_is_exhaustive():
+    """Absent, malformed, and unknown values all fail closed to observe; only
+    the exact tokens observe/propose (trimmed, case-insensitive) are honored;
+    only propose is a non-observe result."""
+    for raw in (None, "", "   ", "garbage", "commit", "COMMIT", "obserform",
+                "propose!", "0", "true", "observe ; propose"):
+        assert resolve_mode(raw) == MODE_OBSERVE
+    for raw in ("observe", "OBSERVE", " observe ", "Observe"):
+        assert resolve_mode(raw) == MODE_OBSERVE
+    for raw in ("propose", "PROPOSE", " propose ", "Propose"):
+        assert resolve_mode(raw) == MODE_PROPOSE
+
+
+def test_config_from_env_mode(monkeypatch):
+    monkeypatch.setenv("MEDUSA_ORCHESTRATOR_MODE", "propose")
+    assert OrchestratorConfig.from_env().mode == MODE_PROPOSE
+    monkeypatch.setenv("MEDUSA_ORCHESTRATOR_MODE", "observe")
+    assert OrchestratorConfig.from_env().mode == MODE_OBSERVE
+    # Malformed → fail closed to observe.
+    monkeypatch.setenv("MEDUSA_ORCHESTRATOR_MODE", "commit-everything")
+    assert OrchestratorConfig.from_env().mode == MODE_OBSERVE
+    monkeypatch.delenv("MEDUSA_ORCHESTRATOR_MODE", raising=False)
+    assert OrchestratorConfig.from_env().mode == MODE_OBSERVE  # absent → observe
+
+
+def test_tools_for_mode_inventories():
+    observe_names = {t.name for t in tools_for_mode(MODE_OBSERVE)}
+    propose_names = {t.name for t in tools_for_mode(MODE_PROPOSE)}
+    assert "propose_tuning" not in observe_names
+    assert "commit_tuning" not in observe_names
+    assert "propose_tuning" in propose_names
+    assert "commit_tuning" not in propose_names
+    # propose is a strict superset of observe by exactly the proposal tool.
+    assert propose_names - observe_names == {"propose_tuning"}
+
+
+def test_observe_mode_makes_zero_posts_even_if_model_tries_to_write():
+    """In observe mode, a model that emits propose/commit tool calls gets
+    unknown_tool for both and the client makes zero POST requests."""
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_1", "propose_tuning",
+                           {"params": {"signal_interval": 12}, "justification": "x"}),
+        _tool_use_response("tu_2", "commit_tuning", {"proposal_id": "prop-x"}),
+        _text_response("done"),
+    ])
+    orch, http = _make_orchestrator(backend, mode=MODE_OBSERVE)
+    result = orch.run_one_iteration("observe")
+    assert result.proposals_created == []
+    assert result.commits_applied == []
+    post_calls = [c for c in http.calls if c["method"] == "POST"]
+    assert post_calls == []
+
+
+def test_create_orchestrator_propose_mode_wires_router_and_tools():
+    backend = MockBackend(responses=[_text_response("ok")])
+    orch = create_orchestrator(
+        config=OrchestratorConfig(mode=MODE_PROPOSE),
+        backend=backend,
+    )
+    assert orch.mode == MODE_PROPOSE
+    assert orch.router.mode == MODE_PROPOSE
+    tool_names = {t.name for t in orch.tools}
+    assert "propose_tuning" in tool_names
+    assert "commit_tuning" not in tool_names

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -208,13 +208,6 @@ def test_router_never_registers_commit_tool_in_any_mode():
         assert http.calls == []  # no POST attempted
 
 
-def test_router_commit_empty_proposal_id_rejected_client_side():
-    client, _ = _client_with_fake()
-    router = ToolRouter(client)
-    payload, _ = router.execute("commit_tuning", {})
-    assert payload["error"] == "bad_request"
-
-
 def test_router_handler_exception_becomes_error_payload():
     """Any bug in a handler must not crash the loop — surfaces as a tool error."""
     client, http = _client_with_fake()

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -54,6 +54,7 @@ from scripts.agent_backends import (
     ToolUseBlock,
 )
 from scripts.orchestrator import (
+    MODE_PROPOSE,
     Orchestrator,
     OrchestratorClient,
     ToolRouter,
@@ -236,7 +237,7 @@ def _anthropic_script() -> list:
                 "tu_propose_a",
                 "propose_tuning",
                 {"params": PROPOSAL_PARAMS, "justification": JUSTIFICATION,
-                 "mode": "commit-pending"},
+                 "mode": "dry-run"},
             ),
         ], stop_reason="tool_use"),
         _anthropic_response([
@@ -264,7 +265,7 @@ def _openai_script() -> list:
                 "tu_propose_o",
                 "propose_tuning",
                 {"params": PROPOSAL_PARAMS, "justification": JUSTIFICATION,
-                 "mode": "commit-pending"},
+                 "mode": "dry-run"},
             )],
             finish_reason="tool_calls",
         ),
@@ -310,10 +311,12 @@ def _patch_commit_id_openai(script: list, real_proposal_id: str) -> list:
 def _run_one(backend, tuning_stack) -> tuple:
     state, http_do, _gen = tuning_stack
     client = OrchestratorClient("http://test:8080", http_do=http_do)
-    router = ToolRouter(client, orchestrator_source=SOURCE, commit_approver="policy:auto")
+    router = ToolRouter(client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
+                        commit_approver="policy:auto")
     orch = Orchestrator(
         backend=backend, client=client,
         system_prompt="be concise",
+        mode=MODE_PROPOSE,
         router=router,
         max_tool_depth=6,
     )
@@ -354,10 +357,10 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     a_client.messages.create = patched_create_a
 
     a_orch_client = OrchestratorClient("http://test:8080", http_do=http_do_a)
-    a_router = ToolRouter(a_orch_client, orchestrator_source=SOURCE,
+    a_router = ToolRouter(a_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
                           commit_approver="policy:auto")
     a_orch = Orchestrator(
-        backend=a_backend, client=a_orch_client,
+        backend=a_backend, client=a_orch_client, mode=MODE_PROPOSE,
         system_prompt="be concise", router=a_router, max_tool_depth=6,
     )
     a_result = a_orch.run_one_iteration("Observe Medusa; tune if needed.")
@@ -384,22 +387,23 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     o_client.chat.completions.create = patched_create_o
 
     o_orch_client = OrchestratorClient("http://test:8080", http_do=http_do_o)
-    o_router = ToolRouter(o_orch_client, orchestrator_source=SOURCE,
+    o_router = ToolRouter(o_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
                           commit_approver="policy:auto")
     o_orch = Orchestrator(
-        backend=o_backend, client=o_orch_client,
+        backend=o_backend, client=o_orch_client, mode=MODE_PROPOSE,
         system_prompt="be concise", router=o_router, max_tool_depth=6,
     )
     o_result = o_orch.run_one_iteration("Observe Medusa; tune if needed.")
 
     # ---- Parity assertions ----
     #
-    # Post-quarantine (Package R): the orchestrator's commit identity
-    # (approver="policy:auto") is refused at the server boundary, so the commit
-    # tool call attempted by both scripts is rejected identically. Provider
-    # parity is preserved — both backends behave the same — but now at the
-    # *rejected* outcome: one dry-run proposal each, zero commits, state
-    # unchanged. This proves backend-equivalence of the quarantined path.
+    # Post-quarantine: the orchestrator runs in `propose` mode, which exposes a
+    # dry-run-only proposal tool and NO commit tool (Package S). Each script
+    # also emits a commit_tuning tool call, which resolves to unknown_tool. So
+    # both backends behave identically at the *no-commit* outcome: one dry-run
+    # proposal each, zero commits, state unchanged. (Defense in depth: even if a
+    # commit reached the server it would be refused — Package R.) This proves
+    # backend-equivalence of the quarantined path.
 
     # 1. Both stopped naturally.
     assert a_result.stopped_because == o_result.stopped_because == "end_turn"

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -51,6 +51,7 @@ from scripts.agent_backends import (
     Message,
     OpenAICompatBackend,
     TextBlock,
+    ToolResultBlock,
     ToolUseBlock,
 )
 from scripts.orchestrator import (
@@ -311,8 +312,7 @@ def _patch_commit_id_openai(script: list, real_proposal_id: str) -> list:
 def _run_one(backend, tuning_stack) -> tuple:
     state, http_do, _gen = tuning_stack
     client = OrchestratorClient("http://test:8080", http_do=http_do)
-    router = ToolRouter(client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
-                        commit_approver="policy:auto")
+    router = ToolRouter(client, mode=MODE_PROPOSE, orchestrator_source=SOURCE)
     orch = Orchestrator(
         backend=backend, client=client,
         system_prompt="be concise",
@@ -357,8 +357,7 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     a_client.messages.create = patched_create_a
 
     a_orch_client = OrchestratorClient("http://test:8080", http_do=http_do_a)
-    a_router = ToolRouter(a_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
-                          commit_approver="policy:auto")
+    a_router = ToolRouter(a_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE)
     a_orch = Orchestrator(
         backend=a_backend, client=a_orch_client, mode=MODE_PROPOSE,
         system_prompt="be concise", router=a_router, max_tool_depth=6,
@@ -387,8 +386,7 @@ def test_anthropic_and_openai_compat_produce_equivalent_ledger_entries(tmp_path:
     o_client.chat.completions.create = patched_create_o
 
     o_orch_client = OrchestratorClient("http://test:8080", http_do=http_do_o)
-    o_router = ToolRouter(o_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE,
-                          commit_approver="policy:auto")
+    o_router = ToolRouter(o_orch_client, mode=MODE_PROPOSE, orchestrator_source=SOURCE)
     o_orch = Orchestrator(
         backend=o_backend, client=o_orch_client, mode=MODE_PROPOSE,
         system_prompt="be concise", router=o_router, max_tool_depth=6,
@@ -509,3 +507,67 @@ def test_orchestrator_treats_both_backends_identically_for_text_only():
         assert result.stopped_because == "end_turn"
         assert result.tool_calls_executed == 0
         assert result.final_text == "looks healthy"
+
+
+# ---------------------------------------------------------------------------
+# Package S amendment (Jack audit): failed-tool-result parity across encodings.
+# An identical error result must remain recognizable as an error through BOTH
+# backend wire formats — Anthropic's native `is_error` flag and the
+# OpenAI-compatible backend's `[ERROR] ` content marker (it has no native
+# flag). This locks the two representations the system prompt tells the model
+# to recognise (orchestrator_config rule 6).
+# ---------------------------------------------------------------------------
+
+
+def test_failed_tool_result_recognizable_through_both_encodings():
+    failed = Message(
+        role="user",
+        content=[
+            ToolResultBlock(
+                tool_use_id="tid-1",
+                content="rate_limited: try later",
+                is_error=True,
+            )
+        ],
+    )
+
+    # Anthropic native shape: a tool_result block carrying is_error=True.
+    a_wire = AnthropicBackend._message_to_wire(failed)
+    a_results = [
+        blk for blk in a_wire["content"] if blk.get("type") == "tool_result"
+    ]
+    assert len(a_results) == 1
+    assert a_results[0]["is_error"] is True
+    # The native flag carries the signal; the payload text is NOT marker-mangled.
+    assert a_results[0]["content"] == "rate_limited: try later"
+
+    # OpenAI-compatible shape: a role:tool message whose content is marked.
+    o_wire = OpenAICompatBackend._message_to_wire(failed)
+    o_tool_msgs = [msg for msg in o_wire if msg.get("role") == "tool"]
+    assert len(o_tool_msgs) == 1
+    assert o_tool_msgs[0]["content"].startswith("[ERROR] ")
+    assert "rate_limited: try later" in o_tool_msgs[0]["content"]
+
+
+def test_successful_tool_result_carries_no_error_marker_in_either_encoding():
+    """The mirror of the above: a non-error result must NOT gain an error flag
+    or an "[ERROR] " marker in either encoding, so success and failure stay
+    distinguishable through both transports."""
+    ok = Message(
+        role="user",
+        content=[
+            ToolResultBlock(
+                tool_use_id="tid-2",
+                content="census: 42 live",
+                is_error=False,
+            )
+        ],
+    )
+
+    a_wire = AnthropicBackend._message_to_wire(ok)
+    a_result = [b for b in a_wire["content"] if b.get("type") == "tool_result"][0]
+    assert "is_error" not in a_result
+
+    o_tool_msg = [m for m in OpenAICompatBackend._message_to_wire(ok) if m.get("role") == "tool"][0]
+    assert not o_tool_msg["content"].startswith("[ERROR] ")
+    assert o_tool_msg["content"] == "census: 42 live"


### PR DESCRIPTION
## Package S — observe-by-default client capability model

Stacked on **Package R** ([#328](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/328)); base is R's branch. Removes write tools from the default and supported LLM-facing surface of the legacy tuning orchestrator, while keeping deterministic observation and an explicitly-selected dry-run proposal mode. Design evidence: [#322](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/322).

**Capability model (`OrchestratorMode`):**
- **`observe`** (default) — observation tools only; no proposal tool, no commit tool.
- **`propose`** — observation + a proposal tool that the router **forces to `mode="dry-run"`** and which **rejects `commit-pending`** outright (deterministic `commit_pending_forbidden`, no silent downgrade).
- **No supported LLM-facing `commit` mode** — `commit_tuning` is never registered as a router handler in any mode.

**Fail-closed resolution:** `resolve_mode()` maps absent / malformed / unknown values all to `observe`; only the exact tokens `observe`/`propose` (trimmed, case-insensitive) are honored, and only `propose` exposes any write-adjacent tool. Wired via `MEDUSA_ORCHESTRATOR_MODE`.

**Low-level client method retained, proven non-LLM-facing:** `OrchestratorClient.commit_tuning`/`rollback_tuning` stay for existing direct callers (provider-parity), but a test asserts `commit_tuning` returns `unknown_tool` with zero POST in **both** modes — it cannot enter the tool registry.

**Prompt reconciled with reality:** renamed active vocabulary "Swarm Hunter" → "legacy tuning orchestrator" in module/config text and the system prompt; removed the false `[ERROR]`-prefix instruction (tool errors are structured `is_error` blocks) and the commit-related promises now structurally enforced. Historical records are not rewritten wholesale.

**Before → after (LLM-facing capability):**

| | before | after (observe, default) | after (propose) |
|---|---|---|---|
| observation tools | ✅ | ✅ | ✅ |
| propose tool | ✅ (mode toggle) | ❌ | ✅ (forced dry-run) |
| commit tool | ✅ | ❌ | ❌ |
| commit-pending | accepted | n/a | rejected |

**Tests:** default/observe/propose inventories; exhaustive fail-closed `resolve_mode`; commit unknown in both modes with zero POST; commit-pending rejected at the router; observe makes zero POST even when the model emits write tool calls; env/config construction. `test_provider_parity` runs in propose mode (dry-run scripts) — both backends reach the identical no-commit outcome.

**Verification lane:** no local Python on this seat; the full suite runs in GitHub CI (`verify-python`) on this push — counts recorded once green. **Note:** because this PR targets R's branch, CI runs the *cumulative* R+S diff.

Part 2 of a 3-PR stack (R → S → T). Open and **unmerged** for Jack; keeps `swarm-hunter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
