### PR TITLE
test/ci: enforceable per-file coverage floors — scope-expansion safety made mechanical (PACKAGE AC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,15 @@ jobs:
         # repeated runs, adds ~2s over the plain unit run.
         run: npm run test:unit:coverage
 
+      - name: Coverage-gate self-tests
+        run: npm run test:coverage-gate
+
+      - name: Per-file coverage floors
+        # Enforceable per-module floors over the json-summary the previous
+        # step generated — a regression, a silently missing module row, or
+        # a malformed summary all fail (scripts/check-unit-coverage.mjs).
+        run: npm run check:unit-coverage
+
       - name: Budget-script unit tests
         run: npm run test:budget
 

--- a/utilityfog_frontend/frontend/package.json
+++ b/utilityfog_frontend/frontend/package.json
@@ -14,7 +14,9 @@
     "test:budget": "node --test scripts/check-bundle-budget.test.mjs",
     "check:budget": "node scripts/check-bundle-budget.mjs",
     "test:unit": "vitest run",
-    "test:unit:coverage": "vitest run --coverage"
+    "test:unit:coverage": "vitest run --coverage",
+    "check:unit-coverage": "node scripts/check-unit-coverage.mjs",
+    "test:coverage-gate": "node --test scripts/check-unit-coverage.test.mjs"
   },
   "dependencies": {
     "@react-three/drei": "^9.92.0",

--- a/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
@@ -28,7 +28,7 @@
 // Exit codes: 0 pass · 1 floor regression or missing module row ·
 // 2 malformed/unreadable summary. Machine line: UNIT_COVERAGE v1.
 import { readFileSync } from 'node:fs'
-import { resolve, sep } from 'node:path'
+import { resolve } from 'node:path'
 
 const METRICS = ['statements', 'branches', 'functions', 'lines']
 
@@ -52,11 +52,14 @@ export function checkCoverage(summary, floors = FLOORS) {
     return { status: 'MALFORMED', failures: ['summary is not an object'] }
   }
   // Normalize absolute Windows/POSIX paths to repo-relative forward-slash
-  // keys so the table stays platform-independent.
+  // keys HOST-INDEPENDENTLY: the summary may have been generated on a
+  // different platform than the checker runs on (Windows-authored
+  // fixtures checked on the Ubuntu CI runner), so BOTH separators are
+  // normalized explicitly — never via node:path's host-specific sep.
   const byModule = new Map()
   for (const [key, value] of Object.entries(summary)) {
     if (key === 'total') continue
-    const normalized = key.split(sep).join('/').split('/')
+    const normalized = key.replace(/\\/g, '/').split('/')
     const srcIndex = normalized.lastIndexOf('src')
     if (srcIndex === -1) continue
     byModule.set(normalized.slice(srcIndex).join('/'), value)
@@ -106,6 +109,9 @@ function main() {
   if (status === 'FAIL') process.exit(1)
 }
 
-if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split(sep).join('/').split('/').pop())) {
+const invokedBasename = process.argv[1]
+  ? process.argv[1].replace(/\\/g, '/').split('/').pop()
+  : ''
+if (invokedBasename && import.meta.url.endsWith(`/${invokedBasename}`)) {
   main()
 }

--- a/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Per-file unit-coverage floor gate (Package AC).
+//
+// Makes "scope expansion did not weaken existing coverage" MECHANICALLY
+// true: every unit-owned module carries an explicit checked-in floor, a
+// module missing from the coverage summary FAILS (it cannot silently
+// disappear from the report), and a malformed summary fails with its own
+// exit code.
+//
+// Why not vitest's native per-file thresholds: the installed vitest
+// supports `coverage.thresholds.perFile` (verified in its local dist),
+// but that applies the GLOBAL thresholds uniformly per file; glob-keyed
+// thresholds exist but neither missing-row failure nor malformed-summary
+// diagnostics are contractually guaranteed there. This checker owns all
+// three semantics and is unit-tested for them.
+//
+// Floor derivation (documented evidence): per-file numbers measured at
+// the AC head, byte-identical across 3 repeated runs after the adapter
+// random-fallbacks were stubbed deterministically. Saturated dimensions
+// (measured 100) carry floor 100 with margin 0 — in these small owned
+// modules any drop means a contract line went untested. Non-saturated
+// dimensions carry floor = floor(measured) - 1: with per-file statement
+// counts <= ~90, a single lost statement/branch moves the percentage by
+// more than a point, so every whole-unit regression trips the gate.
+// Never lower a floor merely to obtain green — a conscious contract
+// change must edit this table in review.
+//
+// Exit codes: 0 pass · 1 floor regression or missing module row ·
+// 2 malformed/unreadable summary. Machine line: UNIT_COVERAGE v1.
+import { readFileSync } from 'node:fs'
+import { resolve, sep } from 'node:path'
+
+const METRICS = ['statements', 'branches', 'functions', 'lines']
+
+// module (repo-relative, forward slashes) → floors [stmts, branch, funcs, lines]
+export const FLOORS = {
+  'src/App.tsx': [84, 65, 86, 83],
+  'src/components/ConnectionBadge.tsx': [100, 100, 100, 100],
+  'src/components/EventFeed.tsx': [96, 95, 100, 96],
+  'src/components/NetworkView2D.tsx': [43, 49, 68, 40],
+  'src/components/ViewErrorBoundary.tsx': [100, 100, 100, 100],
+  'src/viz3d/adapters.ts': [96, 94, 100, 100],
+  'src/viz3d/edgeValidation.ts': [100, 100, 100, 100],
+  'src/viz3d/nodeValidation.ts': [100, 100, 100, 100],
+  'src/viz3d/useEventQueue.ts': [95, 90, 91, 96],
+  'src/viz3d/useSceneStore.ts': [100, 100, 100, 100],
+  'src/ws/SimBridgeClient.ts': [96, 88, 100, 97],
+}
+
+export function checkCoverage(summary, floors = FLOORS) {
+  if (summary === null || typeof summary !== 'object' || Array.isArray(summary)) {
+    return { status: 'MALFORMED', failures: ['summary is not an object'] }
+  }
+  // Normalize absolute Windows/POSIX paths to repo-relative forward-slash
+  // keys so the table stays platform-independent.
+  const byModule = new Map()
+  for (const [key, value] of Object.entries(summary)) {
+    if (key === 'total') continue
+    const normalized = key.split(sep).join('/').split('/')
+    const srcIndex = normalized.lastIndexOf('src')
+    if (srcIndex === -1) continue
+    byModule.set(normalized.slice(srcIndex).join('/'), value)
+  }
+
+  const failures = []
+  for (const [module, moduleFloors] of Object.entries(floors)) {
+    const row = byModule.get(module)
+    if (row === undefined) {
+      failures.push(`${module}: MISSING from coverage summary (row cannot silently disappear)`)
+      continue
+    }
+    METRICS.forEach((metric, i) => {
+      const pct = row?.[metric]?.pct
+      if (typeof pct !== 'number' || Number.isNaN(pct)) {
+        failures.push(`${module}: malformed ${metric} entry`)
+        return
+      }
+      if (pct < moduleFloors[i]) {
+        failures.push(`${module}: ${metric} ${pct}% < floor ${moduleFloors[i]}%`)
+      }
+    })
+  }
+  const malformed = failures.some(f => f.includes('malformed'))
+  return {
+    status: failures.length === 0 ? 'PASS' : malformed ? 'MALFORMED' : 'FAIL',
+    failures,
+  }
+}
+
+function main() {
+  const summaryPath = resolve(process.argv[2] ?? 'coverage/coverage-summary.json')
+  let summary
+  try {
+    summary = JSON.parse(readFileSync(summaryPath, 'utf8'))
+  } catch (error) {
+    console.error(`UNIT_COVERAGE v1 status=MALFORMED reason=unreadable-summary path=${summaryPath}`)
+    console.error(String(error))
+    process.exit(2)
+  }
+  const { status, failures } = checkCoverage(summary)
+  for (const failure of failures) console.error(`  ${failure}`)
+  console.log(
+    `UNIT_COVERAGE v1 modules=${Object.keys(FLOORS).length} failures=${failures.length} status=${status}`,
+  )
+  if (status === 'MALFORMED') process.exit(2)
+  if (status === 'FAIL') process.exit(1)
+}
+
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split(sep).join('/').split('/').pop())) {
+  main()
+}

