### PR TITLE
fix/test: review convergence — node/edge ownership materialization, queue error policy, harness corrections (PACKAGE Y)

### DIFF
--- a/utilityfog_frontend/frontend/src/components/NetworkView2D.tsx
+++ b/utilityfog_frontend/frontend/src/components/NetworkView2D.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { SimBridgeClient, NetworkNode, NetworkEdge } from '../ws/SimBridgeClient'
 import { applyNodeUpdate, sanitizeNodeList } from '../viz3d/nodeValidation'
+import { sanitizeEdgeList } from '../viz3d/edgeValidation'
 
 interface NetworkView2DProps {
   simClient: SimBridgeClient | null
@@ -21,11 +22,11 @@ export default function NetworkView2D({ simClient }: NetworkView2DProps) {
       if (!data || typeof data !== 'object') return
       const d = data as { nodes?: unknown; edges?: unknown }
       // Per-side tolerance mirrors the store: malformed one side never
-      // discards the other; explicit [] clears its collection. Edge
-      // ELEMENT shape stays tolerated (the draw effect skips dangling
-      // references) — the array check is the documented boundary.
+      // discards the other; explicit [] clears its collection. Both sides
+      // use the shared materializing validators — well-formed dangling
+      // references stay tolerated (the draw effect skips unmatched ids).
       if (Array.isArray(d.nodes)) setNodes(prev => sanitizeNodeList(d.nodes, prev))
-      if (Array.isArray(d.edges)) setEdges(d.edges as NetworkEdge[])
+      if (Array.isArray(d.edges)) setEdges(prev => sanitizeEdgeList(d.edges, prev))
     }
 
     const handleNodeUpdate = (node?: unknown) => {

--- a/utilityfog_frontend/frontend/src/viz3d/adapters.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/adapters.ts
@@ -1,4 +1,5 @@
 import { NetworkNode, NetworkEdge } from '../ws/SimBridgeClient'
+import { materializeEdge } from './edgeValidation'
 
 // Adapter functions to convert between different data formats.
 // Raw simulation payloads are an external-data boundary: elements are
@@ -10,16 +11,6 @@ interface RawAgent {
   position?: [number, number, number]
   connections?: string[]
   active?: boolean
-}
-
-interface RawConnection {
-  id?: string
-  source?: string
-  target?: string
-  from?: string
-  to?: string
-  strength?: number
-  weight?: number
 }
 
 export function adaptSimulationData(rawData: unknown): {
@@ -52,18 +43,15 @@ export function adaptSimulationData(rawData: unknown): {
     })
   }
 
-  if (raw.connections) {
+  if (Array.isArray(raw.connections)) {
     raw.connections.forEach((rawConn: unknown, index: number) => {
-      const conn = rawConn as RawConnection
-      edges.push({
-        id: conn.id || `edge_${index}`,
-        // Legacy adapter tolerance preserved exactly: a connection with
-        // neither field yields undefined at runtime (as before); edge
-        // consumers skip dangling references.
-        source: (conn.source || conn.from) as string,
-        target: (conn.target || conn.to) as string,
-        strength: conn.strength || conn.weight || 1
-      })
+      // Shared edge ownership contract (edgeValidation.ts) in its legacy
+      // dialect: source/from + target/to aliases, strength||weight||1
+      // fallback, and the index-generated id for missing/falsy ids.
+      // Connections without string endpoints are rejected (endpoints are
+      // never invented); well-formed dangling references stay admitted.
+      const edge = materializeEdge(rawConn, { legacyAliases: true, fallbackId: `edge_${index}` })
+      if (edge) edges.push(edge)
     })
   }
 
@@ -80,15 +68,12 @@ export function adaptSimulationData(rawData: unknown): {
     })
   }
 
