### PR TITLE
perf: lazy view delivery — heavy 3D/2D views code-split from the shell (PACKAGE AG)

### DIFF
--- a/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
+++ b/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
@@ -16,8 +16,16 @@ const server = spawn('npx', ['vite', 'preview', '--port', String(PORT), '--stric
   stdio: 'pipe',
 })
 const kill = () => {
+  // shell:true wraps the server in a shell: killing only server.pid leaves
+  // the node child alive holding esbuild/rollup binaries (observed live —
+  // it broke a later npm ci with EPERM). Kill the whole tree on Windows;
+  // elsewhere the direct kill suffices for vite preview.
   try {
-    process.kill(server.pid)
+    if (process.platform === 'win32') {
+      spawn('taskkill', ['/PID', String(server.pid), '/T', '/F'], { shell: true })
+    } else {
+      process.kill(server.pid)
+    }
   } catch {
     /* already gone */
   }

--- a/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
+++ b/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
@@ -5,7 +5,7 @@
 // the view must arrive once it lands. Run manually / in the lab:
 //   node scripts/delayed-chunk-check.mjs
 // Not wired into CI (spawns a server + real browser).
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { chromium } from '@playwright/test'
 
 const PORT = 4199
@@ -22,7 +22,9 @@ const kill = () => {
   // elsewhere the direct kill suffices for vite preview.
   try {
     if (process.platform === 'win32') {
-      spawn('taskkill', ['/PID', String(server.pid), '/T', '/F'], { shell: true })
+      // Synchronous: the script exits right after kill(), and an async
+      // taskkill would race that exit and never fire.
+      spawnSync('taskkill', ['/PID', String(server.pid), '/T', '/F'], { shell: true })
     } else {
       process.kill(server.pid)
     }

--- a/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
+++ b/utilityfog_frontend/frontend/scripts/delayed-chunk-check.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Package AG lab receipt: serve the BUILT app (vite preview) and delay the
+// async 3D chunk at the network layer — the shell must be interactive and
+// the accessible loading status visible while the chunk is in flight, and
+// the view must arrive once it lands. Run manually / in the lab:
+//   node scripts/delayed-chunk-check.mjs
+// Not wired into CI (spawns a server + real browser).
+import { spawn } from 'node:child_process'
+import { chromium } from '@playwright/test'
+
+const PORT = 4199
+const DELAY_MS = 1500
+
+const server = spawn('npx', ['vite', 'preview', '--port', String(PORT), '--strictPort'], {
+  shell: true,
+  stdio: 'pipe',
+})
+const kill = () => {
+  try {
+    process.kill(server.pid)
+  } catch {
+    /* already gone */
+  }
+}
+
+try {
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('preview server timeout')), 15000)
+    server.stdout.on('data', d => {
+      if (String(d).includes(String(PORT))) {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+    server.on('exit', () => reject(new Error('preview server exited early')))
+  })
+
+  const browser = await chromium.launch()
+  const page = await browser.newPage()
+  let chunkDelayed = false
+  await page.route('**/assets/NetworkView3D*.js', async route => {
+    chunkDelayed = true
+    await new Promise(r => setTimeout(r, DELAY_MS))
+    await route.continue()
+  })
+
+  const t0 = Date.now()
+  await page.goto(`http://localhost:${PORT}/`)
+  // Shell interactive + accessible loading status WHILE the chunk is delayed.
+  await page.getByRole('button', { name: '3D View' }).waitFor({ timeout: DELAY_MS - 300 })
+  await page
+    .getByText('Loading 3D network view…')
+    .waitFor({ timeout: DELAY_MS - 300 })
+  const shellVisibleAt = Date.now() - t0
+  // The view arrives after the delayed chunk lands (canvas mounted).
+  await page.locator('canvas').waitFor({ timeout: DELAY_MS + 15000 })
+  const viewVisibleAt = Date.now() - t0
+
+  console.log(
+    `DELAYED_CHUNK_CHECK v1 delayed=${chunkDelayed} shell_ms=${shellVisibleAt} view_ms=${viewVisibleAt} status=PASS`,
+  )
+  await browser.close()
+  kill()
+  process.exit(0)
+} catch (error) {
+  console.error('DELAYED_CHUNK_CHECK v1 status=FAIL')
+  console.error(error)
+  kill()
+  process.exit(1)
+}

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -37,10 +37,23 @@ function App() {
   const [view, setView] = useState<'2d' | '3d'>('3d')
   const [isConnected, setIsConnected] = useState(false)
   const [simClient, setSimClient] = useState<SimBridgeClient | null>(null)
-  // Lazy components live in STATE so Retry can mint a fresh instance (a
+  // Lazy components live in STATE so a fresh instance can be minted (a
   // rejected lazy caches its rejection; a new lazy re-runs the import).
   const [Lazy3D, setLazy3D] = useState(() => lazy(load3D))
   const [Lazy2D, setLazy2D] = useState(() => lazy(load2D))
+
+  // Explicit view selection (audit amendment): switching TO a view mints a
+  // fresh lazy for the TARGET, so a chunk import that failed earlier is
+  // retried on entry — without an unconditional effect (no first-load
+  // churn: the slot remounts on switch anyway, and a successfully loaded
+  // module resolves instantly from the module cache). Clicking the
+  // already-active view is a NO-OP: no remount, no reload.
+  const selectView = (target: '2d' | '3d') => {
+    if (target === view) return
+    if (target === '3d') setLazy3D(() => lazy(load3D))
+    else setLazy2D(() => lazy(load2D))
+    setView(target)
+  }
 
   useEffect(() => {
     const client = new SimBridgeClient(WS_URL)
@@ -59,8 +72,8 @@ function App() {
   return (
     <div className="app-container">
       <div className="controls">
-        <button aria-pressed={view === '2d'} onClick={() => setView('2d')}>2D View</button>
-        <button aria-pressed={view === '3d'} onClick={() => setView('3d')}>3D View</button>
+        <button aria-pressed={view === '2d'} onClick={() => selectView('2d')}>2D View</button>
+        <button aria-pressed={view === '3d'} onClick={() => selectView('3d')}>3D View</button>
       </div>
 
       <EventFeed simClient={simClient} />

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -1,11 +1,22 @@
 /// <reference types="vite/client" />
-import { useState, useEffect } from 'react'
-import NetworkView3D from './viz3d/NetworkView3D'
-import NetworkView2D from './components/NetworkView2D'
+import { useState, useEffect, lazy, Suspense } from 'react'
 import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
 import ViewErrorBoundary from './components/ViewErrorBoundary'
 import { SimBridgeClient } from './ws/SimBridgeClient'
+
+// LAZY VIEW DELIVERY (Package AG): the heavy 3D/2D view modules are
+// code-split behind dynamic imports — the shell (controls, badge, feed)
+// renders independently of view code. No eager static import of a view
+// module may appear in this file.
+//
+// React caches a REJECTED lazy factory permanently, so the lazy components
+// live in state: the error boundary's Retry mints a fresh lazy instance
+// whose mount re-runs the dynamic import — reloading a failed chunk
+// without touching the SimBridge connection (which lives in this
+// component, above the boundary).
+const load3D = () => import('./viz3d/NetworkView3D')
+const load2D = () => import('./components/NetworkView2D')
 
 // Robust WS URL computation
 const envUrl = import.meta.env.VITE_WS_URL as string | undefined;
@@ -26,6 +37,10 @@ function App() {
   const [view, setView] = useState<'2d' | '3d'>('3d')
   const [isConnected, setIsConnected] = useState(false)
   const [simClient, setSimClient] = useState<SimBridgeClient | null>(null)
+  // Lazy components live in STATE so Retry can mint a fresh instance (a
+  // rejected lazy caches its rejection; a new lazy re-runs the import).
+  const [Lazy3D, setLazy3D] = useState(() => lazy(load3D))
+  const [Lazy2D, setLazy2D] = useState(() => lazy(load2D))
 
   useEffect(() => {
     const client = new SimBridgeClient(WS_URL)
@@ -71,8 +86,22 @@ function App() {
           aria-label="3D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
-          <ViewErrorBoundary viewLabel="3D network view">
-            <NetworkView3D simClient={simClient} />
+          <ViewErrorBoundary
+            viewLabel="3D network view"
+            onRetry={() => setLazy3D(() => lazy(load3D))}
+          >
+            {/* The transient loading status is scoped inside the active
+                region; steady-state keeps the badge as the only status
+                region. */}
+            <Suspense
+              fallback={
+                <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
+                  Loading 3D network view…
+                </div>
+              }
+            >
+              <Lazy3D simClient={simClient} />
+            </Suspense>
           </ViewErrorBoundary>
         </section>
       ) : (
@@ -82,8 +111,19 @@ function App() {
           aria-label="2D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
-          <ViewErrorBoundary viewLabel="2D network view">
-            <NetworkView2D simClient={simClient} />
+          <ViewErrorBoundary
+            viewLabel="2D network view"
+            onRetry={() => setLazy2D(() => lazy(load2D))}
+          >
+            <Suspense
+              fallback={
+                <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
+                  Loading 2D network view…
+                </div>
+              }
+            >
+              <Lazy2D simClient={simClient} />
+            </Suspense>
           </ViewErrorBoundary>
         </section>
       )}

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -23,6 +23,10 @@ import type { ErrorInfo, ReactNode } from 'react'
 interface ViewErrorBoundaryProps {
   // Names the guarded surface in the fallback message ("3D network view").
   viewLabel: string
+  // Invoked when the user clicks Retry, BEFORE the boundary clears its
+  // failed state — the owner can mint fresh lazy-loaded children so a
+  // cached chunk-load rejection is retried (Package AG).
+  onRetry?: () => void
   children: ReactNode
 }
 
@@ -48,6 +52,7 @@ export default class ViewErrorBoundary extends Component<
   }
 
   handleRetry = (): void => {
+    this.props.onRetry?.()
     this.setState({ failed: false })
   }
 

--- a/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
@@ -61,19 +61,20 @@ afterEach(() => {
 })
 
 describe('App view switching', () => {
-  it('defaults to the 3D view with semantic pressed state and a labelled region', () => {
+  it('defaults to the 3D view with semantic pressed state and a labelled region', async () => {
     render(<App />)
-    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
     expect(screen.queryByTestId('view-2d')).not.toBeInTheDocument()
     expect(screen.getByRole('region', { name: '3D network view' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '3D View' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('button', { name: '2D View' })).toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('switching shows exactly one active view and swaps pressed state + region label', () => {
+  it('switching shows exactly one active view and swaps pressed state + region label', async () => {
     render(<App />)
+    await screen.findByTestId('view-3d')
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
-    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
     expect(screen.queryByTestId('view-3d')).not.toBeInTheDocument()
     expect(screen.getAllByRole('region')).toHaveLength(1)
     expect(screen.getByRole('region', { name: '2D network view' })).toBeInTheDocument()
@@ -81,8 +82,9 @@ describe('App view switching', () => {
     expect(screen.getByRole('button', { name: '3D View' })).toHaveAttribute('aria-pressed', 'false')
   })
 
-  it('switching preserves the persistent connection/status surfaces and feed content', () => {
+  it('switching preserves the persistent connection/status surfaces and feed content', async () => {
     render(<App />)
+    await screen.findByTestId('view-3d')
     act(() => live().serverOpen())
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
 
@@ -91,6 +93,7 @@ describe('App view switching', () => {
     expect(feed.querySelectorAll('[data-event-channel]')).toHaveLength(1)
 
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    await screen.findByTestId('view-2d')
     // One status region, one log region — same content, nothing remounted.
     expect(screen.getAllByRole('status')).toHaveLength(1)
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
@@ -100,18 +103,20 @@ describe('App view switching', () => {
     ).toHaveLength(1)
 
     fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    await screen.findByTestId('view-3d')
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
     expect(
       screen.getByRole('log', { name: 'Event feed' }).querySelectorAll('[data-event-channel]'),
     ).toHaveLength(1)
   })
 
-  it('StrictMode: one live socket lineage, single status region, no duplicated feed entries', () => {
+  it('StrictMode: one live socket lineage, single status region, no duplicated feed entries', async () => {
     render(
       <StrictMode>
         <App />
       </StrictMode>,
     )
+    await screen.findByTestId('view-3d')
     // Development StrictMode mounts effects twice: the first client is
     // disconnected by its own cleanup; the LAST socket is the live one.
     expect(FakeWebSocket.instances.length).toBe(2)

--- a/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
@@ -148,3 +148,129 @@ describe('lazy rejection reaches the boundary (direct harness)', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 })
+
+describe('switch-away/back retries a failed chunk import (audit amendment)', () => {
+  // Two-view direct harness replicating App's selection semantics with
+  // CONTROLLABLE import factories (vi.mock factories cannot reject
+  // cleanly): switching TO a view mints a fresh lazy for the target;
+  // clicking the active view is a no-op.
+  function TwoViewHarness({ factories }: { factories: { a: () => Promise<{ default: () => JSX.Element }>; b: () => Promise<{ default: () => JSX.Element }> } }) {
+    const [view, setView] = useState<'a' | 'b'>('a')
+    const [LazyA, setLazyA] = useState(() => lazy(factories.a))
+    const [LazyB, setLazyB] = useState(() => lazy(factories.b))
+    const selectView = (target: 'a' | 'b') => {
+      if (target === view) return
+      if (target === 'a') setLazyA(() => lazy(factories.a))
+      else setLazyB(() => lazy(factories.b))
+      setView(target)
+    }
+    const Active = view === 'a' ? LazyA : LazyB
+    return (
+      <div>
+        <button type="button" onClick={() => selectView('a')}>go a</button>
+        <button type="button" onClick={() => selectView('b')}>go b</button>
+        {/* key mirrors App's load-bearing per-view boundary remount */}
+        <ViewErrorBoundary key={view} viewLabel={`${view} view`}>
+          <Suspense fallback={<div role="status">loading…</div>}>
+            <Active />
+          </Suspense>
+        </ViewErrorBoundary>
+      </div>
+    )
+  }
+
+  it('reject A -> switch B -> return A -> the import RETRIES and recovers', async () => {
+    let aAttempts = 0
+    const factories = {
+      a: () => {
+        aAttempts++
+        return aAttempts === 1
+          ? Promise.reject(new Error('chunk A failed'))
+          : Promise.resolve({ default: () => <div data-testid="view-a" /> })
+      },
+      b: () => Promise.resolve({ default: () => <div data-testid="view-b" /> }),
+    }
+    render(<TwoViewHarness factories={factories} />)
+    expect(await screen.findByRole('alert')).toHaveTextContent('failed to render')
+    expect(aAttempts).toBe(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'go b' }))
+    expect(await screen.findByTestId('view-b')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'go a' }))
+    expect(await screen.findByTestId('view-a')).toBeInTheDocument() // recovered
+    expect(aAttempts).toBe(2) // switch-back minted a fresh lazy: import re-ran
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('the same recovery works for the second view', async () => {
+    let bAttempts = 0
+    const factories = {
+      a: () => Promise.resolve({ default: () => <div data-testid="view-a" /> }),
+      b: () => {
+        bAttempts++
+        return bAttempts === 1
+          ? Promise.reject(new Error('chunk B failed'))
+          : Promise.resolve({ default: () => <div data-testid="view-b" /> })
+      },
+    }
+    render(<TwoViewHarness factories={factories} />)
+    await screen.findByTestId('view-a')
+    fireEvent.click(screen.getByRole('button', { name: 'go b' }))
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: 'go a' }))
+    await screen.findByTestId('view-a')
+    fireEvent.click(screen.getByRole('button', { name: 'go b' }))
+    expect(await screen.findByTestId('view-b')).toBeInTheDocument()
+    expect(bAttempts).toBe(2)
+  })
+
+  it('App mints a FRESH lazy on switch-back (fallback reappears) and keeps one connection', async () => {
+    render(<App />)
+    await screen.findByTestId('view-3d')
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    await screen.findByTestId('view-2d')
+
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    // A fresh lazy instance suspends for at least one microtask even on a
+    // module-cache hit — the reappearing fallback is the observable proof
+    // of re-import. (The pre-amendment cached instance rendered
+    // synchronously with no fallback.)
+    expect(screen.getByText('Loading 3D network view…')).toBeInTheDocument()
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+  })
+
+  it('clicking the already-active view button neither remounts nor reloads it', async () => {
+    render(<App />)
+    const before = await screen.findByTestId('view-3d')
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    expect(screen.getByTestId('view-3d')).toBe(before) // same DOM node: no remount
+    expect(screen.queryByText('Loading 3D network view…')).not.toBeInTheDocument()
+  })
+
+  it('manual Retry is preserved (direct harness reject-once)', async () => {
+    let attempts = 0
+    const factory = () => {
+      attempts++
+      return attempts === 1
+        ? Promise.reject(new Error('chunk failed'))
+        : Promise.resolve({ default: () => <div data-testid="late-view-2" /> })
+    }
+    function RetryHarness() {
+      const [LazyView, setLazyView] = useState(() => lazy(factory))
+      return (
+        <ViewErrorBoundary viewLabel="retry view" onRetry={() => setLazyView(() => lazy(factory))}>
+          <Suspense fallback={<div role="status">loading…</div>}>
+            <LazyView />
+          </Suspense>
+        </ViewErrorBoundary>
+      )
+    }
+    render(<RetryHarness />)
+    await screen.findByRole('alert')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry retry view' }))
+    expect(await screen.findByTestId('late-view-2')).toBeInTheDocument()
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
@@ -1,0 +1,150 @@
+// Package AG: lazy view delivery — the shell renders independently of view
+// code; chunk-load rejection reaches the existing ViewErrorBoundary; Retry
+// re-runs the import.
+//
+// The heavy views are mocked at the module seam (jsdom renders no WebGL);
+// the DYNAMIC import path in App resolves through the same mocks. A
+// direct-harness section proves the lazy-rejection contract with a
+// controllable factory (vi.mock factories cannot toggle rejection per
+// test).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { lazy, Suspense, useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../src/App'
+import ViewErrorBoundary from '../src/components/ViewErrorBoundary'
+import appSource from '../src/App.tsx?raw'
+
+vi.mock('../src/viz3d/NetworkView3D', () => ({
+  default: () => <div data-testid="view-3d" />,
+}))
+vi.mock('../src/components/NetworkView2D', () => ({
+  default: () => <div data-testid="view-2d" />,
+}))
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('lazy view delivery through App', () => {
+  it('no eager static import of a heavy view module remains in App (source contract)', () => {
+    expect(appSource).not.toMatch(/^import .*NetworkView3D/m)
+    expect(appSource).not.toMatch(/^import .*NetworkView2D/m)
+    expect(appSource).toContain("import('./viz3d/NetworkView3D')")
+    expect(appSource).toContain("import('./components/NetworkView2D')")
+  })
+
+  it('the shell renders immediately with an accessible loading status inside the region, then the view arrives', async () => {
+    render(<App />)
+    // Shell is up synchronously — controls, badge, feed — while the view
+    // chunk is still pending.
+    expect(screen.getByRole('button', { name: '3D View' })).toBeInTheDocument()
+    expect(screen.getAllByRole('log')).toHaveLength(1)
+    const region = screen.getByRole('region', { name: '3D network view' })
+    const loading = screen.getByText('Loading 3D network view…')
+    expect(region.contains(loading)).toBe(true)
+    expect(loading).toHaveAttribute('role', 'status')
+
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
+    // Steady state: the transient loading status is gone; the badge is the
+    // single status region again.
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+  })
+
+  it('exactly one SimBridge connection lineage regardless of lazy loading', async () => {
+    render(<App />)
+    await screen.findByTestId('view-3d')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    await screen.findByTestId('view-2d')
+    expect(FakeWebSocket.instances).toHaveLength(1) // switching never reconnects
+  })
+
+  it('switching views remains fresh and deterministic with exactly one active view', async () => {
+    render(<App />)
+    await screen.findByTestId('view-3d')
+    for (const [button, testId] of [
+      ['2D View', 'view-2d'],
+      ['3D View', 'view-3d'],
+      ['2D View', 'view-2d'],
+    ] as const) {
+      fireEvent.click(screen.getByRole('button', { name: button }))
+      expect(await screen.findByTestId(testId)).toBeInTheDocument()
+      expect(screen.getAllByRole('region')).toHaveLength(1)
+    }
+  })
+})
+
+describe('lazy rejection reaches the boundary (direct harness)', () => {
+  // A controllable factory: first import rejects, the retry resolves —
+  // exactly the failed-chunk-then-network-recovers sequence.
+  function Harness() {
+    const attemptRef = { current: 0 }
+    const factory = () => {
+      attemptRef.current++
+      return attemptRef.current === 1
+        ? Promise.reject(new Error('chunk load failed'))
+        : Promise.resolve({ default: () => <div data-testid="late-view" /> })
+    }
+    const [LazyView, setLazyView] = useState(() => lazy(factory))
+    return (
+      <ViewErrorBoundary
+        viewLabel="test view"
+        onRetry={() => setLazyView(() => lazy(factory))}
+      >
+        <Suspense fallback={<div role="status">Loading test view…</div>}>
+          <LazyView />
+        </Suspense>
+      </ViewErrorBoundary>
+    )
+  }
+
+  it('a rejected chunk shows the boundary fallback; Retry re-imports and mounts the view', async () => {
+    render(<Harness />)
+    // Rejection propagates through Suspense into the boundary.
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('The test view failed to render.')
+    const reports = vi
+      .mocked(console.error)
+      .mock.calls.filter(args => args[0] === 'View render failed:')
+    expect(reports).toHaveLength(1)
+    expect((reports[0][1] as Error).message).toBe('chunk load failed')
+
+    // Retry mints a fresh lazy instance → the import re-runs → the view
+    // mounts. No reconnect side effects exist in this harness by
+    // construction (the boundary owns no network).
+    fireEvent.click(screen.getByRole('button', { name: 'Retry test view' }))
+    expect(await screen.findByTestId('late-view')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -79,93 +79,109 @@ afterEach(() => {
 })
 
 describe('view failure containment', () => {
-  it('a throwing 3D view shows an accessible fallback while the shell survives', () => {
+  it('a throwing 3D view shows an accessible fallback while the shell survives', async () => {
     failures.v3d = true
     render(<App />)
-    const alert = screen.getByRole('alert')
+    const alert = await screen.findByRole('alert')
     expect(alert).toHaveTextContent('The 3D network view failed to render.')
     expect(screen.queryByTestId('view-3d')).not.toBeInTheDocument()
     shellAlive()
     expect(reportCount()).toBe(1) // reported once, not swallowed
   })
 
-  it('a throwing 2D view is contained identically', () => {
+  it('a throwing 2D view is contained identically', async () => {
     failures.v2d = true
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
-    expect(screen.getByRole('alert')).toHaveTextContent('The 2D network view failed to render.')
+    expect(await screen.findByRole('alert')).toHaveTextContent('The 2D network view failed to render.')
     shellAlive()
     expect(reportCount()).toBe(1)
   })
 
-  it('connection state survives a view failure (badge keeps announcing)', () => {
+  it('connection state survives a view failure (badge keeps announcing)', async () => {
     failures.v3d = true
     render(<App />)
+    await screen.findByRole('alert') // failure settled: the transient loading status is gone
     act(() => live().serverOpen())
     expect(screen.getByRole('status')).toHaveTextContent('Connected')
     expect(screen.getByRole('alert')).toBeInTheDocument()
     expect(FakeWebSocket.instances).toHaveLength(1) // no hidden reconnect
   })
 
-  it('switching away recovers: the healthy view renders with no fallback', () => {
+  it('switching away recovers: the healthy view renders with no fallback', async () => {
     failures.v3d = true
     render(<App />)
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
   })
 
-  it('switching back after the failure clears remounts a healthy view (boundary reset)', () => {
+  it('switching back after the failure clears remounts a healthy view (boundary reset)', async () => {
     failures.v3d = true
     render(<App />)
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
     failures.v3d = false
     fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
   })
 
-  it('explicit retry remounts only the failed view', () => {
+  it('explicit retry remounts only the failed view', async () => {
     failures.v3d = true
     render(<App />)
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
     failures.v3d = false
     fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
     shellAlive()
   })
 
-  it('repeated failure stays bounded: each retry yields one fallback and one report — no loop', () => {
+  it('repeated failure stays bounded: each retry yields one fallback and one report — no loop', async () => {
     failures.v3d = true
     render(<App />)
+    await screen.findByRole('alert')
     expect(reportCount()).toBe(1)
     fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' })) // still failing
+    await screen.findByRole('alert')
     expect(screen.getAllByRole('alert')).toHaveLength(1)
     expect(reportCount()).toBe(2) // one more failure, one more report — user-paced, no retry loop
     fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    await screen.findByRole('alert')
     expect(screen.getAllByRole('alert')).toHaveLength(1)
     expect(reportCount()).toBe(3)
   })
 
-  it('successful views never show the fallback', () => {
+  it('explicit retry recovers the 2D view identically (fresh lazy instance)', async () => {
+    failures.v2d = true
     render(<App />)
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    expect(screen.getByTestId('view-3d')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    await screen.findByRole('alert')
+    failures.v2d = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry 2D network view' }))
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
   })
 
-  it('StrictMode: single fallback, singular connection lifecycle, no duplicate live regions', () => {
+  it('successful views never show the fallback', async () => {
+    render(<App />)
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('StrictMode: single fallback, singular connection lifecycle, no duplicate live regions', async () => {
     failures.v3d = true
     render(
       <StrictMode>
         <App />
       </StrictMode>,
     )
+    await screen.findByRole('alert')
     expect(screen.getAllByRole('alert')).toHaveLength(1)
     expect(FakeWebSocket.instances).toHaveLength(2) // documented dev-mode double-mount artifact
     act(() => live().serverOpen())
@@ -176,9 +192,10 @@ describe('view failure containment', () => {
 })
 
 describe('AB audit amendments', () => {
-  it('the single diagnostic carries the error AND the locating componentStack', () => {
+  it('the single diagnostic carries the error AND the locating componentStack', async () => {
     failures.v3d = true
     render(<App />)
+    await screen.findByRole('alert')
     const reports = boundaryReports()
     expect(reports).toHaveLength(1)
     const [, error, componentStack] = reports[0]
@@ -191,10 +208,10 @@ describe('AB audit amendments', () => {
     expect(vi.mocked(console.error).mock.calls.length).toBeGreaterThanOrEqual(reports.length)
   })
 
-  it('the Retry control is an explicit type="button" (never an implicit submit)', () => {
+  it('the Retry control is an explicit type="button" (never an implicit submit)', async () => {
     failures.v3d = true
     render(<App />)
-    expect(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    expect(await screen.findByRole('button', { name: 'Retry 3D network view' }))
       .toHaveAttribute('type', 'button')
   })
 })

--- a/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
@@ -125,7 +125,10 @@ const activeSocket = (page: Page, action: '_open' | '_close') =>
     active[act]();
   }, action);
 
-const status = (page: Page) => page.getByRole('status');
+// The badge's live region specifically: lazy view delivery (Package AG)
+// shows a TRANSIENT role=status loading indicator inside the view region,
+// so the badge is disambiguated by its aria-atomic contract.
+const status = (page: Page) => page.getByRole('status').and(page.locator('[aria-atomic="true"]'))
 const dot = (page: Page) => page.locator('.connection-badge [aria-hidden="true"]');
 const dotAnimation = (page: Page) =>
   dot(page).evaluate((el) => getComputedStyle(el).animationName);


### PR DESCRIPTION
## PACKAGE AG — lazy view delivery (refs #6 — no closing keyword)

**Independent PR against main.**

### What
The shell (controls, connection badge, event feed) renders independently; the heavy view modules load behind `React.lazy` + `Suspense` **inside the existing ViewErrorBoundary**. No eager static view import remains in App — **locked by a source-contract test** over `App.tsx?raw`. Lazy components live in **state**: a rejected lazy caches its rejection permanently, so the boundary's new optional `onRetry` seam mints a fresh instance — **Retry re-runs the import without reconnecting** (single SimBridge lineage asserted through loading/failure/retry/switching). Transient accessible loading status scoped inside the active region; steady state keeps the badge as the sole status region; fresh-boundary-per-view keys preserved; default stays 3D; exactly one active view.

### Measured (local build evidence only — no network/user-perception claims)
| | BEFORE | AFTER |
|---|---|---|
| entry raw/gzip | 987,556 / 274,495 | **155,478 / 50,405 (−84% raw)** |
| async 3D chunk | — | 826,250 / 223,083 |
| async 2D chunk | — | 1,679 / 834 |
| shared chunk (edgeValidation) | — | 3,231 / 1,150 |
| **TOTAL JS raw** | 987,556 | **986,638 (−918 — the split hid nothing)** |
| CSS | 912 / 482 | 912 / 482 |
| build time | 2.62 s | 2.43 s |

**DELAYED_CHUNK_CHECK** (built `vite preview`, 3D chunk held 1,500 ms at the network layer): shell interactive at **376 ms** with the loading status visible; view mounted at 2,245 ms. Script committed (`scripts/delayed-chunk-check.mjs`, manual/lab — not CI-wired).

### Honest notes
- The transient loading status made bare `getByRole('status')` ambiguous in E2E — **3 real Playwright failures that my first run's tail-piping hid**; caught, the badge locator is now disambiguated by its `aria-atomic` contract, and full result lines are checked. 
- App.tsx per-file floor initially tripped (functions 81.25 < 86 — the un-exercised 2D Retry arrow): **covered, not lowered**.
- Chunk-rejection→boundary is proven via a direct harness with a controllable reject-once factory (vi.mock factories can't toggle rejection per test).

### Verification
unit **266/266** · lint 0/0 · tsc clean · coverage aggregate + per-file floors PASS · budget 11/11 · BUNDLE_BUDGET v1 PASS 986,638/275,640 · **Playwright 56/56 ×3** · delayed-chunk PASS.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)