--- a/utilityfog_frontend/frontend/scripts/check-unit-coverage.test.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-unit-coverage.test.mjs
@@ -1,0 +1,83 @@
+// Unit tests for the per-file coverage floor gate (node:test, zero deps —
+// same pattern as check-bundle-budget.test.mjs).
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { checkCoverage, FLOORS } from './check-unit-coverage.mjs'
+
+const row = (s, b, f, l) => ({
+  statements: { pct: s },
+  branches: { pct: b },
+  functions: { pct: f },
+  lines: { pct: l },
+})
+
+// A synthetic summary satisfying every floor exactly.
+function passingSummary() {
+  const summary = { total: row(100, 100, 100, 100) }
+  for (const [module, floors] of Object.entries(FLOORS)) {
+    summary[`C:\\repo\\utilityfog_frontend\\frontend\\${module.split('/').join('\\')}`] = row(
+      floors[0],
+      floors[1],
+      floors[2],
+      floors[3],
+    )
+  }
+  return summary
+}
+
+test('passes when every module meets its floor (windows-style absolute keys)', () => {
+  const { status, failures } = checkCoverage(passingSummary())
+  assert.equal(status, 'PASS')
+  assert.deepEqual(failures, [])
+})
+
+test('passes with posix-style keys too', () => {
+  const summary = { total: row(100, 100, 100, 100) }
+  for (const [module, floors] of Object.entries(FLOORS)) {
+    summary[`/repo/utilityfog_frontend/frontend/${module}`] = row(...floors)
+  }
+  assert.equal(checkCoverage(summary).status, 'PASS')
+})
+
+test('a single-metric regression below its floor fails with a precise message', () => {
+  const summary = passingSummary()
+  const key = Object.keys(summary).find(k => k.includes('nodeValidation'))
+  summary[key] = row(99, 100, 100, 100) // floor is 100
+  const { status, failures } = checkCoverage(summary)
+  assert.equal(status, 'FAIL')
+  assert.equal(failures.length, 1)
+  assert.match(failures[0], /nodeValidation\.ts: statements 99% < floor 100%/)
+})
+
+test('a module MISSING from the summary fails — rows cannot silently disappear', () => {
+  const summary = passingSummary()
+  const key = Object.keys(summary).find(k => k.includes('edgeValidation'))
+  delete summary[key]
+  const { status, failures } = checkCoverage(summary)
+  assert.equal(status, 'FAIL')
+  assert.equal(failures.length, 1)
+  assert.match(failures[0], /edgeValidation\.ts: MISSING from coverage summary/)
+})
+
+test('malformed summaries are rejected with MALFORMED status', () => {
+  assert.equal(checkCoverage(null).status, 'MALFORMED')
+  assert.equal(checkCoverage([]).status, 'MALFORMED')
+  assert.equal(checkCoverage('junk').status, 'MALFORMED')
+
+  const summary = passingSummary()
+  const key = Object.keys(summary).find(k => k.includes('App.tsx'))
+  summary[key] = { statements: { pct: 'not-a-number' } }
+  const { status, failures } = checkCoverage(summary)
+  assert.equal(status, 'MALFORMED')
+  assert.ok(failures.some(f => f.includes('malformed')))
+})
+
+test('the floor table itself is well-formed (4 numeric floors per module)', () => {
+  for (const [module, floors] of Object.entries(FLOORS)) {
+    assert.equal(floors.length, 4, module)
+    for (const value of floors) {
+      assert.equal(typeof value, 'number', module)
+      assert.ok(value >= 0 && value <= 100, module)
+    }
+  }
+})