-  if (raw.edges) {
+  if (Array.isArray(raw.edges)) {
     raw.edges.forEach((rawEdge: unknown) => {
-      const edge = rawEdge as Partial<NetworkEdge> & { id: string; source: string; target: string }
-      edges.push({
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        strength: edge.strength || 1
-      })
+      // Generic dialect of the same contract: string id/source/target
+      // required (no aliases, no generated ids), strength||1 preserved.
+      const edge = materializeEdge(rawEdge)
+      if (edge) edges.push(edge)
     })
   }
 

--- a/utilityfog_frontend/frontend/src/viz3d/edgeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/edgeValidation.ts
@@ -1,0 +1,85 @@
+import { NetworkEdge } from '../ws/SimBridgeClient'
+
+// Shared edge ownership contract — the one ingestion validator for every
+// surface that stores or renders edges (legacy adapter, scene store,
+// NetworkView2D subscription).
+//
+// Renderer evidence (source-verified): consumers key on edge.id and index
+// edge.source/edge.target against node ids; unmatched ids are skipped, so
+// well-formed DANGLING references stay tolerated. Missing or non-string
+// endpoints are rejected outright — endpoints are never invented and never
+// silently stringified.
+//
+// Ownership: admitted edges are MATERIALIZED plain objects. Every field is
+// read exactly once inside the containment boundary, so throwing getters
+// reject the candidate and live getters can never reach stored state.
+
+export interface EdgeMaterializeOptions {
+  // Legacy adapter dialect: source/from and target/to aliases, and the
+  // strength || weight || 1 fallback chain's weight leg.
+  legacyAliases?: boolean
+  // Legacy adapter id contract: a missing/falsy id takes the caller's
+  // index-generated id (`edge_${index}`). The adapter is the only caller
+  // that supplies this.
+  fallbackId?: string
+}
+
+export function materializeEdge(
+  incoming: unknown,
+  opts: EdgeMaterializeOptions = {},
+): NetworkEdge | null {
+  if (!incoming || typeof incoming !== 'object') return null
+  try {
+    const source = incoming as Record<string, unknown>
+    const rawId = 'id' in source ? source.id : undefined
+    const rawSource = 'source' in source ? source.source : undefined
+    const rawTarget = 'target' in source ? source.target : undefined
+    const rawStrength = 'strength' in source ? source.strength : undefined
+    const rawFrom = opts.legacyAliases && 'from' in source ? source.from : undefined
+    const rawTo = opts.legacyAliases && 'to' in source ? source.to : undefined
+    const rawWeight = opts.legacyAliases && 'weight' in source ? source.weight : undefined
+
+    // The legacy || chains treated falsy values ('' ids, 0 strengths) as
+    // absent — that contract is preserved exactly.
+    const id = (typeof rawId === 'string' && rawId) || opts.fallbackId
+    if (typeof id !== 'string' || id === '') return null
+
+    const src =
+      (typeof rawSource === 'string' && rawSource) ||
+      (typeof rawFrom === 'string' && rawFrom) ||
+      undefined
+    const tgt =
+      (typeof rawTarget === 'string' && rawTarget) ||
+      (typeof rawTo === 'string' && rawTo) ||
+      undefined
+    if (src === undefined || tgt === undefined) return null
+
+    const strength =
+      (typeof rawStrength === 'number' && Number.isFinite(rawStrength) && rawStrength) ||
+      (typeof rawWeight === 'number' && Number.isFinite(rawWeight) && rawWeight) ||
+      1
+
+    return { id, source: src, target: tgt, strength }
+  } catch {
+    // Hostile shapes (throwing getters, poisoned proxies) are contained at
+    // the boundary exactly like any other malformed input.
+    return null
+  }
+}
+
+// Sanitize a wholesale edge list. Mirrors sanitizeNodeList: a non-array
+// keeps the previous list (per-side tolerance); elements are materialized
+// individually; duplicate ids keep the first occurrence.
+export function sanitizeEdgeList(incoming: unknown, previous: NetworkEdge[]): NetworkEdge[] {
+  if (!Array.isArray(incoming)) return previous
+  const result: NetworkEdge[] = []
+  const seen = new Set<string>()
+  for (const candidate of incoming) {
+    const edge = materializeEdge(candidate)
+    if (edge !== null && !seen.has(edge.id)) {
+      result.push(edge)
+      seen.add(edge.id)
+    }
+  }
+  return result
+}

--- a/utilityfog_frontend/frontend/src/viz3d/edgeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/edgeValidation.ts
@@ -70,16 +70,30 @@ export function materializeEdge(
 // Sanitize a wholesale edge list. Mirrors sanitizeNodeList: a non-array
 // keeps the previous list (per-side tolerance); elements are materialized
 // individually; duplicate ids keep the first occurrence.
+//
+// REFERENTIAL STABILITY: an admitted edge whose owned fields equal the
+// previous edge with the same id REUSES that previous object, and when
+// length, order and every element reference are unchanged the previous
+// ARRAY reference is returned — no-op wholesale updates notify nobody.
 export function sanitizeEdgeList(incoming: unknown, previous: NetworkEdge[]): NetworkEdge[] {
   if (!Array.isArray(incoming)) return previous
+  const byId = new Map(previous.map(e => [e.id, e]))
   const result: NetworkEdge[] = []
   const seen = new Set<string>()
   for (const candidate of incoming) {
     const edge = materializeEdge(candidate)
-    if (edge !== null && !seen.has(edge.id)) {
-      result.push(edge)
-      seen.add(edge.id)
-    }
+    if (edge === null || seen.has(edge.id)) continue
+    const prior = byId.get(edge.id)
+    const unchanged =
+      prior !== undefined &&
+      prior.source === edge.source &&
+      prior.target === edge.target &&
+      prior.strength === edge.strength
+    result.push(unchanged ? prior : edge)
+    seen.add(edge.id)
+  }
+  if (result.length === previous.length && result.every((e, i) => e === previous[i])) {
+    return previous
   }
   return result
 }

--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -8,11 +8,38 @@ import { NetworkNode } from '../ws/SimBridgeClient'
 // Transport (SimBridgeClient) is deliberately untouched: invalid
 // visualization data must not affect WebSocket connectivity.
 //
-// OWNERSHIP CONTRACT (Package Y): admitted nodes are MATERIALIZED — every
+// OWNERSHIP CONTRACT: admitted nodes are MATERIALIZED — every
 // renderer-consumed field is read exactly once inside a containment
 // boundary into a plain owned object. The untrusted incoming object (with
 // any live getters, proxies or extra fields) never reaches stored state,
 // and a throwing getter on ANY read field rejects the candidate.
+//
+// FIELD CONTRACT (audit-hardened):
+//  - id: nonempty string, enforced at EVERY public admission seam.
+//  - position: exactly three finite numbers, copied into an owned tuple.
+//  - status: validated against the real NetworkNode union; an invalid
+//    value is DISCARDED AS ABSENT (the renderers' documented default-color
+//    path covers status-less records) — an update never fails solely on a
+//    bad status, and it can never clobber a valid existing status.
+//  - connections: owned copy retaining STRING elements only; a non-array
+//    value is treated as absent. No untrusted array reference is retained.
+//
+// REFERENTIAL STABILITY: when an update changes nothing, the EXISTING
+// object (and, list-wise, the previous ARRAY) is returned unchanged so
+// subscribers are not notified for no-op updates; changed records always
+// get fresh owned references.
+
+const VALID_STATUSES: ReadonlyArray<NetworkNode['status']> = ['active', 'inactive', 'error']
+
+/// Type PREDICATE (not an assertion): narrows only when the value really
+/// is one of the union members.
+export function isValidStatus(v: unknown): v is NetworkNode['status'] {
+  return typeof v === 'string' && (VALID_STATUSES as readonly string[]).includes(v)
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v !== ''
+}
 
 /// A position is valid only when it is an array of exactly three finite
 /// numbers. (NaN/Infinity are rejected — they draw nothing meaningful and
@@ -42,8 +69,20 @@ function readPositionTriple(p: unknown): [number, number, number] | null {
   return [x, y, z]
 }
 
+/// Owned string-only copy of a connections candidate; null when the value
+/// is not an array (treated as absent by the merge). Elements are read
+/// once; non-string elements are dropped.
+function readStringArray(v: unknown): string[] | null {
+  if (!Array.isArray(v)) return null
+  const out: string[] = []
+  for (const item of v) {
+    if (typeof item === 'string') out.push(item)
+  }
+  return out
+}
+
 /// One single-pass, contained read of an untrusted node payload: every
-/// renderer-relevant field is pulled into plain locals exactly once.
+/// renderer-relevant field is pulled into plain owned locals exactly once.
 /// Returns null for non-objects and for ANY throw during reading
 /// (hostile getters, poisoned `in`/ownKeys proxy traps).
 interface NodeCandidate {
@@ -51,9 +90,9 @@ interface NodeCandidate {
   id: unknown
   position: [number, number, number] | null
   hasConnections: boolean
-  connections: unknown
+  connections: string[] | null
   hasStatus: boolean
-  status: unknown
+  status: NetworkNode['status'] | null
 }
 
 function readNodeCandidate(incoming: unknown): NodeCandidate | null {
@@ -64,32 +103,42 @@ function readNodeCandidate(incoming: unknown): NodeCandidate | null {
     const id = hasId ? source.id : undefined
     const position = readPositionTriple('position' in source ? source.position : undefined)
     const hasConnections = 'connections' in source
-    const connections = hasConnections ? source.connections : undefined
+    const connections = hasConnections ? readStringArray(source.connections) : null
     const hasStatus = 'status' in source
-    const status = hasStatus ? source.status : undefined
+    const rawStatus = hasStatus ? source.status : undefined
+    const status = isValidStatus(rawStatus) ? rawStatus : null
     return { hasId, id, position, hasConnections, connections, hasStatus, status }
   } catch {
     return null
   }
 }
 
+function sameStringArray(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b || a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
 /// Build the owned node from a contained read. Presence semantics mirror
-/// the original `{ ...existing, ...incoming }` merge: a field present on
-/// the incoming payload wins; an absent field survives from the existing
-/// record. Unknown extra fields are DROPPED (ownership: only
-/// renderer-consumed fields are stored). Position rules unchanged:
+/// the original `{ ...existing, ...incoming }` merge for VALID values: a
+/// valid field present on the incoming payload wins; an absent (or
+/// invalid — see the field contract above) field survives from the
+/// existing record. Unknown extra fields are DROPPED. Position rules:
 ///  - valid incoming position → owned copy of it;
 ///  - otherwise, existing valid position → preserved;
 ///  - otherwise (unknown node without a valid position) → null. No
 ///    [0,0,0] is ever invented; a later valid update recovers normally.
-/// Required-field evidence (source-verified): renderers read `id`
-/// (matching), `position` (InstancedNodes matrix + 2D draw) and `status`
-/// (color switches with safe defaults); `connections` is read by no
-/// renderer — its VALUE stays tolerated as supplied.
+/// When nothing changed, the EXISTING object is returned unchanged.
 function reconcileCandidate(
   c: NodeCandidate,
   existing: NetworkNode | undefined,
 ): NetworkNode | null {
+  const id = c.hasId ? c.id : existing?.id
+  if (!isNonEmptyString(id)) return null
+
   let position: [number, number, number]
   if (c.position) {
     position = c.position
@@ -98,14 +147,26 @@ function reconcileCandidate(
   } else {
     return null
   }
-  const owned = {
-    id: (c.hasId ? c.id : existing?.id) as NetworkNode['id'],
-    position,
-  } as NetworkNode
-  if (c.hasConnections) owned.connections = c.connections as NetworkNode['connections']
-  else if (existing) owned.connections = existing.connections
-  if (c.hasStatus) owned.status = c.status as NetworkNode['status']
-  else if (existing) owned.status = existing.status
+
+  // Invalid status/connections values behave as absent (contract above).
+  const connections = c.connections !== null ? c.connections : existing?.connections
+  const status = c.status !== null ? c.status : existing?.status
+
+  if (
+    existing &&
+    id === existing.id &&
+    position[0] === existing.position[0] &&
+    position[1] === existing.position[1] &&
+    position[2] === existing.position[2] &&
+    status === existing.status &&
+    sameStringArray(connections, existing.connections)
+  ) {
+    return existing
+  }
+
+  const owned = { id, position } as NetworkNode
+  if (connections !== undefined) owned.connections = connections
+  if (status !== undefined) owned.status = status
   return owned
 }
 
@@ -123,20 +184,22 @@ export function reconcileNode(
 
 /// Apply one incoming node to a node list (update-or-append by id),
 /// enforcing the reconcile contract. Non-object payloads and payloads
-/// without a string id are dropped (nothing to identify or render).
-/// Mixed valid/invalid updates can never duplicate a node: matching is
-/// always by id. The payload is read ONCE (single contained pass) — a
-/// hostile getter is never invoked twice.
+/// without a nonempty string id are dropped (nothing to identify or
+/// render). Mixed valid/invalid updates can never duplicate a node:
+/// matching is always by id. The payload is read ONCE (single contained
+/// pass) — a hostile getter is never invoked twice. A no-op update
+/// returns the previous ARRAY reference unchanged.
 export function applyNodeUpdate(
   previous: NetworkNode[],
   incoming: unknown,
 ): NetworkNode[] {
   const candidate = readNodeCandidate(incoming)
-  if (candidate === null || typeof candidate.id !== 'string') return previous
+  if (candidate === null || !isNonEmptyString(candidate.id)) return previous
   const index = previous.findIndex(n => n.id === candidate.id)
   const next = reconcileCandidate(candidate, index >= 0 ? previous[index] : undefined)
   if (next === null) return previous
   if (index >= 0) {
+    if (next === previous[index]) return previous
     const copy = [...previous]
     copy[index] = next
     return copy
@@ -148,7 +211,8 @@ export function applyNodeUpdate(
 /// against the previously known nodes so a bulk update cannot smuggle
 /// invalid positions past the boundary either. Hostile entries are skipped
 /// without losing the rest of the batch; duplicate ids keep the first
-/// occurrence.
+/// occurrence. When length, order and every element reference are
+/// unchanged, the previous ARRAY reference is returned.
 export function sanitizeNodeList(
   incoming: unknown,
   previous: NetworkNode[],
@@ -159,12 +223,15 @@ export function sanitizeNodeList(
   const seen = new Set<string>()
   for (const entry of incoming) {
     const candidate = readNodeCandidate(entry)
-    if (candidate === null || typeof candidate.id !== 'string' || seen.has(candidate.id)) continue
+    if (candidate === null || !isNonEmptyString(candidate.id) || seen.has(candidate.id)) continue
     const next = reconcileCandidate(candidate, byId.get(candidate.id))
     if (next !== null) {
       result.push(next)
       seen.add(candidate.id)
     }
+  }
+  if (result.length === previous.length && result.every((n, i) => n === previous[i])) {
+    return previous
   }
   return result
 }

--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -7,6 +7,12 @@ import { NetworkNode } from '../ws/SimBridgeClient'
 // (`node.position[0]`), throwing and unmounting the whole React tree.
 // Transport (SimBridgeClient) is deliberately untouched: invalid
 // visualization data must not affect WebSocket connectivity.
+//
+// OWNERSHIP CONTRACT (Package Y): admitted nodes are MATERIALIZED — every
+// renderer-consumed field is read exactly once inside a containment
+// boundary into a plain owned object. The untrusted incoming object (with
+// any live getters, proxies or extra fields) never reaches stored state,
+// and a throwing getter on ANY read field rejects the candidate.
 
 /// A position is valid only when it is an array of exactly three finite
 /// numbers. (NaN/Infinity are rejected — they draw nothing meaningful and
@@ -22,67 +28,113 @@ export function isValidPosition(p: unknown): p is [number, number, number] {
   return true
 }
 
-/// Reconcile an incoming node-shaped payload against the previously known
-/// node with the same id. Partial updates MERGE with the existing record
-/// ({ ...existing, ...incoming }) so omitted fields such as `connections`
-/// survive. Returns the node to store, or null when it must not reach any
-/// renderer:
-///  - valid incoming position → merged record with the incoming position;
-///  - invalid/missing position on a node whose previous state holds a valid
-///    position → merged record with the LAST VALID position preserved;
-///  - previously unknown node without a valid position → null. No [0,0,0]
-///    is ever invented; a later valid update recovers the node normally.
-/// Required-field evidence (source-verified): the renderers read `id`
+/// Read a position candidate into an OWNED tuple, or null. Each index is
+/// read exactly once (hostile index getters are invoked at most once, and
+/// holes in sparse arrays read as undefined and fail the number check).
+function readPositionTriple(p: unknown): [number, number, number] | null {
+  if (!Array.isArray(p) || p.length !== 3) return null
+  const x: unknown = p[0]
+  const y: unknown = p[1]
+  const z: unknown = p[2]
+  if (typeof x !== 'number' || !Number.isFinite(x)) return null
+  if (typeof y !== 'number' || !Number.isFinite(y)) return null
+  if (typeof z !== 'number' || !Number.isFinite(z)) return null
+  return [x, y, z]
+}
+
+/// One single-pass, contained read of an untrusted node payload: every
+/// renderer-relevant field is pulled into plain locals exactly once.
+/// Returns null for non-objects and for ANY throw during reading
+/// (hostile getters, poisoned `in`/ownKeys proxy traps).
+interface NodeCandidate {
+  hasId: boolean
+  id: unknown
+  position: [number, number, number] | null
+  hasConnections: boolean
+  connections: unknown
+  hasStatus: boolean
+  status: unknown
+}
+
+function readNodeCandidate(incoming: unknown): NodeCandidate | null {
+  if (!incoming || typeof incoming !== 'object') return null
+  try {
+    const source = incoming as Record<string, unknown>
+    const hasId = 'id' in source
+    const id = hasId ? source.id : undefined
+    const position = readPositionTriple('position' in source ? source.position : undefined)
+    const hasConnections = 'connections' in source
+    const connections = hasConnections ? source.connections : undefined
+    const hasStatus = 'status' in source
+    const status = hasStatus ? source.status : undefined
+    return { hasId, id, position, hasConnections, connections, hasStatus, status }
+  } catch {
+    return null
+  }
+}
+
+/// Build the owned node from a contained read. Presence semantics mirror
+/// the original `{ ...existing, ...incoming }` merge: a field present on
+/// the incoming payload wins; an absent field survives from the existing
+/// record. Unknown extra fields are DROPPED (ownership: only
+/// renderer-consumed fields are stored). Position rules unchanged:
+///  - valid incoming position → owned copy of it;
+///  - otherwise, existing valid position → preserved;
+///  - otherwise (unknown node without a valid position) → null. No
+///    [0,0,0] is ever invented; a later valid update recovers normally.
+/// Required-field evidence (source-verified): renderers read `id`
 /// (matching), `position` (InstancedNodes matrix + 2D draw) and `status`
 /// (color switches with safe defaults); `connections` is read by no
-/// renderer. A previously unknown node with a valid position is therefore
-/// admitted as supplied — no missing fields are invented.
+/// renderer — its VALUE stays tolerated as supplied.
+function reconcileCandidate(
+  c: NodeCandidate,
+  existing: NetworkNode | undefined,
+): NetworkNode | null {
+  let position: [number, number, number]
+  if (c.position) {
+    position = c.position
+  } else if (existing && isValidPosition(existing.position)) {
+    position = [existing.position[0], existing.position[1], existing.position[2]]
+  } else {
+    return null
+  }
+  const owned = {
+    id: (c.hasId ? c.id : existing?.id) as NetworkNode['id'],
+    position,
+  } as NetworkNode
+  if (c.hasConnections) owned.connections = c.connections as NetworkNode['connections']
+  else if (existing) owned.connections = existing.connections
+  if (c.hasStatus) owned.status = c.status as NetworkNode['status']
+  else if (existing) owned.status = existing.status
+  return owned
+}
+
+/// Reconcile an incoming node-shaped payload against the previously known
+/// node with the same id. See reconcileCandidate for the merge/position
+/// contract; this public seam performs the contained single-pass read.
 export function reconcileNode(
   incoming: unknown,
   existing: NetworkNode | undefined,
 ): NetworkNode | null {
-  if (!incoming || typeof incoming !== 'object') return null
-  // The candidate is only trusted after the runtime position validation
-  // below (id is checked by callers); status/connections stay tolerated
-  // per the source-verified renderer-requirements evidence.
-  try {
-    const candidate = incoming as Partial<NetworkNode> & { position?: unknown }
-    const merged = (existing ? { ...existing, ...candidate } : candidate) as NetworkNode
-    if (isValidPosition(candidate.position)) {
-      return merged
-    }
-    if (existing && isValidPosition(existing.position)) {
-      return { ...merged, position: existing.position }
-    }
-    return null
-  } catch {
-    // Hostile payload shapes (throwing getters, poisoned proxies) are
-    // contained at the boundary exactly like any other malformed input —
-    // property access and the merge spread both evaluate getters, and an
-    // exception here must not cross into store/render code.
-    return null
-  }
+  const candidate = readNodeCandidate(incoming)
+  if (candidate === null) return null
+  return reconcileCandidate(candidate, existing)
 }
 
 /// Apply one incoming node to a node list (update-or-append by id),
 /// enforcing the reconcile contract. Non-object payloads and payloads
 /// without a string id are dropped (nothing to identify or render).
 /// Mixed valid/invalid updates can never duplicate a node: matching is
-/// always by id.
+/// always by id. The payload is read ONCE (single contained pass) — a
+/// hostile getter is never invoked twice.
 export function applyNodeUpdate(
   previous: NetworkNode[],
   incoming: unknown,
 ): NetworkNode[] {
-  let id: unknown
-  try {
-    id = (incoming as { id?: unknown } | null | undefined)?.id
-  } catch {
-    // A throwing id getter identifies nothing — same outcome as no id.
-    return previous
-  }
-  if (typeof id !== 'string') return previous
-  const index = previous.findIndex(n => n.id === id)
-  const next = reconcileNode(incoming, index >= 0 ? previous[index] : undefined)
+  const candidate = readNodeCandidate(incoming)
+  if (candidate === null || typeof candidate.id !== 'string') return previous
+  const index = previous.findIndex(n => n.id === candidate.id)
+  const next = reconcileCandidate(candidate, index >= 0 ? previous[index] : undefined)
   if (next === null) return previous
   if (index >= 0) {
     const copy = [...previous]
@@ -94,7 +146,9 @@ export function applyNodeUpdate(
 
 /// Sanitize a wholesale node list (network_update), reconciling each entry
 /// against the previously known nodes so a bulk update cannot smuggle
-/// invalid positions past the boundary either.
+/// invalid positions past the boundary either. Hostile entries are skipped
+/// without losing the rest of the batch; duplicate ids keep the first
+/// occurrence.
 export function sanitizeNodeList(
   incoming: unknown,
   previous: NetworkNode[],
@@ -103,19 +157,13 @@ export function sanitizeNodeList(
   const byId = new Map(previous.map(n => [n.id, n]))
   const result: NetworkNode[] = []
   const seen = new Set<string>()
-  for (const candidate of incoming) {
-    let id: unknown
-    try {
-      id = (candidate as { id?: unknown } | null | undefined)?.id
-    } catch {
-      // A hostile entry is skipped without losing the rest of the batch.
-      continue
-    }
-    if (typeof id !== 'string' || seen.has(id)) continue
-    const next = reconcileNode(candidate, byId.get(id))
+  for (const entry of incoming) {
+    const candidate = readNodeCandidate(entry)
+    if (candidate === null || typeof candidate.id !== 'string' || seen.has(candidate.id)) continue
+    const next = reconcileCandidate(candidate, byId.get(candidate.id))
     if (next !== null) {
       result.push(next)
-      seen.add(id)
+      seen.add(candidate.id)
     }
   }
   return result

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -48,6 +48,10 @@ export function useEventQueue(
           }
         }
 
+        // Schedule the next yield frame ONLY while still active with more
+        // work queued — an unmount during the LAST handler (or an emptied
+        // queue) must not request an extra animation frame.
+        if (!activeRef.current || queueRef.current.length === 0) break
         // Allow browser to render
         await new Promise(resolve => requestAnimationFrame(resolve))
       }

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -29,18 +29,35 @@ export function useEventQueue(
   const processQueue = useCallback(async () => {
     if (processingRef.current) return
     processingRef.current = true
+    try {
+      // The active guard is re-checked before EVERY handler (not merely
+      // every batch): an unmount performed by a handler stops the rest of
+      // its own batch, and an unmount between frames stops the drain.
+      while (activeRef.current && queueRef.current.length > 0) {
+        const batch = queueRef.current.splice(0, 10) // Process in batches of 10
+        for (const fn of batch) {
+          if (!activeRef.current) return
+          try {
+            fn()
+          } catch (error) {
+            // Handler-error policy: one failing handler must not lock the
+            // queue, abort its batch-mates, or be retried. The failure is
+            // reported exactly once through the bounded diagnostic channel
+            // and later independent events process normally.
+            console.error('Event handler failed:', error)
+          }
+        }
 
-    // Re-checked after every awaited frame: an unmount mid-drain stops the
-    // loop at the batch boundary.
-    while (activeRef.current && queueRef.current.length > 0) {
-      const batch = queueRef.current.splice(0, 10) // Process in batches of 10
-      batch.forEach(fn => fn())
-
-      // Allow browser to render
-      await new Promise(resolve => requestAnimationFrame(resolve))
+        // Allow browser to render
+        await new Promise(resolve => requestAnimationFrame(resolve))
+      }
+    } finally {
+      // Restoration lives in a finally boundary so no exit path — normal,
+      // early-return on unmount, or a future throw — can leave the queue
+      // permanently locked. Nothing in the loop rethrows, so this async
+      // fire-and-forget drain also never yields an unhandled rejection.
+      processingRef.current = false
     }
-
-    processingRef.current = false
   }, [])
 
   const enqueueUpdate = useCallback(

--- a/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { NetworkNode, NetworkEdge } from '../ws/SimBridgeClient'
 import { applyNodeUpdate, sanitizeNodeList } from './nodeValidation'
+import { sanitizeEdgeList } from './edgeValidation'
 
 interface SceneStore {
   nodes: NetworkNode[]
@@ -40,14 +41,12 @@ export const useSceneStore = create<SceneStore>((set) => ({
     set((state) => ({
       // Per-side tolerance: a malformed side never discards the valid
       // other side; explicit empty arrays remain meaningful and clear.
-      // Edge elements must at least be non-null objects — renderers index
-      // edge.source/edge.target, so a null/primitive element throws in
-      // render code. Dangling REFERENCES on real edge objects stay
-      // tolerated (renderers skip unmatched ids).
+      // Both sides go through their shared materializing validators —
+      // admitted records are plain owned objects (see nodeValidation.ts
+      // and edgeValidation.ts for the contracts). Dangling REFERENCES on
+      // well-formed edges stay tolerated (renderers skip unmatched ids).
       nodes: Array.isArray(nodes) ? sanitizeNodeList(nodes, state.nodes) : state.nodes,
-      edges: Array.isArray(edges)
-        ? edges.filter((e): e is NetworkEdge => !!e && typeof e === 'object')
-        : state.edges,
+      edges: sanitizeEdgeList(edges, state.edges),
     })),
 
   clearNetwork: () =>

--- a/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useSceneStore.ts
@@ -12,17 +12,22 @@ interface SceneStore {
   clearNetwork: () => void
 }
 
-export const useSceneStore = create<SceneStore>((set) => ({
+export const useSceneStore = create<SceneStore>((set, get) => ({
   nodes: [],
   edges: [],
 
-  updateNode: (node: unknown) =>
-    set((state) => {
-      // Ingestion boundary: malformed positions never reach the renderers
-      // (see nodeValidation.ts for the reconcile contract).
-      const nodes = applyNodeUpdate(state.nodes, node)
-      return nodes === state.nodes ? {} : { nodes }
-    }),
+  // No-op discipline: the validators return the PREVIOUS references for
+  // updates that change nothing, and these actions then skip set()
+  // entirely — zustand notifies subscribers on every set() (even an empty
+  // partial produces a fresh merged state object), so skipping is the only
+  // way an identical update reaches zero notifications.
+  updateNode: (node: unknown) => {
+    // Ingestion boundary: malformed positions never reach the renderers
+    // (see nodeValidation.ts for the reconcile contract).
+    const state = get()
+    const nodes = applyNodeUpdate(state.nodes, node)
+    if (nodes !== state.nodes) set({ nodes })
+  },
 
   updateEdge: (edge: NetworkEdge) =>
     set((state) => {
@@ -37,17 +42,20 @@ export const useSceneStore = create<SceneStore>((set) => ({
       }
     }),
 
-  setNetwork: (nodes: unknown, edges: unknown) =>
-    set((state) => ({
-      // Per-side tolerance: a malformed side never discards the valid
-      // other side; explicit empty arrays remain meaningful and clear.
-      // Both sides go through their shared materializing validators —
-      // admitted records are plain owned objects (see nodeValidation.ts
-      // and edgeValidation.ts for the contracts). Dangling REFERENCES on
-      // well-formed edges stay tolerated (renderers skip unmatched ids).
-      nodes: Array.isArray(nodes) ? sanitizeNodeList(nodes, state.nodes) : state.nodes,
-      edges: sanitizeEdgeList(edges, state.edges),
-    })),
+  setNetwork: (nodes: unknown, edges: unknown) => {
+    // Per-side tolerance: a malformed side never discards the valid
+    // other side; explicit empty arrays remain meaningful and clear.
+    // Both sides go through their shared materializing validators —
+    // admitted records are plain owned objects (see nodeValidation.ts
+    // and edgeValidation.ts for the contracts). Dangling REFERENCES on
+    // well-formed edges stay tolerated (renderers skip unmatched ids).
+    const state = get()
+    const nextNodes = Array.isArray(nodes) ? sanitizeNodeList(nodes, state.nodes) : state.nodes
+    const nextEdges = sanitizeEdgeList(edges, state.edges)
+    if (nextNodes !== state.nodes || nextEdges !== state.edges) {
+      set({ nodes: nextNodes, edges: nextEdges })
+    }
+  },
 
   clearNetwork: () =>
     set({ nodes: [], edges: [] }),

--- a/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
@@ -56,6 +56,8 @@ beforeEach(() => {
 
 afterEach(() => {
   FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('App view switching', () => {

--- a/utilityfog_frontend/frontend/tests-unit/connection-badge.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/connection-badge.test.tsx
@@ -21,10 +21,12 @@ describe('ConnectionBadge (foundation)', () => {
   it('connected: the same region reads "Connected" and the dot stays decorative', () => {
     const { container } = render(<ConnectionBadge isConnected={true} />)
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
-    // The indicator dot is presentation only — hidden from the
-    // accessibility tree.
-    const dot = container.querySelector('[aria-hidden="true"]')
+    // The indicator dot is presentation only — queried by its structural
+    // class (independent of the attribute under test), then the hidden
+    // contract asserted explicitly.
+    const dot = container.querySelector('.connection-badge-dot')
     expect(dot).not.toBeNull()
+    expect(dot).toHaveAttribute('aria-hidden', 'true')
     expect(dot).toHaveTextContent('')
   })
 

--- a/utilityfog_frontend/frontend/tests-unit/edge-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/edge-validation.test.ts
@@ -163,3 +163,31 @@ describe('sanitizeEdgeList', () => {
     expect(previous).toEqual([])
   })
 })
+
+describe('edge referential stability (Jack audit amendment)', () => {
+  it('reuses unchanged edge objects and returns the previous array when wholesale-identical', () => {
+    const previous = [edge('e1', 'a', 'b', 2), edge('e2', 'b', 'c', 1)]
+    const wholesale = [
+      { id: 'e1', source: 'a', target: 'b', strength: 2 },
+      { id: 'e2', source: 'b', target: 'c', strength: 1 },
+    ]
+    const result = sanitizeEdgeList(wholesale, previous)
+    expect(result).toBe(previous)
+  })
+
+  it('reuses unchanged elements while changed ones get new owned references', () => {
+    const keep = edge('keep', 'a', 'b', 1)
+    const previous = [keep, edge('mod', 'a', 'b', 1)]
+    const result = sanitizeEdgeList(
+      [
+        { id: 'keep', source: 'a', target: 'b', strength: 1 },
+        { id: 'mod', source: 'a', target: 'b', strength: 9 },
+      ],
+      previous,
+    )
+    expect(result).not.toBe(previous)
+    expect(result[0]).toBe(keep) // unchanged element reference reused
+    expect(result[1]).not.toBe(previous[1])
+    expect(result[1].strength).toBe(9)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/edge-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/edge-validation.test.ts
@@ -1,0 +1,165 @@
+// Package Y: the shared edge ownership contract (edgeValidation.ts) —
+// one safely-evaluated materializer used by the legacy adapter, the scene
+// store and the NetworkView2D subscription.
+//
+// Renderer evidence: consumers key on edge.id and index edge.source /
+// edge.target against node ids (unmatched ids are skipped — dangling
+// REFERENCES are tolerated); strength feeds visual weighting with the
+// legacy `|| weight || 1` fallback chain.
+import { describe, it, expect } from 'vitest'
+import { materializeEdge, sanitizeEdgeList } from '../src/viz3d/edgeValidation'
+import type { NetworkEdge } from '../src/ws/SimBridgeClient'
+
+const edge = (id: string, source: string, target: string, strength = 1): NetworkEdge => ({
+  id,
+  source,
+  target,
+  strength,
+})
+
+describe('materializeEdge', () => {
+  it.each([
+    { label: 'null', value: null },
+    { label: 'undefined', value: undefined },
+    { label: 'string', value: 'edge' },
+    { label: 'number', value: 42 },
+  ])('rejects non-object input: $label', ({ value }) => {
+    expect(materializeEdge(value)).toBeNull()
+  })
+
+  it('admits a well-formed edge as a NEW owned plain object', () => {
+    const input = { id: 'e1', source: 'a', target: 'b', strength: 2 }
+    const result = materializeEdge(input)
+    expect(result).toEqual(edge('e1', 'a', 'b', 2))
+    expect(result).not.toBe(input) // materialized, never the untrusted object
+  })
+
+  it('does not retain live getters: each field is read once into owned data', () => {
+    let reads = 0
+    const sneaky = {
+      id: 'e1',
+      get source(): unknown {
+        reads++
+        return 'a'
+      },
+      target: 'b',
+      strength: 1,
+    }
+    const result = materializeEdge(sneaky)
+    expect(result).toEqual(edge('e1', 'a', 'b', 1))
+    expect(reads).toBe(1)
+    expect(Object.getOwnPropertyDescriptor(result, 'source')!.get).toBeUndefined()
+  })
+
+  it.each([
+    { label: 'missing id', value: { source: 'a', target: 'b' } },
+    { label: 'numeric id', value: { id: 7, source: 'a', target: 'b' } },
+    { label: 'missing source', value: { id: 'e', target: 'b' } },
+    { label: 'numeric source', value: { id: 'e', source: 1, target: 'b' } },
+    { label: 'missing target', value: { id: 'e', source: 'a' } },
+    { label: 'null target', value: { id: 'e', source: 'a', target: null } },
+  ])('rejects $label — endpoints are never invented or stringified', ({ value }) => {
+    expect(materializeEdge(value)).toBeNull()
+  })
+
+  it('contains throwing getters on any field', () => {
+    for (const field of ['id', 'source', 'target', 'strength']) {
+      const hostile: Record<string, unknown> = { id: 'e', source: 'a', target: 'b', strength: 1 }
+      Object.defineProperty(hostile, field, {
+        enumerable: true,
+        get(): unknown {
+          throw new Error(`hostile ${field}`)
+        },
+      })
+      expect(materializeEdge(hostile)).toBeNull()
+    }
+  })
+
+  it('legacy aliases resolve source/from and target/to only when enabled', () => {
+    const legacy = { id: 'e', from: 'a', to: 'b', weight: 3 }
+    expect(materializeEdge(legacy)).toBeNull() // strict mode: no aliases
+    expect(materializeEdge(legacy, { legacyAliases: true })).toEqual(edge('e', 'a', 'b', 3))
+    // source/target win over their aliases when both are present.
+    expect(
+      materializeEdge(
+        { id: 'e', source: 's', from: 'f', target: 't', to: 'x', strength: 5, weight: 9 },
+        { legacyAliases: true },
+      ),
+    ).toEqual(edge('e', 's', 't', 5))
+  })
+
+  it('fallbackId substitutes only a missing/falsy id (the legacy index contract)', () => {
+    expect(materializeEdge({ source: 'a', target: 'b' }, { legacyAliases: true, fallbackId: 'edge_4' }))
+      .toEqual(edge('edge_4', 'a', 'b', 1))
+    expect(materializeEdge({ id: '', source: 'a', target: 'b' }, { legacyAliases: true, fallbackId: 'edge_4' }))
+      .toEqual(edge('edge_4', 'a', 'b', 1)) // '' was falsy under the old || contract
+    expect(materializeEdge({ id: 'real', source: 'a', target: 'b' }, { fallbackId: 'edge_4' }))
+      .toEqual(edge('real', 'a', 'b', 1))
+  })
+
+  it('preserves the strength || weight || 1 fallback chain (falsy and non-finite fall through)', () => {
+    const base = { id: 'e', source: 'a', target: 'b' }
+    expect(materializeEdge({ ...base, strength: 2 })!.strength).toBe(2)
+    expect(materializeEdge({ ...base, strength: 0 })!.strength).toBe(1) // 0 was falsy before
+    expect(materializeEdge({ ...base, strength: Number.NaN })!.strength).toBe(1)
+    expect(materializeEdge({ ...base })!.strength).toBe(1)
+    expect(
+      materializeEdge({ ...base, strength: 0, weight: 4 }, { legacyAliases: true })!.strength,
+    ).toBe(4)
+  })
+
+  it('admits prototype-less objects', () => {
+    const bare = Object.create(null) as Record<string, unknown>
+    bare.id = 'e'
+    bare.source = 'a'
+    bare.target = 'b'
+    expect(materializeEdge(bare)).toEqual(edge('e', 'a', 'b', 1))
+  })
+
+  it('keeps well-formed dangling references (unmatched node ids are the renderer\'s decision)', () => {
+    expect(materializeEdge({ id: 'e', source: 'nowhere', target: 'nothing' }))
+      .toEqual(edge('e', 'nowhere', 'nothing', 1))
+  })
+})
+
+describe('sanitizeEdgeList', () => {
+  it.each([
+    { label: 'null', value: null },
+    { label: 'object', value: { length: 1 } },
+    { label: 'string', value: 'edges' },
+  ])('returns the previous list unchanged (same reference) for non-array: $label', ({ value }) => {
+    const previous = [edge('e1', 'a', 'b')]
+    expect(sanitizeEdgeList(value, previous)).toBe(previous)
+  })
+
+  it('filters nulls, primitives, invalid shapes and hostile getters while admitting valid neighbours', () => {
+    const hostile = {
+      id: 'h',
+      source: 'a',
+      get target(): unknown {
+        throw new Error('hostile target')
+      },
+    }
+    const result = sanitizeEdgeList(
+      [null, 'junk', 42, edge('ok1', 'a', 'b'), { id: 'e', source: 9, target: 'b' }, hostile, edge('ok2', 'b', 'c')],
+      [],
+    )
+    expect(result).toEqual([edge('ok1', 'a', 'b'), edge('ok2', 'b', 'c')])
+  })
+
+  it('deduplicates by id, first occurrence wins (matching the node contract)', () => {
+    const result = sanitizeEdgeList(
+      [edge('e1', 'a', 'b', 1), edge('e2', 'b', 'c', 1), { ...edge('e1', 'x', 'y', 9) }],
+      [],
+    )
+    expect(result).toEqual([edge('e1', 'a', 'b', 1), edge('e2', 'b', 'c', 1)])
+  })
+
+  it('does not mutate its input', () => {
+    const input = Object.freeze([Object.freeze(edge('e1', 'a', 'b'))]) as unknown as unknown[]
+    const previous: NetworkEdge[] = []
+    const result = sanitizeEdgeList(input, previous)
+    expect(result).toEqual([edge('e1', 'a', 'b')])
+    expect(previous).toEqual([])
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
@@ -347,3 +347,101 @@ describe('node materialization (ownership contract — Package Y)', () => {
     expect('junk' in result).toBe(false)
   })
 })
+
+describe('node contract hardening (Jack audit amendment)', () => {
+  it.each([
+    { label: 'numeric id', incoming: { id: 7, position: [1, 2, 3] } },
+    { label: 'empty-string id', incoming: { id: '', position: [1, 2, 3] } },
+  ])('rejects $label at every public admission seam', ({ incoming }) => {
+    expect(reconcileNode(incoming, undefined)).toBeNull()
+    const previous = [node('a', [1, 2, 3])]
+    expect(applyNodeUpdate(previous, incoming)).toBe(previous)
+    expect(sanitizeNodeList([incoming], [])).toEqual([])
+  })
+
+  it('discards an invalid status as absent on a new node (documented rule, no assertion-lie)', () => {
+    const result = reconcileNode({ id: 'n', position: [1, 2, 3], status: 'weird' }, undefined)!
+    expect(result.id).toBe('n')
+    expect(result.status).toBeUndefined()
+  })
+
+  it('an invalid incoming status never clobbers a valid existing one', () => {
+    const existing = node('n', [1, 2, 3], { status: 'error' })
+    const result = reconcileNode({ id: 'n', status: 'nonsense' }, existing)!
+    expect(result.status).toBe('error')
+  })
+
+  it.each(['active', 'inactive', 'error'] as const)('valid status %s passes', (status) => {
+    expect(reconcileNode({ id: 'n', position: [1, 2, 3], status }, undefined)!.status).toBe(status)
+  })
+
+  it('mixed connection arrays retain only strings, copied into an owned array', () => {
+    const suppliedConnections = ['a', 1, null, 'b', { evil: true }, 'c']
+    const result = reconcileNode(
+      { id: 'n', position: [1, 2, 3], connections: suppliedConnections },
+      undefined,
+    )!
+    expect(result.connections).toEqual(['a', 'b', 'c'])
+    expect(result.connections).not.toBe(suppliedConnections)
+  })
+
+  it('non-array connections are treated as absent (existing value survives)', () => {
+    const existing = node('n', [1, 2, 3], { connections: ['keep'] })
+    const result = reconcileNode({ id: 'n', connections: 'garbage' }, existing)!
+    expect(result.connections).toEqual(['keep'])
+  })
+
+  it('a hostile getter inside a connections ELEMENT is contained', () => {
+    const hostileElement = {}
+    Object.defineProperty(hostileElement, 'toString', {
+      get(): unknown {
+        throw new Error('hostile element')
+      },
+    })
+    const result = reconcileNode(
+      { id: 'n', position: [1, 2, 3], connections: ['ok', hostileElement] },
+      undefined,
+    )!
+    expect(result.connections).toEqual(['ok'])
+  })
+})
+
+describe('referential stability (Jack audit amendment)', () => {
+  const EXISTING = node('stable', [1, 2, 3], { status: 'active', connections: ['x'] })
+
+  it('reconcileNode returns the EXISTING object when every owned field is unchanged', () => {
+    const identical = { id: 'stable', position: [1, 2, 3], status: 'active', connections: ['x'] }
+    expect(reconcileNode(identical, EXISTING)).toBe(EXISTING)
+  })
+
+  it('a positionless partial that changes nothing returns the existing reference', () => {
+    expect(reconcileNode({ id: 'stable', status: 'active' }, EXISTING)).toBe(EXISTING)
+  })
+
+  it('changed fields still produce a NEW owned reference', () => {
+    const changed = reconcileNode({ id: 'stable', status: 'error' }, EXISTING)!
+    expect(changed).not.toBe(EXISTING)
+    expect(changed.status).toBe('error')
+    const moved = reconcileNode({ id: 'stable', position: [9, 9, 9] }, EXISTING)!
+    expect(moved).not.toBe(EXISTING)
+    expect(moved.position).toEqual([9, 9, 9])
+  })
+
+  it('applyNodeUpdate returns the previous ARRAY reference for a no-op update', () => {
+    const previous = [EXISTING]
+    expect(applyNodeUpdate(previous, { id: 'stable', status: 'active' })).toBe(previous)
+  })
+
+  it('sanitizeNodeList returns the previous array reference when nothing changed', () => {
+    const previous = [EXISTING]
+    const wholesale = [{ id: 'stable', position: [1, 2, 3], status: 'active', connections: ['x'] }]
+    expect(sanitizeNodeList(wholesale, previous)).toBe(previous)
+  })
+
+  it('sanitizeNodeList produces a new array when membership or order changes', () => {
+    const previous = [EXISTING]
+    const reduced = sanitizeNodeList([], previous)
+    expect(reduced).not.toBe(previous)
+    expect(reduced).toEqual([])
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
@@ -280,3 +280,70 @@ describe('sanitizeNodeList', () => {
     expect(previous.map(n => n.id)).toEqual(['a'])
   })
 })
+
+describe('node materialization (ownership contract — Package Y)', () => {
+  it('never returns the untrusted incoming object itself, even for new nodes', () => {
+    const incoming = { id: 'own1', position: [1, 2, 3], connections: [], status: 'active' }
+    const result = reconcileNode(incoming, undefined)
+    expect(result).toEqual(node('own1', [1, 2, 3]))
+    expect(result).not.toBe(incoming)
+  })
+
+  it('does not retain live getters on admitted NEW nodes (each field read exactly once)', () => {
+    let positionReads = 0
+    let statusReads = 0
+    const sneaky = {
+      id: 'sneak',
+      get position(): unknown {
+        positionReads++
+        return [1, 2, 3]
+      },
+      connections: [],
+      get status(): unknown {
+        statusReads++
+        return 'active'
+      },
+    }
+    const result = reconcileNode(sneaky, undefined)!
+    expect(result).toEqual(node('sneak', [1, 2, 3]))
+    expect(positionReads).toBe(1)
+    expect(statusReads).toBe(1)
+    expect(Object.getOwnPropertyDescriptor(result, 'position')!.get).toBeUndefined()
+    expect(Object.getOwnPropertyDescriptor(result, 'status')!.get).toBeUndefined()
+  })
+
+  it('returns an owned position tuple, never the caller-supplied array', () => {
+    const suppliedPosition = [4, 5, 6]
+    const result = reconcileNode(
+      { id: 'own2', position: suppliedPosition, connections: [], status: 'active' },
+      undefined,
+    )!
+    expect(result.position).toEqual([4, 5, 6])
+    expect(result.position).not.toBe(suppliedPosition)
+    suppliedPosition[0] = 999 // later mutation of the input cannot reach the store
+    expect(result.position).toEqual([4, 5, 6])
+  })
+
+  it('contains a throwing getter on a non-position field when existing is undefined (new node)', () => {
+    const hostile = {
+      id: 'h-new',
+      position: [1, 2, 3],
+      get status(): unknown {
+        throw new Error('hostile status on new node')
+      },
+    }
+    expect(reconcileNode(hostile, undefined)).toBeNull()
+  })
+
+  it('owns only renderer-consumed fields — unknown extras are dropped, not carried', () => {
+    const incoming = {
+      id: 'own3',
+      position: [1, 2, 3],
+      connections: [],
+      status: 'active',
+      junk: { deep: 'payload' },
+    }
+    const result = reconcileNode(incoming, undefined)!
+    expect('junk' in result).toBe(false)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
@@ -164,3 +164,70 @@ describe('deterministic sequence through the store boundary', () => {
     expect(state.edges).toEqual([edge('e1', 'b', 'c')])
   })
 })
+
+describe('store ownership (Package Y)', () => {
+  it('updateNode rejects a NEW node whose non-position getter throws; state unaffected', () => {
+    const hostile = {
+      id: 'h-new',
+      position: [1, 2, 3],
+      get status(): unknown {
+        throw new Error('hostile status')
+      },
+    }
+    expect(() => useSceneStore.getState().updateNode(hostile)).not.toThrow()
+    expect(useSceneStore.getState().nodes).toEqual([])
+  })
+
+  it('admitted nodes are materialized: no live getters survive into store state', () => {
+    const sneaky = {
+      id: 'sneak',
+      get position(): unknown {
+        return [1, 2, 3]
+      },
+      connections: [],
+      status: 'active',
+    }
+    useSceneStore.getState().updateNode(sneaky)
+    const [stored] = useSceneStore.getState().nodes
+    expect(stored).toEqual(node('sneak', [1, 2, 3]))
+    expect(stored).not.toBe(sneaky)
+    expect(Object.getOwnPropertyDescriptor(stored, 'position')!.get).toBeUndefined()
+  })
+
+  it('setNetwork filters edges with invalid property types and throwing getters', () => {
+    const hostile = {
+      id: 'h',
+      source: 'a',
+      get target(): unknown {
+        throw new Error('hostile target')
+      },
+    }
+    useSceneStore.getState().setNetwork(
+      [],
+      [edge('ok', 'a', 'b'), { id: 9, source: 'a', target: 'b' }, hostile, { id: 'e', source: 'a' }],
+    )
+    expect(useSceneStore.getState().edges).toEqual([edge('ok', 'a', 'b')])
+  })
+
+  it('admitted edges are materialized owned objects', () => {
+    let reads = 0
+    const sneakyEdge = {
+      id: 'se',
+      get source(): unknown {
+        reads++
+        return 'a'
+      },
+      target: 'b',
+      strength: 1,
+    }
+    useSceneStore.getState().setNetwork([], [sneakyEdge])
+    // Read-count asserted FIRST: vitest's .not.toBe failure-path fallback
+    // deep-compares its operands and would read the getter itself,
+    // polluting the count (probe-verified: the store path reads exactly
+    // once). Ownership is asserted via the property descriptor instead.
+    expect(reads).toBe(1)
+    const [stored] = useSceneStore.getState().edges
+    expect(stored).toEqual(edge('se', 'a', 'b'))
+    expect(Object.getOwnPropertyDescriptor(stored, 'source')!.get).toBeUndefined()
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/scene-store.test.ts
@@ -231,3 +231,41 @@ describe('store ownership (Package Y)', () => {
     expect(Object.getOwnPropertyDescriptor(stored, 'source')!.get).toBeUndefined()
   })
 })
+
+describe('zustand notification measurement (Jack audit amendment)', () => {
+  it('identical updates notify NO subscriber; changed updates notify exactly once', () => {
+    const s = useSceneStore.getState()
+    s.updateNode({ id: 'n', position: [1, 2, 3], connections: [], status: 'active' })
+    s.setNetwork(
+      [{ id: 'n', position: [1, 2, 3], connections: [], status: 'active' }],
+      [{ id: 'e', source: 'n', target: 'n', strength: 1 }],
+    )
+
+    let notifications = 0
+    const unsubscribe = useSceneStore.subscribe(() => {
+      notifications++
+    })
+
+    // Identical singular update: same refs -> zero notifications.
+    s.updateNode({ id: 'n', position: [1, 2, 3], connections: [], status: 'active' })
+    expect(notifications).toBe(0)
+    // Identical wholesale update: zero notifications.
+    s.setNetwork(
+      [{ id: 'n', position: [1, 2, 3], connections: [], status: 'active' }],
+      [{ id: 'e', source: 'n', target: 'n', strength: 1 }],
+    )
+    expect(notifications).toBe(0)
+    // Rejected garbage: zero notifications.
+    s.updateNode({ id: 'ghost' })
+    s.updateNode('junk')
+    expect(notifications).toBe(0)
+
+    // Real changes notify exactly once each.
+    s.updateNode({ id: 'n', status: 'error' })
+    expect(notifications).toBe(1)
+    s.setNetwork([], [])
+    expect(notifications).toBe(2)
+
+    unsubscribe()
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/simbridge-client.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/simbridge-client.test.ts
@@ -84,7 +84,15 @@ let client: SimBridgeClient
 let events: string[]
 
 const sockets = () => FakeWebSocket.instances
-const last = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+const last = () => {
+  const instance = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+  if (!instance) {
+    throw new Error(
+      'No fake socket has been constructed yet — call client.connect() before driving socket events.',
+    )
+  }
+  return instance
+}
 
 beforeEach(() => {
   vi.useFakeTimers()
@@ -107,12 +115,21 @@ afterEach(() => {
   // reconnect delay must produce NO new sockets and leave NO timers —
   // the teardown contract itself.
   client.disconnect()
-  vi.runAllTimers()
+  // Bounded drain: run only the timers pending at each step, with a hard
+  // iteration cap — a recursive-timer defect fails this assertion loudly
+  // instead of hanging the runner the way runAllTimers() could.
+  for (let i = 0; i < 25 && vi.getTimerCount() > 0; i++) {
+    vi.runOnlyPendingTimers()
+  }
   const settled = sockets().length
   vi.advanceTimersByTime(60 * DELAY)
   expect(sockets().length).toBe(settled)
   expect(vi.getTimerCount()).toBe(0)
   FakeWebSocket.reset()
+  // Explicit restoration (the config also does this; stating it here makes
+  // the isolation contract local and audit-visible).
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
   vi.useRealTimers()
 })
 

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -246,3 +246,30 @@ describe('unmount during a handler (Package Y)', () => {
     expect(handlers.updateNode).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('frame-scheduling discipline (Jack audit amendment)', () => {
+  it('unmount during the LAST handler schedules no extra animation frame', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    handlers.updateNode.mockImplementationOnce(() => {
+      view.unmount()
+    })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } }) // schedules exactly one frame
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    await vi.runAllTimersAsync()
+    // The drain must NOT have scheduled a post-batch yield frame: the
+    // active/empty check runs BEFORE requesting the next frame.
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('an emptied queue schedules no trailing yield frame either', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    await vi.runAllTimersAsync()
+    expect(rafSpy).toHaveBeenCalledTimes(1) // batch drained; no idle frame requested
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -63,9 +63,15 @@ beforeEach(() => {
 
 afterEach(() => {
   client.disconnect()
-  vi.runAllTimers()
+  // Bounded drain (mirrors the SimBridge suite): pending timers only, with
+  // a hard cap so a recursive-timer defect fails instead of hanging.
+  for (let i = 0; i < 25 && vi.getTimerCount() > 0; i++) {
+    vi.runOnlyPendingTimers()
+  }
   expect(vi.getTimerCount()).toBe(0)
   FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
   vi.useRealTimers()
 })
 
@@ -184,5 +190,59 @@ describe('useEventQueue unmount safety', () => {
     unmount()
     await vi.runAllTimersAsync()
     expect(handlers.updateNode.mock.calls.length).toBe(deliveredBeforeUnmount)
+  })
+})
+
+describe('handler-error policy (Package Y)', () => {
+  it('a throwing handler does not lock the queue: error reported once, later events deliver', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderHook(() => useEventQueue(client, handlers))
+    handlers.updateNode.mockImplementationOnce(() => {
+      throw new Error('handler boom')
+    })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } }) // throws inside drain
+    await vi.runAllTimersAsync()
+
+    // Later, INDEPENDENT event: must process normally (queue not locked).
+    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, { seq: 2 })
+
+    // Bounded diagnostic channel: exactly one report for the one failure.
+    const reports = vi.mocked(console.error).mock.calls.filter(
+      args => args[0] === 'Event handler failed:',
+    )
+    expect(reports).toHaveLength(1)
+  })
+
+  it('a throwing handler does not abort the remaining handlers in its batch', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderHook(() => useEventQueue(client, handlers))
+    handlers.updateNode.mockImplementationOnce(() => {
+      throw new Error('first of batch fails')
+    })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 3 } })
+    await vi.runAllTimersAsync()
+    // Failed event is skipped (no retry); its batch-mates still deliver.
+    expect(handlers.updateNode).toHaveBeenCalledTimes(3)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, { seq: 2 })
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(3, { seq: 3 })
+  })
+})
+
+describe('unmount during a handler (Package Y)', () => {
+  it('an unmount performed BY a handler prevents every remaining handler in that batch', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    handlers.updateNode.mockImplementationOnce(() => {
+      view.unmount() // the handler itself tears the consumer down
+    })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
+    socket().serverMessage({ type: 'node_update', payload: { seq: 3 } })
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
   })
 })

--- a/utilityfog_frontend/frontend/tests-unit/viz3d-utils.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/viz3d-utils.test.ts
@@ -70,9 +70,11 @@ describe('findNearbyNodes', () => {
     expect(findNearbyNodes([1000, 1000, 1000], nodes, 5)).toEqual([])
   })
 
-  it('does not mutate the node list', () => {
-    const before = nodes.map((n) => n.id)
+  it('does not mutate the node list or any node within it', () => {
+    // Deep snapshot BEFORE the call: every field of every node, not just
+    // ids/order, must be byte-equal afterwards.
+    const snapshot = structuredClone(nodes)
     findNearbyNodes([0, 0, 0], nodes, 5)
-    expect(nodes.map((n) => n.id)).toEqual(before)
+    expect(nodes).toEqual(snapshot)
   })
 })

--- a/utilityfog_frontend/frontend/vitest.config.ts
+++ b/utilityfog_frontend/frontend/vitest.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
         'src/App.tsx',
         'src/components/ConnectionBadge.tsx',
         'src/components/EventFeed.tsx',
+        'src/viz3d/edgeValidation.ts',
         'src/viz3d/nodeValidation.ts',
         'src/viz3d/useEventQueue.ts',
         'src/viz3d/useSceneStore.ts',


### PR DESCRIPTION
## PACKAGE Y — review convergence (continuation runway, refs #6 — no closing keyword)

**Stacked PR: base is `test/frontend-component-unit-contracts` (X → W → V → U → Q → P → O → main). Merge order O→P→Q→U→V→W→X→Y.**

Addresses **every actionable finding from the 14 unresolved review threads** on #326/#329/#330/#331/#332 in one downstream correction PR. Threads themselves are left untouched for Jack. **12 failing-first receipts** captured before repair.

### Review-thread dispositions (all 14)
| Thread | Disposition | Evidence |
|---|---|---|
| #326 adapters.ts:68 — connections array/element validation | **Addressed** | `Array.isArray` guard + shared `materializeEdge` (legacy dialect); hostile/invalid elements rejected |
| #326 NetworkView2D.tsx:28 — edge element validation | **Addressed** | subscription now uses `sanitizeEdgeList` |
| #326 useSceneStore.ts:46 — edge element validation | **Addressed** (superseding the earlier non-null-object filter) | `sanitizeEdgeList` with full property validation |
| #329 badge test circular aria-hidden query | **Addressed** | dot queried by structural class; `aria-hidden` asserted explicitly |
| #329 shallow immutability assertion | **Addressed** | `structuredClone` deep snapshot compared whole-structure |
| #330 nodeValidation.ts:50 **security-high** — unmaterialized new-node candidate | **Addressed** | full materialization (below) |
| #330 useSceneStore.ts:50 — edge property types + throwing getters | **Addressed** | `materializeEdge` requires string id/source/target, contains getters |
| #330 test: new-node non-position throwing getter | **Addressed** | test added (was failing-first: previously ADMITTED) |
| #330 test: updateNode new-node hostile getter | **Addressed** | test added (failing-first) |
| #330 test: setNetwork hostile-getter edges | **Addressed** | test added (failing-first) |
| #330 codex P2 — live getters retained in store state | **Addressed** | materialization + read-once assertions with property-descriptor proofs |
| #331 `last()` explicit assertion | **Addressed** | descriptive throw when no socket exists |
| #331 recursive `runAllTimers` teardown | **Addressed** | capped `runOnlyPendingTimers` drain (25 iterations) + explicit `restoreAllMocks`/`unstubAllGlobals` |
| #332 **high** — handler exception locks queue | **Addressed** | `finally` restoration + per-handler containment (below) |

### Node materialization (ownership contract)
One contained single-pass read pulls every renderer-consumed field **exactly once** into a plain owned object — the untrusted object, its live getters, and unknown extra fields never reach stored state. A throwing getter on **any** read field (including non-position fields on NEW nodes — previously admitted unchecked) rejects the candidate. Positions are copied into owned tuples; no getter is ever invoked twice (id reads unified into the same pass). Merge-presence semantics, last-valid-position, ghost exclusion, dup-id rules unchanged and re-verified.

### Shared edge contract (`edgeValidation.ts`, new — used by adapters, store, and NetworkView2D)
String `id`/`source`/`target` required — **endpoints never invented or stringified**; legacy `source/from`+`target/to` aliases and the `strength||weight||1` falsy-fallback chain preserved exactly (legacy dialect only); adapter index-generated ids for missing/falsy ids; hostile getters/nulls/primitives filtered; **well-formed dangling references still admitted** (renderers skip unmatched ids); duplicate ids first-wins.

### Event-queue error/unmount policy
`finally`-guarded processing flag (no exit path locks the queue) · active guard **before every handler** (an unmount performed BY a handler stops its remaining batch-mates) · explicit policy: a throwing handler is contained, **reported exactly once** through `console.error('Event handler failed:', …)`, never retried, never aborts batch-mates; later independent events process normally · no unhandled rejection from the fire-and-forget drain.

### Notable probe finding (documented in-test)
vitest's `.not.toBe` failure-path deep-compares operands and **reads getters itself** — read-count assertions therefore precede comparison assertions, with ownership proven via property descriptors.

### Verification
unit **171/171** (35 new) — full suite · serial · shuffle seeds 1/42/1337/271828/314159 · targeted Y suites **×5** · lint 0/0 · tsc clean · **coverage rose to 97.26/94.14/97.59/97.80** (edgeValidation joined the contract; thresholds 93/85/92/93 unchanged — never lowered) · budget-unit 11/11 · build ok · BUNDLE_BUDGET PASS 985,784/274,626 (+1,614 raw — the validators ship; limits unchanged) · **Playwright 56/56 ×3**.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)