### PR TITLE
security(orchestrator): bounded loop, error semantics, LeanCTX receipts (T of R/S/T, stacked on #333)

### DIFF
--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -72,12 +72,27 @@ Error-shape guarantees (Jack amendment):
 ## LeanCTX audit receipt
 
 `IterationResult.audit_receipt()` returns a bounded, deterministic,
-payload-free handoff (`build_audit_receipt`): stop reason, turn/tool-call
-counts, per-category outcome counts, successful proposal ids, and token usage —
-**never** tool payloads, prompts, credentials, headers, or raw backend
-responses. It serializes deterministically (sorted keys) and is guaranteed
-≤ 64 KiB (`MAX_RECEIPT_BYTES`), with deterministic truncation as a last-resort
-safety net.
+payload-free handoff (`build_audit_receipt`) built by **strict allowlist
+normalization** — the receipt carries only a fixed schema, and any value
+outside it is discarded or replaced by a fixed token, never stringified:
+
+| Field | Supported domain | Out-of-domain handling |
+|---|---|---|
+| `schema` | fixed literal `leanctx-orchestrator-v1` | — |
+| `stopped_because` | `end_turn` / `max_depth` / `tool_budget_exhausted` | any other value → `unknown` (text never copied) |
+| `turns`, `tool_calls_executed` | non-negative int, magnitude-clamped (≤ 10¹²) | bool/negative/non-int → `0`; oversized → clamped |
+| `outcome_counts` | only the known categories (`ok`, `unknown_tool`, `handler_exception`, `transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`, `local_rejection`) → non-negative ints | unknown / non-string keys discarded |
+| `usage_total` | only `input_tokens` / `output_tokens` → non-negative ints | other keys discarded |
+| `proposals_created`, `commits_applied` | id-alphabet strings (`[A-Za-z0-9_-]`, ≤ 128 chars), list-capped at 64 | invalid / non-string entries omitted (no `__str__`) |
+| `truncated` | `true` whenever any value was normalized away, or the trim loop / minimal fallback fired | — |
+
+Because every surviving value is a bounded JSON primitive, it serializes with
+ordinary `json.dumps(..., sort_keys=True)` (no `default=str`), the ≤ 64 KiB
+(`MAX_RECEIPT_BYTES`) bound holds **before** serialization, and no arbitrary
+input key, secret-looking text, or object `__str__` can enter the receipt. A
+deterministic trim loop and a fixed minimal fallback are the final size
+guarantee. The receipt **never** contains tool payloads, prompts, credentials,
+headers, or raw backend responses.
 
 ## Supported modes and invocation
 

--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -1,0 +1,101 @@
+# Legacy Tuning Orchestrator — Quarantine
+
+> **What this is.** `scripts/orchestrator.py` (Phase 18 PR 6), historically
+> described as *"the Swarm Hunter's brain,"* is an LLM-driven tuning
+> orchestrator that could observe Medusa and POST to the tuning API. This
+> document records the **proven boundaries** placed around it by the R/S/T
+> package stack so its default and supported LLM-facing operation cannot mutate
+> Medusa.
+>
+> **What this is NOT.** This is not the offline candidate-structure detector
+> proposed in [`docs/SWARM_HUNTER_V1_PREFLIGHT.md`](SWARM_HUNTER_V1_PREFLIGHT.md)
+> (PR #322). The two share vocabulary only. This document also does **not**
+> claim the tuning API is authenticated or generally secure, that the
+> Glass-Wall is complete, or anything about live engine behavior.
+
+## The three enforced boundaries
+
+**R — server-side auto-commit refusal** (`scripts/tuning_api.py`). The commit
+endpoint refuses the orchestrator's autonomous approver identity
+(`approver="policy:auto"` → `403 auto_commit_disabled`), checked before the
+human-approval branch, for every parameter category. There is no env flag,
+query param, header, or alternate route that re-enables it; re-enablement
+requires a reviewed code change. Human commits (`approver="human:<name>"`),
+reads, dry-run/propose, LOCKED-at-propose rejection, and the per-parameter rate
+limit are unchanged.
+
+**S — observe-by-default capability model** (`scripts/orchestrator.py`,
+`scripts/orchestrator_config.py`). The LLM-facing surface is capability-gated:
+
+| Mode | Observation tools | Proposal tool | Commit tool |
+|---|---|---|---|
+| `observe` (default) | ✅ | ❌ | ❌ |
+| `propose` | ✅ | ✅ (forced `dry-run`; `commit-pending` refused) | ❌ |
+
+`commit_tuning` is **never** registered as an LLM-facing router handler in any
+mode. Mode resolution (`resolve_mode` / `MEDUSA_ORCHESTRATOR_MODE`) fails closed:
+absent, malformed, or unknown values all resolve to `observe`; only the exact
+tokens `observe`/`propose` are honored, and only `propose` exposes any
+write-adjacent tool. The low-level `OrchestratorClient.commit_tuning` /
+`rollback_tuning` primitives are retained for direct **non-LLM** callers and are
+proven unable to enter the tool registry.
+
+**T — hard runtime limits, honest error semantics, bounded audit receipts**
+(`scripts/orchestrator.py`). Two validated budgets bound each iteration: a
+per-turn `max_tool_depth` and a total `max_total_tool_calls` (both positive
+integers within `MAX_LIMIT_CEILING`; malformed values are rejected at
+construction). When a turn's tool calls would exceed the total budget, only the
+permitted prefix executes; every remaining call gets an explicit
+`budget_rejection` error result so the conversation history stays structurally
+valid, and the iteration stops (`tool_budget_exhausted`) — the cap is never
+exceeded. At most one proposal attempt per iteration is enforced in code. Tool
+outcomes are categorized (`ok`, `unknown_tool`, `handler_exception`,
+`transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`);
+HTTP status ≥ 400 is a genuine tool error and is never counted as a created
+proposal or applied commit.
+
+## LeanCTX audit receipt
+
+`IterationResult.audit_receipt()` returns a bounded, deterministic,
+payload-free handoff (`build_audit_receipt`): stop reason, turn/tool-call
+counts, per-category outcome counts, successful proposal ids, and token usage —
+**never** tool payloads, prompts, credentials, headers, or raw backend
+responses. It serializes deterministically (sorted keys) and is guaranteed
+≤ 64 KiB (`MAX_RECEIPT_BYTES`), with deterministic truncation as a last-resort
+safety net.
+
+## Supported modes and invocation
+
+`observe` is the default for any construction path (bare `Orchestrator`,
+`create_orchestrator`, or `MEDUSA_ORCHESTRATOR_MODE` unset/garbage). A human who
+wants dry-run proposal validation sets `MEDUSA_ORCHESTRATOR_MODE=propose`. No
+supported configuration exposes an LLM-facing commit.
+
+## Non-claims
+
+- Not general API authentication or security — only the `policy:auto` path is
+  closed at the server.
+- Not a completed Glass-Wall — this quarantines one write-capable module.
+- Not a statement about live engine behavior, production deployment, or
+  statistical validity.
+- Rollback is **not** exposed to the LLM in any mode.
+
+## Rollback (per package)
+
+- **T:** revert `scripts/orchestrator.py` budget/receipt additions and remove
+  this document; capability model (S) and server refusal (R) remain.
+- **S:** revert the capability-model changes to
+  `scripts/orchestrator.py` / `orchestrator_config.py`; the server refusal (R)
+  remains as the backstop.
+- **R:** revert the `_commit_locked` `auto_commit_disabled` guard in
+  `scripts/tuning_api.py`. (Doing so re-opens the autonomous commit path — a
+  reviewed decision, by design.)
+
+## Relationship to the offline detector (PR #322)
+
+The proposed offline Swarm Hunter detector reads immutable evidence and surfaces
+candidates for human review; it has no write path. This quarantine is the
+disposition of the pre-existing *tuning* orchestrator that #322's evidence pass
+uncovered. The offline detector must never import, or be imported by, this
+orchestrator — a one-directional boundary asserted by a static-import test in
+`tests/test_orchestrator.py`.

--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -50,9 +50,24 @@ permitted prefix executes; every remaining call gets an explicit
 valid, and the iteration stops (`tool_budget_exhausted`) — the cap is never
 exceeded. At most one proposal attempt per iteration is enforced in code. Tool
 outcomes are categorized (`ok`, `unknown_tool`, `handler_exception`,
-`transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`);
-HTTP status ≥ 400 is a genuine tool error and is never counted as a created
-proposal or applied commit.
+`transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`,
+`local_rejection`); HTTP status ≥ 400 is a genuine tool error and is never
+counted as a created proposal or applied commit.
+
+Error-shape guarantees (Jack amendment):
+
+- **Non-dict handler returns** — the handler call, its return-shape check, and
+  the `_status`/`_local_rejection` inspection all run inside one defensive
+  `try`, so a handler that returns `None`, a list, a scalar, or any non-dict
+  becomes a bounded `handler_exception` result and can never crash the loop.
+- **`local_rejection`** — a request the router refuses *before* any HTTP call
+  (blank justification, forbidden `commit-pending`) is flagged `is_error=True`
+  with category `local_rejection`, counted as an error (not `ok`), and — since
+  no request is sent — never mints a proposal id. Distinct from
+  `http_rejection`, where the server said no.
+- **Error visibility across transports** — an `is_error` result is surfaced by
+  native backends via the `is_error` flag and by the OpenAI-compatible backend
+  via a leading `[ERROR]` marker, so a model recognises the failure either way.
 
 ## LeanCTX audit receipt
 

--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -83,7 +83,7 @@ outside it is discarded or replaced by a fixed token, never stringified:
 | `turns`, `tool_calls_executed` | non-negative int, magnitude-clamped (≤ 10¹²) | bool/negative/non-int → `0`; oversized → clamped |
 | `outcome_counts` | only the known categories (`ok`, `unknown_tool`, `handler_exception`, `transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`, `local_rejection`) → non-negative ints | unknown / non-string keys discarded |
 | `usage_total` | only `input_tokens` / `output_tokens` → non-negative ints | other keys discarded |
-| `proposals_created`, `commits_applied` | id-alphabet strings (`[A-Za-z0-9_-]`, ≤ 128 chars), list-capped at 64 | invalid / non-string entries omitted (no `__str__`) |
+| `proposals_created`, `commits_applied` | canonical proposal ids only — `prop-` + 8 lowercase hex (`^prop-[0-9a-f]{8}$`, as minted by `tuning_api._new_proposal_id`), list-capped at 64 | secret-looking / arbitrary-valid / uppercase / overlong / non-string entries omitted (no `__str__`) |
 | `truncated` | `true` whenever any value was normalized away, or the trim loop / minimal fallback fired | — |
 
 Because every surviving value is a bounded JSON primitive, it serializes with

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -275,6 +275,39 @@ def tools_for_mode(mode: OrchestratorMode) -> list[ToolSpec]:
     return tools
 
 
+# -- error categories & runtime limits ---------------------------------------
+
+# Deterministic outcome categories for every tool call. "ok" is success; the
+# rest are distinct failure kinds so the audit receipt can distinguish them.
+OUTCOME_OK = "ok"
+CATEGORY_UNKNOWN_TOOL = "unknown_tool"
+CATEGORY_HANDLER_EXCEPTION = "handler_exception"
+CATEGORY_TRANSPORT_FAILURE = "transport_failure"
+CATEGORY_HTTP_REJECTION = "http_rejection"
+CATEGORY_BUDGET_REJECTION = "budget_rejection"
+CATEGORY_PROPOSAL_LIMIT = "proposal_limit"
+
+DEFAULT_MAX_TOTAL_TOOL_CALLS = 24
+"""Total tool calls permitted across an entire iteration, independent of the
+per-turn `max_tool_depth`. Bounds a model that emits many tool calls per turn."""
+
+MAX_LIMIT_CEILING = 1000
+"""Defensible upper bound for any configurable numeric limit; values above this
+(or non-positive, or non-integer) are rejected rather than trusted."""
+
+MAX_RECEIPT_BYTES = 64 * 1024
+"""Hard ceiling on the serialized LeanCTX audit receipt."""
+
+
+def _validate_positive_limit(name: str, value: int) -> int:
+    """A configurable limit must be a positive int within the ceiling."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    if value < 1 or value > MAX_LIMIT_CEILING:
+        raise ValueError(f"{name} must be in [1, {MAX_LIMIT_CEILING}], got {value}")
+    return value
+
+
 # -- tool router -------------------------------------------------------------
 
 
@@ -317,22 +350,39 @@ class ToolRouter:
         self._handlers: dict[str, ToolHandler] = handlers
 
     def execute(self, name: str, arguments: dict) -> tuple[dict, bool]:
-        """Run a tool call. Returns `(result_payload, is_error)`."""
+        """Run a tool call. Returns `(result_payload, is_error)`.
+
+        Error kinds are distinguished by a stable ``category`` field:
+        unknown_tool, transport_failure, handler_exception, and http_rejection
+        (HTTP status >= 400 is a genuine tool error, not a silent success)."""
         handler = self._handlers.get(name)
         if handler is None:
             return (
-                {"error": "unknown_tool", "message": f"tool {name} not registered"},
+                {"error": "unknown_tool", "category": CATEGORY_UNKNOWN_TOOL,
+                 "message": f"tool {name} not registered"},
                 True,
             )
         try:
-            return handler(arguments), False
-        except Exception as e:  # defensive: any handler bug → LLM-visible error
+            payload = handler(arguments)
+        except urllib.error.URLError as e:  # network/transport-level failure
             return (
-                {"error": "tool_handler_exception",
-                 "tool": name,
-                 "message": f"{type(e).__name__}: {e}"},
+                {"error": "transport_failure", "category": CATEGORY_TRANSPORT_FAILURE,
+                 "tool": name, "message": type(e).__name__},
                 True,
             )
+        except Exception as e:  # defensive: any handler bug → LLM-visible error
+            return (
+                {"error": "tool_handler_exception", "category": CATEGORY_HANDLER_EXCEPTION,
+                 "tool": name, "message": f"{type(e).__name__}: {e}"},
+                True,
+            )
+        status = payload.get("_status")
+        if isinstance(status, int) and status >= 400:
+            # An HTTP rejection is a genuine tool error. Keep bounded metadata
+            # (status + any error code/message) but flag it so callers do not
+            # count a rejected proposal/commit as applied.
+            return ({**payload, "category": CATEGORY_HTTP_REJECTION}, True)
+        return payload, False
 
     # handlers ---
 
@@ -391,26 +441,43 @@ class IterationResult:
     """Outcome of one observe-decide-act cycle."""
 
     stopped_because: str
-    """One of: "end_turn" (LLM finished), "max_depth" (tool_call cap reached),
-    "transport_error" (LLM call failed)."""
+    """One of: "end_turn" (LLM finished), "max_depth" (per-turn cap reached),
+    "tool_budget_exhausted" (total tool-call budget reached)."""
 
     turns: int
     """Number of LLM `complete()` calls made this iteration."""
 
     tool_calls_executed: int
-    """Total tool calls executed across all turns this iteration."""
+    """Total tool calls executed across all turns this iteration (excludes calls
+    refused unexecuted once the budget was exhausted)."""
 
     proposals_created: list[str] = field(default_factory=list)
     """Proposal IDs returned by successful propose_tuning calls."""
 
     commits_applied: list[str] = field(default_factory=list)
-    """Proposal IDs successfully committed."""
+    """Proposal IDs successfully committed. Always empty under the quarantine —
+    there is no LLM-facing commit path — but retained for shape stability."""
 
     final_text: Optional[str] = None
     """Last assistant text block, if any."""
 
     usage_total: dict[str, int] = field(default_factory=dict)
     """Sum of input/output tokens across all turns this iteration."""
+
+    outcome_counts: dict[str, int] = field(default_factory=dict)
+    """Deterministic count of tool-call outcomes by category (ok, unknown_tool,
+    handler_exception, transport_failure, http_rejection, budget_rejection,
+    proposal_limit)."""
+
+    def audit_receipt(self) -> dict[str, Any]:
+        """A bounded, payload-free LeanCTX audit handoff for this iteration.
+
+        Contains only outcome metadata: stop reason, counts, usage, and the
+        ids of successful proposals — never tool payloads, prompts, credentials,
+        headers, or raw backend responses. Deterministically serializable and
+        guaranteed <= MAX_RECEIPT_BYTES (deterministic truncation if ever
+        exceeded)."""
+        return build_audit_receipt(self)
 
 
 class Orchestrator:
@@ -432,6 +499,7 @@ class Orchestrator:
         tools: Optional[list[ToolSpec]] = None,
         router: Optional[ToolRouter] = None,
         max_tool_depth: int = 8,
+        max_total_tool_calls: int = DEFAULT_MAX_TOTAL_TOOL_CALLS,
         max_tokens_per_call: int = 2048,
         temperature: float = 0.0,
     ) -> None:
@@ -444,21 +512,49 @@ class Orchestrator:
         # but a bare Orchestrator is observation-only.
         self.tools = tools if tools is not None else tools_for_mode(mode)
         self.router = router or ToolRouter(client, mode=mode)
-        self.max_tool_depth = max_tool_depth
+        # Two independent, validated budgets: per-turn depth and total tool
+        # calls. Malformed/out-of-range limits are rejected at construction.
+        self.max_tool_depth = _validate_positive_limit("max_tool_depth", max_tool_depth)
+        self.max_total_tool_calls = _validate_positive_limit(
+            "max_total_tool_calls", max_total_tool_calls)
         self.max_tokens_per_call = max_tokens_per_call
         self.temperature = temperature
 
     def run_one_iteration(self, trigger_message: str) -> IterationResult:
-        """Run one observe-decide-act cycle triggered by `trigger_message`."""
+        """Run one observe-decide-act cycle triggered by `trigger_message`.
+
+        Two budgets bound the loop: `max_tool_depth` caps LLM turns, and
+        `max_total_tool_calls` caps total tool executions across the whole
+        iteration. When a turn's tool calls would exceed the total budget, only
+        the permitted prefix is executed; every remaining call in that turn gets
+        an explicit budget_rejection error result (so the conversation history
+        stays structurally valid) and the iteration stops."""
         messages: list[Message] = [Message(role="user", content=trigger_message)]
         turns = 0
         tool_calls_executed = 0
+        proposal_attempts = 0
         proposals_created: list[str] = []
         commits_applied: list[str] = []
         usage_total: dict[str, int] = {}
+        outcome_counts: dict[str, int] = {}
         final_text: Optional[str] = None
 
-        for depth in range(self.max_tool_depth):
+        def _record(category: str) -> None:
+            outcome_counts[category] = outcome_counts.get(category, 0) + 1
+
+        def _result(stopped: str) -> IterationResult:
+            return IterationResult(
+                stopped_because=stopped,
+                turns=turns,
+                tool_calls_executed=tool_calls_executed,
+                proposals_created=proposals_created,
+                commits_applied=commits_applied,
+                final_text=final_text,
+                usage_total=usage_total,
+                outcome_counts=dict(outcome_counts),
+            )
+
+        for _depth in range(self.max_tool_depth):
             response = self.backend.complete(
                 messages=messages,
                 tools=self.tools,
@@ -469,34 +565,49 @@ class Orchestrator:
             turns += 1
             _accumulate_usage(usage_total, response.usage)
             final_text = response.text if response.text is not None else final_text
-
-            # Append assistant content to history for the next turn.
             messages.append(Message(role="assistant", content=list(response.raw_content)))
 
             if not response.tool_calls:
-                return IterationResult(
-                    stopped_because="end_turn",
-                    turns=turns,
-                    tool_calls_executed=tool_calls_executed,
-                    proposals_created=proposals_created,
-                    commits_applied=commits_applied,
-                    final_text=final_text,
-                    usage_total=usage_total,
-                )
+                return _result("end_turn")
 
-            # Execute every tool call in this turn; gather result blocks.
             result_blocks: list = []
+            budget_hit = False
             for call in response.tool_calls:
+                # Total-tool-call budget: once exhausted, refuse every remaining
+                # call in this batch with an explicit error result (unexecuted).
+                if tool_calls_executed >= self.max_total_tool_calls:
+                    _record(CATEGORY_BUDGET_REJECTION)
+                    budget_hit = True
+                    result_blocks.append(_error_block(
+                        call.id, "budget_exhausted", CATEGORY_BUDGET_REJECTION,
+                        "total tool-call budget reached; call not executed"))
+                    continue
+
+                # At most one proposal attempt per iteration, enforced in code.
+                if call.name == "propose_tuning":
+                    if proposal_attempts >= 1:
+                        tool_calls_executed += 1
+                        _record(CATEGORY_PROPOSAL_LIMIT)
+                        result_blocks.append(_error_block(
+                            call.id, "proposal_limit_exceeded", CATEGORY_PROPOSAL_LIMIT,
+                            "at most one proposal attempt per iteration"))
+                        continue
+                    proposal_attempts += 1
+
                 payload, is_error = self.router.execute(call.name, call.arguments)
                 tool_calls_executed += 1
-                if call.name == "propose_tuning" and not is_error:
-                    pid = payload.get("proposal_id")
-                    if pid:
-                        proposals_created.append(pid)
-                elif call.name == "commit_tuning" and not is_error:
-                    pid = payload.get("proposal_id")
-                    if pid and payload.get("status") == "committed":
-                        commits_applied.append(pid)
+                if is_error:
+                    _record(str(payload.get("category", CATEGORY_HANDLER_EXCEPTION)))
+                else:
+                    _record(OUTCOME_OK)
+                    if call.name == "propose_tuning":
+                        pid = payload.get("proposal_id")
+                        if pid:
+                            proposals_created.append(pid)
+                    elif call.name == "commit_tuning":
+                        pid = payload.get("proposal_id")
+                        if pid and payload.get("status") == "committed":
+                            commits_applied.append(pid)
                 result_blocks.append(
                     ToolResultBlock(
                         tool_use_id=call.id,
@@ -505,17 +616,61 @@ class Orchestrator:
                     )
                 )
             messages.append(Message(role="user", content=result_blocks))
+            if budget_hit:
+                return _result("tool_budget_exhausted")
 
-        # Hit depth cap without the LLM naturally ending.
-        return IterationResult(
-            stopped_because="max_depth",
-            turns=turns,
-            tool_calls_executed=tool_calls_executed,
-            proposals_created=proposals_created,
-            commits_applied=commits_applied,
-            final_text=final_text,
-            usage_total=usage_total,
-        )
+        return _result("max_depth")
+
+
+def _error_block(tool_use_id: str, error: str, category: str, message: str) -> ToolResultBlock:
+    """A structured, bounded error tool-result block (no payloads)."""
+    return ToolResultBlock(
+        tool_use_id=tool_use_id,
+        content=json.dumps(
+            {"error": error, "category": category, "message": message},
+            sort_keys=True,
+        ),
+        is_error=True,
+    )
+
+
+def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
+    """Build a bounded, payload-free LeanCTX audit receipt from an
+    IterationResult. Deterministic (sorted keys, stable ordering) and capped at
+    MAX_RECEIPT_BYTES; if the id lists were ever large enough to exceed the cap
+    they are truncated deterministically and ``truncated`` is set true.
+
+    The receipt intentionally excludes tool payloads, prompts, credentials,
+    headers, and raw backend responses — only outcome metadata is retained."""
+    receipt: dict[str, Any] = {
+        "schema": "leanctx-orchestrator-v1",
+        "stopped_because": result.stopped_because,
+        "turns": result.turns,
+        "tool_calls_executed": result.tool_calls_executed,
+        "outcome_counts": dict(sorted(result.outcome_counts.items())),
+        "proposals_created": list(result.proposals_created),
+        "commits_applied": list(result.commits_applied),
+        "usage_total": dict(sorted(result.usage_total.items())),
+        "truncated": False,
+    }
+
+    def _size(obj: dict) -> int:
+        return len(json.dumps(obj, sort_keys=True).encode("utf-8"))
+
+    # Deterministic truncation safety net (never expected to trigger, since the
+    # receipt holds only ids/counts, but enforced so the bound is a guarantee).
+    while _size(receipt) > MAX_RECEIPT_BYTES:
+        receipt["truncated"] = True
+        if receipt["proposals_created"]:
+            receipt["proposals_created"] = receipt["proposals_created"][:-1]
+            continue
+        if receipt["commits_applied"]:
+            receipt["commits_applied"] = receipt["commits_applied"][:-1]
+            continue
+        # Nothing left to trim; drop the counts detail as a last resort.
+        receipt["outcome_counts"] = {}
+        break
+    return receipt
 
 
 def _accumulate_usage(total: dict[str, int], step: dict[str, Any]) -> None:
@@ -539,4 +694,15 @@ __all__ = [
     "observation_tools",
     "proposal_tools",
     "tools_for_mode",
+    "build_audit_receipt",
+    "DEFAULT_MAX_TOTAL_TOOL_CALLS",
+    "MAX_LIMIT_CEILING",
+    "MAX_RECEIPT_BYTES",
+    "OUTCOME_OK",
+    "CATEGORY_UNKNOWN_TOOL",
+    "CATEGORY_HANDLER_EXCEPTION",
+    "CATEGORY_TRANSPORT_FAILURE",
+    "CATEGORY_HTTP_REJECTION",
+    "CATEGORY_BUDGET_REJECTION",
+    "CATEGORY_PROPOSAL_LIMIT",
 ]

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -37,6 +37,7 @@ Capability quarantine (Package S):
 from __future__ import annotations
 
 import json
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -493,21 +494,25 @@ class IterationResult:
     """Last assistant text block, if any."""
 
     usage_total: dict[str, int] = field(default_factory=dict)
-    """Sum of input/output tokens across all turns this iteration."""
+    """Sum of tokens across all turns this iteration. In the audit receipt only
+    ``input_tokens`` / ``output_tokens`` are retained (other keys discarded)."""
 
     outcome_counts: dict[str, int] = field(default_factory=dict)
-    """Deterministic count of tool-call outcomes by category (ok, unknown_tool,
-    handler_exception, transport_failure, http_rejection, budget_rejection,
-    proposal_limit)."""
+    """Deterministic count of tool-call outcomes by category: ``ok``,
+    ``unknown_tool``, ``handler_exception``, ``transport_failure``,
+    ``http_rejection``, ``budget_rejection``, ``proposal_limit``,
+    ``local_rejection``. The audit receipt keeps only these known categories."""
 
     def audit_receipt(self) -> dict[str, Any]:
         """A bounded, payload-free LeanCTX audit handoff for this iteration.
 
-        Contains only outcome metadata: stop reason, counts, usage, and the
-        ids of successful proposals — never tool payloads, prompts, credentials,
-        headers, or raw backend responses. Deterministically serializable and
-        guaranteed <= MAX_RECEIPT_BYTES (deterministic truncation if ever
-        exceeded)."""
+        Built by strict allowlist normalization (see ``build_audit_receipt``):
+        only the fixed receipt schema survives — stop reason (allowlisted or
+        ``unknown``), non-negative clamped counts, known outcome/usage keys, and
+        id-alphabet proposal/commit ids. Never tool payloads, prompts,
+        credentials, headers, or raw backend responses. Deterministically
+        serializable with plain ``json.dumps`` and guaranteed
+        ≤ MAX_RECEIPT_BYTES."""
         return build_audit_receipt(self)
 
 
@@ -665,103 +670,144 @@ def _error_block(tool_use_id: str, error: str, category: str, message: str) -> T
     )
 
 
