### PR TITLE
perf: typed bounded event queue — single-drain scheduling, snapshot supersession, coalescing, explicit overflow (PACKAGE AF)

### DIFF
--- a/utilityfog_frontend/frontend/src/viz3d/ThreeScene.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/ThreeScene.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import InstancedNodes from './InstancedNodes'
 import Edges from './Edges'
 import { useSceneStore } from './useSceneStore'
@@ -10,8 +11,13 @@ interface ThreeSceneProps {
 
 export default function ThreeScene({ simClient }: ThreeSceneProps) {
   const { nodes, edges, updateNode, setNetwork } = useSceneStore()
-  
-  useEventQueue(simClient, { updateNode, setNetwork })
+
+  // Stable handlers identity (evidence: the store actions are stable, but
+  // the previous INLINE object changed identity on every render, which
+  // resubscribed all three SimBridge channels on every store change).
+  const handlers = useMemo(() => ({ updateNode, setNetwork }), [updateNode, setNetwork])
+
+  useEventQueue(simClient, handlers)
 
   return (
     <>

--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -239,14 +239,19 @@ export function sanitizeNodeList(
 // ---------------------------------------------------------------------------
 // QUEUE-SIDE SEAM (Package AF): the event queue folds repeated updates for
 // the same node id before delivery. The fold lives HERE, next to the
-// admission contract it must match, with the equivalence argument:
-// sequential application resolves each field to the LATEST VALID value
-// (invalid reads behave as absent and never erase an earlier valid one),
-// so a per-field latest-valid-wins fold applied once produces the exact
-// final state the same updates applied one-by-one would produce. The one
-// deliberate difference — intermediate per-event store notifications
-// within a single drain — is not a contract any consumer holds (renderers
-// read latest state; EventFeed subscribes to the transport, not the store).
+// admission contract it must match. EQUIVALENCE PRECONDITION (audit-
+// corrected): the per-field latest-valid-wins fold equals sequential
+// application ONLY when the fold target is ANCHORED (carries a valid
+// position — the node provably exists from that update on) or when both
+// updates are positionless (both merge into an existing node, or both are
+// rejected whole). A positionless update on an UNKNOWN node is rejected
+// WHOLE by sequential application, so folding its fields into a later
+// position-bearing update would resurrect them — the queue therefore
+// keeps a positionless→positionful transition as two ordered candidates
+// and never folds across snapshot barriers. The one deliberate difference
+// — intermediate per-event store notifications within a single drain — is
+// not a contract any consumer holds (renderers read latest state;
+// EventFeed subscribes to the transport, not the store).
 
 export interface NodeUpdateCandidate {
   id: string

--- a/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/nodeValidation.ts
@@ -235,3 +235,59 @@ export function sanitizeNodeList(
   }
   return result
 }
+
+// ---------------------------------------------------------------------------
+// QUEUE-SIDE SEAM (Package AF): the event queue folds repeated updates for
+// the same node id before delivery. The fold lives HERE, next to the
+// admission contract it must match, with the equivalence argument:
+// sequential application resolves each field to the LATEST VALID value
+// (invalid reads behave as absent and never erase an earlier valid one),
+// so a per-field latest-valid-wins fold applied once produces the exact
+// final state the same updates applied one-by-one would produce. The one
+// deliberate difference — intermediate per-event store notifications
+// within a single drain — is not a contract any consumer holds (renderers
+// read latest state; EventFeed subscribes to the transport, not the store).
+
+export interface NodeUpdateCandidate {
+  id: string
+  position: [number, number, number] | null
+  connections: string[] | null
+  status: NetworkNode['status'] | null
+}
+
+/// Contained single-pass read for queue-side use. Returns null for
+/// non-objects, hostile shapes, and UNIDENTIFIABLE payloads (no nonempty
+/// string id) — such payloads never enter the queue. Field semantics are
+/// identical to admission: invalid position/status/connections read as
+/// null (absent-equivalent).
+export function readNodeUpdate(incoming: unknown): NodeUpdateCandidate | null {
+  const c = readNodeCandidate(incoming)
+  if (c === null || !isNonEmptyString(c.id)) return null
+  return { id: c.id, position: c.position, connections: c.connections, status: c.status }
+}
+
+/// Fold two queued updates for the same id (older first). Per-field, the
+/// newer VALID value wins; a null (invalid/absent) field never erases an
+/// older valid one — mirroring sequential admission exactly.
+export function foldNodeUpdates(
+  older: NodeUpdateCandidate,
+  newer: NodeUpdateCandidate,
+): NodeUpdateCandidate {
+  return {
+    id: newer.id,
+    position: newer.position ?? older.position,
+    connections: newer.connections ?? older.connections,
+    status: newer.status ?? older.status,
+  }
+}
+
+/// Plain owned payload for store delivery — only fields with valid values
+/// are present, so the store's admission path treats the folded update
+/// exactly like the original sequence's net effect.
+export function nodeUpdatePayload(c: NodeUpdateCandidate): Record<string, unknown> {
+  const payload: Record<string, unknown> = { id: c.id }
+  if (c.position !== null) payload.position = c.position
+  if (c.connections !== null) payload.connections = c.connections
+  if (c.status !== null) payload.status = c.status
+  return payload
+}

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -13,89 +13,110 @@ interface EventQueueHandlers {
 }
 
 export interface EventQueueOptions {
-  // Deterministic test seam. The default is derived from measured evidence
-  // (see DEFAULT_MAX_PENDING_NODES); read once at mount.
-  maxPendingNodes?: number
+  // Deterministic test seam; read once at mount. Bounds TOTAL queued work
+  // items (node candidates + snapshots/barriers).
+  maxPendingWork?: number
 }
 
 export interface EventQueueStats {
   // Stable counters (a live object, mutated in place — a diagnostic/test
   // seam, deliberately not reactive state).
   coalesced: number
-  superseded: number
   dropped: number
   invalidDropped: number
 }
 
-// TYPED QUEUE (Package AF). The previous queue stored arbitrary closures:
-// unbounded growth under bursts, one rAF callback scheduled PER enqueue
-// before the first drain ran (measured: 15 synchronous enqueues scheduled
-// 15 frames), and invalid payloads occupied queue slots. This queue stores
-// typed work instead:
-//   - pendingSnapshot: the latest authoritative network_update, kept per
-//     side (a newer nodes/edges side replaces the older queued one);
-//   - pendingUpdates: post-snapshot node updates keyed by id in insertion
-//     order, folded latest-valid-wins per field (see nodeValidation's
-//     foldNodeUpdates for the sequential-equivalence argument).
+// TYPED ORDERED QUEUE (Package AF, audit redesign). The queue is an
+// ORDERED list of typed work items — node-update candidates and
+// snapshot/barrier items — delivered strictly in arrival order.
 //
-// Semantics:
-//   1. At most one scheduled drain exists at any time (scheduledRef), and
-//      the drain loop yields at most one continuation frame at a time.
-//   2. A full network_update carrying a nodes side supersedes queued node
-//      updates OLDER than that snapshot (the snapshot replaces node state
-//      wholesale, so their net effect was overwritten anyway); the
-//      superseded count is recorded. An edges-only update supersedes
-//      nothing on the node side.
-//   3. node_update events arriving AFTER the snapshot stay ordered after
-//      it (snapshot delivers first in the drain).
-//   4. Repeated updates for one id coalesce; distinct ids preserve
-//      insertion order.
-//   5. Invalid/unidentifiable payloads are counted and dropped at the
-//      boundary — they can never grow the queue. (Contract change from
-//      the closure queue, which forwarded garbage for the store to
-//      reject; the net store state is identical.)
-//   6. Pending DISTINCT node ids are bounded. Default derivation
-//      (measured on this corpus, Node 24 + jsdom): one folded candidate
-//      costs ≈200–400 bytes (5,000 ≈ ≤2 MB, trivial next to the three.js
-//      scene) and the drain retires 50 items/frame (5,000 ≈ 100 frames
-//      ≈ 1.7 s to fully retire, acceptable recovery for a burst 100×
-//      the 50-node default scene). Overflow drops NEW ids only — folds
-//      into already-pending ids always proceed.
-//   7. Overflow is explicit: stable dropped/coalesced/superseded counters
-//      and ONE bounded diagnostic per overflow episode (an episode ends
-//      when the queue fully drains). No losslessness is claimed.
-//   8. Unmount clears all queued work and scheduling state.
-//   9. A throwing handler is contained (report-once channel), never locks
-//      processing, and never aborts its batch-mates.
-//  10. For ordinary (non-overflowing) traffic the delivered FINAL state is
-//      identical to sequential application — locked by an
-//      equivalence-versus-reference test.
-export const DEFAULT_MAX_PENDING_NODES = 5000
+// SEQUENTIAL EQUIVALENCE is the load-bearing contract: for every
+// non-overflowing trace, the delivered final store state equals plain
+// sequential application (locked by a differential harness incl. the two
+// audit counterexamples). Consequences:
+//   - Snapshots are ORDERING BARRIERS. They never discard earlier queued
+//     node updates (a partial snapshot must observe them), they are never
+//     merged with each other (a later partial snapshot reconciles against
+//     the state the earlier one produced), and node updates never fold
+//     across them.
+//   - Coalescing happens only within an uninterrupted node-update segment
+//     and only when ALGEBRAICALLY SAFE for both the node-exists and
+//     node-unknown cases: a candidate may fold into the id's latest
+//     queued candidate unless that candidate is POSITIONLESS and the new
+//     one carries a position. Sequential application rejects a
+//     positionless update on an unknown node WHOLE, so folding its fields
+//     into a later creating update would resurrect them (audit CE1);
+//     keeping the positionless→positionful transition as two ordered
+//     candidates preserves that semantics exactly. Positionless→
+//     positionless folds are safe (both merge, or both reject); an
+//     anchored (position-bearing) candidate accepts every later fold —
+//     the node exists from that candidate on, so per-field latest-valid
+//     equals sequential merging, and the anchored candidate also pins the
+//     node's creation slot so array append order is preserved.
+//   - Invalid/unidentifiable payloads are counted and dropped at the
+//     boundary; they never occupy queue capacity.
+//
+// BOUND: total work items (candidates + snapshots) ≤ maxPendingWork.
+// Fold-into-existing never grows the queue and is always allowed; NEW
+// items (including snapshots — no barrier evades accounting) are dropped
+// under overflow with stable counters and ONE diagnostic per overflow
+// episode (an episode ends when the queue fully drains). Overflow is
+// explicitly lossy; no losslessness is claimed. Default derivation
+// (measured, Node 24 + jsdom): a queued item costs ≈200–400 bytes
+// (5,000 ≈ ≤2 MB) and the drain retires 50 items/frame (5,000 ≈ 100
+// frames ≈ 1.7 s full recovery) — 100× the default 50-node scene.
+//
+// SCHEDULING: at most one scheduled rAF drain at any time; the drain
+// yields one continuation frame per batch and requests no trailing or
+// post-unmount frames.
+//
+// HANDLERS: delivered through a ref refreshed on every commit — handler
+// identity changes NEVER resubscribe the WebSocket (subscription depends
+// only on the client), and the next event after a rerender reaches the
+// NEWEST handlers with no gap.
+export const DEFAULT_MAX_PENDING_WORK = 5000
 const BATCH_SIZE = 50
 
-interface PendingSnapshot {
+interface NodeWorkItem {
+  kind: 'node'
+  id: string
+  candidate: NodeUpdateCandidate
+}
+interface SnapshotWorkItem {
+  kind: 'snapshot'
   nodes: unknown
   hasNodes: boolean
   edges: unknown
   hasEdges: boolean
 }
+type WorkItem = NodeWorkItem | SnapshotWorkItem
 
 export function useEventQueue(
   simClient: SimBridgeClient | null,
   handlers: EventQueueHandlers,
   options?: EventQueueOptions,
 ) {
-  const updatesRef = useRef<Map<string, NodeUpdateCandidate>>(new Map())
-  const snapshotRef = useRef<PendingSnapshot | null>(null)
+  const queueRef = useRef<WorkItem[]>([])
+  // Drained items are passed by advancing head (index-stable, so the
+  // per-id fold index below never dangles); storage is reclaimed on full
+  // drain.
+  const headRef = useRef(0)
+  // id → index of that id's LATEST queued node item within the current
+  // tail segment. Cleared at every barrier and on full drain.
+  const lastNodeIndexRef = useRef<Map<string, number>>(new Map())
   const processingRef = useRef(false)
   const scheduledRef = useRef(false)
   const overflowEpisodeRef = useRef(false)
-  const maxPendingRef = useRef(options?.maxPendingNodes ?? DEFAULT_MAX_PENDING_NODES)
+  const maxPendingRef = useRef(options?.maxPendingWork ?? DEFAULT_MAX_PENDING_WORK)
   const statsRef = useRef<EventQueueStats>({
     coalesced: 0,
-    superseded: 0,
     dropped: 0,
     invalidDropped: 0,
+  })
+  // Newest handlers, refreshed every commit — see HANDLERS note above.
+  const handlersRef = useRef(handlers)
+  useEffect(() => {
+    handlersRef.current = handlers
   })
   // Lifetime guard: rAF callbacks scheduled while mounted can fire AFTER
   // unmount, and queued work must never invoke handlers then. Armed on
@@ -105,20 +126,36 @@ export function useEventQueue(
 
   useEffect(() => {
     activeRef.current = true
-    // The Map instance is created once and never reassigned; captured
-    // locally so the cleanup closes over the instance itself.
-    const updates = updatesRef.current
+    const lastNodeIndex = lastNodeIndexRef.current
     return () => {
       activeRef.current = false
-      updates.clear()
-      snapshotRef.current = null
+      queueRef.current = []
+      headRef.current = 0
+      lastNodeIndex.clear()
       overflowEpisodeRef.current = false
     }
   }, [])
 
-  const hasWork = useCallback(
-    () => snapshotRef.current !== null || updatesRef.current.size > 0,
-    [],
+  const pendingCount = useCallback(() => queueRef.current.length - headRef.current, [])
+
+  const admitOrDrop = useCallback(
+    (item: WorkItem): boolean => {
+      if (pendingCount() >= maxPendingRef.current) {
+        statsRef.current.dropped++
+        if (!overflowEpisodeRef.current) {
+          overflowEpisodeRef.current = true
+          console.error(
+            `Event queue overflow: dropping new ${item.kind} work ` +
+              `(pending=${pendingCount()}, limit=${maxPendingRef.current}). ` +
+              'Dropped/coalesced counts are tracked; delivery is NOT lossless under overflow.',
+          )
+        }
+        return false
+      }
+      queueRef.current.push(item)
+      return true
+    },
+    [pendingCount],
   )
 
   const processQueue = useCallback(async () => {
@@ -126,48 +163,44 @@ export function useEventQueue(
     if (processingRef.current) return
     processingRef.current = true
     try {
-      while (activeRef.current && hasWork()) {
+      while (activeRef.current && pendingCount() > 0) {
         let budget = BATCH_SIZE
-
-        const snapshot = snapshotRef.current
-        if (snapshot !== null) {
-          snapshotRef.current = null
-          budget--
-          try {
-            handlers.setNetwork(
-              snapshot.hasNodes ? snapshot.nodes : undefined,
-              snapshot.hasEdges ? snapshot.edges : undefined,
-            )
-          } catch (error) {
-            // Handler-error policy (unchanged): contained, reported once
-            // through the bounded diagnostic channel, never retried.
-            console.error('Event handler failed:', error)
-          }
-        }
-
-        const updates = updatesRef.current
-        for (const [id, candidate] of updates) {
-          if (budget <= 0) break
+        const queue = queueRef.current
+        while (budget > 0 && headRef.current < queue.length) {
           if (!activeRef.current) return
-          updates.delete(id)
+          const item = queue[headRef.current]
+          headRef.current++
           budget--
           try {
-            handlers.updateNode(nodeUpdatePayload(candidate))
+            if (item.kind === 'node') {
+              handlersRef.current.updateNode(nodeUpdatePayload(item.candidate))
+            } else {
+              handlersRef.current.setNetwork(
+                item.hasNodes ? item.nodes : undefined,
+                item.hasEdges ? item.edges : undefined,
+              )
+            }
           } catch (error) {
+            // Handler-error policy: contained, reported once through the
+            // bounded diagnostic channel, never retried, batch-mates
+            // unaffected.
             console.error('Event handler failed:', error)
           }
         }
 
-        if (!activeRef.current || !hasWork()) break
+        if (headRef.current >= queueRef.current.length) {
+          // Fully drained: reclaim storage and end any overflow episode.
+          queueRef.current = []
+          headRef.current = 0
+          lastNodeIndexRef.current.clear()
+          overflowEpisodeRef.current = false
+          break
+        }
+        if (!activeRef.current) break
         // Schedule the next yield frame ONLY while still active with more
         // work queued — an unmount during the LAST handler (or an emptied
         // queue) must not request an extra animation frame.
         await new Promise(resolve => requestAnimationFrame(resolve))
-      }
-      if (!hasWork()) {
-        // The overflow episode ends once the queue fully drains; the next
-        // overflow starts a new episode with its own single diagnostic.
-        overflowEpisodeRef.current = false
       }
     } finally {
       // Restoration lives in a finally boundary so no exit path — normal,
@@ -175,11 +208,11 @@ export function useEventQueue(
       // permanently locked.
       processingRef.current = false
     }
-  }, [handlers, hasWork])
+  }, [pendingCount])
 
   const schedule = useCallback(() => {
     // At most one scheduled drain at any time: enqueues while a frame is
-    // already pending (or a drain is running, which re-checks hasWork)
+    // already pending (or a drain is running, which re-checks the queue)
     // schedule nothing.
     if (scheduledRef.current || processingRef.current) return
     scheduledRef.current = true
@@ -198,30 +231,20 @@ export function useEventQueue(
       if (!data || typeof data !== 'object') return
       const d = data as { nodes?: unknown; edges?: unknown }
       if (d.nodes === undefined && d.edges === undefined) return
-      const prior = snapshotRef.current
-      const next: PendingSnapshot = prior ?? {
-        nodes: undefined,
-        hasNodes: false,
-        edges: undefined,
-        hasEdges: false,
+      const admitted = admitOrDrop({
+        kind: 'snapshot',
+        nodes: d.nodes,
+        hasNodes: d.nodes !== undefined,
+        edges: d.edges,
+        hasEdges: d.edges !== undefined,
+      })
+      if (admitted) {
+        // BARRIER: later node updates start a fresh segment — they must
+        // never fold across this snapshot. Earlier queued work is KEPT
+        // (the snapshot must observe it).
+        lastNodeIndexRef.current.clear()
+        schedule()
       }
-      if (d.nodes !== undefined) {
-        next.nodes = d.nodes
-        next.hasNodes = true
-        // Supersession: this snapshot replaces node state wholesale, so
-        // node updates queued BEFORE it can never affect the final state.
-        const superseded = updatesRef.current.size
-        if (superseded > 0) {
-          statsRef.current.superseded += superseded
-          updatesRef.current.clear()
-        }
-      }
-      if (d.edges !== undefined) {
-        next.edges = d.edges
-        next.hasEdges = true
-      }
-      snapshotRef.current = next
-      schedule()
     }
 
     const handleNodeUpdate = (node?: unknown) => {
@@ -232,28 +255,23 @@ export function useEventQueue(
         statsRef.current.invalidDropped++
         return
       }
-      const updates = updatesRef.current
-      const prior = updates.get(candidate.id)
-      if (prior !== undefined) {
-        // Coalesce latest-valid-wins; refolding an existing id never grows
-        // the queue, so it is always allowed — even during overflow.
-        updates.set(candidate.id, foldNodeUpdates(prior, candidate))
-        statsRef.current.coalesced++
-      } else if (updates.size >= maxPendingRef.current) {
-        statsRef.current.dropped++
-        if (!overflowEpisodeRef.current) {
-          overflowEpisodeRef.current = true
-          console.error(
-            'Event queue overflow: dropping updates for new node ids ' +
-              `(pending=${updates.size}, limit=${maxPendingRef.current}). ` +
-              'Dropped/coalesced counts are tracked; delivery is NOT lossless under overflow.',
-          )
+      const lastIndex = lastNodeIndexRef.current.get(candidate.id)
+      if (lastIndex !== undefined && lastIndex >= headRef.current) {
+        const target = queueRef.current[lastIndex] as NodeWorkItem
+        // Anchored-fold safety rule (see header): never fold a
+        // position-bearing candidate into a positionless one.
+        const safe = target.candidate.position !== null || candidate.position === null
+        if (safe) {
+          target.candidate = foldNodeUpdates(target.candidate, candidate)
+          statsRef.current.coalesced++
+          schedule()
+          return
         }
-        return
-      } else {
-        updates.set(candidate.id, candidate)
       }
-      schedule()
+      if (admitOrDrop({ kind: 'node', id: candidate.id, candidate })) {
+        lastNodeIndexRef.current.set(candidate.id, queueRef.current.length - 1)
+        schedule()
+      }
     }
 
     const handleEdgeUpdate = (edge?: unknown) => {
@@ -270,15 +288,14 @@ export function useEventQueue(
       simClient.off('node_update', handleNodeUpdate)
       simClient.off('edge_update', handleEdgeUpdate)
     }
-  }, [simClient, handlers, schedule])
+  }, [simClient, admitOrDrop, schedule])
 
   return useMemo(
     () => ({
       stats: statsRef.current,
-      pendingCount: () =>
-        updatesRef.current.size + (snapshotRef.current !== null ? 1 : 0),
+      pendingCount,
       isProcessing: () => processingRef.current,
     }),
-    [],
+    [pendingCount],
   )
 }

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { SimBridgeClient } from '../ws/SimBridgeClient'
 import {
   NodeUpdateCandidate,
@@ -70,10 +70,14 @@ export interface EventQueueStats {
 // yields one continuation frame per batch and requests no trailing or
 // post-unmount frames.
 //
-// HANDLERS: delivered through a ref refreshed on every commit — handler
-// identity changes NEVER resubscribe the WebSocket (subscription depends
-// only on the client), and the next event after a rerender reaches the
-// NEWEST handlers with no gap.
+// HANDLERS: delivered through a ref refreshed COMMIT-SYNCHRONOUSLY
+// (layout phase) — handler identity changes NEVER resubscribe the
+// WebSocket (subscription depends only on the client), and because the
+// refresh happens inside the commit itself, no delivery can observe
+// stale handlers after a committed rerender. A passive-effect refresh
+// would leave a window between commit and effect flush in which an
+// already-scheduled rAF drain (paint-aligned, and paint is not ordered
+// after passive effects) delivers to the PREVIOUS handlers.
 export const DEFAULT_MAX_PENDING_WORK = 5000
 const BATCH_SIZE = 50
 
@@ -113,9 +117,10 @@ export function useEventQueue(
     dropped: 0,
     invalidDropped: 0,
   })
-  // Newest handlers, refreshed every commit — see HANDLERS note above.
+  // Newest handlers, refreshed inside every commit (layout phase, before
+  // any paint/rAF can run) — see HANDLERS note above.
   const handlersRef = useRef(handlers)
-  useEffect(() => {
+  useLayoutEffect(() => {
     handlersRef.current = handlers
   })
   // Lifetime guard: rAF callbacks scheduled while mounted can fire AFTER

--- a/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/useEventQueue.ts
@@ -1,97 +1,259 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { SimBridgeClient } from '../ws/SimBridgeClient'
+import {
+  NodeUpdateCandidate,
+  foldNodeUpdates,
+  nodeUpdatePayload,
+  readNodeUpdate,
+} from './nodeValidation'
 
 interface EventQueueHandlers {
   updateNode: (node: unknown) => void
   setNetwork: (nodes: unknown, edges: unknown) => void
 }
 
+export interface EventQueueOptions {
+  // Deterministic test seam. The default is derived from measured evidence
+  // (see DEFAULT_MAX_PENDING_NODES); read once at mount.
+  maxPendingNodes?: number
+}
+
+export interface EventQueueStats {
+  // Stable counters (a live object, mutated in place — a diagnostic/test
+  // seam, deliberately not reactive state).
+  coalesced: number
+  superseded: number
+  dropped: number
+  invalidDropped: number
+}
+
+// TYPED QUEUE (Package AF). The previous queue stored arbitrary closures:
+// unbounded growth under bursts, one rAF callback scheduled PER enqueue
+// before the first drain ran (measured: 15 synchronous enqueues scheduled
+// 15 frames), and invalid payloads occupied queue slots. This queue stores
+// typed work instead:
+//   - pendingSnapshot: the latest authoritative network_update, kept per
+//     side (a newer nodes/edges side replaces the older queued one);
+//   - pendingUpdates: post-snapshot node updates keyed by id in insertion
+//     order, folded latest-valid-wins per field (see nodeValidation's
+//     foldNodeUpdates for the sequential-equivalence argument).
+//
+// Semantics:
+//   1. At most one scheduled drain exists at any time (scheduledRef), and
+//      the drain loop yields at most one continuation frame at a time.
+//   2. A full network_update carrying a nodes side supersedes queued node
+//      updates OLDER than that snapshot (the snapshot replaces node state
+//      wholesale, so their net effect was overwritten anyway); the
+//      superseded count is recorded. An edges-only update supersedes
+//      nothing on the node side.
+//   3. node_update events arriving AFTER the snapshot stay ordered after
+//      it (snapshot delivers first in the drain).
+//   4. Repeated updates for one id coalesce; distinct ids preserve
+//      insertion order.
+//   5. Invalid/unidentifiable payloads are counted and dropped at the
+//      boundary — they can never grow the queue. (Contract change from
+//      the closure queue, which forwarded garbage for the store to
+//      reject; the net store state is identical.)
+//   6. Pending DISTINCT node ids are bounded. Default derivation
+//      (measured on this corpus, Node 24 + jsdom): one folded candidate
+//      costs ≈200–400 bytes (5,000 ≈ ≤2 MB, trivial next to the three.js
+//      scene) and the drain retires 50 items/frame (5,000 ≈ 100 frames
+//      ≈ 1.7 s to fully retire, acceptable recovery for a burst 100×
+//      the 50-node default scene). Overflow drops NEW ids only — folds
+//      into already-pending ids always proceed.
+//   7. Overflow is explicit: stable dropped/coalesced/superseded counters
+//      and ONE bounded diagnostic per overflow episode (an episode ends
+//      when the queue fully drains). No losslessness is claimed.
+//   8. Unmount clears all queued work and scheduling state.
+//   9. A throwing handler is contained (report-once channel), never locks
+//      processing, and never aborts its batch-mates.
+//  10. For ordinary (non-overflowing) traffic the delivered FINAL state is
+//      identical to sequential application — locked by an
+//      equivalence-versus-reference test.
+export const DEFAULT_MAX_PENDING_NODES = 5000
+const BATCH_SIZE = 50
+
+interface PendingSnapshot {
+  nodes: unknown
+  hasNodes: boolean
+  edges: unknown
+  hasEdges: boolean
+}
+
 export function useEventQueue(
   simClient: SimBridgeClient | null,
-  handlers: EventQueueHandlers
+  handlers: EventQueueHandlers,
+  options?: EventQueueOptions,
 ) {
-  const queueRef = useRef<Array<() => void>>([])
+  const updatesRef = useRef<Map<string, NodeUpdateCandidate>>(new Map())
+  const snapshotRef = useRef<PendingSnapshot | null>(null)
   const processingRef = useRef(false)
+  const scheduledRef = useRef(false)
+  const overflowEpisodeRef = useRef(false)
+  const maxPendingRef = useRef(options?.maxPendingNodes ?? DEFAULT_MAX_PENDING_NODES)
+  const statsRef = useRef<EventQueueStats>({
+    coalesced: 0,
+    superseded: 0,
+    dropped: 0,
+    invalidDropped: 0,
+  })
   // Lifetime guard: rAF callbacks scheduled while mounted can fire AFTER
   // unmount, and queued work must never invoke handlers then. Armed on
-  // mount, disarmed (and the queue released) in cleanup; StrictMode's
-  // mount→cleanup→mount cycle re-arms correctly.
+  // mount, disarmed (and all pending work released) in cleanup;
+  // StrictMode's mount→cleanup→mount cycle re-arms correctly.
   const activeRef = useRef(false)
 
   useEffect(() => {
     activeRef.current = true
+    // The Map instance is created once and never reassigned; captured
+    // locally so the cleanup closes over the instance itself.
+    const updates = updatesRef.current
     return () => {
       activeRef.current = false
-      queueRef.current = []
+      updates.clear()
+      snapshotRef.current = null
+      overflowEpisodeRef.current = false
     }
   }, [])
 
+  const hasWork = useCallback(
+    () => snapshotRef.current !== null || updatesRef.current.size > 0,
+    [],
+  )
+
   const processQueue = useCallback(async () => {
+    scheduledRef.current = false
     if (processingRef.current) return
     processingRef.current = true
     try {
-      // The active guard is re-checked before EVERY handler (not merely
-      // every batch): an unmount performed by a handler stops the rest of
-      // its own batch, and an unmount between frames stops the drain.
-      while (activeRef.current && queueRef.current.length > 0) {
-        const batch = queueRef.current.splice(0, 10) // Process in batches of 10
-        for (const fn of batch) {
-          if (!activeRef.current) return
+      while (activeRef.current && hasWork()) {
+        let budget = BATCH_SIZE
+
+        const snapshot = snapshotRef.current
+        if (snapshot !== null) {
+          snapshotRef.current = null
+          budget--
           try {
-            fn()
+            handlers.setNetwork(
+              snapshot.hasNodes ? snapshot.nodes : undefined,
+              snapshot.hasEdges ? snapshot.edges : undefined,
+            )
           } catch (error) {
-            // Handler-error policy: one failing handler must not lock the
-            // queue, abort its batch-mates, or be retried. The failure is
-            // reported exactly once through the bounded diagnostic channel
-            // and later independent events process normally.
+            // Handler-error policy (unchanged): contained, reported once
+            // through the bounded diagnostic channel, never retried.
             console.error('Event handler failed:', error)
           }
         }
 
+        const updates = updatesRef.current
+        for (const [id, candidate] of updates) {
+          if (budget <= 0) break
+          if (!activeRef.current) return
+          updates.delete(id)
+          budget--
+          try {
+            handlers.updateNode(nodeUpdatePayload(candidate))
+          } catch (error) {
+            console.error('Event handler failed:', error)
+          }
+        }
+
+        if (!activeRef.current || !hasWork()) break
         // Schedule the next yield frame ONLY while still active with more
         // work queued — an unmount during the LAST handler (or an emptied
         // queue) must not request an extra animation frame.
-        if (!activeRef.current || queueRef.current.length === 0) break
-        // Allow browser to render
         await new Promise(resolve => requestAnimationFrame(resolve))
+      }
+      if (!hasWork()) {
+        // The overflow episode ends once the queue fully drains; the next
+        // overflow starts a new episode with its own single diagnostic.
+        overflowEpisodeRef.current = false
       }
     } finally {
       // Restoration lives in a finally boundary so no exit path — normal,
       // early-return on unmount, or a future throw — can leave the queue
-      // permanently locked. Nothing in the loop rethrows, so this async
-      // fire-and-forget drain also never yields an unhandled rejection.
+      // permanently locked.
       processingRef.current = false
     }
-  }, [])
+  }, [handlers, hasWork])
 
-  const enqueueUpdate = useCallback(
-    (updateFn: () => void) => {
-      if (!activeRef.current) return
-      queueRef.current.push(updateFn)
-      if (!processingRef.current) {
-        requestAnimationFrame(processQueue)
-      }
-    },
-    [processQueue],
-  )
+  const schedule = useCallback(() => {
+    // At most one scheduled drain at any time: enqueues while a frame is
+    // already pending (or a drain is running, which re-checks hasWork)
+    // schedule nothing.
+    if (scheduledRef.current || processingRef.current) return
+    scheduledRef.current = true
+    requestAnimationFrame(processQueue)
+  }, [processQueue])
 
   useEffect(() => {
     if (!simClient) return
 
     const handleNetworkUpdate = (data?: unknown) => {
+      if (!activeRef.current) return
       // Null/primitive payloads must not throw, and one malformed side
       // must not discard the other: forward whatever is present and let
       // the store's per-side validation decide (empty arrays stay
       // meaningful and clear their collection).
       if (!data || typeof data !== 'object') return
       const d = data as { nodes?: unknown; edges?: unknown }
-      if (d.nodes !== undefined || d.edges !== undefined) {
-        enqueueUpdate(() => handlers.setNetwork(d.nodes, d.edges))
+      if (d.nodes === undefined && d.edges === undefined) return
+      const prior = snapshotRef.current
+      const next: PendingSnapshot = prior ?? {
+        nodes: undefined,
+        hasNodes: false,
+        edges: undefined,
+        hasEdges: false,
       }
+      if (d.nodes !== undefined) {
+        next.nodes = d.nodes
+        next.hasNodes = true
+        // Supersession: this snapshot replaces node state wholesale, so
+        // node updates queued BEFORE it can never affect the final state.
+        const superseded = updatesRef.current.size
+        if (superseded > 0) {
+          statsRef.current.superseded += superseded
+          updatesRef.current.clear()
+        }
+      }
+      if (d.edges !== undefined) {
+        next.edges = d.edges
+        next.hasEdges = true
+      }
+      snapshotRef.current = next
+      schedule()
     }
 
     const handleNodeUpdate = (node?: unknown) => {
-      enqueueUpdate(() => handlers.updateNode(node))
+      if (!activeRef.current) return
+      const candidate = readNodeUpdate(node)
+      if (candidate === null) {
+        // Invalid/unidentifiable payloads never occupy queue capacity.
+        statsRef.current.invalidDropped++
+        return
+      }
+      const updates = updatesRef.current
+      const prior = updates.get(candidate.id)
+      if (prior !== undefined) {
+        // Coalesce latest-valid-wins; refolding an existing id never grows
+        // the queue, so it is always allowed — even during overflow.
+        updates.set(candidate.id, foldNodeUpdates(prior, candidate))
+        statsRef.current.coalesced++
+      } else if (updates.size >= maxPendingRef.current) {
+        statsRef.current.dropped++
+        if (!overflowEpisodeRef.current) {
+          overflowEpisodeRef.current = true
+          console.error(
+            'Event queue overflow: dropping updates for new node ids ' +
+              `(pending=${updates.size}, limit=${maxPendingRef.current}). ` +
+              'Dropped/coalesced counts are tracked; delivery is NOT lossless under overflow.',
+          )
+        }
+        return
+      } else {
+        updates.set(candidate.id, candidate)
+      }
+      schedule()
     }
 
     const handleEdgeUpdate = (edge?: unknown) => {
@@ -108,10 +270,15 @@ export function useEventQueue(
       simClient.off('node_update', handleNodeUpdate)
       simClient.off('edge_update', handleEdgeUpdate)
     }
-  }, [simClient, handlers, enqueueUpdate])
+  }, [simClient, handlers, schedule])
 
-  return {
-    queueLength: queueRef.current.length,
-    isProcessing: processingRef.current
-  }
+  return useMemo(
+    () => ({
+      stats: statsRef.current,
+      pendingCount: () =>
+        updatesRef.current.size + (snapshotRef.current !== null ? 1 : 0),
+      isProcessing: () => processingRef.current,
+    }),
+    [],
+  )
 }

--- a/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/node-validation.test.ts
@@ -11,6 +11,9 @@ import {
   reconcileNode,
   applyNodeUpdate,
   sanitizeNodeList,
+  readNodeUpdate,
+  foldNodeUpdates,
+  nodeUpdatePayload,
 } from '../src/viz3d/nodeValidation'
 import type { NetworkNode } from '../src/ws/SimBridgeClient'
 
@@ -468,5 +471,72 @@ describe('coverage-contract completions (Package AC)', () => {
     )!
     expect(elementChanged).not.toBe(existing)
     expect(elementChanged.connections).toEqual(['y'])
+  })
+})
+
+describe('queue-side fold seam (Package AF)', () => {
+  it('readNodeUpdate rejects non-objects, hostile shapes and unidentifiable payloads', () => {
+    expect(readNodeUpdate(null)).toBeNull()
+    expect(readNodeUpdate('junk')).toBeNull()
+    expect(readNodeUpdate({ status: 'active' })).toBeNull() // no id
+    expect(readNodeUpdate({ id: '', position: [1, 2, 3] })).toBeNull()
+    expect(readNodeUpdate({ id: 7, position: [1, 2, 3] })).toBeNull()
+    expect(
+      readNodeUpdate({
+        get id(): unknown {
+          throw new Error('hostile')
+        },
+      }),
+    ).toBeNull()
+  })
+
+  it('readNodeUpdate reads valid fields once into owned values, invalid fields as null', () => {
+    const c = readNodeUpdate({
+      id: 'n',
+      position: [1, 2, 3],
+      connections: ['a', 1, 'b'],
+      status: 'weird',
+    })!
+    expect(c).toEqual({ id: 'n', position: [1, 2, 3], connections: ['a', 'b'], status: null })
+  })
+
+  it('foldNodeUpdates: newer valid values win, null never erases older valid ones', () => {
+    const older = readNodeUpdate({ id: 'n', position: [1, 1, 1], status: 'active', connections: ['x'] })!
+    const newer = readNodeUpdate({ id: 'n', position: 'garbage', status: 'error' })!
+    expect(foldNodeUpdates(older, newer)).toEqual({
+      id: 'n',
+      position: [1, 1, 1], // newer invalid position never erases the older valid one
+      connections: ['x'],
+      status: 'error',
+    })
+    const newerValid = readNodeUpdate({ id: 'n', position: [9, 9, 9] })!
+    expect(foldNodeUpdates(older, newerValid).position).toEqual([9, 9, 9])
+  })
+
+  it('fold equivalence: folded-once delivery equals sequential application', () => {
+    const updates: unknown[] = [
+      { id: 'n', position: [1, 1, 1], status: 'active' },
+      { id: 'n', status: 'nonsense' },     // invalid status: absent-equivalent
+      { id: 'n', position: [2, 2, 2] },
+      { id: 'n', position: 'garbage', connections: ['c1'] },
+    ]
+    // Sequential (the old queue's semantics).
+    let seq: ReturnType<typeof applyNodeUpdate> = []
+    for (const u of updates) seq = applyNodeUpdate(seq, u)
+    // Folded-once (the new queue's semantics).
+    let folded = readNodeUpdate(updates[0])!
+    for (const u of updates.slice(1)) folded = foldNodeUpdates(folded, readNodeUpdate(u)!)
+    const once = applyNodeUpdate([], nodeUpdatePayload(folded))
+    expect(once).toEqual(seq)
+  })
+
+  it('nodeUpdatePayload emits only fields with valid values', () => {
+    expect(nodeUpdatePayload(readNodeUpdate({ id: 'n', position: [1, 2, 3] })!)).toEqual({
+      id: 'n',
+      position: [1, 2, 3],
+    })
+    expect(
+      nodeUpdatePayload(readNodeUpdate({ id: 'n', status: 'error', connections: ['a'] })!),
+    ).toEqual({ id: 'n', status: 'error', connections: ['a'] })
   })
 })

--- a/utilityfog_frontend/frontend/tests-unit/queue-differential.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/queue-differential.test.tsx
@@ -1,12 +1,23 @@
-// Package AF (audit redesign): DIFFERENTIAL testing — for every
-// non-overflowing trace, the queue-delivered final store state must equal
-// a plain sequential reference reducer built from the same validators the
-// store uses. Includes the two exact counterexamples from Jack's audit.
+// Package AF (audit redesign + amendment): DIFFERENTIAL testing — for
+// every non-overflowing trace, the queue-delivered final store state must
+// equal a plain sequential reference reducer built from the same
+// validators the store uses. Includes the two exact counterexamples from
+// Jack's audit, 500 fixed-seed generated traces (overflow disabled: no
+// trace approaches the 5,000-item default bound, so equality must be
+// exact with zero drops), ordered-DELIVERY assertions (not merely
+// final-state equality), and the commit-synchronous handler-refresh
+// proof.
+import { useLayoutEffect } from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { render, renderHook } from '@testing-library/react'
 import { useEventQueue } from '../src/viz3d/useEventQueue'
 import { SimBridgeClient } from '../src/ws/SimBridgeClient'
-import { applyNodeUpdate, sanitizeNodeList } from '../src/viz3d/nodeValidation'
+import {
+  applyNodeUpdate,
+  isValidPosition,
+  readNodeUpdate,
+  sanitizeNodeList,
+} from '../src/viz3d/nodeValidation'
 import { sanitizeEdgeList } from '../src/viz3d/edgeValidation'
 import type { NetworkNode, NetworkEdge } from '../src/ws/SimBridgeClient'
 
@@ -64,16 +75,27 @@ function referenceReduce(trace: TraceEvent[]): { nodes: NetworkNode[]; edges: Ne
 let client: SimBridgeClient
 const socket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
 
+// Every handler invocation, in delivery order — the ordered-delivery
+// assertions consume this alongside the final state.
+type Delivery = { kind: 'node'; id: string; hasPosition: boolean } | { kind: 'snapshot' }
+
 // Drive one trace through the real queue against real-validator handlers;
 // rerender events swap in FRESH handler objects that keep writing to the
 // same state (proving no subscription gap and newest-handler delivery).
 async function queueReduce(trace: TraceEvent[]) {
-  const state = { nodes: [] as NetworkNode[], edges: [] as NetworkEdge[] }
+  const state = {
+    nodes: [] as NetworkNode[],
+    edges: [] as NetworkEdge[],
+    deliveries: [] as Delivery[],
+  }
   const makeHandlers = () => ({
     updateNode: (p: unknown) => {
+      const rec = p as { id: string; position?: unknown }
+      state.deliveries.push({ kind: 'node', id: rec.id, hasPosition: isValidPosition(rec.position) })
       state.nodes = applyNodeUpdate(state.nodes, p)
     },
     setNetwork: (nodes: unknown, edges: unknown) => {
+      state.deliveries.push({ kind: 'snapshot' })
       if (Array.isArray(nodes)) state.nodes = sanitizeNodeList(nodes, state.nodes)
       state.edges = sanitizeEdgeList(edges, state.edges)
     },
@@ -156,7 +178,7 @@ describe('generated mixed traces (seeded, thousands of events)', () => {
     const trace: TraceEvent[] = []
     for (let i = 0; i < length; i++) {
       const r = rand()
-      if (r < 0.45) {
+      if (r < 0.42) {
         // node updates: positionful, positionless, malformed
         const roll = rand()
         trace.push({
@@ -168,7 +190,7 @@ describe('generated mixed traces (seeded, thousands of events)', () => {
                 ? { id: pick(), status: rand() < 0.5 ? 'error' : 'inactive', connections: rand() < 0.5 ? ['k'] : undefined }
                 : { id: pick(), position: 'garbage' },
         })
-      } else if (r < 0.62) {
+      } else if (r < 0.56) {
         // full/partial/malformed nodes snapshots
         const entries: unknown[] = []
         const count = Math.floor(rand() * 4)
@@ -183,7 +205,21 @@ describe('generated mixed traces (seeded, thousands of events)', () => {
           )
         }
         trace.push({ type: 'network_update', payload: { nodes: entries } })
-      } else if (r < 0.75) {
+      } else if (r < 0.63) {
+        // POSITIONLESS BARRIER: a snapshot whose every entry is a
+        // positionless partial — it contributes nothing without the state
+        // produced by the work queued BEFORE it, so any queue that
+        // discards or reorders around barriers diverges here.
+        trace.push({
+          type: 'network_update',
+          payload: {
+            nodes: [
+              { id: pick(), status: 'error' },
+              { id: pick(), status: 'inactive' },
+            ],
+          },
+        })
+      } else if (r < 0.74) {
         // edges-only snapshots
         trace.push({
           type: 'network_update',
@@ -208,16 +244,67 @@ describe('generated mixed traces (seeded, thousands of events)', () => {
     return trace
   }
 
-  it('every non-overflow trace matches the sequential reference exactly (nodes AND edges)', async () => {
-    // 60 traces x 60 events = 3,600 mixed events across all shapes.
-    for (let seed = 1; seed <= 60; seed++) {
-      const trace = generateTrace(seed * 7919, 60)
-      const expected = referenceReduce(trace)
-      const actual = await queueReduce(trace)
-      expect(actual.nodes, `trace seed ${seed * 7919} nodes`).toEqual(expected.nodes)
-      expect(actual.edges, `trace seed ${seed * 7919} edges`).toEqual(expected.edges)
+  // 500 traces × 60 events = 30,000 mixed events across all shapes
+  // (chunked so a divergence names its hundred immediately). No trace
+  // approaches the 5,000-item bound: overflow is disabled for
+  // equivalence, so drops are impossible and equality must be exact.
+  for (const chunk of [0, 1, 2, 3, 4]) {
+    it(`traces ${chunk * 100 + 1}–${(chunk + 1) * 100} match the sequential reference exactly (nodes AND edges)`, async () => {
+      for (let seed = chunk * 100 + 1; seed <= (chunk + 1) * 100; seed++) {
+        const trace = generateTrace(seed * 7919, 60)
+        const expected = referenceReduce(trace)
+        const actual = await queueReduce(trace)
+        expect(actual.nodes, `trace seed ${seed * 7919} nodes`).toEqual(expected.nodes)
+        expect(actual.edges, `trace seed ${seed * 7919} edges`).toEqual(expected.edges)
+      }
+    }, 120000)
+  }
+
+  it('ordered-delivery invariants hold on generated traces (segment residency, ≤2 deliveries/id/segment, positionless-before-anchored)', async () => {
+    for (let seed = 1; seed <= 100; seed++) {
+      // Mirror arrival segments through the SAME reader the queue uses:
+      // barriers are the valid-shaped snapshots, and a node id belongs to
+      // the segment its candidate arrived in.
+      const trace = generateTrace(seed * 104729, 60)
+      const arrivals: Array<Set<string>> = [new Set()]
+      for (const event of trace) {
+        if (event.type === 'rerender') continue
+        if (event.type === 'network_update') {
+          const d = event.payload as { nodes?: unknown; edges?: unknown } | null
+          if (!d || typeof d !== 'object') continue
+          if (d.nodes === undefined && d.edges === undefined) continue
+          arrivals.push(new Set())
+        } else {
+          const c = readNodeUpdate(event.payload)
+          if (c !== null) arrivals[arrivals.length - 1].add(c.id)
+        }
+      }
+      const { deliveries } = await queueReduce(trace)
+      let seg = 0
+      const perId = new Map<string, { count: number; sawAnchored: boolean }>()
+      for (const d of deliveries) {
+        if (d.kind === 'snapshot') {
+          seg++
+          perId.clear()
+          continue
+        }
+        expect(arrivals[seg].has(d.id), `seed ${seed * 104729}: id ${d.id} delivered outside its arrival segment ${seg}`).toBe(true)
+        const entry = perId.get(d.id) ?? { count: 0, sawAnchored: false }
+        entry.count++
+        expect(entry.count, `seed ${seed * 104729}: >2 deliveries for ${d.id} in one segment`).toBeLessThanOrEqual(2)
+        if (entry.count === 2) {
+          // A second delivery exists ONLY for the unsafe-fold split:
+          // positionless first, position-bearing second (audit CE1).
+          expect(entry.sawAnchored, `seed ${seed * 104729}: second delivery for ${d.id} after an anchored first`).toBe(false)
+          expect(d.hasPosition, `seed ${seed * 104729}: second delivery for ${d.id} is not position-bearing`).toBe(true)
+        }
+        entry.sawAnchored = entry.sawAnchored || d.hasPosition
+        perId.set(d.id, entry)
+      }
+      // Every arrived barrier was delivered — none skipped or merged.
+      expect(seg, `seed ${seed * 104729}: barrier deliveries`).toBe(arrivals.length - 1)
     }
-  }, 60000)
+  }, 120000)
 
   it('subscription count stays exactly one per channel across handler rerenders', async () => {
     const onSpy = vi.spyOn(client, 'on')
@@ -228,5 +315,72 @@ describe('generated mixed traces (seeded, thousands of events)', () => {
     // rerenders with fresh handler objects add NOTHING.
     expect(onSpy.mock.calls.length).toBe(3)
     expect(offSpy.mock.calls.length).toBe(3)
+  })
+})
+
+describe('exact ordered delivery (a trace of calls, not merely final state)', () => {
+  it('delivers segment slots in arrival order: folds land in the anchor slot, barriers hold their place, post-barrier work follows', async () => {
+    const calls: Array<{ fn: 'updateNode' | 'setNetwork'; arg: unknown }> = []
+    const handlers = {
+      updateNode: (p: unknown) => calls.push({ fn: 'updateNode', arg: p }),
+      setNetwork: (nodes: unknown) => calls.push({ fn: 'setNetwork', arg: nodes }),
+    }
+    const view = renderHook(() => useEventQueue(client, handlers))
+    socket().serverMessage({ type: 'node_update', payload: { id: 'a', position: [1, 1, 1] } })
+    socket().serverMessage({ type: 'node_update', payload: { id: 'b', position: [2, 2, 2] } })
+    // Folds into a's ANCHOR slot (slot 1), not into a new tail slot.
+    socket().serverMessage({ type: 'node_update', payload: { id: 'a', status: 'error' } })
+    socket().serverMessage({
+      type: 'network_update',
+      payload: { nodes: [{ id: 'c', position: [3, 3, 3], connections: [], status: 'active' }] },
+    })
+    // A fresh segment AFTER the barrier — must deliver last.
+    socket().serverMessage({ type: 'node_update', payload: { id: 'a', position: [4, 4, 4] } })
+    await vi.runAllTimersAsync()
+    expect(calls.map(c => c.fn)).toEqual(['updateNode', 'updateNode', 'setNetwork', 'updateNode'])
+    expect(calls[0].arg).toMatchObject({ id: 'a', position: [1, 1, 1], status: 'error' })
+    expect(calls[1].arg).toMatchObject({ id: 'b', position: [2, 2, 2] })
+    expect(calls[3].arg).toMatchObject({ id: 'a', position: [4, 4, 4] })
+    view.unmount()
+  })
+})
+
+describe('commit-synchronous handler refresh (useLayoutEffect)', () => {
+  it('a paint-aligned drain firing between a committed rerender and its passive effects reaches the NEW handlers', async () => {
+    // Run rAF callbacks SYNCHRONOUSLY at schedule time: this simulates
+    // the browser interleaving a paint-aligned drain into the window
+    // between a commit and its passive-effect flush. A passive-effect
+    // (useEffect) handler refresh observably delivers to the PREVIOUS
+    // generation in exactly this window — verified failing-first against
+    // the useEffect implementation; the layout-phase refresh closes it.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+    const received: string[] = []
+    const makeHandlers = (generation: string) => ({
+      updateNode: () => received.push(generation),
+      setNetwork: () => received.push(generation),
+    })
+    function Harness({ generation }: { generation: string }) {
+      useEventQueue(client, makeHandlers(generation))
+      // Declared AFTER the hook call: by the time this layout effect
+      // emits, the queue's own layout effect in the SAME commit has
+      // already refreshed the handler ref (in-component declaration
+      // order) — the emission is the very first thing that can happen
+      // after the commit, before any passive effect.
+      useLayoutEffect(() => {
+        if (generation === 'second') {
+          socket().serverMessage({ type: 'node_update', payload: { id: 'k', position: [1, 2, 3] } })
+        }
+      }, [generation])
+      return null
+    }
+    const view = render(<Harness generation="first" />)
+    view.rerender(<Harness generation="second" />)
+    expect(received).toEqual(['second'])
+    await vi.runAllTimersAsync()
+    expect(received).toEqual(['second'])
+    view.unmount()
   })
 })

--- a/utilityfog_frontend/frontend/tests-unit/queue-differential.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/queue-differential.test.tsx
@@ -1,0 +1,232 @@
+// Package AF (audit redesign): DIFFERENTIAL testing — for every
+// non-overflowing trace, the queue-delivered final store state must equal
+// a plain sequential reference reducer built from the same validators the
+// store uses. Includes the two exact counterexamples from Jack's audit.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useEventQueue } from '../src/viz3d/useEventQueue'
+import { SimBridgeClient } from '../src/ws/SimBridgeClient'
+import { applyNodeUpdate, sanitizeNodeList } from '../src/viz3d/nodeValidation'
+import { sanitizeEdgeList } from '../src/viz3d/edgeValidation'
+import type { NetworkNode, NetworkEdge } from '../src/ws/SimBridgeClient'
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+  serverOpen() {
+    this.readyState = 1
+    this.onopen?.({})
+  }
+  serverMessage(obj: unknown) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+}
+
+type TraceEvent = { type: 'node_update' | 'network_update'; payload: unknown } | { type: 'rerender' }
+
+// The sequential reference: exactly what the old closure queue delivered —
+// every event applied in arrival order through the store's own validators.
+function referenceReduce(trace: TraceEvent[]): { nodes: NetworkNode[]; edges: NetworkEdge[] } {
+  let nodes: NetworkNode[] = []
+  let edges: NetworkEdge[] = []
+  for (const event of trace) {
+    if (event.type === 'rerender') continue
+    if (event.type === 'node_update') {
+      nodes = applyNodeUpdate(nodes, event.payload)
+    } else {
+      const d = event.payload as { nodes?: unknown; edges?: unknown } | null
+      if (!d || typeof d !== 'object') continue
+      if (d.nodes === undefined && d.edges === undefined) continue
+      if (Array.isArray(d.nodes)) nodes = sanitizeNodeList(d.nodes, nodes)
+      edges = sanitizeEdgeList(d.edges, edges)
+    }
+  }
+  return { nodes, edges }
+}
+
+let client: SimBridgeClient
+const socket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+
+// Drive one trace through the real queue against real-validator handlers;
+// rerender events swap in FRESH handler objects that keep writing to the
+// same state (proving no subscription gap and newest-handler delivery).
+async function queueReduce(trace: TraceEvent[]) {
+  const state = { nodes: [] as NetworkNode[], edges: [] as NetworkEdge[] }
+  const makeHandlers = () => ({
+    updateNode: (p: unknown) => {
+      state.nodes = applyNodeUpdate(state.nodes, p)
+    },
+    setNetwork: (nodes: unknown, edges: unknown) => {
+      if (Array.isArray(nodes)) state.nodes = sanitizeNodeList(nodes, state.nodes)
+      state.edges = sanitizeEdgeList(edges, state.edges)
+    },
+  })
+  const view = renderHook(({ h }) => useEventQueue(client, h), {
+    initialProps: { h: makeHandlers() },
+  })
+  for (const event of trace) {
+    if (event.type === 'rerender') {
+      view.rerender({ h: makeHandlers() })
+    } else {
+      socket().serverMessage(event)
+    }
+  }
+  await vi.runAllTimersAsync()
+  view.unmount()
+  return state
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  client = new SimBridgeClient('ws://diff-test', 1000)
+  client.connect()
+  socket().serverOpen()
+})
+
+afterEach(() => {
+  client.disconnect()
+  for (let i = 0; i < 25 && vi.getTimerCount() > 0; i++) vi.runOnlyPendingTimers()
+  FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe("Jack's exact counterexamples", () => {
+  it('CE1: positionless update BEFORE a position-bearing update for an unknown node', async () => {
+    // Sequentially the first update is rejected WHOLE (unknown node, no
+    // position) — its fields must never resurrect via folding.
+    const trace: TraceEvent[] = [
+      { type: 'node_update', payload: { id: 'x', status: 'error' } },
+      { type: 'node_update', payload: { id: 'x', position: [1, 2, 3] } },
+    ]
+    const expected = referenceReduce(trace)
+    expect(expected.nodes[0].status).toBeUndefined() // the reference itself: no status
+    const actual = await queueReduce(trace)
+    expect(actual.nodes).toEqual(expected.nodes)
+  })
+
+  it('CE2: queued node update BEFORE a partial nodes snapshot must be observed by that snapshot', async () => {
+    // Sequentially the update lands first, so the snapshot's positionless
+    // entry keeps the freshly updated position. Discarding the queued
+    // update makes the snapshot reconcile against stale state.
+    const trace: TraceEvent[] = [
+      { type: 'node_update', payload: { id: 'a', position: [9, 9, 9], connections: [], status: 'active' } },
+      { type: 'network_update', payload: { nodes: [{ id: 'a', status: 'error' }] } },
+    ]
+    const expected = referenceReduce(trace)
+    expect(expected.nodes).toEqual([
+      { id: 'a', position: [9, 9, 9], connections: [], status: 'error' },
+    ])
+    const actual = await queueReduce(trace)
+    expect(actual.nodes).toEqual(expected.nodes)
+  })
+})
+
+describe('generated mixed traces (seeded, thousands of events)', () => {
+  // Deterministic LCG; NO Math.random.
+  const makeRand = (seed: number) => () =>
+    (seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648
+
+  function generateTrace(seed: number, length: number): TraceEvent[] {
+    const rand = makeRand(seed)
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+    const pick = () => ids[Math.floor(rand() * ids.length)]
+    const trace: TraceEvent[] = []
+    for (let i = 0; i < length; i++) {
+      const r = rand()
+      if (r < 0.45) {
+        // node updates: positionful, positionless, malformed
+        const roll = rand()
+        trace.push({
+          type: 'node_update',
+          payload:
+            roll < 0.5
+              ? { id: pick(), position: [i, Math.floor(rand() * 10), 0], status: rand() < 0.5 ? 'error' : 'active' }
+              : roll < 0.8
+                ? { id: pick(), status: rand() < 0.5 ? 'error' : 'inactive', connections: rand() < 0.5 ? ['k'] : undefined }
+                : { id: pick(), position: 'garbage' },
+        })
+      } else if (r < 0.62) {
+        // full/partial/malformed nodes snapshots
+        const entries: unknown[] = []
+        const count = Math.floor(rand() * 4)
+        for (let k = 0; k < count; k++) {
+          const roll = rand()
+          entries.push(
+            roll < 0.5
+              ? { id: pick(), position: [i, k, 1], connections: [], status: 'active' }
+              : roll < 0.8
+                ? { id: pick(), status: 'error' } // partial: relies on prior state
+                : null, // malformed entry
+          )
+        }
+        trace.push({ type: 'network_update', payload: { nodes: entries } })
+      } else if (r < 0.75) {
+        // edges-only snapshots
+        trace.push({
+          type: 'network_update',
+          payload: { edges: [{ id: `e${Math.floor(rand() * 4)}`, source: pick(), target: pick(), strength: 1 }] },
+        })
+      } else if (r < 0.85) {
+        // combined snapshot
+        trace.push({
+          type: 'network_update',
+          payload: {
+            nodes: [{ id: pick(), position: [i, 0, 2], connections: [], status: 'inactive' }],
+            edges: [{ id: `e${Math.floor(rand() * 4)}`, source: pick(), target: pick(), strength: 2 }],
+          },
+        })
+      } else if (r < 0.93) {
+        trace.push({ type: 'rerender' })
+      } else {
+        // junk payloads
+        trace.push({ type: 'node_update', payload: rand() < 0.5 ? null : 'junk' })
+      }
+    }
+    return trace
+  }
+
+  it('every non-overflow trace matches the sequential reference exactly (nodes AND edges)', async () => {
+    // 60 traces x 60 events = 3,600 mixed events across all shapes.
+    for (let seed = 1; seed <= 60; seed++) {
+      const trace = generateTrace(seed * 7919, 60)
+      const expected = referenceReduce(trace)
+      const actual = await queueReduce(trace)
+      expect(actual.nodes, `trace seed ${seed * 7919} nodes`).toEqual(expected.nodes)
+      expect(actual.edges, `trace seed ${seed * 7919} edges`).toEqual(expected.edges)
+    }
+  }, 60000)
+
+  it('subscription count stays exactly one per channel across handler rerenders', async () => {
+    const onSpy = vi.spyOn(client, 'on')
+    const offSpy = vi.spyOn(client, 'off')
+    const trace = generateTrace(31337, 40)
+    await queueReduce(trace)
+    // One subscription set at mount, one unsubscription set at unmount —
+    // rerenders with fresh handler objects add NOTHING.
+    expect(onSpy.mock.calls.length).toBe(3)
+    expect(offSpy.mock.calls.length).toBe(3)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -266,6 +266,26 @@ describe('overflow boundary', () => {
     expect(overflowReports()).toHaveLength(2) // new episode, one new report
   })
 
+  it('snapshots occupy the same finite bound — no barrier evades accounting — and overflow stays explicitly lossy', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers, { maxPendingWork: 2 }))
+    netMsg({ nodes: [] })
+    netMsg({ nodes: [] }) // the bound filled ENTIRELY by snapshots
+    expect(view.result.current.pendingCount()).toBe(2)
+
+    netMsg({ nodes: [] }) // a further snapshot is dropped, not privileged
+    nodeMsg(NODE('a')) //    and so is a new node item
+    expect(view.result.current.stats.dropped).toBe(2)
+    expect(view.result.current.pendingCount()).toBe(2)
+    const report = vi
+      .mocked(console.error)
+      .mock.calls.find(args => String(args[0]).startsWith('Event queue overflow'))
+    expect(String(report?.[0])).toContain('NOT lossless')
+
+    await vi.runAllTimersAsync()
+    expect(handlers.setNetwork).toHaveBeenCalledTimes(2)
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+  })
+
   it('the documented default limit is in force when no injection is provided', () => {
     const view = renderHook(() => useEventQueue(client, handlers))
     expect(DEFAULT_MAX_PENDING_WORK).toBe(5000)

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -7,7 +7,7 @@
 // variants interleave the microtasks the drain loop awaits.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useEventQueue, DEFAULT_MAX_PENDING_NODES } from '../src/viz3d/useEventQueue'
+import { useEventQueue, DEFAULT_MAX_PENDING_WORK } from '../src/viz3d/useEventQueue'
 import { SimBridgeClient } from '../src/ws/SimBridgeClient'
 import { applyNodeUpdate, sanitizeNodeList } from '../src/viz3d/nodeValidation'
 import { sanitizeEdgeList } from '../src/viz3d/edgeValidation'
@@ -150,46 +150,63 @@ describe('coalescing and ordering', () => {
   })
 })
 
-describe('snapshot supersession', () => {
-  it('a nodes-carrying snapshot supersedes OLDER queued node updates; later ones stay ordered after it', async () => {
-    const view = renderHook(() => useEventQueue(client, handlers))
+describe('snapshot barriers (audit redesign)', () => {
+  it('a nodes-carrying snapshot PRESERVES earlier queued node updates, in order', async () => {
+    renderHook(() => useEventQueue(client, handlers))
     nodeMsg(NODE('pre1'))
     nodeMsg(NODE('pre2'))
     netMsg({ nodes: [NODE('snap')], edges: [] })
     nodeMsg(NODE('post1'))
     await vi.runAllTimersAsync()
 
-    expect(view.result.current.stats.superseded).toBe(2)
+    // Barrier ordering: pre-updates deliver BEFORE the snapshot, post-
+    // updates after — nothing is discarded.
+    expect(handlers.updateNode).toHaveBeenCalledTimes(3)
     expect(handlers.setNetwork).toHaveBeenCalledTimes(1)
-    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
-    expect((handlers.updateNode.mock.calls[0][0] as { id: string }).id).toBe('post1')
-    // Ordering: snapshot delivered BEFORE the post-snapshot update.
-    expect(handlers.setNetwork.mock.invocationCallOrder[0]).toBeLessThan(
-      handlers.updateNode.mock.invocationCallOrder[0],
-    )
+    const preOrders = handlers.updateNode.mock.invocationCallOrder.slice(0, 2)
+    const snapOrder = handlers.setNetwork.mock.invocationCallOrder[0]
+    const postOrder = handlers.updateNode.mock.invocationCallOrder[2]
+    expect(Math.max(...preOrders)).toBeLessThan(snapOrder)
+    expect(snapOrder).toBeLessThan(postOrder)
   })
 
-  it('an edges-only update supersedes nothing on the node side', async () => {
-    const view = renderHook(() => useEventQueue(client, handlers))
-    nodeMsg(NODE('keep'))
-    netMsg({ edges: [{ id: 'e', source: 'a', target: 'b' }] })
+  it('updates never fold ACROSS a barrier — same id before and after stays two deliveries', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    nodeMsg({ id: 'x', position: [1, 1, 1] })
+    netMsg({ nodes: [] })
+    nodeMsg({ id: 'x', position: [2, 2, 2] })
     await vi.runAllTimersAsync()
-    expect(view.result.current.stats.superseded).toBe(0)
-    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
-    expect(handlers.setNetwork).toHaveBeenCalledWith(undefined, [
-      { id: 'e', source: 'a', target: 'b' },
-    ])
+    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(1, { id: 'x', position: [1, 1, 1] })
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, { id: 'x', position: [2, 2, 2] })
   })
 
-  it('queued snapshots keep the latest side each (per-side latest-wins)', async () => {
+  it('consecutive snapshots stay ordered as separate deliveries (never merged)', async () => {
     renderHook(() => useEventQueue(client, handlers))
     netMsg({ nodes: [NODE('n1')], edges: [{ id: 'e1', source: 'a', target: 'b' }] })
     netMsg({ nodes: [NODE('n2')] })
     await vi.runAllTimersAsync()
-    expect(handlers.setNetwork).toHaveBeenCalledTimes(1)
-    const [nodes, edges] = handlers.setNetwork.mock.calls[0]
-    expect((nodes as Array<{ id: string }>)[0].id).toBe('n2')
-    expect((edges as Array<{ id: string }>)[0].id).toBe('e1')
+    expect(handlers.setNetwork).toHaveBeenCalledTimes(2)
+    expect((handlers.setNetwork.mock.calls[0][0] as Array<{ id: string }>)[0].id).toBe('n1')
+    expect((handlers.setNetwork.mock.calls[1][0] as Array<{ id: string }>)[0].id).toBe('n2')
+    expect(handlers.setNetwork.mock.calls[1][1]).toBeUndefined()
+  })
+
+  it('the positionless->positionful transition stays two ordered candidates (CE1 mechanism)', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    nodeMsg({ id: 'x', status: 'error' })            // positionless: not folded forward
+    nodeMsg({ id: 'x', position: [1, 2, 3] })        // anchored: new candidate
+    nodeMsg({ id: 'x', status: 'inactive' })         // folds into the anchored one
+    expect(view.result.current.pendingCount()).toBe(2)
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(1, { id: 'x', status: 'error' })
+    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, {
+      id: 'x',
+      position: [1, 2, 3],
+      status: 'inactive',
+    })
+    expect(view.result.current.stats.coalesced).toBe(1)
   })
 
   it('null/primitive/empty network payloads enqueue nothing', async () => {
@@ -206,7 +223,7 @@ describe('snapshot supersession', () => {
 describe('overflow boundary', () => {
   it('exact limit fills; limit+1 NEW id drops with an accurate counter; folds still proceed', async () => {
     const view = renderHook(() =>
-      useEventQueue(client, handlers, { maxPendingNodes: 3 }),
+      useEventQueue(client, handlers, { maxPendingWork: 3 }),
     )
     nodeMsg(NODE('a'))
     nodeMsg(NODE('b'))
@@ -230,7 +247,7 @@ describe('overflow boundary', () => {
   })
 
   it('one bounded diagnostic per overflow episode — no console spam', async () => {
-    renderHook(() => useEventQueue(client, handlers, { maxPendingNodes: 2 }))
+    renderHook(() => useEventQueue(client, handlers, { maxPendingWork: 2 }))
     nodeMsg(NODE('a'))
     nodeMsg(NODE('b'))
     nodeMsg(NODE('c'))
@@ -251,7 +268,7 @@ describe('overflow boundary', () => {
 
   it('the documented default limit is in force when no injection is provided', () => {
     const view = renderHook(() => useEventQueue(client, handlers))
-    expect(DEFAULT_MAX_PENDING_NODES).toBe(5000)
+    expect(DEFAULT_MAX_PENDING_WORK).toBe(5000)
     expect(view.result.current.stats.dropped).toBe(0)
   })
 })
@@ -259,7 +276,7 @@ describe('overflow boundary', () => {
 describe('100,000-event deterministic burst', () => {
   it('bounded memory, coalesced counters, latest state per id, single-drain discipline', async () => {
     const view = renderHook(() =>
-      useEventQueue(client, handlers, { maxPendingNodes: 1000 }),
+      useEventQueue(client, handlers, { maxPendingWork: 1000 }),
     )
     const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
     const IDS = 500

--- a/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/use-event-queue.test.tsx
@@ -1,14 +1,17 @@
-// Package X: useEventQueue hook contracts — subscription identity, cleanup,
-// rAF batching, and the no-update-after-unmount guarantee.
+// Package AF: the typed backpressure queue — bounded pending work, single
+// scheduled drain, snapshot supersession, per-id coalescing, explicit
+// overflow.
 //
-// The hook is driven through the REAL SimBridgeClient against a typed fake
-// WebSocket, so wire → queue → handler is exercised end to end. Fake timers
-// make the rAF pipeline fully deterministic (the async advance variants
-// interleave the microtasks the processing loop awaits).
+// Driven through the REAL SimBridgeClient against a typed fake WebSocket
+// (wire → queue → handler end to end) under fake timers; the async advance
+// variants interleave the microtasks the drain loop awaits.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useEventQueue } from '../src/viz3d/useEventQueue'
+import { useEventQueue, DEFAULT_MAX_PENDING_NODES } from '../src/viz3d/useEventQueue'
 import { SimBridgeClient } from '../src/ws/SimBridgeClient'
+import { applyNodeUpdate, sanitizeNodeList } from '../src/viz3d/nodeValidation'
+import { sanitizeEdgeList } from '../src/viz3d/edgeValidation'
+import type { NetworkNode, NetworkEdge } from '../src/ws/SimBridgeClient'
 
 class FakeWebSocket {
   static CONNECTING = 0
@@ -46,13 +49,23 @@ let handlers: {
 }
 
 const socket = () => FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+const nodeMsg = (payload: unknown) => socket().serverMessage({ type: 'node_update', payload })
+const netMsg = (payload: unknown) => socket().serverMessage({ type: 'network_update', payload })
+const NODE = (id: string, extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id,
+  position: [1, 2, 3],
+  connections: [],
+  status: 'active',
+  ...extra,
+})
 
 beforeEach(() => {
   vi.useFakeTimers()
   vi.stubGlobal('WebSocket', FakeWebSocket)
   FakeWebSocket.instances = []
   vi.spyOn(console, 'log').mockImplementation(() => {})
-  client = new SimBridgeClient('ws://hook-test', 1000)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  client = new SimBridgeClient('ws://queue-test', 1000)
   client.connect()
   socket().serverOpen()
   handlers = {
@@ -63,8 +76,6 @@ beforeEach(() => {
 
 afterEach(() => {
   client.disconnect()
-  // Bounded drain (mirrors the SimBridge suite): pending timers only, with
-  // a hard cap so a recursive-timer defect fails instead of hanging.
   for (let i = 0; i < 25 && vi.getTimerCount() > 0; i++) {
     vi.runOnlyPendingTimers()
   }
@@ -75,201 +86,367 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('useEventQueue subscriptions', () => {
-  it('subscribes once per channel; rerenders with identical inputs do not resubscribe', () => {
-    const onSpy = vi.spyOn(client, 'on')
-    const { rerender } = renderHook(() => useEventQueue(client, handlers))
-    const initialCalls = onSpy.mock.calls.length
-    expect(initialCalls).toBe(3) // network_update, node_update, edge_update
-
-    rerender()
-    rerender()
-    expect(onSpy.mock.calls.length).toBe(initialCalls) // listener identity stable
+describe('single scheduled drain', () => {
+  it('many synchronous enqueues schedule EXACTLY ONE animation frame', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    for (let i = 0; i < 15; i++) nodeMsg(NODE(`n${i}`))
+    expect(rafSpy).toHaveBeenCalledTimes(1) // the old closure queue scheduled 15
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(15)
   })
 
-  it('unsubscribes the SAME handler references on unmount', () => {
-    const onSpy = vi.spyOn(client, 'on')
-    const offSpy = vi.spyOn(client, 'off')
-    const { unmount } = renderHook(() => useEventQueue(client, handlers))
-    unmount()
-    expect(offSpy.mock.calls.length).toBe(3)
-    // Every off() must pass exactly the function that on() registered.
-    for (const [channel, handler] of offSpy.mock.calls) {
-      expect(onSpy.mock.calls.some(([ch, h]) => ch === channel && h === handler)).toBe(true)
-    }
-  })
-
-  it('a null client subscribes to nothing', () => {
-    renderHook(() => useEventQueue(null, handlers))
-    socket().serverMessage({ type: 'node_update', payload: { id: 'n' } })
-    vi.runAllTimers()
-    expect(handlers.updateNode).not.toHaveBeenCalled()
+  it('a drain over multiple batches yields one continuation frame at a time', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    for (let i = 0; i < 120; i++) nodeMsg(NODE(`n${i}`)) // 3 batches of 50
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(120)
+    // 1 schedule + 2 continuation yields (120 items / 50 per frame).
+    expect(rafSpy).toHaveBeenCalledTimes(3)
   })
 })
 
-describe('useEventQueue delivery', () => {
-  it('delivers node_update payloads to updateNode through the rAF batch', async () => {
-    renderHook(() => useEventQueue(client, handlers))
-    socket().serverMessage({ type: 'node_update', payload: { id: 'n1' } })
-    expect(handlers.updateNode).not.toHaveBeenCalled() // queued, not synchronous
+describe('coalescing and ordering', () => {
+  it('repeated updates for one id deliver once, latest-valid-wins per field', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    nodeMsg({ id: 'n1', position: [1, 1, 1], status: 'active' })
+    nodeMsg({ id: 'n1', status: 'error' })                    // no position: keeps [1,1,1]
+    nodeMsg({ id: 'n1', position: 'garbage' })                // invalid: keeps [1,1,1]
+    nodeMsg({ id: 'n1', position: [9, 9, 9] })                // latest valid position
     await vi.runAllTimersAsync()
     expect(handlers.updateNode).toHaveBeenCalledTimes(1)
-    expect(handlers.updateNode).toHaveBeenCalledWith({ id: 'n1' })
+    expect(handlers.updateNode).toHaveBeenCalledWith({
+      id: 'n1',
+      position: [9, 9, 9],
+      status: 'error',
+    })
+    expect(view.result.current.stats.coalesced).toBe(3)
   })
 
-  it('forwards network_update sides as-received (store owns per-side validation)', async () => {
+  it('distinct ids preserve insertion order', async () => {
     renderHook(() => useEventQueue(client, handlers))
-    socket().serverMessage({ type: 'network_update', payload: { nodes: [], edges: [{ id: 'e' }] } })
-    socket().serverMessage({ type: 'network_update', payload: { nodes: [] } }) // one side absent
+    for (const id of ['a', 'b', 'c', 'd']) nodeMsg(NODE(id))
     await vi.runAllTimersAsync()
-    expect(handlers.setNetwork).toHaveBeenCalledTimes(2)
-    expect(handlers.setNetwork).toHaveBeenNthCalledWith(1, [], [{ id: 'e' }])
-    expect(handlers.setNetwork).toHaveBeenNthCalledWith(2, [], undefined)
+    expect(handlers.updateNode.mock.calls.map(args => (args[0] as { id: string }).id)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ])
   })
 
-  it.each([
-    { label: 'null payload', payload: null },
-    { label: 'string payload', payload: 'junk' },
-    { label: 'numeric payload', payload: 7 },
-    { label: 'empty object (no nodes/edges keys)', payload: {} },
-  ])('network_update with $label enqueues nothing', async ({ payload }) => {
-    renderHook(() => useEventQueue(client, handlers))
-    socket().serverMessage({ type: 'network_update', payload })
+  it('invalid/unidentifiable payloads are counted and never enter the queue', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    nodeMsg(null)
+    nodeMsg('junk')
+    nodeMsg({ status: 'active' })              // no id
+    nodeMsg({ id: '', position: [1, 2, 3] })   // empty id
+    expect(view.result.current.pendingCount()).toBe(0)
     await vi.runAllTimersAsync()
-    expect(handlers.setNetwork).not.toHaveBeenCalled()
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+    expect(view.result.current.stats.invalidDropped).toBe(4)
   })
+})
 
-  it('node_update payloads pass through opaquely — null and hostile shapes reach the validating store', async () => {
-    renderHook(() => useEventQueue(client, handlers))
-    socket().serverMessage({ type: 'node_update', payload: null })
-    socket().serverMessage({ type: 'node_update', payload: 'not-a-node' })
+describe('snapshot supersession', () => {
+  it('a nodes-carrying snapshot supersedes OLDER queued node updates; later ones stay ordered after it', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    nodeMsg(NODE('pre1'))
+    nodeMsg(NODE('pre2'))
+    netMsg({ nodes: [NODE('snap')], edges: [] })
+    nodeMsg(NODE('post1'))
     await vi.runAllTimersAsync()
-    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
-    expect(handlers.updateNode).toHaveBeenNthCalledWith(1, null)
-    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, 'not-a-node')
-  })
 
-  it('processes a burst in batches, preserving order', async () => {
-    renderHook(() => useEventQueue(client, handlers))
-    for (let i = 1; i <= 25; i++) {
-      socket().serverMessage({ type: 'node_update', payload: { seq: i } })
-    }
-    await vi.runAllTimersAsync()
-    expect(handlers.updateNode).toHaveBeenCalledTimes(25)
-    expect(handlers.updateNode.mock.calls.map(args => (args[0] as { seq: number }).seq)).toEqual(
-      Array.from({ length: 25 }, (_, i) => i + 1),
+    expect(view.result.current.stats.superseded).toBe(2)
+    expect(handlers.setNetwork).toHaveBeenCalledTimes(1)
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    expect((handlers.updateNode.mock.calls[0][0] as { id: string }).id).toBe('post1')
+    // Ordering: snapshot delivered BEFORE the post-snapshot update.
+    expect(handlers.setNetwork.mock.invocationCallOrder[0]).toBeLessThan(
+      handlers.updateNode.mock.invocationCallOrder[0],
     )
   })
-})
 
-describe('useEventQueue unmount safety', () => {
-  it('queued rAF work cannot invoke handlers after unmount', async () => {
-    const { unmount } = renderHook(() => useEventQueue(client, handlers))
-    // Enqueue while mounted — the rAF that will process it is now pending.
-    socket().serverMessage({ type: 'node_update', payload: { id: 'late' } })
-    expect(handlers.updateNode).not.toHaveBeenCalled()
+  it('an edges-only update supersedes nothing on the node side', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    nodeMsg(NODE('keep'))
+    netMsg({ edges: [{ id: 'e', source: 'a', target: 'b' }] })
+    await vi.runAllTimersAsync()
+    expect(view.result.current.stats.superseded).toBe(0)
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    expect(handlers.setNetwork).toHaveBeenCalledWith(undefined, [
+      { id: 'e', source: 'a', target: 'b' },
+    ])
+  })
 
-    unmount()
-    await vi.runAllTimersAsync() // the pending rAF fires after unmount
-    expect(handlers.updateNode).not.toHaveBeenCalled()
+  it('queued snapshots keep the latest side each (per-side latest-wins)', async () => {
+    renderHook(() => useEventQueue(client, handlers))
+    netMsg({ nodes: [NODE('n1')], edges: [{ id: 'e1', source: 'a', target: 'b' }] })
+    netMsg({ nodes: [NODE('n2')] })
+    await vi.runAllTimersAsync()
+    expect(handlers.setNetwork).toHaveBeenCalledTimes(1)
+    const [nodes, edges] = handlers.setNetwork.mock.calls[0]
+    expect((nodes as Array<{ id: string }>)[0].id).toBe('n2')
+    expect((edges as Array<{ id: string }>)[0].id).toBe('e1')
+  })
+
+  it('null/primitive/empty network payloads enqueue nothing', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    netMsg(null)
+    netMsg('junk')
+    netMsg({})
+    expect(view.result.current.pendingCount()).toBe(0)
+    await vi.runAllTimersAsync()
     expect(handlers.setNetwork).not.toHaveBeenCalled()
   })
+})
 
-  it('a queue mid-processing stops at the unmount boundary', async () => {
-    const { unmount } = renderHook(() => useEventQueue(client, handlers))
-    // Two batches' worth: the loop must yield to rAF between batches of 10.
-    for (let i = 1; i <= 15; i++) {
-      socket().serverMessage({ type: 'node_update', payload: { seq: i } })
-    }
-    // Fire ONLY the first pending rAF: batch 1 (10 items) processes, then
-    // the loop awaits the next frame.
-    await vi.advanceTimersByTimeAsync(20)
-    expect(handlers.updateNode.mock.calls.length).toBeGreaterThanOrEqual(10)
-    const deliveredBeforeUnmount = handlers.updateNode.mock.calls.length
+describe('overflow boundary', () => {
+  it('exact limit fills; limit+1 NEW id drops with an accurate counter; folds still proceed', async () => {
+    const view = renderHook(() =>
+      useEventQueue(client, handlers, { maxPendingNodes: 3 }),
+    )
+    nodeMsg(NODE('a'))
+    nodeMsg(NODE('b'))
+    nodeMsg(NODE('c'))          // exactly at limit: all admitted
+    expect(view.result.current.pendingCount()).toBe(3)
+    expect(view.result.current.stats.dropped).toBe(0)
 
-    unmount()
+    nodeMsg(NODE('d'))          // limit+1: new id dropped
+    expect(view.result.current.stats.dropped).toBe(1)
+    nodeMsg({ id: 'b', status: 'error' }) // fold into pending id: allowed during overflow
+    expect(view.result.current.stats.coalesced).toBe(1)
+    expect(view.result.current.pendingCount()).toBe(3)
+
     await vi.runAllTimersAsync()
-    expect(handlers.updateNode.mock.calls.length).toBe(deliveredBeforeUnmount)
+    expect(handlers.updateNode).toHaveBeenCalledTimes(3)
+    expect(handlers.updateNode.mock.calls.map(args => (args[0] as { id: string }).id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
+  it('one bounded diagnostic per overflow episode — no console spam', async () => {
+    renderHook(() => useEventQueue(client, handlers, { maxPendingNodes: 2 }))
+    nodeMsg(NODE('a'))
+    nodeMsg(NODE('b'))
+    nodeMsg(NODE('c'))
+    nodeMsg(NODE('d'))
+    nodeMsg(NODE('e'))
+    const overflowReports = () =>
+      vi.mocked(console.error).mock.calls.filter(args =>
+        String(args[0]).startsWith('Event queue overflow'),
+      )
+    expect(overflowReports()).toHaveLength(1) // three drops, one episode report
+
+    await vi.runAllTimersAsync() // queue drains: episode ends
+    nodeMsg(NODE('f'))
+    nodeMsg(NODE('g'))
+    nodeMsg(NODE('h'))
+    expect(overflowReports()).toHaveLength(2) // new episode, one new report
+  })
+
+  it('the documented default limit is in force when no injection is provided', () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    expect(DEFAULT_MAX_PENDING_NODES).toBe(5000)
+    expect(view.result.current.stats.dropped).toBe(0)
   })
 })
 
-describe('handler-error policy (Package Y)', () => {
-  it('a throwing handler does not lock the queue: error reported once, later events deliver', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+describe('100,000-event deterministic burst', () => {
+  it('bounded memory, coalesced counters, latest state per id, single-drain discipline', async () => {
+    const view = renderHook(() =>
+      useEventQueue(client, handlers, { maxPendingNodes: 1000 }),
+    )
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    const IDS = 500
+    const ROUNDS = 200 // 500 ids × 200 rounds = 100,000 events
+    for (let round = 0; round < ROUNDS; round++) {
+      for (let i = 0; i < IDS; i++) {
+        nodeMsg({ id: `n${i}`, position: [round, i, 0], status: 'active' })
+      }
+    }
+    // Pending work stayed bounded by id cardinality, far under the limit.
+    expect(view.result.current.pendingCount()).toBe(IDS)
+    expect(view.result.current.stats.coalesced).toBe(IDS * (ROUNDS - 1))
+    expect(view.result.current.stats.dropped).toBe(0)
+    expect(rafSpy).toHaveBeenCalledTimes(1) // one scheduled drain for the whole burst
+
+    await vi.runAllTimersAsync()
+    // Exactly one delivery per id, carrying the LATEST round's position.
+    expect(handlers.updateNode).toHaveBeenCalledTimes(IDS)
+    const delivered = new Map(
+      handlers.updateNode.mock.calls.map(args => {
+        const p = args[0] as { id: string; position: [number, number, number] }
+        return [p.id, p.position] as const
+      }),
+    )
+    expect(delivered.get('n0')).toEqual([ROUNDS - 1, 0, 0])
+    expect(delivered.get(`n${IDS - 1}`)).toEqual([ROUNDS - 1, IDS - 1, 0])
+    // No retry/infinite loop: the queue is empty and no frame is pending.
+    expect(view.result.current.pendingCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('equivalence against sequential application (non-overflowing traffic)', () => {
+  it('the queued final state equals the old sequential semantics on a mixed deterministic trace', async () => {
+    // Reference: the exact state sequential application (the old closure
+    // queue's semantics) produces, computed with the same pure validators.
+    let refNodes: NetworkNode[] = []
+    let refEdges: NetworkEdge[] = []
+    const referenceApply = (event: { type: string; payload: unknown }) => {
+      if (event.type === 'node_update') {
+        refNodes = applyNodeUpdate(refNodes, event.payload)
+      } else {
+        const d = event.payload as { nodes?: unknown; edges?: unknown }
+        if (d.nodes !== undefined && Array.isArray(d.nodes)) refNodes = sanitizeNodeList(d.nodes, refNodes)
+        refEdges = sanitizeEdgeList(d.edges, refEdges)
+      }
+    }
+    // Queue path drives the SAME validators through the handler seam.
+    let qNodes: NetworkNode[] = []
+    let qEdges: NetworkEdge[] = []
+    handlers.updateNode.mockImplementation((p: unknown) => {
+      qNodes = applyNodeUpdate(qNodes, p)
+    })
+    handlers.setNetwork.mockImplementation((nodes: unknown, edges: unknown) => {
+      if (Array.isArray(nodes)) qNodes = sanitizeNodeList(nodes, qNodes)
+      qEdges = sanitizeEdgeList(edges, qEdges)
+    })
+    renderHook(() => useEventQueue(client, handlers))
+
+    // Deterministic mixed trace: interleaved valid/partial/invalid updates
+    // and per-side snapshots (seeded LCG — no Math.random).
+    let seed = 42
+    const rand = () => (seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648
+    const trace: Array<{ type: string; payload: unknown }> = []
+    for (let i = 0; i < 400; i++) {
+      const r = rand()
+      if (r < 0.6) {
+        trace.push({
+          type: 'node_update',
+          payload:
+            rand() < 0.8
+              ? { id: `n${Math.floor(rand() * 20)}`, position: [i, rand(), 0], status: rand() < 0.5 ? 'error' : 'active' }
+              : { id: `n${Math.floor(rand() * 20)}`, position: 'garbage' },
+        })
+      } else if (r < 0.8) {
+        trace.push({
+          type: 'network_update',
+          payload: { nodes: [NODE(`snap${Math.floor(rand() * 5)}`, { position: [i, 0, 0] })] },
+        })
+      } else {
+        trace.push({
+          type: 'network_update',
+          payload: { edges: [{ id: `e${Math.floor(rand() * 5)}`, source: 'a', target: 'b', strength: 1 }] },
+        })
+      }
+    }
+    for (const event of trace) {
+      referenceApply(event)
+      socket().serverMessage(event)
+    }
+    await vi.runAllTimersAsync()
+    expect(qNodes).toEqual(refNodes)
+    expect(qEdges).toEqual(refEdges)
+  })
+})
+
+describe('lifecycle and failure', () => {
+  it('unmount clears queued work and schedules no further frames', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    for (let i = 0; i < 5; i++) nodeMsg(NODE(`n${i}`))
+    expect(view.result.current.pendingCount()).toBe(5)
+    view.unmount()
+    expect(view.result.current.pendingCount()).toBe(0)
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).not.toHaveBeenCalled()
+  })
+
+  it('an unmount performed BY a handler stops the remaining batch and requests no extra frame', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
+    handlers.updateNode.mockImplementationOnce(() => {
+      view.unmount()
+    })
+    nodeMsg(NODE('a'))
+    nodeMsg(NODE('b'))
+    nodeMsg(NODE('c'))
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    expect(rafSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('a throwing handler is contained, reported once, and never locks later processing', async () => {
     renderHook(() => useEventQueue(client, handlers))
     handlers.updateNode.mockImplementationOnce(() => {
       throw new Error('handler boom')
     })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } }) // throws inside drain
+    nodeMsg(NODE('a'))
+    nodeMsg(NODE('b'))
     await vi.runAllTimersAsync()
-
-    // Later, INDEPENDENT event: must process normally (queue not locked).
-    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
+    expect(handlers.updateNode).toHaveBeenCalledTimes(2) // batch-mate survived
+    nodeMsg(NODE('c'))
     await vi.runAllTimersAsync()
-    expect(handlers.updateNode).toHaveBeenCalledTimes(2)
-    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, { seq: 2 })
-
-    // Bounded diagnostic channel: exactly one report for the one failure.
+    expect(handlers.updateNode).toHaveBeenCalledTimes(3) // queue not locked
     const reports = vi.mocked(console.error).mock.calls.filter(
       args => args[0] === 'Event handler failed:',
     )
     expect(reports).toHaveLength(1)
   })
 
-  it('a throwing handler does not abort the remaining handlers in its batch', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+  it('a throwing setNetwork handler is equally contained', async () => {
     renderHook(() => useEventQueue(client, handlers))
-    handlers.updateNode.mockImplementationOnce(() => {
-      throw new Error('first of batch fails')
+    handlers.setNetwork.mockImplementationOnce(() => {
+      throw new Error('snapshot boom')
     })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 3 } })
+    netMsg({ nodes: [NODE('s')] })
+    nodeMsg(NODE('after'))
     await vi.runAllTimersAsync()
-    // Failed event is skipped (no retry); its batch-mates still deliver.
-    expect(handlers.updateNode).toHaveBeenCalledTimes(3)
-    expect(handlers.updateNode).toHaveBeenNthCalledWith(2, { seq: 2 })
-    expect(handlers.updateNode).toHaveBeenNthCalledWith(3, { seq: 3 })
+    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('subscribes once per channel; identical rerenders do not resubscribe; unmount detaches', () => {
+    const onSpy = vi.spyOn(client, 'on')
+    const offSpy = vi.spyOn(client, 'off')
+    const view = renderHook(() => useEventQueue(client, handlers))
+    expect(onSpy.mock.calls.length).toBe(3)
+    view.rerender()
+    expect(onSpy.mock.calls.length).toBe(3)
+    view.unmount()
+    expect(offSpy.mock.calls.length).toBe(3)
+  })
+
+  it('a null client subscribes to nothing', async () => {
+    renderHook(() => useEventQueue(null, handlers))
+    nodeMsg(NODE('n'))
+    await vi.runAllTimersAsync()
+    expect(handlers.updateNode).not.toHaveBeenCalled()
   })
 })
 
-describe('unmount during a handler (Package Y)', () => {
-  it('an unmount performed BY a handler prevents every remaining handler in that batch', async () => {
+describe('diagnostic surface', () => {
+  it('edge_update events are logged through the existing channel (no queue effect)', async () => {
     const view = renderHook(() => useEventQueue(client, handlers))
-    handlers.updateNode.mockImplementationOnce(() => {
-      view.unmount() // the handler itself tears the consumer down
-    })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 2 } })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 3 } })
-    await vi.runAllTimersAsync()
-    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('frame-scheduling discipline (Jack audit amendment)', () => {
-  it('unmount during the LAST handler schedules no extra animation frame', async () => {
-    const view = renderHook(() => useEventQueue(client, handlers))
-    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
-    handlers.updateNode.mockImplementationOnce(() => {
-      view.unmount()
-    })
-    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } }) // schedules exactly one frame
-    expect(rafSpy).toHaveBeenCalledTimes(1)
-    await vi.runAllTimersAsync()
-    // The drain must NOT have scheduled a post-batch yield frame: the
-    // active/empty check runs BEFORE requesting the next frame.
-    expect(rafSpy).toHaveBeenCalledTimes(1)
-    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    socket().serverMessage({ type: 'edge_update', payload: { id: 'e1' } })
+    expect(view.result.current.pendingCount()).toBe(0)
+    const logs = vi.mocked(console.log).mock.calls.filter(args => args[0] === 'Edge update:')
+    expect(logs).toHaveLength(1)
   })
 
-  it('an emptied queue schedules no trailing yield frame either', async () => {
-    renderHook(() => useEventQueue(client, handlers))
-    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame')
-    socket().serverMessage({ type: 'node_update', payload: { seq: 1 } })
-    expect(rafSpy).toHaveBeenCalledTimes(1)
+  it('isProcessing reflects the drain lifecycle', async () => {
+    const view = renderHook(() => useEventQueue(client, handlers))
+    expect(view.result.current.isProcessing()).toBe(false)
+    handlers.updateNode.mockImplementationOnce(() => {
+      expect(view.result.current.isProcessing()).toBe(true) // observed mid-drain
+    })
+    nodeMsg(NODE('n'))
     await vi.runAllTimersAsync()
-    expect(rafSpy).toHaveBeenCalledTimes(1) // batch drained; no idle frame requested
-    expect(handlers.updateNode).toHaveBeenCalledTimes(1)
+    expect(view.result.current.isProcessing()).toBe(false)
   })
 })


### PR DESCRIPTION
## PACKAGE AF — bounded event queue and backpressure (refs #6 — no closing keyword)

**Independent PR against main.**

### Evidence map (measured against the old closure queue)
| Finding | Evidence |
|---|---|
| **15 sync enqueues scheduled 15 rAF callbacks** | rAF-spy measurement; only the first drain did work — 14 wasted frames | 
| **Unbounded closure queue** | `Array<() => void>` grew linearly under bursts; invalid payloads occupied slots |
| **Handler identity churn** | ThreeScene passed an inline object — all three SimBridge channels resubscribed on every store-driven render |
| **Snapshot semantics** | store-verified: a nodes-carrying `network_update` replaces node state wholesale per side → node updates queued before it cannot affect final state |
| Event/contract inventory | `node_update` (partial, per-id merge, admission validates) · `network_update` (per-side wholesale) · `edge_update` (log-only) · `simulation_event` (EventFeed's own subscription, outside this queue) |

### Queue state machine
| State | `node_update` (valid) | `node_update` (invalid/no-id) | `network_update` w/ nodes | `network_update` edges-only | drain |
|---|---|---|---|---|---|
| idle | admit→Map, schedule 1 frame | count `invalidDropped`, no growth | snapshot set, **queued node updates superseded+counted**, schedule | edges side set, node updates kept | — |
| pending, id known | **fold latest-valid-wins** (`coalesced++`, allowed even during overflow) | count, no growth | same as above | same | — |
| pending, id new, at limit | **drop** (`dropped++`, one diagnostic per episode) | count | same | same | — |
| draining | enqueue as above (no second frame — `scheduledRef`) | — | — | — | snapshot first, then folded updates in insertion order, 50/frame, per-item containment; episode resets when empty |

The fold lives in **nodeValidation.ts beside the admission contract it mirrors**, with the sequential-equivalence argument documented and **test-locked**: per-field the latest VALID value wins and invalid reads behave as absent — a mixed 400-event seeded trace through the queue produces a final state **exactly equal** to a pure sequential reference.

### Burst measurements (100,000-event deterministic burst: 500 ids × 200 rounds)
pending work bounded at **500** (id cardinality, limit 1000 untouched) · `coalesced` = **99,500 exactly** · **1 rAF scheduled** for the whole burst · delivery = one update per id carrying the latest round's position · zero residual timers/frames.

### Overflow receipts
Boundary exact (limit 3: third admits, fourth drops, `dropped=1`); folds proceed during overflow; **one diagnostic per episode** across two forced episodes (5 drops → 2 reports); the diagnostic itself states delivery is **not lossless** under overflow — no silent losslessness claim anywhere.

### Documented contract change
Invalid/unidentifiable `node_update` payloads are now counted+dropped at the queue boundary instead of being forwarded for the store to reject. Net store state is identical (the store rejected them anyway); the old forward-garbage handler contract is gone with the closure queue.

### Verification
unit **269/269** (+shuffle seed) · lint 0/0 · tsc clean · coverage aggregate + **per-file floor gate PASS** — noteworthy: the AC floor gate **failed this PR's first draft** (useEventQueue 94.82 stmts / 86.66 funcs) and the gaps were covered rather than floors lowered, exactly as designed · budget 11/11 · build ok · BUNDLE_BUDGET PASS 989,252/275,739 (+1,696 raw) · **Playwright 56/56 ×3**.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment (Jack runway, 2026-07-12 evening) — head `bccd2953`

- **Commit-synchronous handler refresh**: `handlersRef` now refreshes in `useLayoutEffect`. A paint-aligned rAF drain firing between a committed rerender and its passive-effect flush can no longer observe stale handlers. **Failing-first receipt**: the new test run against the previous `useEffect` implementation delivered the *first*-generation handlers (`expected ['first'] to deeply equal ['second']`); the layout-phase refresh turns it green. WebSocket subscriptions remain one-per-channel across handler rerenders (zero-churn test re-run).
- **Differential extended to 500 fixed-seed traces** x 60 events (30,000 mixed events: existing/unknown nodes, partial/full/malformed snapshots, a new positionless-barrier generator branch). Overflow disabled for equivalence — no trace approaches the 5,000-item bound, so equality with the sequential reference must be exact with zero drops.
- **Ordered delivery asserted, not merely final state**: exact call-sequence test (folds land in the anchor slot, barriers hold their place, post-barrier segments deliver last) + invariants over 100 further generated traces (segment residency, <=2 deliveries/id/segment, positionless-before-anchored split, every barrier delivered).
- **Snapshots occupy the finite bound**: a bound filled entirely by snapshots drops further snapshots and node items alike; the diagnostic's explicit *NOT lossless* wording is test-locked.
- Both audit counterexamples (CE1 positionless->position-bearing unknown node; CE2 update->partial snapshot) re-run green.

### Review-thread disposition (non-outdated)

| Thread | Classification | Evidence |
|---|---|---|
| codex P2 — "Do not fold positionless updates before a node exists" (`nodeValidation.ts`) | **ADDRESSED** by the ordered-barrier redesign already on this branch | This is exactly audit CE1. The anchored-fold safety rule in `useEventQueue.ts` (a position-bearing candidate never folds into a positionless one: `target.candidate.position !== null || candidate.position === null`) keeps the positionless->positionful transition as two ordered candidates, so sequential rejection of the positionless update is preserved. Locked by: the CE1 differential test (whose reference asserts no `status` resurrection), 500-trace equivalence, and the ordered-delivery invariant that a two-delivery split is always positionless-first. Thread left open for reviewer confirmation. |

Battery at `bccd2953`: lint 0 · tsc 0 · 282/282 unit · UNIT_COVERAGE PASS · floor-gate self-tests 6/6.