--- a/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
@@ -445,3 +445,28 @@ describe('referential stability (Jack audit amendment)', () => {
     expect(reduced).toEqual([])
   })
 })
+
+describe('coverage-contract completions (Package AC)', () => {
+  it.each([
+    { label: 'invalid y coordinate', position: [1, 'two', 3] },
+    { label: 'invalid z coordinate', position: [1, 2, Number.NaN] },
+  ])('owned-position reads reject $label through the public seam', ({ position }) => {
+    expect(reconcileNode({ id: 'n', position }, undefined)).toBeNull()
+  })
+
+  it('connections comparisons detect length and element mismatches (new refs, not reuse)', () => {
+    const existing = node('n', [1, 2, 3], { connections: ['x'] })
+    const lengthChanged = reconcileNode(
+      { id: 'n', position: [1, 2, 3], status: 'active', connections: ['x', 'y'] },
+      existing,
+    )!
+    expect(lengthChanged).not.toBe(existing)
+    expect(lengthChanged.connections).toEqual(['x', 'y'])
+    const elementChanged = reconcileNode(
+      { id: 'n', position: [1, 2, 3], status: 'active', connections: ['y'] },
+      existing,
+    )!
+    expect(elementChanged).not.toBe(existing)
+    expect(elementChanged.connections).toEqual(['y'])
+  })
+})

