### PR TITLE
test: deterministic property testing over ingress validators — fast-check, fixed seeds, hostile adversaries (PACKAGE AA)

### DIFF
--- a/utilityfog_frontend/frontend/package-lock.json
+++ b/utilityfog_frontend/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "fast-check": "4.9.0",
         "jsdom": "29.1.1",
         "typescript": "^5.2.2",
         "vite": "^6.4.3",
@@ -4365,6 +4366,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6444,6 +6468,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/utilityfog_frontend/frontend/package.json
+++ b/utilityfog_frontend/frontend/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "fast-check": "4.9.0",
     "jsdom": "29.1.1",
     "typescript": "^5.2.2",
     "vite": "^6.4.3",

--- a/utilityfog_frontend/frontend/tests-unit/ingress-properties.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/ingress-properties.test.ts
@@ -13,7 +13,7 @@
 // Seed strategy: FC_SEED overrides the recorded default so the suite can
 // be repeated under several fixed seeds; FC_NUM_RUNS overrides the run
 // count (local verification used 2000 per central invariant).
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fc from 'fast-check'
 import {
   isValidPosition,
@@ -38,6 +38,27 @@ const EXISTING: NetworkNode = {
 }
 
 const jsonValue = () => fc.jsonValue({ maxDepth: 4 })
+
+// Global-store isolation (audit amendment): the zustand store is a module
+// singleton, so every test starts from an ASSERTED empty state and must
+// leave it empty — store-mutating predicates reset at the end of every
+// property iteration, making cross-test (and cross-iteration) state
+// dependence structurally impossible. Verified additionally by
+// order-randomized runs (--sequence.shuffle.tests).
+const assertStoreEmpty = () => {
+  expect(useSceneStore.getState().nodes).toEqual([])
+  expect(useSceneStore.getState().edges).toEqual([])
+}
+
+beforeEach(() => {
+  useSceneStore.setState({ nodes: [], edges: [] })
+  assertStoreEmpty()
+})
+
+afterEach(() => {
+  assertStoreEmpty()
+  useSceneStore.setState({ nodes: [], edges: [] })
+})
 
 describe(`ingress properties (seed ${SEED}, ${NUM_RUNS} runs per invariant)`, () => {
   it('validators never throw for generated JSON-like values', () => {
@@ -78,6 +99,7 @@ describe(`ingress properties (seed ${SEED}, ${NUM_RUNS} runs per invariant)`, ()
           expect(typeof e.target).toBe('string')
           expect(Number.isFinite(e.strength)).toBe(true)
         }
+        useSceneStore.setState({ nodes: [], edges: [] })
       }),
       PARAMS,
     )
@@ -167,6 +189,7 @@ describe(`ingress properties (seed ${SEED}, ${NUM_RUNS} runs per invariant)`, ()
         s.setNetwork(nodes, edges)
         expect(useSceneStore.getState().nodes).toEqual(first)
         expect(useSceneStore.getState().edges).toEqual(firstEdges)
+        useSceneStore.setState({ nodes: [], edges: [] })
       }),
       PARAMS,
     )
@@ -316,6 +339,7 @@ describe('handcrafted adversaries (shapes JSON cannot express)', () => {
       expect(typeof e.source).toBe('string')
       expect(typeof e.target).toBe('string')
     }
+    useSceneStore.setState({ nodes: [], edges: [] })
   })
 
   it('a cyclic node is admitted with only owned fields (cycle never enters the store)', () => {
@@ -327,5 +351,6 @@ describe('handcrafted adversaries (shapes JSON cannot express)', () => {
     expect(stored.id).toBe('cyc')
     expect('self' in stored).toBe(false) // unknown extras dropped by materialization
     expect(() => structuredClone(stored)).not.toThrow() // acyclic, plain data
+    useSceneStore.setState({ nodes: [], edges: [] })
   })
 })