-# -- audit receipt bounding helpers -----------------------------------------
+# -- audit receipt: strict allowlist normalization --------------------------
+#
+# The receipt carries ONLY known, fixed-schema values. Every field is
+# allowlisted, so no arbitrary input key, secret-looking text, or object
+# __str__ can ever enter it — unknown/invalid values are DISCARDED or replaced
+# by a fixed token, never stringified. Because every surviving value is already
+# a bounded JSON primitive, the receipt serializes with plain
+# ``json.dumps(..., sort_keys=True)`` (no ``default=str`` crutch), and the size
+# guarantee holds before serialization rather than being patched after it.
 
-_RECEIPT_MAX_STR = 256
-"""Max length of any single bounded string field before it is truncated."""
 _RECEIPT_MAX_ID = 128
-"""Max length of a single id string in a list field."""
+"""Max length of a single retained id string."""
 _RECEIPT_MAX_LIST = 64
 """Max number of ids retained in a list field."""
-_RECEIPT_MAX_MAP = 64
-"""Max number of entries retained in a count/usage map."""
+_RECEIPT_MAX_UINT = 10 ** 12
+"""Magnitude clamp for any count/usage integer (well beyond any real value)."""
+
+_ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,%d}\Z" % _RECEIPT_MAX_ID)
+"""The proposal/commit id alphabet: ASCII word chars and dashes, bounded."""
+
+_ALLOWED_STOP_REASONS = frozenset({"end_turn", "max_depth", "tool_budget_exhausted"})
+_ALLOWED_OUTCOME_KEYS = frozenset({
+    OUTCOME_OK, CATEGORY_UNKNOWN_TOOL, CATEGORY_HANDLER_EXCEPTION,
+    CATEGORY_TRANSPORT_FAILURE, CATEGORY_HTTP_REJECTION,
+    CATEGORY_BUDGET_REJECTION, CATEGORY_PROPOSAL_LIMIT, CATEGORY_LOCAL_REJECTION,
+})
+_ALLOWED_USAGE_KEYS = frozenset({"input_tokens", "output_tokens"})
 
 
-# Each bounding helper returns (value, truncated) so build_audit_receipt can
-# honestly flag ``truncated=True`` whenever real data was dropped (an overlong
-# string shortened, or a list/map that had more entries than the cap). Pure
-# type coercion of a scalar count is normalization, not truncation, and does
-# not set the flag.
+def _norm_uint(value: Any) -> tuple[int, bool]:
+    """Non-negative bounded integer normalizer → (value, changed). Rejects
+    bool, negatives and non-integers (→ 0) and clamps oversized magnitudes.
+    Never invokes ``__str__`` and never raises (even on 10**10000)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0, True
+    if value < 0:
+        return 0, True
+    if value > _RECEIPT_MAX_UINT:
+        return _RECEIPT_MAX_UINT, True
+    return value, False
 
 
-def _bounded_str(value: Any, limit: int = _RECEIPT_MAX_STR) -> tuple[str, bool]:
-    s = value if isinstance(value, str) else str(value)
-    if len(s) <= limit:
-        return s, False
-    return s[:limit] + "…", True
+def _norm_stop_reason(value: Any) -> tuple[str, bool]:
+    """Allowlist the stop reason. Any unknown or non-string value becomes the
+    fixed token ``"unknown"`` — its text is never copied or prefixed."""
+    if isinstance(value, str) and value in _ALLOWED_STOP_REASONS:
+        return value, False
+    return "unknown", True
 
 
-def _bounded_int(value: Any) -> int:
-    # bool is a subclass of int; treat non-ints (and bools) as 0 so the receipt
-    # never carries an unexpected type or a huge repr.
-    return value if isinstance(value, int) and not isinstance(value, bool) else 0
-
-
-def _bounded_id_list(values: Any) -> tuple[list[str], bool]:
+def _norm_id_list(values: Any) -> tuple[list[str], bool]:
+    """Keep only safe id-alphabet strings (``[A-Za-z0-9_-]``, ≤128 chars), up to
+    the list cap → (ids, changed). Invalid or non-string entries are omitted
+    without invoking ``__str__``; a non-list input yields an empty list."""
     if not isinstance(values, (list, tuple)):
-        return [], False
+        return [], True
     items = list(values)
-    truncated = len(items) > _RECEIPT_MAX_LIST
+    changed = len(items) > _RECEIPT_MAX_LIST
     out: list[str] = []
     for v in items[:_RECEIPT_MAX_LIST]:
-        s, t = _bounded_str(v, _RECEIPT_MAX_ID)
-        out.append(s)
-        truncated = truncated or t
-    return out, truncated
+        if isinstance(v, str) and _ID_RE.match(v):
+            out.append(v)
+        else:
+            changed = True  # dropped an invalid / non-string id
+    return out, changed
 
 
-def _bounded_count_map(mapping: Any) -> tuple[dict[str, int], bool]:
+def _norm_count_map(mapping: Any, allowed_keys: frozenset) -> tuple[dict[str, int], bool]:
+    """Keep only allowlisted string keys mapped to normalized non-negative
+    integers → (map, changed). Unknown or non-string keys are discarded (never
+    stringified, so coercion cannot create a key collision)."""
     if not isinstance(mapping, dict):
-        return {}, False
-    items = list(mapping.items())
-    truncated = len(items) > _RECEIPT_MAX_MAP
+        return {}, True
     out: dict[str, int] = {}
-    for key, value in items[:_RECEIPT_MAX_MAP]:
-        ks, t = _bounded_str(key, 64)
-        out[ks] = _bounded_int(value)
-        truncated = truncated or t
-    return dict(sorted(out.items())), truncated
+    changed = False
+    for key, value in mapping.items():
+        if not isinstance(key, str) or key not in allowed_keys:
+            changed = True  # discard unknown / non-string key, no __str__
+            continue
+        iv, ic = _norm_uint(value)
+        out[key] = iv
+        changed = changed or ic
+    return dict(sorted(out.items())), changed
 
 
 def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
     """Build a bounded, payload-free LeanCTX audit receipt from an
