### PR TITLE
feat: narrow view error boundary — view render exceptions can no longer unmount the shell (PACKAGE AB)

### DIFF
--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import NetworkView3D from './viz3d/NetworkView3D'
 import NetworkView2D from './components/NetworkView2D'
 import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
+import ViewErrorBoundary from './components/ViewErrorBoundary'
 import { SimBridgeClient } from './ws/SimBridgeClient'
 
 // Robust WS URL computation
@@ -54,22 +55,36 @@ function App() {
           mirrors the flex slot the view roots already expect (a flex:1 child
           of the column-flex .app-container) and is itself a flex container,
           so the view root's own flex:1 fills it and child canvas sizing is
-          unchanged. minHeight/minWidth 0 keep flex overflow semantics. */}
+          unchanged. minHeight/minWidth 0 keep flex overflow semantics.
+          ViewErrorBoundary guards ONLY the replaceable view inside the
+          region: a view render exception shows an accessible fallback there
+          while the shell (controls, feed, badge) stays mounted; switching
+          views remounts a fresh boundary. */}
+      {/* The key is load-bearing: both branches are same-type elements in
+          the same tree position, so WITHOUT it React reconciles them as one
+          component and a failed boundary's state would survive the switch.
+          Distinct keys force a remount — a fresh boundary per view. */}
       {view === '3d' ? (
         <section
+          key="view-3d"
           role="region"
           aria-label="3D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
-          <NetworkView3D simClient={simClient} />
+          <ViewErrorBoundary viewLabel="3D network view">
+            <NetworkView3D simClient={simClient} />
+          </ViewErrorBoundary>
         </section>
       ) : (
         <section
+          key="view-2d"
           role="region"
           aria-label="2D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
-          <NetworkView2D simClient={simClient} />
+          <ViewErrorBoundary viewLabel="2D network view">
+            <NetworkView2D simClient={simClient} />
+          </ViewErrorBoundary>
         </section>
       )}
     </div>

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -1,0 +1,74 @@
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+
+// Narrow error boundary for the REPLACEABLE 2D/3D view surface only — the
+// application shell (controls, event feed, connection badge) deliberately
+// sits outside it, so an unexpected render exception in the active view
+// can no longer unmount the whole tree (the failure mode the ingestion
+// validators guard against upstream; this is the last line).
+//
+// Containment contract:
+//  - When healthy, children render UNWRAPPED — zero layout impact.
+//  - On failure: an accessible role="alert" fallback with a concise
+//    message and a Retry button that remounts ONLY the failed view.
+//  - Retry is user-initiated only — no automatic retry loop, no hidden
+//    reconnect (the SimBridge client lives above this boundary and is
+//    untouched by view failures).
+//  - Switching views unmounts this boundary instance, so the replacement
+//    view always starts with a fresh, un-failed boundary.
+//  - Errors are not swallowed: each failure is reported exactly once
+//    through the established bounded diagnostic channel (console.error),
+//    alongside React's own development error output.
+
+interface ViewErrorBoundaryProps {
+  // Names the guarded surface in the fallback message ("3D network view").
+  viewLabel: string
+  children: ReactNode
+}
+
+interface ViewErrorBoundaryState {
+  failed: boolean
+}
+
+export default class ViewErrorBoundary extends Component<
+  ViewErrorBoundaryProps,
+  ViewErrorBoundaryState
+> {
+  state: ViewErrorBoundaryState = { failed: false }
+
+  static getDerivedStateFromError(): ViewErrorBoundaryState {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown, _info: ErrorInfo): void {
+    console.error('View render failed:', error)
+  }
+
+  handleRetry = (): void => {
+    this.setState({ failed: false })
+  }
+
+  render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <div
+          role="alert"
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '12px',
+            color: 'white',
+            backgroundColor: '#1a1a1a',
+          }}
+        >
+          <p style={{ margin: 0 }}>The {this.props.viewLabel} failed to render.</p>
+          <button onClick={this.handleRetry}>Retry {this.props.viewLabel}</button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -40,8 +40,11 @@ export default class ViewErrorBoundary extends Component<
     return { failed: true }
   }
 