--- a/utilityfog_frontend/frontend/tests-unit/ingress-properties.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/ingress-properties.test.ts
@@ -1,0 +1,331 @@
+// Package AA: deterministic property testing over the ingress validators.
+//
+// fast-check drives generated JSON-like hostile inputs through every
+// validator/sanitizer with FIXED RECORDED SEEDS and bounded run counts —
+// on any failure fast-check's assertion error reports the seed and
+// counterexample path for exact replay.
+//
+// SCOPE OF CLAIM (narrow, deliberate): these properties demonstrate
+// no-throw and invariant behavior over the generated input space and the
+// handcrafted adversaries below. They do NOT prove total correctness or
+// security.
+//
+// Seed strategy: FC_SEED overrides the recorded default so the suite can
+// be repeated under several fixed seeds; FC_NUM_RUNS overrides the run
+// count (local verification used 2000 per central invariant).
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  isValidPosition,
+  reconcileNode,
+  applyNodeUpdate,
+  sanitizeNodeList,
+} from '../src/viz3d/nodeValidation'
+import { materializeEdge, sanitizeEdgeList } from '../src/viz3d/edgeValidation'
+import { adaptSimulationData } from '../src/viz3d/adapters'
+import { useSceneStore } from '../src/viz3d/useSceneStore'
+import type { NetworkNode } from '../src/ws/SimBridgeClient'
+
+const SEED = Number(process.env.FC_SEED ?? 1720742400)
+const NUM_RUNS = Number(process.env.FC_NUM_RUNS ?? 2000)
+const PARAMS = { seed: SEED, numRuns: NUM_RUNS }
+
+const EXISTING: NetworkNode = {
+  id: 'existing',
+  position: [7, 8, 9],
+  connections: [],
+  status: 'active',
+}
+
+const jsonValue = () => fc.jsonValue({ maxDepth: 4 })
+
+describe(`ingress properties (seed ${SEED}, ${NUM_RUNS} runs per invariant)`, () => {
+  it('validators never throw for generated JSON-like values', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        isValidPosition(v)
+        reconcileNode(v, undefined)
+        reconcileNode(v, EXISTING)
+        applyNodeUpdate([EXISTING], v)
+        sanitizeNodeList(v, [EXISTING])
+        materializeEdge(v)
+        materializeEdge(v, { legacyAliases: true, fallbackId: 'edge_0' })
+        sanitizeEdgeList(v, [])
+        adaptSimulationData(v)
+      }),
+      PARAMS,
+    )
+  })
+
+  it('the store never throws and never admits invalid records', () => {
+    fc.assert(
+      fc.property(jsonValue(), jsonValue(), (a, b) => {
+        useSceneStore.setState({ nodes: [], edges: [] })
+        const s = useSceneStore.getState()
+        s.updateNode(a)
+        s.setNetwork(a, b)
+        s.updateNode(b)
+        const state = useSceneStore.getState()
+        for (const n of state.nodes) {
+          expect(typeof n.id).toBe('string')
+          expect(isValidPosition(n.position)).toBe(true)
+          // Materialized: data properties only, no live getters.
+          expect(Object.getOwnPropertyDescriptor(n, 'position')!.get).toBeUndefined()
+        }
+        for (const e of state.edges) {
+          expect(typeof e.id).toBe('string')
+          expect(typeof e.source).toBe('string')
+          expect(typeof e.target).toBe('string')
+          expect(Number.isFinite(e.strength)).toBe(true)
+        }
+      }),
+      PARAMS,
+    )
+  })
+
+  it('accepted positions are exactly three finite numbers', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        if (isValidPosition(v)) {
+          expect(v).toHaveLength(3)
+          for (const coord of v) expect(Number.isFinite(coord)).toBe(true)
+        }
+      }),
+      PARAMS,
+    )
+  })
+
+  it('nodes accepted from scratch carry a usable string id and a valid owned position', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        const result = applyNodeUpdate([], v)
+        if (result.length > 0) {
+          expect(result).toHaveLength(1)
+          expect(typeof result[0].id).toBe('string')
+          expect(isValidPosition(result[0].position)).toBe(true)
+        }
+      }),
+      PARAMS,
+    )
+  })
+
+  it('accepted edges carry usable string id/source/target and finite strength', () => {
+    fc.assert(
+      fc.property(jsonValue(), fc.boolean(), (v, legacy) => {
+        const edge = legacy
+          ? materializeEdge(v, { legacyAliases: true, fallbackId: 'edge_0' })
+          : materializeEdge(v)
+        if (edge !== null) {
+          expect(typeof edge.id).toBe('string')
+          expect(typeof edge.source).toBe('string')
+          expect(typeof edge.target).toBe('string')
+          expect(Number.isFinite(edge.strength)).toBe(true)
+        }
+      }),
+      PARAMS,
+    )
+  })
+
+  it('sanitization is deterministic (same input, same output)', () => {
+    // Scope: the deterministic validators. The adapter agents dialect is
+    // deliberately excluded — its unusable-position fallback is the
+    // documented RANDOM legacy scatter.
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        expect(sanitizeNodeList(v, [EXISTING])).toEqual(sanitizeNodeList(v, [EXISTING]))
+        expect(sanitizeEdgeList(v, [])).toEqual(sanitizeEdgeList(v, []))
+        expect(reconcileNode(v, EXISTING)).toEqual(reconcileNode(v, EXISTING))
+        expect(materializeEdge(v)).toEqual(materializeEdge(v))
+      }),
+      PARAMS,
+    )
+  })
+
+  it('sanitization does not mutate its input', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        const snapshot = structuredClone(v)
+        sanitizeNodeList(v, [EXISTING])
+        sanitizeEdgeList(v, [])
+        reconcileNode(v, EXISTING)
+        materializeEdge(v, { legacyAliases: true, fallbackId: 'edge_0' })
+        adaptSimulationData(v)
+        expect(v).toEqual(snapshot)
+      }),
+      PARAMS,
+    )
+  })
+
+  it('applying the same sanitized network twice is idempotent (wholesale contract)', () => {
+    fc.assert(
+      fc.property(jsonValue(), jsonValue(), (nodes, edges) => {
+        useSceneStore.setState({ nodes: [], edges: [] })
+        const s = useSceneStore.getState()
+        s.setNetwork(nodes, edges)
+        const first = structuredClone(useSceneStore.getState().nodes)
+        const firstEdges = structuredClone(useSceneStore.getState().edges)
+        s.setNetwork(nodes, edges)
+        expect(useSceneStore.getState().nodes).toEqual(first)
+        expect(useSceneStore.getState().edges).toEqual(firstEdges)
+      }),
+      PARAMS,
+    )
+  })
+
+  it('malformed updates can never erase the last valid position', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        // Force the arbitrary payload to target the existing node whenever
+        // it is object-shaped; every other shape must leave it untouched.
+        const targeted =
+          v && typeof v === 'object' && !Array.isArray(v) ? { ...(v as object), id: 'existing' } : v
+        const result = applyNodeUpdate([EXISTING], targeted)
+        const kept = result.find(n => n.id === 'existing')!
+        expect(kept).toBeDefined()
+        expect(isValidPosition(kept.position)).toBe(true)
+      }),
+      PARAMS,
+    )
+  })
+
+  it('output size never exceeds valid input count', () => {
+    fc.assert(
+      fc.property(jsonValue(), (v) => {
+        const nodes = sanitizeNodeList(v, [EXISTING])
+        const edges = sanitizeEdgeList(v, [])
+        if (Array.isArray(v)) {
+          expect(nodes.length).toBeLessThanOrEqual(v.length)
+          expect(edges.length).toBeLessThanOrEqual(v.length)
+        } else {
+          // Non-array input: the previous list is returned unchanged.
+          expect(nodes.map(n => n.id)).toEqual(['existing'])
+          expect(edges).toEqual([])
+        }
+        const adapted = adaptSimulationData(v)
+        if (v && typeof v === 'object' && !Array.isArray(v)) {
+          const container = v as Record<string, unknown>
+          const bound = (key: string) =>
+            Array.isArray(container[key]) ? (container[key] as unknown[]).length : 0
+          expect(adapted.nodes.length).toBeLessThanOrEqual(bound('agents') + bound('nodes'))
+          expect(adapted.edges.length).toBeLessThanOrEqual(bound('connections') + bound('edges'))
+        } else {
+          expect(adapted).toEqual({ nodes: [], edges: [] })
+        }
+      }),
+      PARAMS,
+    )
+  })
+})
+
+describe('handcrafted adversaries (shapes JSON cannot express)', () => {
+  const throwingGetter = (field: string): Record<string, unknown> => {
+    const obj: Record<string, unknown> = { id: 'x', position: [1, 2, 3], source: 'a', target: 'b' }
+    Object.defineProperty(obj, field, {
+      enumerable: true,
+      get(): unknown {
+        throw new Error(`hostile ${field}`)
+      },
+    })
+    return obj
+  }
+
+  const adversaries: Array<{ label: string; value: () => unknown }> = [
+    { label: 'throwing id getter', value: () => throwingGetter('id') },
+    { label: 'throwing position getter', value: () => throwingGetter('position') },
+    { label: 'throwing status getter', value: () => throwingGetter('status') },
+    { label: 'throwing source getter', value: () => throwingGetter('source') },
+    {
+      label: 'proxy throwing from get',
+      value: () =>
+        new Proxy({}, {
+          get() {
+            throw new Error('hostile get trap')
+          },
+        }),
+    },
+    {
+      label: 'proxy throwing from has (in operator)',
+      value: () =>
+        new Proxy({}, {
+          has() {
+            throw new Error('hostile has trap')
+          },
+        }),
+    },
+    {
+      label: 'proxy throwing from ownKeys',
+      value: () =>
+        new Proxy({}, {
+          ownKeys() {
+            throw new Error('hostile ownKeys trap')
+          },
+        }),
+    },
+    {
+      label: 'proxy throwing from getOwnPropertyDescriptor',
+      value: () =>
+        new Proxy({}, {
+          getOwnPropertyDescriptor() {
+            throw new Error('hostile descriptor trap')
+          },
+        }),
+    },
+    { label: 'fully sparse array position', value: () => ({ id: 'x', position: new Array(3) }) },
+    {
+      label: 'cyclic object',
+      value: () => {
+        const c: Record<string, unknown> = { id: 'cyc', position: [1, 2, 3] }
+        c.self = c
+        return c
+      },
+    },
+    {
+      label: 'cyclic array in edges slot',
+      value: () => {
+        const arr: unknown[] = [{ id: 'e', source: 'a', target: 'b' }]
+        arr.push(arr)
+        return arr
+      },
+    },
+  ]
+
+  it.each(adversaries)('$label crosses no boundary and corrupts no state', ({ value }) => {
+    const adversary = value()
+    expect(() => {
+      isValidPosition(adversary)
+      reconcileNode(adversary, undefined)
+      reconcileNode(adversary, EXISTING)
+      applyNodeUpdate([EXISTING], adversary)
+      sanitizeNodeList([adversary], [EXISTING])
+      sanitizeNodeList(adversary, [EXISTING])
+      materializeEdge(adversary, { legacyAliases: true, fallbackId: 'edge_0' })
+      sanitizeEdgeList([adversary], [])
+      sanitizeEdgeList(adversary, [])
+      adaptSimulationData(adversary)
+      adaptSimulationData({ agents: [adversary], connections: [adversary], nodes: [adversary], edges: [adversary] })
+    }).not.toThrow()
+
+    useSceneStore.setState({ nodes: [], edges: [] })
+    useSceneStore.getState().updateNode(adversary)
+    useSceneStore.getState().setNetwork([adversary], [adversary])
+    for (const n of useSceneStore.getState().nodes) {
+      expect(typeof n.id).toBe('string')
+      expect(isValidPosition(n.position)).toBe(true)
+    }
+    for (const e of useSceneStore.getState().edges) {
+      expect(typeof e.source).toBe('string')
+      expect(typeof e.target).toBe('string')
+    }
+  })
+
+  it('a cyclic node is admitted with only owned fields (cycle never enters the store)', () => {
+    const c: Record<string, unknown> = { id: 'cyc', position: [1, 2, 3] }
+    c.self = c
+    useSceneStore.setState({ nodes: [], edges: [] })
+    useSceneStore.getState().updateNode(c)
+    const [stored] = useSceneStore.getState().nodes
+    expect(stored.id).toBe('cyc')
+    expect('self' in stored).toBe(false) // unknown extras dropped by materialization
+    expect(() => structuredClone(stored)).not.toThrow() // acyclic, plain data
+  })
+})