--- a/utilityfog_frontend/frontend/vitest.config.ts
+++ b/utilityfog_frontend/frontend/vitest.config.ts
@@ -42,8 +42,13 @@ export default defineConfig({
       // paths unit-owned; its canvas DRAW effect body is unreachable under
       // jsdom (getContext → null, the component's own guarded early
       // return), which is why the aggregate baseline steps down from
-      // Package Y's 97/94/97/97 — a scope expansion, not a coverage
-      // regression (every previously-owned module kept its numbers).
+      // Package Y's 97/94/97/97. The earlier prose assurance that the
+      // expansion "kept every module's numbers" was UNENFORCED and is
+      // withdrawn as a guarantee — it is now made mechanically true by
+      // scripts/check-unit-coverage.mjs, which gates an explicit
+      // checked-in PER-FILE floor for every unit-owned module (missing
+      // rows fail; malformed summaries fail; run via check:unit-coverage
+      // in frontend-quality after coverage generation).
       include: [
         'src/App.tsx',
         'src/components/ConnectionBadge.tsx',


### PR DESCRIPTION
## PACKAGE AC — coverage-contract hardening (Jack-audit pass, refs #6 — no closing keyword)

**Stacked PR: base is `feat/frontend-view-error-containment` (AB → AA → Z → Y → X → … → main). Merge order O→P→Q→U→V→W→X→Y→Z→AA→AB→AC.**

### Goal
Make **“scope expansion did not weaken existing coverage” mechanically true** — the earlier prose assurance is withdrawn and replaced by an enforced gate.

### Evidence chain
- **Baselines reproduced** in disposable worktrees (clean pinned npm ci): X head `23210440` and original Y head `f579f3ee` per-file json-summary tables captured.
- **Determinism first**: AC-head per-file numbers are **byte-identical across 3 runs** (the Z amendment stubbed the adapter random fallbacks — the one wobble source — at its origin).
- **Native support verified from the installed vitest dist**: `thresholds.perFile` exists but applies the *global* thresholds uniformly; glob-keyed thresholds exist but guarantee neither missing-row failure nor malformed-summary diagnostics. Hence the checker.

### The gate
`scripts/check-unit-coverage.mjs` — checked-in **module→floor table for all eleven unit-owned modules**, deterministic json-summary parsing (windows/posix normalization), **missing rows FAIL** (a module cannot silently vanish from the report), malformed summaries exit 2, regressions exit 1, machine line `UNIT_COVERAGE v1`. Floor derivation documented in-file: saturated dimensions floor **100, margin 0**; others **floor(measured)−1** (per-file statement counts make any whole-unit regression move >1 point). `nodeValidation` was returned to **100/100/100/100** by covering its two remaining defensive paths **rather than lowering its floor**.

`scripts/check-unit-coverage.test.mjs` (node:test, 6 tests): pass (both path styles), precise single-metric regression, missing-row, malformed-summary, floor-table well-formedness.

**frontend-quality** now runs the gate's self-tests + the per-file floor check immediately after coverage generation.

### Deliberate-failure receipts
regression fixture → **exit 1** (`nodeValidation.ts: statements 42% < floor 100%`) · missing-row fixture → **exit 1** · malformed fixture → **exit 2** · live summary → **PASS (11 modules, 0 failures)**.

### Verification
unit **260/260** · checker self-tests 6/6 · lint 0/0 · tsc clean · aggregate + per-file coverage PASS · budget 11/11 · build ok · BUNDLE_BUDGET PASS 987,556/275,099 · Playwright 56/56.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)