-    IterationResult. Deterministic (sorted keys, stable ordering) and
-    **guaranteed** ≤ MAX_RECEIPT_BYTES.
+    IterationResult. Deterministic (sorted keys) and **guaranteed**
+    ≤ MAX_RECEIPT_BYTES.
 
-    Every field is whitelisted and bounded on the way in (string lengths, list
-    lengths, map sizes, numeric types), so even a manually- or adversarially-
-    constructed IterationResult — a huge stop reason, oversized outcome/usage
-    keys, enormous id lists, or unusual value types — cannot inflate the
-    receipt. A progressive deterministic trim plus a fixed minimal fallback
-    make the size cap a hard guarantee rather than a hope.
+    Supported schema (all other input is discarded, never stringified):
 
-    The receipt intentionally excludes tool payloads, prompts, credentials,
-    headers, and raw backend responses — only outcome metadata is retained."""
-    stopped, t_stop = _bounded_str(getattr(result, "stopped_because", ""))
-    outcome_counts, t_oc = _bounded_count_map(getattr(result, "outcome_counts", {}))
-    proposals, t_pc = _bounded_id_list(getattr(result, "proposals_created", []))
-    commits, t_ca = _bounded_id_list(getattr(result, "commits_applied", []))
-    usage, t_us = _bounded_count_map(getattr(result, "usage_total", {}))
+    - ``schema`` — fixed literal.
+    - ``stopped_because`` — one of ``end_turn`` / ``max_depth`` /
+      ``tool_budget_exhausted``; any other value becomes ``unknown``.
+    - ``turns`` / ``tool_calls_executed`` — non-negative integers, magnitude-
+      clamped.
+    - ``outcome_counts`` — only the known outcome categories → non-negative
+      ints.
+    - ``usage_total`` — only ``input_tokens`` / ``output_tokens`` → non-negative
+      ints.
+    - ``proposals_created`` / ``commits_applied`` — id-alphabet strings only,
+      list-capped.
+    - ``truncated`` — true whenever any value was normalized away, or the
+      trim loop / fixed minimal fallback fired.
+
+    Because every surviving value is a bounded JSON primitive, no arbitrary
+    input key, secret-looking text, or object ``__str__`` can enter the
+    receipt, and it excludes tool payloads, prompts, credentials, headers, and
+    raw backend responses."""
+    stopped, t_stop = _norm_stop_reason(getattr(result, "stopped_because", ""))
+    turns, t_turns = _norm_uint(getattr(result, "turns", 0))
+    tce, t_tce = _norm_uint(getattr(result, "tool_calls_executed", 0))
+    outcome_counts, t_oc = _norm_count_map(
+        getattr(result, "outcome_counts", {}), _ALLOWED_OUTCOME_KEYS)
+    proposals, t_pc = _norm_id_list(getattr(result, "proposals_created", []))
+    commits, t_ca = _norm_id_list(getattr(result, "commits_applied", []))
+    usage, t_us = _norm_count_map(
+        getattr(result, "usage_total", {}), _ALLOWED_USAGE_KEYS)
     receipt: dict[str, Any] = {
         "schema": "leanctx-orchestrator-v1",
         "stopped_because": stopped,
-        "turns": _bounded_int(getattr(result, "turns", 0)),
-        "tool_calls_executed": _bounded_int(getattr(result, "tool_calls_executed", 0)),
+        "turns": turns,
+        "tool_calls_executed": tce,
         "outcome_counts": outcome_counts,
         "proposals_created": proposals,
         "commits_applied": commits,
         "usage_total": usage,
-        # Honest flag: any field-level drop (overlong string, over-cap list/map)
-        # already marks the receipt truncated; the trim loop below may set it too.
-        "truncated": any((t_stop, t_oc, t_pc, t_ca, t_us)),
+        "truncated": any((t_stop, t_turns, t_tce, t_oc, t_pc, t_ca, t_us)),
     }
 
+    # Every value is already a bounded JSON primitive → plain dumps, no
+    # default=str. This is the true size, computed before any external consumer.
     def _size(obj: dict) -> int:
-        return len(json.dumps(obj, sort_keys=True, default=str).encode("utf-8"))
+        return len(json.dumps(obj, sort_keys=True).encode("utf-8"))
 
-    # The whitelisting above already bounds the receipt well under the cap;
-    # this progressive trim is the hard guarantee if the constants were ever
-    # mis-set. Steps are deterministic and ordered least- to most-destructive.
+    # Allowlisting already bounds the receipt far under the cap; this
+    # deterministic trim + fixed minimal fallback are the final guarantee.
     while _size(receipt) > MAX_RECEIPT_BYTES:
         receipt["truncated"] = True
         if receipt["proposals_created"]:
@@ -776,13 +822,11 @@ def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
         if receipt["usage_total"]:
             receipt["usage_total"] = {}
             continue
-        if len(receipt["stopped_because"]) > 16:
-            receipt["stopped_because"] = receipt["stopped_because"][:16]
-            continue
-        # Fixed minimal fallback — guaranteed tiny, always within the cap.
+        # stopped_because is already a short allowlisted token; nothing else to
+        # trim → fixed minimal fallback, guaranteed tiny.
         receipt = {
             "schema": "leanctx-orchestrator-v1",
-            "stopped_because": "truncated",
+            "stopped_because": "unknown",
             "truncated": True,
         }
         break

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -286,6 +286,11 @@ CATEGORY_TRANSPORT_FAILURE = "transport_failure"
 CATEGORY_HTTP_REJECTION = "http_rejection"
 CATEGORY_BUDGET_REJECTION = "budget_rejection"
 CATEGORY_PROPOSAL_LIMIT = "proposal_limit"
+CATEGORY_LOCAL_REJECTION = "local_rejection"
+"""A request the router refused locally before any HTTP call — e.g. a blank
+justification or a forbidden `commit-pending` mode. Distinct from
+`http_rejection` (server said no) because no request left the process; still a
+genuine tool error (is_error=True) that never creates a proposal."""
 
 DEFAULT_MAX_TOTAL_TOOL_CALLS = 24
 """Total tool calls permitted across an entire iteration, independent of the
@@ -362,8 +367,19 @@ class ToolRouter:
                  "message": f"tool {name} not registered"},
                 True,
             )
+        # Handler invocation, return-shape validation, and the _status /
+        # local-rejection inspection all live inside the defensive try, so a
+        # handler that returns a non-dict (None, list, scalar, …) or that
+        # raises becomes a bounded handler_exception error — it can never crash
+        # the iteration loop.
         try:
             payload = handler(arguments)
+            if not isinstance(payload, dict):
+                raise TypeError(
+                    f"handler returned {type(payload).__name__}, expected dict"
+                )
+            is_local_rejection = bool(payload.get("_local_rejection"))
+            status = payload.get("_status")
         except urllib.error.URLError as e:  # network/transport-level failure
             return (
                 {"error": "transport_failure", "category": CATEGORY_TRANSPORT_FAILURE,
@@ -376,7 +392,15 @@ class ToolRouter:
                  "tool": name, "message": f"{type(e).__name__}: {e}"},
                 True,
             )
-        status = payload.get("_status")
+        if is_local_rejection:
+            # A refusal the router enforced locally (blank justification,
+            # commit-pending). A genuine error: flagged is_error, categorized
+            # local_rejection, and — because no request was sent — it cannot
+            # have created a proposal. The internal marker is stripped so it
+            # never reaches the model.
+            clean = {k: v for k, v in payload.items() if k != "_local_rejection"}
+            clean.setdefault("category", CATEGORY_LOCAL_REJECTION)
+            return (clean, True)
         if isinstance(status, int) and status >= 400:
             # An HTTP rejection is a genuine tool error. Keep bounded metadata
             # (status + any error code/message) but flag it so callers do not
@@ -411,13 +435,20 @@ class ToolRouter:
         params = args.get("params") or {}
         justification = args.get("justification") or ""
         requested_mode = args.get("mode", "dry-run")
+        # Local refusals carry `_local_rejection` so execute() flags them
+        # is_error with the local_rejection category and no request is sent —
+        # so they can never mint a proposal id.
         if not justification.strip():
             return {"error": "bad_request",
+                    "category": CATEGORY_LOCAL_REJECTION,
+                    "_local_rejection": True,
                     "message": "justification is required and must be non-empty"}
         # commit-pending is rejected outright (not silently downgraded) so the
         # caller sees that only dry-run is available in this quarantined path.
         if requested_mode == "commit-pending":
             return {"error": "commit_pending_forbidden",
+                    "category": CATEGORY_LOCAL_REJECTION,
+                    "_local_rejection": True,
                     "message": "This orchestrator validates dry-run only; "
                                "commit-pending is not permitted."}
         # Any other requested mode is forced to dry-run at the boundary.
@@ -634,31 +665,103 @@ def _error_block(tool_use_id: str, error: str, category: str, message: str) -> T
     )
 
 
+# -- audit receipt bounding helpers -----------------------------------------
+
+_RECEIPT_MAX_STR = 256
+"""Max length of any single bounded string field before it is truncated."""
+_RECEIPT_MAX_ID = 128
+"""Max length of a single id string in a list field."""
+_RECEIPT_MAX_LIST = 64
+"""Max number of ids retained in a list field."""
+_RECEIPT_MAX_MAP = 64
+"""Max number of entries retained in a count/usage map."""
+
+
+# Each bounding helper returns (value, truncated) so build_audit_receipt can
+# honestly flag ``truncated=True`` whenever real data was dropped (an overlong
+# string shortened, or a list/map that had more entries than the cap). Pure
+# type coercion of a scalar count is normalization, not truncation, and does
+# not set the flag.
+
+
+def _bounded_str(value: Any, limit: int = _RECEIPT_MAX_STR) -> tuple[str, bool]:
+    s = value if isinstance(value, str) else str(value)
+    if len(s) <= limit:
+        return s, False
+    return s[:limit] + "…", True
+
+
+def _bounded_int(value: Any) -> int:
+    # bool is a subclass of int; treat non-ints (and bools) as 0 so the receipt
+    # never carries an unexpected type or a huge repr.
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _bounded_id_list(values: Any) -> tuple[list[str], bool]:
+    if not isinstance(values, (list, tuple)):
+        return [], False
+    items = list(values)
+    truncated = len(items) > _RECEIPT_MAX_LIST
+    out: list[str] = []
+    for v in items[:_RECEIPT_MAX_LIST]:
+        s, t = _bounded_str(v, _RECEIPT_MAX_ID)
+        out.append(s)
+        truncated = truncated or t
+    return out, truncated
+
+
+def _bounded_count_map(mapping: Any) -> tuple[dict[str, int], bool]:
+    if not isinstance(mapping, dict):
+        return {}, False
+    items = list(mapping.items())
+    truncated = len(items) > _RECEIPT_MAX_MAP
+    out: dict[str, int] = {}
+    for key, value in items[:_RECEIPT_MAX_MAP]:
+        ks, t = _bounded_str(key, 64)
+        out[ks] = _bounded_int(value)
+        truncated = truncated or t
+    return dict(sorted(out.items())), truncated
+
+
 def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
     """Build a bounded, payload-free LeanCTX audit receipt from an
-    IterationResult. Deterministic (sorted keys, stable ordering) and capped at
-    MAX_RECEIPT_BYTES; if the id lists were ever large enough to exceed the cap
-    they are truncated deterministically and ``truncated`` is set true.
+    IterationResult. Deterministic (sorted keys, stable ordering) and
+    **guaranteed** ≤ MAX_RECEIPT_BYTES.
+
+    Every field is whitelisted and bounded on the way in (string lengths, list
+    lengths, map sizes, numeric types), so even a manually- or adversarially-
+    constructed IterationResult — a huge stop reason, oversized outcome/usage
+    keys, enormous id lists, or unusual value types — cannot inflate the
+    receipt. A progressive deterministic trim plus a fixed minimal fallback
+    make the size cap a hard guarantee rather than a hope.
 
     The receipt intentionally excludes tool payloads, prompts, credentials,
     headers, and raw backend responses — only outcome metadata is retained."""
+    stopped, t_stop = _bounded_str(getattr(result, "stopped_because", ""))
+    outcome_counts, t_oc = _bounded_count_map(getattr(result, "outcome_counts", {}))
+    proposals, t_pc = _bounded_id_list(getattr(result, "proposals_created", []))
+    commits, t_ca = _bounded_id_list(getattr(result, "commits_applied", []))
+    usage, t_us = _bounded_count_map(getattr(result, "usage_total", {}))
     receipt: dict[str, Any] = {
         "schema": "leanctx-orchestrator-v1",
-        "stopped_because": result.stopped_because,
-        "turns": result.turns,
-        "tool_calls_executed": result.tool_calls_executed,
-        "outcome_counts": dict(sorted(result.outcome_counts.items())),
-        "proposals_created": list(result.proposals_created),
-        "commits_applied": list(result.commits_applied),
-        "usage_total": dict(sorted(result.usage_total.items())),
-        "truncated": False,
+        "stopped_because": stopped,
+        "turns": _bounded_int(getattr(result, "turns", 0)),
+        "tool_calls_executed": _bounded_int(getattr(result, "tool_calls_executed", 0)),
+        "outcome_counts": outcome_counts,
+        "proposals_created": proposals,
+        "commits_applied": commits,
+        "usage_total": usage,
+        # Honest flag: any field-level drop (overlong string, over-cap list/map)
+        # already marks the receipt truncated; the trim loop below may set it too.
+        "truncated": any((t_stop, t_oc, t_pc, t_ca, t_us)),
     }
 
     def _size(obj: dict) -> int:
-        return len(json.dumps(obj, sort_keys=True).encode("utf-8"))
+        return len(json.dumps(obj, sort_keys=True, default=str).encode("utf-8"))
 
-    # Deterministic truncation safety net (never expected to trigger, since the
-    # receipt holds only ids/counts, but enforced so the bound is a guarantee).
+    # The whitelisting above already bounds the receipt well under the cap;
+    # this progressive trim is the hard guarantee if the constants were ever
+    # mis-set. Steps are deterministic and ordered least- to most-destructive.
     while _size(receipt) > MAX_RECEIPT_BYTES:
         receipt["truncated"] = True
         if receipt["proposals_created"]:
@@ -667,8 +770,21 @@ def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
         if receipt["commits_applied"]:
             receipt["commits_applied"] = receipt["commits_applied"][:-1]
             continue
-        # Nothing left to trim; drop the counts detail as a last resort.
-        receipt["outcome_counts"] = {}
+        if receipt["outcome_counts"]:
+            receipt["outcome_counts"] = {}
+            continue
+        if receipt["usage_total"]:
+            receipt["usage_total"] = {}
+            continue
+        if len(receipt["stopped_because"]) > 16:
+            receipt["stopped_because"] = receipt["stopped_because"][:16]
+            continue
+        # Fixed minimal fallback — guaranteed tiny, always within the cap.
+        receipt = {
+            "schema": "leanctx-orchestrator-v1",
+            "stopped_because": "truncated",
+            "truncated": True,
+        }
         break
     return receipt
 
@@ -705,4 +821,5 @@ __all__ = [
     "CATEGORY_HTTP_REJECTION",
     "CATEGORY_BUDGET_REJECTION",
     "CATEGORY_PROPOSAL_LIMIT",
+    "CATEGORY_LOCAL_REJECTION",
 ]

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -509,7 +509,7 @@ class IterationResult:
         Built by strict allowlist normalization (see ``build_audit_receipt``):
         only the fixed receipt schema survives — stop reason (allowlisted or
         ``unknown``), non-negative clamped counts, known outcome/usage keys, and
-        id-alphabet proposal/commit ids. Never tool payloads, prompts,
+        canonical proposal ids. Never tool payloads, prompts,
         credentials, headers, or raw backend responses. Deterministically
         serializable with plain ``json.dumps`` and guaranteed
         ≤ MAX_RECEIPT_BYTES."""
@@ -680,15 +680,17 @@ def _error_block(tool_use_id: str, error: str, category: str, message: str) -> T
 # ``json.dumps(..., sort_keys=True)`` (no ``default=str`` crutch), and the size
 # guarantee holds before serialization rather than being patched after it.
 
-_RECEIPT_MAX_ID = 128
-"""Max length of a single retained id string."""
 _RECEIPT_MAX_LIST = 64
 """Max number of ids retained in a list field."""
 _RECEIPT_MAX_UINT = 10 ** 12
 """Magnitude clamp for any count/usage integer (well beyond any real value)."""
 