### PR DESCRIPTION
## PACKAGE AA — deterministic property testing (continuation runway, refs #6 — no closing keyword)

**Stacked PR: base is `test/frontend-ingress-contracts` (Z → Y → X → … → main). Merge order O→P→Q→U→V→W→X→Y→Z→AA.**

### Dependency provenance
`fast-check` pinned **exactly 4.9.0** (registry-audited; engines node ≥12.17 — Node 20 ✓). Lockfile delta: **exactly fast-check + its single transitive `pure-rand` 8.4.2**, both registry-resolved with integrity, 0 removed/changed; clean-dir double generation with pinned npm 10.9.8, **byte-identical**.

### What (22 tests)
**Fixed recorded seeds + bounded run counts** (default seed 1720742400; `FC_SEED`/`FC_NUM_RUNS` overrides; 2000 runs per central invariant). Properties: validators never throw for generated JSON-like values · the store never throws and never admits invalid records (string ids, valid positions, **no live getters — property-descriptor-checked**) · accepted positions exactly three finite numbers · from-scratch accepted nodes carry usable string id + valid owned position · accepted edges carry string id/source/target + finite strength · sanitization deterministic (adapter agents dialect excluded — its fallback is the documented random scatter) · no input mutation (structuredClone snapshots) · `setNetwork` idempotent under the wholesale contract · malformed updates can never erase the last valid position · output size never exceeds valid input count (incl. per-dialect adapter bounds).