-  componentDidCatch(error: unknown, _info: ErrorInfo): void {
-    console.error('View render failed:', error)
+  componentDidCatch(error: unknown, info: ErrorInfo): void {
+    // The SINGLE application-owned diagnostic for this failure — error plus
+    // the component stack that locates it. (React's own development-mode
+    // logging is separate and not this boundary's contract.)
+    console.error('View render failed:', error, info.componentStack)
   }
 
   handleRetry = (): void => {
@@ -65,7 +68,9 @@ export default class ViewErrorBoundary extends Component<
           }}
         >
           <p style={{ margin: 0 }}>The {this.props.viewLabel} failed to render.</p>
-          <button onClick={this.handleRetry}>Retry {this.props.viewLabel}</button>
+          <button type="button" onClick={this.handleRetry}>
+            Retry {this.props.viewLabel}
+          </button>
         </div>
       )
     }

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -1,0 +1,175 @@
+// Package AB: view failure containment — an unexpected active-view render
+// exception must never unmount the application shell.
+//
+// The WebGL-heavy views are mocked at the module seam (no real WebGL in
+// unit tests) with CONTROLLABLE failure flags, so genuine render throws
+// exercise the real ViewErrorBoundary inside the real App.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StrictMode } from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import App from '../src/App'
+
+const failures = { v3d: false, v2d: false }
+
+vi.mock('../src/viz3d/NetworkView3D', () => ({
+  default: () => {
+    if (failures.v3d) throw new Error('synthetic 3D render failure')
+    return <div data-testid="view-3d" />
+  },
+}))
+vi.mock('../src/components/NetworkView2D', () => ({
+  default: () => {
+    if (failures.v2d) throw new Error('synthetic 2D render failure')
+    return <div data-testid="view-2d" />
+  },
+}))
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+  serverOpen() {
+    this.readyState = 1
+    this.onopen?.({})
+  }
+}
+
+const live = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+const shellAlive = () => {
+  expect(screen.getByRole('button', { name: '2D View' })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: '3D View' })).toBeInTheDocument()
+  expect(screen.getAllByRole('status')).toHaveLength(1)
+  expect(screen.getAllByRole('log')).toHaveLength(1)
+}
+const reportCount = () =>
+  vi.mocked(console.error).mock.calls.filter(args => args[0] === 'View render failed:').length
+
+beforeEach(() => {
+  failures.v3d = false
+  failures.v2d = false
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  // React's own development error output also lands on console.error; the
+  // bounded-report assertions filter to the boundary's exact channel.
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('view failure containment', () => {
+  it('a throwing 3D view shows an accessible fallback while the shell survives', () => {
+    failures.v3d = true
+    render(<App />)
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('The 3D network view failed to render.')
+    expect(screen.queryByTestId('view-3d')).not.toBeInTheDocument()
+    shellAlive()
+    expect(reportCount()).toBe(1) // reported once, not swallowed
+  })
+
+  it('a throwing 2D view is contained identically', () => {
+    failures.v2d = true
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('The 2D network view failed to render.')
+    shellAlive()
+    expect(reportCount()).toBe(1)
+  })
+
+  it('connection state survives a view failure (badge keeps announcing)', () => {
+    failures.v3d = true
+    render(<App />)
+    act(() => live().serverOpen())
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(FakeWebSocket.instances).toHaveLength(1) // no hidden reconnect
+  })
+
+  it('switching away recovers: the healthy view renders with no fallback', () => {
+    failures.v3d = true
+    render(<App />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
+  })
+
+  it('switching back after the failure clears remounts a healthy view (boundary reset)', () => {
+    failures.v3d = true
+    render(<App />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    failures.v3d = false
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
+  })
+
+  it('explicit retry remounts only the failed view', () => {
+    failures.v3d = true
+    render(<App />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    failures.v3d = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
+    shellAlive()
+  })
+
+  it('repeated failure stays bounded: each retry yields one fallback and one report — no loop', () => {
+    failures.v3d = true
+    render(<App />)
+    expect(reportCount()).toBe(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' })) // still failing
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(reportCount()).toBe(2) // one more failure, one more report — user-paced, no retry loop
+    fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(reportCount()).toBe(3)
+  })
+
+  it('successful views never show the fallback', () => {
+    render(<App />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
+  })
+
+  it('StrictMode: single fallback, singular connection lifecycle, no duplicate live regions', () => {
+    failures.v3d = true
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    )
+    expect(screen.getAllByRole('alert')).toHaveLength(1)
+    expect(FakeWebSocket.instances).toHaveLength(2) // documented dev-mode double-mount artifact
+    act(() => live().serverOpen())
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+    expect(screen.getAllByRole('log')).toHaveLength(1)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -57,8 +57,9 @@ const shellAlive = () => {
   expect(screen.getAllByRole('status')).toHaveLength(1)
   expect(screen.getAllByRole('log')).toHaveLength(1)
 }
-const reportCount = () =>
-  vi.mocked(console.error).mock.calls.filter(args => args[0] === 'View render failed:').length
+const boundaryReports = () =>
+  vi.mocked(console.error).mock.calls.filter(args => args[0] === 'View render failed:')
+const reportCount = () => boundaryReports().length
 
 beforeEach(() => {
   failures.v3d = false
@@ -171,5 +172,29 @@ describe('view failure containment', () => {
     expect(screen.getAllByRole('status')).toHaveLength(1)
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
     expect(screen.getAllByRole('log')).toHaveLength(1)
+  })
+})
+
+describe('AB audit amendments', () => {
+  it('the single diagnostic carries the error AND the locating componentStack', () => {
+    failures.v3d = true
+    render(<App />)
+    const reports = boundaryReports()
+    expect(reports).toHaveLength(1)
+    const [, error, componentStack] = reports[0]
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('synthetic 3D render failure')
+    expect(typeof componentStack).toBe('string')
+    expect((componentStack as string).length).toBeGreaterThan(0)
+    // React dev logging also hits console.error — the boundary-owned
+    // channel stays exactly one call, distinguished by its first argument.
+    expect(vi.mocked(console.error).mock.calls.length).toBeGreaterThanOrEqual(reports.length)
+  })
+
+  it('the Retry control is an explicit type="button" (never an implicit submit)', () => {
+    failures.v3d = true
+    render(<App />)
+    expect(screen.getByRole('button', { name: 'Retry 3D network view' }))
+      .toHaveAttribute('type', 'button')
   })
 })

--- a/utilityfog_frontend/frontend/vitest.config.ts
+++ b/utilityfog_frontend/frontend/vitest.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
         'src/App.tsx',
         'src/components/ConnectionBadge.tsx',
         'src/components/EventFeed.tsx',
+        'src/components/ViewErrorBoundary.tsx',
         'src/components/NetworkView2D.tsx',
         'src/viz3d/adapters.ts',
         'src/viz3d/edgeValidation.ts',


### PR DESCRIPTION
## PACKAGE AB — view failure containment (continuation runway, refs #6 — no closing keyword)

**Stacked PR: base is `test/frontend-ingress-properties` (AA → Z → Y → X → … → main). Merge order O→P→Q→U→V→W→X→Y→Z→AA→AB.**

### What
`ViewErrorBoundary` (new) wraps **only the replaceable 2D/3D view surface** inside each labelled region — never the application shell. Controls, event feed and connection badge survive any active-view render exception.

### Contract (all test-locked)
Healthy children render **unwrapped** (zero layout impact — default rendering equivalence also E2E-confirmed by Playwright ×3) · failure shows an accessible `role=alert` fallback with a concise message · **Retry remounts only the failed view**, user-initiated — no automatic retry loop · **switching views remounts a fresh boundary** · no hidden reconnect (the SimBridge client lives above the boundary; single-socket asserted) · **no swallowed errors** — exactly one report per failure through the established bounded diagnostic channel.

### Failing-first catch during implementation
Both view branches are same-type elements in the same tree position, so React reconciled them as **one** component — a failed boundary's state **survived the view switch** (2 failing tests). Repair: distinct keys on the sections force a per-view remount; the key is documented as load-bearing in-code.

### Tests (9, corpus 222 → 231)
throwing 3D contained/shell survives/one report · throwing 2D identical · connection state survives a view failure · switch-away recovery · switch-back-after-clear (boundary reset) · explicit retry · **repeated failure bounded** (one fallback + one report per user-paced retry) · successful views never show fallback · StrictMode (single fallback, singular lifecycle, no duplicate live regions). Views mocked at the module seam with controllable failure flags — **no real WebGL**; React's own dev error output filtered by exact channel.

### Verification
unit **231/231** — full · serial · seeds 1/42/1337/271828/314159 · coverage gate PASS (90.54/92.66/94.54/91.03 — ViewErrorBoundary joined the contract; thresholds untouched) · lint 0/0 · tsc clean · budget-unit 11/11 · build ok · BUNDLE_BUDGET PASS 986,589/274,851 (+805 raw — the boundary ships; limits unchanged) · **Playwright 56/56 ×3**.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)