-_ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,%d}\Z" % _RECEIPT_MAX_ID)
-"""The proposal/commit id alphabet: ASCII word chars and dashes, bounded."""
+_ID_RE = re.compile(r"\Aprop-[0-9a-f]{8}\Z")
+"""The canonical production proposal id: ``prop-`` + 8 lowercase hex chars, as
+minted by ``tuning_api._new_proposal_id`` (``"prop-" + secrets.token_hex(4)``).
+Both ``proposals_created`` and ``commits_applied`` hold proposal ids. Anything
+that is not exactly this shape — a secret-looking string, arbitrary otherwise-
+valid text, an uppercase/overlong/malformed id, or a non-string — is discarded."""
 
 _ALLOWED_STOP_REASONS = frozenset({"end_turn", "max_depth", "tool_budget_exhausted"})
 _ALLOWED_OUTCOME_KEYS = frozenset({
@@ -721,10 +723,12 @@ def _norm_stop_reason(value: Any) -> tuple[str, bool]:
 
 
 def _norm_id_list(values: Any) -> tuple[list[str], bool]:
-    """Keep only safe id-alphabet strings (``[A-Za-z0-9_-]``, ≤128 chars), up to
-    the list cap → (ids, changed). Invalid or non-string entries are omitted
-    without invoking ``__str__``; a non-list input yields an empty list."""
-    if not isinstance(values, (list, tuple)):
+    """Keep only canonical proposal ids (``prop-`` + 8 lowercase hex), up to the
+    list cap → (ids, changed). Anything else is omitted without invoking
+    ``__str__``. Only an EXACT built-in ``list``/``tuple`` is iterated — a
+    hostile subclass (e.g. one whose ``__iter__`` raises) is rejected by type
+    before iteration, yielding an empty list with ``changed=True``."""
+    if type(values) not in (list, tuple):
         return [], True
     items = list(values)
     changed = len(items) > _RECEIPT_MAX_LIST
@@ -733,15 +737,17 @@ def _norm_id_list(values: Any) -> tuple[list[str], bool]:
         if isinstance(v, str) and _ID_RE.match(v):
             out.append(v)
         else:
-            changed = True  # dropped an invalid / non-string id
+            changed = True  # dropped a non-canonical / non-string id
     return out, changed
 
 
 def _norm_count_map(mapping: Any, allowed_keys: frozenset) -> tuple[dict[str, int], bool]:
     """Keep only allowlisted string keys mapped to normalized non-negative
     integers → (map, changed). Unknown or non-string keys are discarded (never
-    stringified, so coercion cannot create a key collision)."""
-    if not isinstance(mapping, dict):
+    stringified, so coercion cannot create a key collision). Only an EXACT
+    built-in ``dict`` is read — a hostile subclass (e.g. one whose ``items``
+    raises) is rejected by type before ``.items()`` is ever called."""
+    if type(mapping) is not dict:
         return {}, True
     out: dict[str, int] = {}
     changed = False
@@ -771,8 +777,8 @@ def build_audit_receipt(result: "IterationResult") -> dict[str, Any]:
       ints.
     - ``usage_total`` — only ``input_tokens`` / ``output_tokens`` → non-negative
       ints.
-    - ``proposals_created`` / ``commits_applied`` — id-alphabet strings only,
-      list-capped.
+    - ``proposals_created`` / ``commits_applied`` — canonical proposal ids only
+      (``prop-`` + 8 lowercase hex), list-capped; anything else discarded.
     - ``truncated`` — true whenever any value was normalized away, or the
       trim loop / fixed minimal fallback fired.
 

--- a/scripts/orchestrator_config.py
+++ b/scripts/orchestrator_config.py
@@ -64,6 +64,7 @@ from scripts.agent_backends import (
     OpenAICompatBackend,
 )
 from scripts.orchestrator import (
+    DEFAULT_MAX_TOTAL_TOOL_CALLS,
     MODE_OBSERVE,
     Orchestrator,
     OrchestratorClient,
@@ -118,6 +119,7 @@ class OrchestratorConfig:
     system_prompt: str = DEFAULT_SYSTEM_PROMPT
     mode: OrchestratorMode = MODE_OBSERVE
     max_tool_depth: int = 8
+    max_total_tool_calls: int = DEFAULT_MAX_TOTAL_TOOL_CALLS
     max_tokens: int = 2048
     temperature: float = 0.0
     orchestrator_source: str = "agent:orchestrator"
@@ -145,6 +147,8 @@ class OrchestratorConfig:
             # Fail-closed: absent/malformed/unknown → observe (resolve_mode).
             mode=resolve_mode(os.environ.get("MEDUSA_ORCHESTRATOR_MODE")),
             max_tool_depth=int(os.environ.get("MEDUSA_MAX_TOOL_DEPTH", "8")),
+            max_total_tool_calls=int(os.environ.get(
+                "MEDUSA_MAX_TOTAL_TOOL_CALLS", str(DEFAULT_MAX_TOTAL_TOOL_CALLS))),
             max_tokens=int(os.environ.get("MEDUSA_MAX_TOKENS", "2048")),
             openai_base_url=os.environ.get("MEDUSA_OPENAI_BASE_URL") or None,
             openai_model=os.environ.get("MEDUSA_OPENAI_MODEL") or None,
@@ -236,6 +240,7 @@ def create_orchestrator(
         tools=tools_for_mode(config.mode),
         router=router,
         max_tool_depth=config.max_tool_depth,
+        max_total_tool_calls=config.max_total_tool_calls,
         max_tokens_per_call=config.max_tokens,
         temperature=config.temperature,
     )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -36,12 +36,16 @@ from scripts.agent_backends import (
     ToolUseBlock,
 )
 from scripts.orchestrator import (
+    DEFAULT_MAX_TOTAL_TOOL_CALLS,
     IterationResult,
+    MAX_LIMIT_CEILING,
+    MAX_RECEIPT_BYTES,
     MODE_OBSERVE,
     MODE_PROPOSE,
     Orchestrator,
     OrchestratorClient,
     ToolRouter,
+    build_audit_receipt,
     observation_tools,
     proposal_tools,
     resolve_mode,
@@ -223,15 +227,17 @@ def test_router_handler_exception_becomes_error_payload():
     assert payload["error"] == "tool_handler_exception"
 
 
-def test_router_http_error_status_propagates():
+def test_router_http_error_status_is_flagged_as_error():
+    """Package T: HTTP status >= 400 is a genuine tool error (is_error True),
+    categorized http_rejection, with bounded status/error metadata retained."""
     client, http = _client_with_fake()
     http.set("GET", "/api/census", 500, {"error": "server_broke"})
     router = ToolRouter(client)
     payload, is_error = router.execute("get_medusa_census", {})
-    # is_error is False at router level (handler succeeded), but _status is in payload.
-    assert is_error is False
+    assert is_error is True
     assert payload["_status"] == 500
     assert payload["error"] == "server_broke"
+    assert payload["category"] == "http_rejection"
 
 
 # -- Orchestrator ------------------------------------------------------------
@@ -634,3 +640,195 @@ def test_create_orchestrator_propose_mode_wires_router_and_tools():
     tool_names = {t.name for t in orch.tools}
     assert "propose_tuning" in tool_names
     assert "commit_tuning" not in tool_names
+
+
+# -- Package T: hard limits, error semantics, bounded audit receipts ---------
+
+
+def _obs_call(i: int):
+    return _tool_use_response(f"tu_{i}", "get_medusa_census", {})
+
+
+def test_total_tool_call_budget_executes_prefix_then_stops():
+    """A single turn emitting more tool calls than the total budget executes
+    only the permitted prefix; the rest get budget_rejection error results and
+    the iteration stops with tool_budget_exhausted. The cap is never exceeded."""
+    from scripts.agent_backends import AgentResponse, ToolUseBlock
+    blocks = [ToolUseBlock(id=f"tu_{i}", name="get_medusa_census", input={}) for i in range(5)]
+    resp = AgentResponse.from_content(blocks, stop_reason="tool_use",
+                                      usage={"input_tokens": 1, "output_tokens": 1})
+    backend = MockBackend(responses=[resp, _text_response("done")])
+    http = FakeHttp()
+    client = OrchestratorClient("http://test:8080", http_do=http)
+    http.set("GET", "/api/census", 200, {"generation": 1})
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        max_tool_depth=4, max_total_tool_calls=3)
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "tool_budget_exhausted"
+    assert result.tool_calls_executed == 3          # never exceeds the cap
+    assert result.outcome_counts.get("ok") == 3
+    assert result.outcome_counts.get("budget_rejection") == 2
+    assert len([c for c in http.calls if c["path"] == "/api/census"]) == 3
+
+
+def test_budget_shared_across_turns():
+    """The total budget is shared across turns, independent of max_tool_depth."""
+    backend = MockBackend(responses=[_obs_call(i) for i in range(10)] + [_text_response("x")])
+    http = FakeHttp()
+    client = OrchestratorClient("http://test:8080", http_do=http)
+    http.set("GET", "/api/census", 200, {"generation": 1})
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        max_tool_depth=10, max_total_tool_calls=2)
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "tool_budget_exhausted"
+    assert result.tool_calls_executed == 2
+
+
+def test_second_proposal_attempt_is_refused():
+    """At most one proposal attempt per iteration, enforced in code."""
+    from scripts.agent_backends import AgentResponse, ToolUseBlock
+    blocks = [
+        ToolUseBlock(id="p1", name="propose_tuning",
+                     input={"params": {"signal_interval": 12}, "justification": "a"}),
+        ToolUseBlock(id="p2", name="propose_tuning",
+                     input={"params": {"signal_interval": 13}, "justification": "b"}),
+    ]
+    resp = AgentResponse.from_content(blocks, stop_reason="tool_use",
+                                      usage={"input_tokens": 1, "output_tokens": 1})
+    backend = MockBackend(responses=[resp, _text_response("done")])
+    http = FakeHttp()
+    client = OrchestratorClient("http://test:8080", http_do=http)
+    http.set("POST", "/api/tuning/propose", 200, {"proposal_id": "prop-1", "status": "accepted"})
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        mode=MODE_PROPOSE, max_tool_depth=4)
+    result = orch.run_one_iteration("go")
+    assert result.proposals_created == ["prop-1"]           # only the first
+    assert result.outcome_counts.get("proposal_limit") == 1
+    assert len([c for c in http.calls if c["path"] == "/api/tuning/propose"]) == 1
+
+
+def test_http_rejections_are_errors_and_not_counted():
+    """403/422/500 tool responses are is_error, categorized http_rejection, and
+    never counted as created proposals or applied commits."""
+    for status in (403, 422, 500):
+        resp = _tool_use_response("tu_p", "propose_tuning",
+                                  {"params": {"signal_interval": 12}, "justification": "x"})
+        backend = MockBackend(responses=[resp, _text_response("done")])
+        http = FakeHttp()
+        client = OrchestratorClient("http://test:8080", http_do=http)
+        http.set("POST", "/api/tuning/propose", status, {"error": "nope"})
+        orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                            mode=MODE_PROPOSE, max_tool_depth=4)
+        result = orch.run_one_iteration("go")
+        assert result.proposals_created == []
+        assert result.outcome_counts.get("http_rejection") == 1
+
+
+def test_transport_failure_is_categorized():
+    """A URLError from the transport surfaces as a transport_failure category,
+    is_error True, without raising up into the loop."""
+    import urllib.error
+
+    def boom_http(method, url, *, json=None, timeout=5.0):
+        raise urllib.error.URLError("network down")
+
+    client = OrchestratorClient("http://test:8080", http_do=boom_http)
+    router = ToolRouter(client)
+    payload, is_error = router.execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == "transport_failure"
+
+
+def test_handler_exception_message_does_not_leak_into_receipt():
+    """A handler exception carrying a sensitive-looking string is surfaced to
+    the LLM as a tool error, but the audit receipt records only the category —
+    never the exception text."""
+    secret = "SECRET_API_KEY_sk-abc123"
+
+    def boom_http(method, url, *, json=None, timeout=5.0):
+        raise ValueError(secret)
+
+    resp = _tool_use_response("tu_c", "get_medusa_census", {})
+    backend = MockBackend(responses=[resp, _text_response("done")])
+    client = OrchestratorClient("http://test:8080", http_do=boom_http)
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s", max_tool_depth=4)
+    result = orch.run_one_iteration("go")
+    assert result.outcome_counts.get("handler_exception") == 1
+    receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
+    assert secret not in receipt_json
+
+
+def test_audit_receipt_is_deterministic_and_bounded():
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_1", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    orch, http = _make_orchestrator(backend)
+    http.set("GET", "/api/census", 200, {"generation": 1})
+    result = orch.run_one_iteration("go")
+    r1 = json.dumps(build_audit_receipt(result), sort_keys=True)
+    r2 = json.dumps(result.audit_receipt(), sort_keys=True)
+    assert r1 == r2                                   # deterministic
+    assert len(r1.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    receipt = build_audit_receipt(result)
+    assert receipt["schema"] == "leanctx-orchestrator-v1"
+    assert receipt["truncated"] is False
+    for banned in ("content", "payload", "system", "messages", "api_key", "headers"):
+        assert banned not in receipt
+
+
+def test_audit_receipt_excludes_large_tool_payloads():
+    """Even if a tool returns a huge body, the receipt stays bounded and holds
+    no payload text (it records only counts/ids)."""
+    huge = {"generation": 1, "blob": "z" * 200000}
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_1", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    orch, http = _make_orchestrator(backend)
+    http.set("GET", "/api/census", 200, huge)
+    result = orch.run_one_iteration("go")
+    receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
+    assert len(receipt_json.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    assert "z" * 1000 not in receipt_json
+
+
+def test_no_post_after_budget_exhaustion():
+    """Once the total budget is spent, no further HTTP POST is attempted."""
+    from scripts.agent_backends import AgentResponse, ToolUseBlock
+    blocks = [ToolUseBlock(id=f"p_{i}", name="propose_tuning",
+                           input={"params": {"signal_interval": 12}, "justification": "j"})
+              for i in range(3)]
+    resp = AgentResponse.from_content(blocks, stop_reason="tool_use",
+                                      usage={"input_tokens": 1, "output_tokens": 1})
+    backend = MockBackend(responses=[resp, _text_response("done")])
+    http = FakeHttp()
+    client = OrchestratorClient("http://test:8080", http_do=http)
+    http.set("POST", "/api/tuning/propose", 200, {"proposal_id": "prop-1", "status": "accepted"})
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        mode=MODE_PROPOSE, max_tool_depth=4, max_total_tool_calls=1)
+    result = orch.run_one_iteration("go")
+    assert result.tool_calls_executed == 1
+    assert len([c for c in http.calls if c["method"] == "POST"]) == 1
+
+
+def test_numeric_limits_are_validated():
+    backend = MockBackend(responses=[_text_response("x")])
+    client = OrchestratorClient("http://test:8080", http_do=FakeHttp())
+    for bad in (0, -1, MAX_LIMIT_CEILING + 1, True):
+        with pytest.raises(ValueError):
+            Orchestrator(backend=backend, client=client, system_prompt="s",
+                         max_total_tool_calls=bad)
+    with pytest.raises(ValueError):
+        Orchestrator(backend=backend, client=client, system_prompt="s", max_tool_depth=0)
+
+
+def test_orchestrator_has_no_reverse_dependency_on_observer_or_engine():
+    """The legacy orchestrator must not import the offline detector, observer,
+    engine, or physics modules — the quarantine is one-directional."""
+    import inspect
+    import scripts.orchestrator as orch_mod
+    src = inspect.getsource(orch_mod)
+    for banned in ("continuous_evolution_ca", "nextness_observer",
+                   "nextness_calibration", "swarm_hunter"):
+        assert banned not in src

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -957,7 +957,17 @@ def test_receipt_colliding_int_and_str_keys_both_discarded():
     assert json.dumps(receipt, sort_keys=True) == json.dumps(build_audit_receipt(result), sort_keys=True)
 
 
-@pytest.mark.parametrize("count", [True, False, -1, 1.5, "3", None, 10 ** 10000])
+@pytest.mark.parametrize("count", [
+    pytest.param(True, id="bool_true"),
+    pytest.param(False, id="bool_false"),
+    pytest.param(-1, id="negative"),
+    pytest.param(1.5, id="float"),
+    pytest.param("3", id="str"),
+    pytest.param(None, id="none"),
+    # Explicit id: a 10001-digit int must not be stringified for the test id
+    # (Python's int->str 4300-digit limit) — the builder clamps it by value.
+    pytest.param(10 ** 10000, id="ten_pow_10000"),
+])
 def test_receipt_rejects_non_uint_counts(count):
     """bool / negative / non-integer / oversized counts are normalized to a
     bounded non-negative int without raising, and flag truncation."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -933,7 +933,8 @@ def test_receipt_bounded_against_adversarial_result():
     assert all(isinstance(v, int) and v >= 0 for v in receipt["outcome_counts"].values())
     assert all(isinstance(v, int) and v >= 0 for v in receipt["usage_total"].values())
     # Specific coercions.
-    assert receipt["outcome_counts"]["ok"] == 10 ** 12          # clamped
+    assert receipt["outcome_counts"]["ok"] == 3                       # valid small int kept
+    assert receipt["usage_total"]["input_tokens"] == 10 ** 12         # huge value clamped
     assert receipt["outcome_counts"].get("local_rejection", 0) == 0   # negative → 0
     assert receipt["outcome_counts"]["handler_exception"] == 0        # boom value → 0
     assert receipt["usage_total"]["output_tokens"] == 0              # list value → 0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -897,9 +897,10 @@ def _adversarial_iteration_result() -> IterationResult:
         stopped_because="sk-SECRET_" + "X" * 300_000,        # secret-looking, huge, unknown
         turns=10 ** 10000,                                   # absurd magnitude
         tool_calls_executed=-9,                              # negative
-        proposals_created=["prop-abc123", "bad id!!", "y" * 400, None,
-                           _StrBoom(), "ok-1"],              # valid + invalid + non-str
-        commits_applied=["commit_9", 42],
+        proposals_created=["prop-deadbeef", "sk-SECRET_TOKEN", "prop-ABCDEF01",
+                           "prop-abc", "y" * 400, None, _StrBoom(),
+                           "prop-0123abcd"],                 # canonical + secret + malformed + non-str
+        commits_applied=["prop-0123abcd", 42, "commit_9"],
         outcome_counts={"K" * 20_000: 1, "ok": 3, "weird" * 100: 2,    # huge/unknown keys
                         1: 9, "1": 11, "local_rejection": -3,          # colliding + negative
                         "handler_exception": _StrBoom(), True: 1},     # __str__-boom value, bool key
@@ -941,9 +942,10 @@ def test_receipt_bounded_against_adversarial_result():
     # Unknown/secret keys removed entirely.
     for banned in ("K" * 20_000, "weird", "U" * 20_000, "unknown_junk"):
         assert banned not in blob
-    # Ids: only valid id-alphabet strings survive; invalid/non-str omitted.
-    assert receipt["proposals_created"] == ["prop-abc123", "ok-1"]
-    assert receipt["commits_applied"] == ["commit_9"]
+    # Ids: only canonical prop-<8 hex> survive; secret/malformed/non-str omitted.
+    assert receipt["proposals_created"] == ["prop-deadbeef", "prop-0123abcd"]
+    assert receipt["commits_applied"] == ["prop-0123abcd"]
+    assert "SECRET_TOKEN" not in blob  # alphabet-valid secret-looking id dropped
 
 
 def test_receipt_colliding_int_and_str_keys_both_discarded():
@@ -988,16 +990,96 @@ def test_receipt_str_boom_object_never_stringified():
     discards them without invoking __str__ and never raises."""
     result = IterationResult(
         stopped_because=_StrBoom(), turns=1, tool_calls_executed=1,
-        proposals_created=[_StrBoom(), "prop-ok"],
+        proposals_created=[_StrBoom(), "prop-0000000a"],
         outcome_counts={"ok": _StrBoom()},
         usage_total={"input_tokens": _StrBoom()},
     )
     receipt = build_audit_receipt(result)   # must not raise
     assert receipt["stopped_because"] == "unknown"
-    assert receipt["proposals_created"] == ["prop-ok"]
+    assert receipt["proposals_created"] == ["prop-0000000a"]
     assert receipt["outcome_counts"]["ok"] == 0
     assert receipt["usage_total"]["input_tokens"] == 0
     assert len(json.dumps(receipt, sort_keys=True).encode("utf-8")) <= MAX_RECEIPT_BYTES
+
+
+def test_receipt_keeps_only_canonical_proposal_ids():
+    """Only canonical production ids (``prop-`` + 8 lowercase hex) survive.
+    Secret-looking but alphabet-valid strings, arbitrary text, uppercase,
+    overlong, short, non-hex, and non-string entries are all dropped —
+    including their prefixes."""
+    result = IterationResult(
+        stopped_because="end_turn", turns=1, tool_calls_executed=1,
+        proposals_created=[
+            "prop-deadbeef", "prop-0123abcd",   # canonical → survive
+            "sk-SECRET_TOKEN",                  # secret-looking, alphabet-valid → drop
+            "arbitrary-valid-text",             # arbitrary → drop
+            "prop-DEADBEEF",                    # uppercase hex → drop
+            "prop-deadbeef00",                  # overlong → drop
+            "prop-abc",                         # too short → drop
+            "prop-ghijklmn",                    # non-hex letters → drop
+            None, 42,                           # non-string → drop
+        ],
+        commits_applied=["prop-0123abcd"],
+    )
+    receipt = build_audit_receipt(result)
+    assert receipt["proposals_created"] == ["prop-deadbeef", "prop-0123abcd"]
+    assert receipt["commits_applied"] == ["prop-0123abcd"]
+    blob = json.dumps(receipt, sort_keys=True)
+    for banned in ("SECRET", "sk-", "arbitrary", "DEADBEEF", "ghij"):
+        assert banned not in blob
+    assert receipt["truncated"] is True
+
+
+class _HostileList(list):
+    def __iter__(self):  # pragma: no cover - must not be invoked
+        raise RuntimeError("__iter__ must not be invoked")
+
+
+class _HostileDict(dict):
+    def items(self):  # pragma: no cover
+        raise RuntimeError("items must not be invoked")
+
+    def __iter__(self):  # pragma: no cover
+        raise RuntimeError("__iter__ must not be invoked")
+
+
+def test_receipt_rejects_hostile_container_subclasses():
+    """A list/dict subclass whose iteration hooks raise is rejected by exact
+    type BEFORE any iteration — the receipt normalizes to empty with
+    truncated=True and never invokes the hostile __iter__/items."""
+    hostile_ids = _HostileList(["prop-deadbeef"])
+    hostile_map = _HostileDict({"ok": 1})
+    result = IterationResult(
+        stopped_because="end_turn", turns=1, tool_calls_executed=1,
+        proposals_created=hostile_ids, commits_applied=hostile_ids,
+        outcome_counts=hostile_map, usage_total=hostile_map,
+    )
+    receipt = build_audit_receipt(result)   # must not raise
+    assert receipt["proposals_created"] == []
+    assert receipt["commits_applied"] == []
+    assert receipt["outcome_counts"] == {}
+    assert receipt["usage_total"] == {}
+    assert receipt["truncated"] is True
+
+
+def test_receipt_normal_production_result_not_truncated():
+    """A realistic production IterationResult — canonical ids, known outcome
+    categories, token usage — passes through untouched with truncated=False and
+    serializes deterministically with plain json.dumps."""
+    result = IterationResult(
+        stopped_because="end_turn", turns=2, tool_calls_executed=3,
+        proposals_created=["prop-deadbeef"],
+        commits_applied=[],
+        outcome_counts={"ok": 3, "local_rejection": 1},
+        usage_total={"input_tokens": 120, "output_tokens": 340},
+    )
+    receipt = build_audit_receipt(result)
+    assert receipt["truncated"] is False
+    assert receipt["proposals_created"] == ["prop-deadbeef"]
+    assert receipt["outcome_counts"] == {"local_rejection": 1, "ok": 3}
+    assert receipt["usage_total"] == {"input_tokens": 120, "output_tokens": 340}
+    assert json.dumps(receipt, sort_keys=True) == json.dumps(
+        build_audit_receipt(result), sort_keys=True)
 
 
 def test_receipt_minimal_fallback_is_within_limit(monkeypatch):
@@ -1012,7 +1094,7 @@ def test_receipt_minimal_fallback_is_within_limit(monkeypatch):
     result = IterationResult(
         stopped_because="end_turn",
         turns=1, tool_calls_executed=1,
-        proposals_created=[f"prop-{i}" for i in range(500)],
+        proposals_created=[f"prop-{i:08x}" for i in range(500)],  # canonical ids
         outcome_counts={"ok": 500},
         usage_total={"input_tokens": 999_999},
     )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -879,53 +879,114 @@ _RECEIPT_SCHEMA_KEYS = {
 }
 
 
+class _StrBoom:
+    """An object whose __str__/__repr__ raise — must never be invoked by the
+    receipt builder (allowlisting discards it without stringifying)."""
+    def __str__(self):  # pragma: no cover - must not be called
+        raise RuntimeError("__str__ must not be invoked")
+    def __repr__(self):  # pragma: no cover
+        raise RuntimeError("__repr__ must not be invoked")
+    def __hash__(self):
+        return 7
+    def __eq__(self, other):
+        return False
+
+
 def _adversarial_iteration_result() -> IterationResult:
     return IterationResult(
-        stopped_because="X" * 300_000,                       # extremely large
-        turns=7,
-        tool_calls_executed=9,
-        proposals_created=["prop-" + "y" * 400 for _ in range(5_000)],  # thousands, oversized
-        commits_applied=["commit-" + "z" * 400 for _ in range(5_000)],
-        outcome_counts={"K" * 20_000: 1, "ok": 3, "weird" * 100: 2},    # huge/unknown keys
-        usage_total={"U" * 20_000: 999, "input_tokens": [1, 2, 3]},      # huge key + unusual value
+        stopped_because="sk-SECRET_" + "X" * 300_000,        # secret-looking, huge, unknown
+        turns=10 ** 10000,                                   # absurd magnitude
+        tool_calls_executed=-9,                              # negative
+        proposals_created=["prop-abc123", "bad id!!", "y" * 400, None,
+                           _StrBoom(), "ok-1"],              # valid + invalid + non-str
+        commits_applied=["commit_9", 42],
+        outcome_counts={"K" * 20_000: 1, "ok": 3, "weird" * 100: 2,    # huge/unknown keys
+                        1: 9, "1": 11, "local_rejection": -3,          # colliding + negative
+                        "handler_exception": _StrBoom(), True: 1},     # __str__-boom value, bool key
+        usage_total={"U" * 20_000: 999, "input_tokens": 10 ** 10000,   # huge key + huge value
+                     "output_tokens": [1, 2, 3], _StrBoom(): 4},       # list value + boom key
     )
 
 
 def test_receipt_bounded_against_adversarial_result():
     """A manually/adversarially-constructed IterationResult cannot inflate the
-    receipt past the cap, is deterministic, flags truncation, keeps only the
-    fixed schema keys, and coerces unusual value types."""
+    receipt, is deterministic under PLAIN json.dumps (no default=str), flags
+    truncation, and survives with only allowlisted, JSON-primitive values."""
     result = _adversarial_iteration_result()
     receipt = build_audit_receipt(result)
-    blob = json.dumps(receipt, sort_keys=True, default=str)
-    # Deterministic serialization.
-    assert blob == json.dumps(build_audit_receipt(result), sort_keys=True, default=str)
-    # Hard byte bound.
+    blob = json.dumps(receipt, sort_keys=True)          # plain dumps — no default=str
+    assert blob == json.dumps(build_audit_receipt(result), sort_keys=True)  # deterministic
     assert len(blob.encode("utf-8")) <= MAX_RECEIPT_BYTES
-    # Reduction occurred → flagged.
     assert receipt["truncated"] is True
-    # Only fixed-schema top-level keys survive — no arbitrary input key.
     assert set(receipt.keys()) == _RECEIPT_SCHEMA_KEYS
-    # Per-field caps.
-    assert len(receipt["proposals_created"]) <= 64
-    assert len(receipt["commits_applied"]) <= 64
-    assert len(receipt["outcome_counts"]) <= 64
-    assert len(receipt["usage_total"]) <= 64
-    assert len(receipt["stopped_because"]) <= 257  # 256 + ellipsis
-    # Unusual usage value coerced to int; no list survives as a value.
-    assert all(isinstance(v, int) for v in receipt["usage_total"].values())
-    assert all(isinstance(v, int) for v in receipt["outcome_counts"].values())
+    # Magnitude-clamped, non-negative ints.
+    assert receipt["turns"] == 10 ** 12
+    assert receipt["tool_calls_executed"] == 0
+    # Stop reason: unknown token, secret text gone entirely (incl. prefixes).
+    assert receipt["stopped_because"] == "unknown"
+    assert "SECRET" not in blob and "sk-" not in blob
+    # Outcome/usage: only allowlisted keys, all non-negative ints.
+    assert set(receipt["outcome_counts"]) <= {
+        "ok", "unknown_tool", "handler_exception", "transport_failure",
+        "http_rejection", "budget_rejection", "proposal_limit", "local_rejection"}
+    assert set(receipt["usage_total"]) <= {"input_tokens", "output_tokens"}
+    assert all(isinstance(v, int) and v >= 0 for v in receipt["outcome_counts"].values())
+    assert all(isinstance(v, int) and v >= 0 for v in receipt["usage_total"].values())
+    # Specific coercions.
+    assert receipt["outcome_counts"]["ok"] == 10 ** 12          # clamped
+    assert receipt["outcome_counts"].get("local_rejection", 0) == 0   # negative → 0
+    assert receipt["outcome_counts"]["handler_exception"] == 0        # boom value → 0
+    assert receipt["usage_total"]["output_tokens"] == 0              # list value → 0
+    # Unknown/secret keys removed entirely.
+    for banned in ("K" * 20_000, "weird", "U" * 20_000, "unknown_junk"):
+        assert banned not in blob
+    # Ids: only valid id-alphabet strings survive; invalid/non-str omitted.
+    assert receipt["proposals_created"] == ["prop-abc123", "ok-1"]
+    assert receipt["commits_applied"] == ["commit_9"]
 
 
-def test_receipt_truncates_oversized_secret_like_stop_reason():
-    """A secret-looking string longer than the cap does not survive intact in
-    the receipt (it is bounded to 256 chars and the receipt is flagged)."""
-    secret = "sk-" + "A" * 5_000
-    result = IterationResult(stopped_because=secret, turns=1, tool_calls_executed=0)
+def test_receipt_colliding_int_and_str_keys_both_discarded():
+    """Integer 1 and string '1' are both outside the outcome allowlist and are
+    discarded — no coercion, no key collision, no exception."""
+    result = IterationResult(stopped_because="end_turn", turns=1, tool_calls_executed=0,
+                             outcome_counts={1: 5, "1": 7})
     receipt = build_audit_receipt(result)
+    assert receipt["outcome_counts"] == {}
     assert receipt["truncated"] is True
-    assert secret not in json.dumps(receipt)  # the full secret does not survive
-    assert len(receipt["stopped_because"]) <= 257
+    # Deterministic plain serialization round-trips.
+    assert json.dumps(receipt, sort_keys=True) == json.dumps(build_audit_receipt(result), sort_keys=True)
+
+
+@pytest.mark.parametrize("count", [True, False, -1, 1.5, "3", None, 10 ** 10000])
+def test_receipt_rejects_non_uint_counts(count):
+    """bool / negative / non-integer / oversized counts are normalized to a
+    bounded non-negative int without raising, and flag truncation."""
+    result = IterationResult(stopped_because="end_turn", turns=count, tool_calls_executed=0,
+                             outcome_counts={"ok": count}, usage_total={"input_tokens": count})
+    receipt = build_audit_receipt(result)
+    assert isinstance(receipt["turns"], int) and receipt["turns"] >= 0
+    assert receipt["turns"] <= 10 ** 12
+    assert isinstance(receipt["outcome_counts"]["ok"], int) and receipt["outcome_counts"]["ok"] >= 0
+    assert isinstance(receipt["usage_total"]["input_tokens"], int)
+    assert receipt["truncated"] is True
+    assert len(json.dumps(receipt, sort_keys=True).encode("utf-8")) <= MAX_RECEIPT_BYTES
+
+
+def test_receipt_str_boom_object_never_stringified():
+    """Objects whose __str__ raises appear as ids, keys, and values; the builder
+    discards them without invoking __str__ and never raises."""
+    result = IterationResult(
+        stopped_because=_StrBoom(), turns=1, tool_calls_executed=1,
+        proposals_created=[_StrBoom(), "prop-ok"],
+        outcome_counts={"ok": _StrBoom()},
+        usage_total={"input_tokens": _StrBoom()},
+    )
+    receipt = build_audit_receipt(result)   # must not raise
+    assert receipt["stopped_because"] == "unknown"
+    assert receipt["proposals_created"] == ["prop-ok"]
+    assert receipt["outcome_counts"]["ok"] == 0
+    assert receipt["usage_total"]["input_tokens"] == 0
+    assert len(json.dumps(receipt, sort_keys=True).encode("utf-8")) <= MAX_RECEIPT_BYTES
 
 
 def test_receipt_minimal_fallback_is_within_limit(monkeypatch):
@@ -934,14 +995,14 @@ def test_receipt_minimal_fallback_is_within_limit(monkeypatch):
     through to the fixed minimal fallback, which is itself within the limit."""
     import scripts.orchestrator as orch_mod
     minimal = {"schema": "leanctx-orchestrator-v1",
-               "stopped_because": "truncated", "truncated": True}
+               "stopped_because": "unknown", "truncated": True}
     minimal_size = len(json.dumps(minimal, sort_keys=True).encode("utf-8"))
     monkeypatch.setattr(orch_mod, "MAX_RECEIPT_BYTES", minimal_size + 5)
     result = IterationResult(
-        stopped_because="a long reason " * 50,
+        stopped_because="end_turn",
         turns=1, tool_calls_executed=1,
         proposals_created=[f"prop-{i}" for i in range(500)],
-        outcome_counts={f"k{i}": i for i in range(100)},
+        outcome_counts={"ok": 500},
         usage_total={"input_tokens": 999_999},
     )
     receipt = build_audit_receipt(result)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -36,12 +36,15 @@ from scripts.agent_backends import (
     ToolUseBlock,
 )
 from scripts.orchestrator import (
+    CATEGORY_HANDLER_EXCEPTION,
+    CATEGORY_LOCAL_REJECTION,
     DEFAULT_MAX_TOTAL_TOOL_CALLS,
     IterationResult,
     MAX_LIMIT_CEILING,
     MAX_RECEIPT_BYTES,
     MODE_OBSERVE,
     MODE_PROPOSE,
+    OUTCOME_OK,
     Orchestrator,
     OrchestratorClient,
     ToolRouter,
@@ -173,15 +176,20 @@ def test_router_routes_get_census_through_client():
 
 
 def test_router_propose_requires_nonempty_justification():
+    """A blank justification is a local rejection (Package T amendment): the
+    router refuses it before any HTTP call, flags is_error=True, and categorizes
+    it local_rejection. No `_local_rejection` marker leaks to the model."""
     client, _ = _client_with_fake()
     router = ToolRouter(client, mode=MODE_PROPOSE)
     payload, is_error = router.execute(
         "propose_tuning",
         {"params": {"signal_interval": 12}, "justification": "   "},
     )
-    assert is_error is False  # the handler returns the error as a payload, not raises
+    assert is_error is True
     assert payload["error"] == "bad_request"
+    assert payload["category"] == CATEGORY_LOCAL_REJECTION
     assert "justification" in payload["message"]
+    assert "_local_rejection" not in payload
 
 
 def test_router_propose_calls_client_with_orchestrator_source():
@@ -335,7 +343,8 @@ def test_iteration_commit_tool_call_is_unknown_and_uncommitted():
 
 def test_iteration_commit_pending_proposal_is_rejected():
     """propose mode forces dry-run: a commit-pending request is refused with a
-    deterministic error, not silently downgraded."""
+    deterministic local rejection (Package T amendment), not silently
+    downgraded. It counts under local_rejection, never ok, never a proposal."""
     backend = MockBackend(responses=[
         _tool_use_response("tu_1", "propose_tuning", {
             "params": {"signal_interval": 12},
@@ -350,6 +359,9 @@ def test_iteration_commit_pending_proposal_is_rejected():
     # No proposal was created (the router refused commit-pending before POSTing).
     assert result.proposals_created == []
     assert http.calls == []  # no POST — rejected at the router boundary
+    # Accounting: counted as a local rejection, not a success.
+    assert result.outcome_counts.get(CATEGORY_LOCAL_REJECTION) == 1
+    assert result.outcome_counts.get(OUTCOME_OK, 0) == 0
 
 
 def test_iteration_hits_max_depth():
@@ -791,6 +803,151 @@ def test_audit_receipt_excludes_large_tool_payloads():
     receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
     assert len(receipt_json.encode("utf-8")) <= MAX_RECEIPT_BYTES
     assert "z" * 1000 not in receipt_json
+
+
+# -- Package T amendment (Jack audit): non-dict handlers, local rejections,
+#    and adversarial audit-receipt bounding -----------------------------------
+
+
+@pytest.mark.parametrize("bad_return", [None, [1, 2, 3], "scalar-string", True, 42])
+def test_non_dict_handler_return_becomes_handler_exception(bad_return):
+    """A handler that returns a non-dict (None, list, scalar, bool) is caught by
+    the defensive try boundary and surfaced as a bounded handler_exception —
+    router.execute returns normally, so the iteration loop can never crash."""
+    client, _ = _client_with_fake()
+    router = ToolRouter(client)
+    # Simulate a buggy handler returning a non-dict.
+    router._handlers["get_medusa_census"] = lambda _args: bad_return
+    payload, is_error = router.execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_HANDLER_EXCEPTION
+    assert payload["error"] == "tool_handler_exception"
+
+
+@pytest.mark.parametrize("justification", ["", "   ", "\t\n "])
+def test_router_local_rejection_blank_justification(justification):
+    """Blank/whitespace-only justification is a local rejection: is_error, the
+    local_rejection category, no HTTP POST, and no internal marker leaked."""
+    client, http = _client_with_fake()
+    router = ToolRouter(client, mode=MODE_PROPOSE)
+    payload, is_error = router.execute(
+        "propose_tuning",
+        {"params": {"signal_interval": 12}, "justification": justification},
+    )
+    assert is_error is True
+    assert payload["category"] == CATEGORY_LOCAL_REJECTION
+    assert "_local_rejection" not in payload
+    assert http.calls == []  # refused before any POST
+
+
+def test_router_local_rejection_commit_pending():
+    """commit-pending is a local rejection, not a silent downgrade: is_error,
+    local_rejection category, no POST."""
+    client, http = _client_with_fake()
+    router = ToolRouter(client, mode=MODE_PROPOSE)
+    payload, is_error = router.execute(
+        "propose_tuning",
+        {"params": {"signal_interval": 12}, "justification": "ok", "mode": "commit-pending"},
+    )
+    assert is_error is True
+    assert payload["error"] == "commit_pending_forbidden"
+    assert payload["category"] == CATEGORY_LOCAL_REJECTION
+    assert "_local_rejection" not in payload
+    assert http.calls == []
+
+
+def test_iteration_blank_justification_accounting():
+    """Iteration-level accounting: a blank-justification proposal increments the
+    local_rejection category, never ok, and never enters proposals_created."""
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_1", "propose_tuning",
+                           {"params": {"signal_interval": 12}, "justification": "  "}),
+        _text_response("acknowledged"),
+    ])
+    orch, http = _make_orchestrator(backend, mode=MODE_PROPOSE)
+    result = orch.run_one_iteration("observe")
+    assert result.outcome_counts.get(CATEGORY_LOCAL_REJECTION) == 1
+    assert result.outcome_counts.get(OUTCOME_OK, 0) == 0
+    assert result.proposals_created == []
+    assert http.calls == []
+
+
+_RECEIPT_SCHEMA_KEYS = {
+    "schema", "stopped_because", "turns", "tool_calls_executed",
+    "outcome_counts", "proposals_created", "commits_applied",
+    "usage_total", "truncated",
+}
+
+
+def _adversarial_iteration_result() -> IterationResult:
+    return IterationResult(
+        stopped_because="X" * 300_000,                       # extremely large
+        turns=7,
+        tool_calls_executed=9,
+        proposals_created=["prop-" + "y" * 400 for _ in range(5_000)],  # thousands, oversized
+        commits_applied=["commit-" + "z" * 400 for _ in range(5_000)],
+        outcome_counts={"K" * 20_000: 1, "ok": 3, "weird" * 100: 2},    # huge/unknown keys
+        usage_total={"U" * 20_000: 999, "input_tokens": [1, 2, 3]},      # huge key + unusual value
+    )
+
+
+def test_receipt_bounded_against_adversarial_result():
+    """A manually/adversarially-constructed IterationResult cannot inflate the
+    receipt past the cap, is deterministic, flags truncation, keeps only the
+    fixed schema keys, and coerces unusual value types."""
+    result = _adversarial_iteration_result()
+    receipt = build_audit_receipt(result)
+    blob = json.dumps(receipt, sort_keys=True, default=str)
+    # Deterministic serialization.
+    assert blob == json.dumps(build_audit_receipt(result), sort_keys=True, default=str)
+    # Hard byte bound.
+    assert len(blob.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    # Reduction occurred → flagged.
+    assert receipt["truncated"] is True
+    # Only fixed-schema top-level keys survive — no arbitrary input key.
+    assert set(receipt.keys()) == _RECEIPT_SCHEMA_KEYS
+    # Per-field caps.
+    assert len(receipt["proposals_created"]) <= 64
+    assert len(receipt["commits_applied"]) <= 64
+    assert len(receipt["outcome_counts"]) <= 64
+    assert len(receipt["usage_total"]) <= 64
+    assert len(receipt["stopped_because"]) <= 257  # 256 + ellipsis
+    # Unusual usage value coerced to int; no list survives as a value.
+    assert all(isinstance(v, int) for v in receipt["usage_total"].values())
+    assert all(isinstance(v, int) for v in receipt["outcome_counts"].values())
+
+
+def test_receipt_truncates_oversized_secret_like_stop_reason():
+    """A secret-looking string longer than the cap does not survive intact in
+    the receipt (it is bounded to 256 chars and the receipt is flagged)."""
+    secret = "sk-" + "A" * 5_000
+    result = IterationResult(stopped_because=secret, turns=1, tool_calls_executed=0)
+    receipt = build_audit_receipt(result)
+    assert receipt["truncated"] is True
+    assert secret not in json.dumps(receipt)  # the full secret does not survive
+    assert len(receipt["stopped_because"]) <= 257
+
+
+def test_receipt_minimal_fallback_is_within_limit(monkeypatch):
+    """Exercise the fixed minimal fallback directly: with the cap forced just
+    above the minimal receipt but below any populated one, the trim loop falls
+    through to the fixed minimal fallback, which is itself within the limit."""
+    import scripts.orchestrator as orch_mod
+    minimal = {"schema": "leanctx-orchestrator-v1",
+               "stopped_because": "truncated", "truncated": True}
+    minimal_size = len(json.dumps(minimal, sort_keys=True).encode("utf-8"))
+    monkeypatch.setattr(orch_mod, "MAX_RECEIPT_BYTES", minimal_size + 5)
+    result = IterationResult(
+        stopped_because="a long reason " * 50,
+        turns=1, tool_calls_executed=1,
+        proposals_created=[f"prop-{i}" for i in range(500)],
+        outcome_counts={f"k{i}": i for i in range(100)},
+        usage_total={"input_tokens": 999_999},
+    )
+    receipt = build_audit_receipt(result)
+    assert receipt == minimal
+    assert receipt["truncated"] is True
+    assert len(json.dumps(receipt, sort_keys=True).encode("utf-8")) <= minimal_size + 5
 
 
 def test_no_post_after_budget_exhaustion():


### PR DESCRIPTION
## Package T — hard limits, error semantics, and bounded audit receipts

Stacked on **Package S** ([#333](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/333)); base is S's branch. Replaces prompt-only loop expectations with deterministic runtime limits and truthful error/audit behavior. Design evidence: [#322](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/322).

**Hard limits:**
- A total `max_total_tool_calls` budget (default 24) **independent of** the per-turn `max_tool_depth`. Both are validated positive integers within `MAX_LIMIT_CEILING` (1000); malformed/out-of-range/boolean values are rejected at construction.
- **Over-budget rule (documented, deterministic):** execute only the permitted prefix; every remaining call in the turn gets an explicit `budget_rejection` error result so the conversation history stays structurally valid, then the iteration stops with `tool_budget_exhausted`. The cap is never exceeded.
- **At most one proposal attempt per iteration**, enforced in code (not prompt prose).

**Honest error semantics:** HTTP status ≥ 400 is a genuine tool error (`is_error=True`, category `http_rejection`) and is never counted as a created proposal or applied commit. Outcome categories are distinguished: `ok`, `unknown_tool`, `handler_exception`, `transport_failure`, `http_rejection`, `budget_rejection`, `proposal_limit`. Rollback is not exposed to the LLM.

**LeanCTX audit receipt** (`IterationResult.audit_receipt()` / `build_audit_receipt`): bounded, deterministic, **payload-free** — stop reason, turn/tool-call counts, per-category outcome counts, successful proposal ids, token usage. **Never** tool payloads, prompts, credentials, headers, or raw backend responses. Deterministic (sorted keys); guaranteed ≤ 64 KiB (`MAX_RECEIPT_BYTES`) with deterministic truncation as a last-resort net.

**Doc:** [`docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/blob/security/legacy-orchestrator-bounded-loop/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md) — proven R/S/T boundaries, supported modes, non-claims, per-package rollback, and the relationship to PR #322's proposed offline detector.

**Adversarial tests:** many tool calls in one turn; cross-turn budget exhaustion; two proposal attempts; 403/422/500 responses; transport failure; a handler exception carrying a sensitive-looking string (asserted absent from the receipt); a huge tool payload (receipt stays bounded and payload-free); deterministic + bounded receipt serialization; no POST after budget exhaustion; numeric-limit validation; and a static **no-reverse-dependency** check (the orchestrator imports no observer/detector/engine module).

**Verification lane:** no local Python on this seat; the full suite runs in GitHub CI (`verify-python`) on this push — the deterministic adversarial tests are re-run every CI run and in the stack-integration lab. **Note:** because this PR targets S's branch, CI runs the *cumulative* R+S+T diff.

Part 3 of a 3-PR stack (R → S → T). Open and **unmerged** for Jack; keeps `swarm-hunter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Amendment 2 (Jack delta — allowlist-grade audit receipt)

**Final T head:** `8396bbc86bad4c9179f8dae79235f0ba923be76e` (base = S branch `7c4daace`). CI **green: verify-python 980 passed / 10 skipped**; `verify`, `agent-safety` pass. Incremental over the prior T head `9a4dcd3`: 3 files, +253/−122.

`build_audit_receipt` is now **allowlist-grade** — the payload-free and ≤64 KiB guarantees hold by construction, before serialization:

- **Stop reason** allowlisted to `{end_turn, max_depth, tool_budget_exhausted}`; any other/non-str value → fixed `unknown` token (text never copied or prefixed).
- **Outcome keys** allowlisted to the 8 known categories; **usage keys** to `{input_tokens, output_tokens}`. Unknown/non-string keys **discarded**, never stringified → coercion cannot create a key collision (`int 1` vs `str "1"` both dropped).
- **Integers** via `_norm_uint`: non-negative only; bool/negative/non-int → `0`; magnitude-clamped to `10¹²` (so `10**10000` never risks a huge string conversion).
- **IDs** kept only if they match `^[A-Za-z0-9_-]{1,128}$`; invalid/non-string entries omitted **without invoking `__str__`**.
- Objects whose `__str__` raises are discarded by isinstance guards. Every surviving value is a bounded JSON primitive, so `_size()` and the guarantee tests use **plain `json.dumps(sort_keys=True)` — no `default=str`**.
- `truncated=True` whenever any value is normalized away, plus the trim loop / fixed minimal fallback (`unknown`) as the final defense.

**Exact receipts (verified on Python 3.13.7 + CI):**
- Worst-case adversarial `IterationResult` (secret+300 KB stop reason, `10**10000` counts/usage, 5 000 oversized/invalid ids, unknown+colliding+`__str__`-boom keys): **358 bytes**, `truncated=True`, only the 9 fixed-schema keys, all values non-negative ints / id-alphabet strings.
- Fixed minimal fallback: `{"schema":"leanctx-orchestrator-v1","stopped_because":"unknown","truncated":true}` — itself within a forced tiny cap.
- Normal receipt: `truncated=False` (no spurious flags).

New adversarial regressions: `10**10000` in turns/counts/usage; secret-like stop reason/keys absent incl. prefixes; colliding int/str keys; `__str__`-throwing objects as id/key/value; negative/bool/non-int counts (parametrized); unknown-key removal; deterministic plain-`dumps` output + honest `truncated`; minimal fallback under a forced tiny cap. The 200 KiB-payload and credential-redaction tests are retained. Docs + `IterationResult` field docstrings updated to the exact supported schema; universal claims narrowed to the allowlisted domain.

Still **OPEN / UNMERGED**; all review threads left unresolved for Jack.


---

## Amendment 3 (Jack final delta — canonical proposal identifiers)

**Final T head:** `12eb7499aeb0b3367216493420dee3b8cd99da81`. CI **green: verify-python 983 passed / 10 skipped**.

- The receipt id filter is now the **canonical production identifier** `^prop-[0-9a-f]{8}$` — exactly what `tuning_api._new_proposal_id` mints (`"prop-" + secrets.token_hex(4)`) — for both `proposals_created` and `commits_applied`. Secret-looking-but-alphabet-valid strings, arbitrary text, uppercase, overlong, short, non-hex, and non-string entries are all discarded (incl. prefixes).
- **Exact-type container guards:** id lists accept only a built-in `list`/`tuple`; count/usage maps only a built-in `dict`. A hostile subclass whose `__iter__`/`items` raises is rejected by `type()` **before any iteration**, normalizing to empty with `truncated=True` — the hooks are never invoked.
- Source/doc/PR wording updated from "id-alphabet strings" to "canonical proposal ids".

New regressions: canonical ids (`prop-deadbeef`, `prop-0123abcd`) survive; secret-looking alphabet-valid ids do not (incl. prefixes); list/dict subclasses whose `__iter__`/`items` raise are rejected without invocation; normal production `IterationResult` stays `truncated=False`; adversarial receipt deterministic and ≤64 KiB. Verified via `py_compile` + dependency-free py 3.13.7 smoke (six test mirrors).

Still **OPEN / UNMERGED**; review threads unresolved for Jack.