**Handcrafted adversaries JSON cannot express (12)**: throwing getters (id/position/status/source) · proxies throwing from `get`/`has`/`ownKeys`/`getOwnPropertyDescriptor` traps · fully sparse array positions · cyclic objects/arrays — all cross no boundary, corrupt no state; a cyclic node admits with only owned fields (cycle never enters the store).

### Run-count calibration (measured, not guessed)
1 run → 10ms · 2000 → 320ms · 20,000 → 3.19s test time (linear). **CI count = 2000, identical to local** — bounded at ~2s wall. Suite green under **five fixed seeds** (1720742400 / 42 / 1337 / 271828 / 9001) and at 20,000 runs per invariant. On failure, fast-check reports **seed + counterexample path** for exact replay.

### Non-claim (explicit)
These properties demonstrate no-throw and invariant behavior over the generated space and the listed adversaries. **They do not prove total correctness or security.**

### Verification
unit **222/222** — full · serial · shuffle seeds 1/42/1337 · coverage gate PASS (90.39/92.62/94.33/90.86 — property runs *lifted* branch coverage; thresholds untouched) · lint 0/0 · tsc clean · budget-unit 11/11 · build ok · BUNDLE_BUDGET PASS byte-identical (devDeps don't ship) · **Playwright 56/56 ×3**.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)