### PR TITLE
ci: bundle budget v2 — fail-closed entry/chunk budgets, totals kept (PACKAGE AH)

### DIFF
--- a/utilityfog_frontend/frontend/PERF_NOTES.md
+++ b/utilityfog_frontend/frontend/PERF_NOTES.md
@@ -102,3 +102,38 @@ Budgets change **only with evidence**: a PR that (a) re-measures and records
 the new baseline in this file, (b) names the change that legitimately moved
 it (e.g. an approved dependency), and (c) re-derives the limits from the
 stated policy. Casually raising limits to silence the gate defeats it.
+
+## Bundle budget v2 — entry/chunk budgets (Package AH, 2026-07-12)
+
+Package AG split the build: the shell entry loads synchronously and the
+heavy views arrive as async chunks. v2 adds fail-closed budgets for the
+pieces while KEEPING the v1 totals unchanged — chunk splitting must never
+disguise total growth.
+
+Measured baseline (AG build, Node zlib gzip level 9):
+
+| dimension | measured | budget | derivation |
+|---|---|---|---|
+| entry raw | 155,478 | 196,608 | 12 x 16 KiB (~+26.5%) |
+| entry gzip | 50,240 | 65,536 | 4 x 16 KiB (~+30%) |
+| largest async raw (3D) | 826,250 | 1,048,576 | 64 x 16 KiB (~+26.9%) |
+| largest async gzip | 223,412 | 294,912 | 18 x 16 KiB (~+32%) |
+| total JS raw/gzip | 986,638 / 275,640 | 1,228,800 / 344,064 | **kept from v1** |
+| CSS raw/gzip | 912 / 483 | 16,384 / 16,384 | floor, kept |
+
+Mechanics: the entry set is every module `<script src="/assets/*.js">` in
+the BUILT `dist/index.html` (duplicates count once); every other JS asset
+is an async chunk; the largest is budgeted individually. Fail-closed exits:
+missing dist/assets, missing or script-less `index.html`, malformed script
+references, references to absent assets, and empty JS output all exit 2/1
+rather than passing silently. Machine line: `BUNDLE_BUDGET v2 ...` (the v1
+line is retired with this change).
+
+Non-claims: budgets bound BUILT sizes only — nothing here measures network
+transfer, caching behavior, or user-perceived latency.
+
+Budget-change protocol (unchanged from v1, restated): budgets move only in
+a dedicated commit that (1) states the measured trigger, (2) re-derives via
+baseline + 25% rounded up to the next 16 KiB (16 KiB floor), and (3) is
+reviewed like any contract change. Never widen a budget to absorb
+unexplained growth; find the growth first.

--- a/utilityfog_frontend/frontend/scripts/check-bundle-budget.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-bundle-budget.mjs
@@ -69,11 +69,32 @@ export function classifyAssets(distDir, inventory) {
   const refs = [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map((m) => m[1])
   const entryNames = new Set()
   for (const ref of refs) {
-    const match = /\/assets\/([^/"?#]+\.js)$/.exec(ref)
+    // Accepted forms: /assets/x.js · assets/x.js · ./assets/x.js, each
+    // optionally with a query string and/or hash fragment. Rejected (fail
+    // closed): external origins and protocol-relative URLs, path
+    // traversal, non-JS, and anything else — a reference may never escape
+    // dist/assets. Decoding is applied to the FILENAME only, purely to
+    // re-check for smuggled separators/traversal; the raw name is used
+    // for the inventory match.
+    if (/^[a-z][a-z0-9+.-]*:/i.test(ref) || ref.startsWith('//')) {
+      throw new Error(`external script reference in index.html: ${ref} (fail closed)`)
+    }
+    const withoutSuffix = ref.split(/[?#]/)[0]
+    const match = /^(?:\.?\/)?assets\/([^/\\]+\.js)$/.exec(withoutSuffix)
     if (!match) {
       throw new Error(`malformed script reference in index.html: ${ref} (fail closed)`)
     }
-    entryNames.add(match[1])
+    const name = match[1]
+    let decoded = name
+    try {
+      decoded = decodeURIComponent(name)
+    } catch {
+      throw new Error(`undecodable script reference in index.html: ${ref} (fail closed)`)
+    }
+    if (decoded.includes('/') || decoded.includes('\\') || decoded.includes('..')) {
+      throw new Error(`traversal in script reference in index.html: ${ref} (fail closed)`)
+    }
+    entryNames.add(name)
   }
   if (entryNames.size === 0) {
     throw new Error('index.html references no entry script (fail closed)')
@@ -88,9 +109,15 @@ export function classifyAssets(distDir, inventory) {
     entries.push(asset)
   }
   const asyncChunks = inventory.filter((i) => i.kind === 'js' && !entryNames.has(i.name))
-  let largestAsync = null
+  // Raw-largest and gzip-largest are tracked INDEPENDENTLY: a chunk that
+  // is smaller raw but less compressible can be the gzip maximum, and the
+  // gzip budget must bind THAT chunk (audit correction — previously the
+  // gzip limit was applied to the raw-largest chunk only).
+  let largestAsyncRaw = null
+  let largestAsyncGzip = null
   for (const chunk of asyncChunks) {
-    if (largestAsync === null || chunk.raw > largestAsync.raw) largestAsync = chunk
+    if (largestAsyncRaw === null || chunk.raw > largestAsyncRaw.raw) largestAsyncRaw = chunk
+    if (largestAsyncGzip === null || chunk.gzip > largestAsyncGzip.gzip) largestAsyncGzip = chunk
   }
   return {
     entry: {
@@ -99,7 +126,8 @@ export function classifyAssets(distDir, inventory) {
       gzip: entries.reduce((n, a) => n + a.gzip, 0),
     },
     asyncCount: asyncChunks.length,
-    largestAsync,
+    largestAsyncRaw,
+    largestAsyncGzip,
   }
 }
 
@@ -140,12 +168,13 @@ export function checkBudgets(summary, budgets = BUDGETS, classification = null) 
       ['entry_gzip', classification.entry.gzip],
     )
     // A build with no async chunks has no largest-chunk dimension; the
-    // entry and total budgets still bound it completely.
-    if (classification.largestAsync !== null) {
-      checks.push(
-        ['largest_async_raw', classification.largestAsync.raw],
-        ['largest_async_gzip', classification.largestAsync.gzip],
-      )
+    // entry and total budgets still bound it completely. Raw and gzip
+    // maxima are checked against their own maximal chunks.
+    if (classification.largestAsyncRaw !== null) {
+      checks.push(['largest_async_raw', classification.largestAsyncRaw.raw])
+    }
+    if (classification.largestAsyncGzip !== null) {
+      checks.push(['largest_async_gzip', classification.largestAsyncGzip.gzip])
     }
   }
   for (const [key, actual] of checks) {
@@ -175,8 +204,10 @@ export function machineLine(summary, result, classification = null) {
       ? ''
       : `entry_raw=${classification.entry.raw} entry_gzip=${classification.entry.gzip} ` +
         `async_chunks=${classification.asyncCount} ` +
-        `largest_async_raw=${classification.largestAsync?.raw ?? 0} ` +
-        `largest_async_gzip=${classification.largestAsync?.gzip ?? 0} `
+        `largest_async_raw=${classification.largestAsyncRaw?.raw ?? 0} ` +
+        `largest_async_raw_chunk=${classification.largestAsyncRaw?.name ?? '-'} ` +
+        `largest_async_gzip=${classification.largestAsyncGzip?.gzip ?? 0} ` +
+        `largest_async_gzip_chunk=${classification.largestAsyncGzip?.name ?? '-'} `
   return (
     `BUNDLE_BUDGET v2 ` +
     `js_raw=${summary.js.raw} js_gzip=${summary.js.gzip} ` +
@@ -213,9 +244,14 @@ function main() {
   console.log(
     `  entry (${classification.entry.names.join('+')}): raw=${classification.entry.raw}/${BUDGETS.entry_raw} gzip=${classification.entry.gzip}/${BUDGETS.entry_gzip}`,
   )
-  if (classification.largestAsync !== null) {
+  if (classification.largestAsyncRaw !== null) {
     console.log(
-      `  largest async (${classification.largestAsync.name}): raw=${classification.largestAsync.raw}/${BUDGETS.largest_async_raw} gzip=${classification.largestAsync.gzip}/${BUDGETS.largest_async_gzip}`,
+      `  largest async raw (${classification.largestAsyncRaw.name}): ${classification.largestAsyncRaw.raw}/${BUDGETS.largest_async_raw}`,
+    )
+  }
+  if (classification.largestAsyncGzip !== null) {
+    console.log(
+      `  largest async gzip (${classification.largestAsyncGzip.name}): ${classification.largestAsyncGzip.gzip}/${BUDGETS.largest_async_gzip}`,
     )
   }
   console.log(machineLine(summary, result, classification))

--- a/utilityfog_frontend/frontend/scripts/check-bundle-budget.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-bundle-budget.mjs
@@ -14,16 +14,23 @@ import { join, extname } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import { fileURLToPath } from 'node:url'
 
-// Limits in exact bytes. Baseline (PR #316 build, measured on 2026-07-11):
-//   JS  raw 979,384 · gzip 272,585   (single index-*.js chunk)
-//   CSS raw     912 · gzip     483   (single index-*.css)
-// Policy: baseline + 25% headroom, rounded UP to the next 16 KiB boundary;
-// 16 KiB acts as a floor for tiny assets so hash-level noise never trips.
+// Limits in exact bytes.
+// v1 totals baseline (PR #316 build, 2026-07-11): JS raw 979,384 / gzip
+// 272,585; CSS 912/483. v2 entry/chunk baseline (Package AG lazy-split
+// build, 2026-07-12): entry 155,478/50,405; largest async chunk (3D)
+// 826,250/223,083. Policy (unchanged): baseline + 25% headroom, rounded UP
+// to the next 16 KiB boundary; 16 KiB floors tiny assets so hash-level
+// noise never trips. TOTAL budgets are deliberately KEPT from v1 -- chunk
+// splitting must never disguise total growth.
 export const BUDGETS = {
-  js_raw: 1_228_800,   // 75 × 16 KiB  (~25.5% over baseline)
-  js_gzip: 344_064,    // 21 × 16 KiB  (~26.2% over baseline)
-  css_raw: 16_384,     // floor
-  css_gzip: 16_384,    // floor
+  js_raw: 1_228_800,           // 75 x 16 KiB  (~25.5% over v1 baseline)
+  js_gzip: 344_064,            // 21 x 16 KiB  (~26.2% over v1 baseline)
+  css_raw: 16_384,             // floor
+  css_gzip: 16_384,            // floor
+  entry_raw: 196_608,          // 12 x 16 KiB  (~26.5% over 155,478)
+  entry_gzip: 65_536,          //  4 x 16 KiB  (~30.0% over 50,405)
+  largest_async_raw: 1_048_576,   // 64 x 16 KiB (~26.9% over 826,250)
+  largest_async_gzip: 294_912,    // 18 x 16 KiB (~32.2% over 223,083)
 }
 
 const KINDS = { '.js': 'js', '.css': 'css' }
@@ -48,6 +55,54 @@ export function inventoryAssets(assetsDir) {
     })
 }
 
+// v2: classify JS assets into synchronous ENTRY scripts (those referenced
+// by module <script> tags in the built index.html) and ASYNC chunks
+// (everything else). Fails closed on a missing index.html, an index.html
+// referencing no entry script, a malformed reference, or a reference to an
+// asset absent from the inventory. Duplicate references count once.
+export function classifyAssets(distDir, inventory) {
+  const indexPath = join(distDir, 'index.html')
+  if (!existsSync(indexPath)) {
+    throw new Error(`missing built index.html: ${indexPath} (fail closed)`)
+  }
+  const html = readFileSync(indexPath, 'utf8')
+  const refs = [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map((m) => m[1])
+  const entryNames = new Set()
+  for (const ref of refs) {
+    const match = /\/assets\/([^/"?#]+\.js)$/.exec(ref)
+    if (!match) {
+      throw new Error(`malformed script reference in index.html: ${ref} (fail closed)`)
+    }
+    entryNames.add(match[1])
+  }
+  if (entryNames.size === 0) {
+    throw new Error('index.html references no entry script (fail closed)')
+  }
+  const byName = new Map(inventory.filter((i) => i.kind === 'js').map((i) => [i.name, i]))
+  const entries = []
+  for (const name of entryNames) {
+    const asset = byName.get(name)
+    if (!asset) {
+      throw new Error(`index.html references a missing asset: ${name} (fail closed)`)
+    }
+    entries.push(asset)
+  }
+  const asyncChunks = inventory.filter((i) => i.kind === 'js' && !entryNames.has(i.name))
+  let largestAsync = null
+  for (const chunk of asyncChunks) {
+    if (largestAsync === null || chunk.raw > largestAsync.raw) largestAsync = chunk
+  }
+  return {
+    entry: {
+      names: [...entryNames].sort(),
+      raw: entries.reduce((n, a) => n + a.raw, 0),
+      gzip: entries.reduce((n, a) => n + a.gzip, 0),
+    },
+    asyncCount: asyncChunks.length,
+    largestAsync,
+  }
+}
+
 // Per-kind and total aggregation.
 export function summarize(inventory) {
   const sum = {
@@ -68,7 +123,7 @@ export function summarize(inventory) {
 
 // Budget evaluation. Fails closed when no JavaScript asset exists (an empty
 // or partial build must not pass silently).
-export function checkBudgets(summary, budgets = BUDGETS) {
+export function checkBudgets(summary, budgets = BUDGETS, classification = null) {
   const failures = []
   if (summary.js.count === 0) {
     failures.push('no JavaScript assets found in the build output (fail closed)')
@@ -79,6 +134,20 @@ export function checkBudgets(summary, budgets = BUDGETS) {
     ['css_raw', summary.css.raw],
     ['css_gzip', summary.css.gzip],
   ]
+  if (classification !== null) {
+    checks.push(
+      ['entry_raw', classification.entry.raw],
+      ['entry_gzip', classification.entry.gzip],
+    )
+    // A build with no async chunks has no largest-chunk dimension; the
+    // entry and total budgets still bound it completely.
+    if (classification.largestAsync !== null) {
+      checks.push(
+        ['largest_async_raw', classification.largestAsync.raw],
+        ['largest_async_gzip', classification.largestAsync.gzip],
+      )
+    }
+  }
   for (const [key, actual] of checks) {
     if (actual > budgets[key]) {
       failures.push(`${key} ${actual} bytes exceeds budget ${budgets[key]} bytes`)
@@ -100,11 +169,19 @@ export function formatHuman(inventory, summary, budgets = BUDGETS) {
 }
 
 // One stable machine-readable summary line (space-separated key=value).
-export function machineLine(summary, result) {
+export function machineLine(summary, result, classification = null) {
+  const entryPart =
+    classification === null
+      ? ''
+      : `entry_raw=${classification.entry.raw} entry_gzip=${classification.entry.gzip} ` +
+        `async_chunks=${classification.asyncCount} ` +
+        `largest_async_raw=${classification.largestAsync?.raw ?? 0} ` +
+        `largest_async_gzip=${classification.largestAsync?.gzip ?? 0} `
   return (
-    `BUNDLE_BUDGET v1 ` +
+    `BUNDLE_BUDGET v2 ` +
     `js_raw=${summary.js.raw} js_gzip=${summary.js.gzip} ` +
     `css_raw=${summary.css.raw} css_gzip=${summary.css.gzip} ` +
+    entryPart +
     `total_raw=${summary.total.raw} total_gzip=${summary.total.gzip} ` +
     `status=${result.pass ? 'PASS' : 'FAIL'}`
   )
@@ -124,9 +201,24 @@ function main() {
     process.exit(2)
   }
   const summary = summarize(inventory)
-  const result = checkBudgets(summary)
+  let classification
+  try {
+    classification = classifyAssets(distDir, inventory)
+  } catch (error) {
+    console.error(`bundle budget: ${error.message}`)
+    process.exit(2)
+  }
+  const result = checkBudgets(summary, BUDGETS, classification)
   console.log(formatHuman(inventory, summary))
-  console.log(machineLine(summary, result))
+  console.log(
+    `  entry (${classification.entry.names.join('+')}): raw=${classification.entry.raw}/${BUDGETS.entry_raw} gzip=${classification.entry.gzip}/${BUDGETS.entry_gzip}`,
+  )
+  if (classification.largestAsync !== null) {
+    console.log(
+      `  largest async (${classification.largestAsync.name}): raw=${classification.largestAsync.raw}/${BUDGETS.largest_async_raw} gzip=${classification.largestAsync.gzip}/${BUDGETS.largest_async_gzip}`,
+    )
+  }
+  console.log(machineLine(summary, result, classification))
   if (!result.pass) {
     for (const failure of result.failures) {
       console.error(`bundle budget FAIL: ${failure}`)

--- a/utilityfog_frontend/frontend/scripts/check-bundle-budget.test.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-bundle-budget.test.mjs
@@ -212,7 +212,8 @@ test('v2: single-chunk build classifies as entry-only (no async dimension)', () 
     assert.deepEqual(c.entry.names, ['index-abc.js'])
     assert.equal(c.entry.raw, 100)
     assert.equal(c.asyncCount, 0)
-    assert.equal(c.largestAsync, null)
+    assert.equal(c.largestAsyncRaw, null)
+    assert.equal(c.largestAsyncGzip, null)
     const result = checkBudgets(summarize(inv), undefined, c)
     assert.equal(result.pass, true)
   } finally {
@@ -233,8 +234,8 @@ test('v2: several async chunks — largest identified by raw size', () => {
   try {
     const c = classifyAssets(dir, inventoryAssets(join(dir, 'assets')))
     assert.equal(c.asyncCount, 3)
-    assert.equal(c.largestAsync.name, 'chunk-b.js')
-    assert.equal(c.largestAsync.raw, 900)
+    assert.equal(c.largestAsyncRaw.name, 'chunk-b.js')
+    assert.equal(c.largestAsyncRaw.raw, 900)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -272,7 +273,7 @@ test('v2: malformed script references fail closed', () => {
   try {
     assert.throws(
       () => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))),
-      /malformed script reference/,
+      /external script reference/,
     )
   } finally {
     rmSync(dir, { recursive: true, force: true })
@@ -354,7 +355,7 @@ test('v2: machine line is stable, versioned and carries the chunk dimensions', (
     const line = machineLine(summarize(inv), { pass: true }, c)
     assert.match(
       line,
-      /^BUNDLE_BUDGET v2 js_raw=\d+ js_gzip=\d+ css_raw=\d+ css_gzip=\d+ entry_raw=10 entry_gzip=\d+ async_chunks=1 largest_async_raw=20 largest_async_gzip=\d+ total_raw=\d+ total_gzip=\d+ status=PASS$/,
+      /^BUNDLE_BUDGET v2 js_raw=\d+ js_gzip=\d+ css_raw=\d+ css_gzip=\d+ entry_raw=10 entry_gzip=\d+ async_chunks=1 largest_async_raw=20 largest_async_raw_chunk=chunk-a\.js largest_async_gzip=\d+ largest_async_gzip_chunk=chunk-a\.js total_raw=\d+ total_gzip=\d+ status=PASS$/,
     )
   } finally {
     rmSync(dir, { recursive: true, force: true })
@@ -375,5 +376,73 @@ test('v2: gzip settings are deterministic (same bytes, same gzip size, twice)', 
   } finally {
     rmSync(dir1, { recursive: true, force: true })
     rmSync(dir2, { recursive: true, force: true })
+  }
+})
+
+test('v2 audit: accepted reference forms — relative, dot-relative, query and hash', () => {
+  for (const form of ['/assets/index-e.js', 'assets/index-e.js', './assets/index-e.js', '/assets/index-e.js?v=1', 'assets/index-e.js#frag', './assets/index-e.js?v=1#frag']) {
+    const dir = v2Fixture({ 'index-e.js': 'e' }, `<script type="module" src="${form}"></script>`)
+    try {
+      const c = classifyAssets(dir, inventoryAssets(join(dir, 'assets')))
+      assert.deepEqual(c.entry.names, ['index-e.js'], form)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+test('v2 audit: rejected reference forms — external origins, traversal, non-JS, protocol-relative', () => {
+  const cases = [
+    ['http://evil.example/assets/x.js', /external/],
+    ['https://evil.example/assets/x.js', /external/],
+    ['//evil.example/assets/x.js', /external/],
+    ['/assets/../secrets.js', /malformed|traversal/],
+    ['/assets/x.css', /malformed/],
+    ['/other/x.js', /malformed/],
+    ['/assets/%2e%2e.js', /traversal/],
+  ]
+  for (const [form, expected] of cases) {
+    const dir = v2Fixture({ 'index-e.js': 'e' }, `<script type="module" src="${form}"></script>`)
+    try {
+      assert.throws(() => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))), expected, form)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+test('v2 audit: gzip budget binds the GZIP-largest chunk, not the raw-largest', () => {
+  // A: raw-largest but hugely compressible. B: smaller raw, incompressible
+  // — the gzip maximum, and over the gzip budget. The gate must fail on B.
+  let seed = 99
+  const rand = () => (seed = (seed * 1103515245 + 12345) % 2147483648) / 2147483648
+  let noise = ''
+  for (let i = 0; i < 3000; i++) noise += String.fromCharCode(33 + Math.floor(rand() * 90))
+  const dir = v2Fixture(
+    { 'index-e.js': 'e', 'chunk-a.js': 'a'.repeat(10000), 'chunk-b.js': noise },
+    INDEX(['index-e.js']),
+  )
+  try {
+    const inv = inventoryAssets(join(dir, 'assets'))
+    const c = classifyAssets(dir, inv)
+    assert.equal(c.largestAsyncRaw.name, 'chunk-a.js')
+    assert.equal(c.largestAsyncGzip.name, 'chunk-b.js')
+    assert.ok(c.largestAsyncGzip.gzip > c.largestAsyncRaw.gzip, 'B must be the gzip max')
+    const budgets = {
+      js_raw: 1_000_000, js_gzip: 1_000_000, css_raw: 1_000_000, css_gzip: 1_000_000,
+      entry_raw: 1_000_000, entry_gzip: 1_000_000,
+      largest_async_raw: 1_000_000,
+      largest_async_gzip: 1_000, // under B's gzip, above A's
+    }
+    assert.ok(c.largestAsyncRaw.gzip < 1_000, 'A gzip must be under the budget')
+    const result = checkBudgets(summarize(inv), budgets, c)
+    assert.equal(result.pass, false)
+    assert.match(result.failures.join(';'), /largest_async_gzip \d+ bytes exceeds budget 1000/)
+    // The machine line names BOTH maxima distinctly.
+    const line = machineLine(summarize(inv), result, c)
+    assert.match(line, /largest_async_raw_chunk=chunk-a\.js/)
+    assert.match(line, /largest_async_gzip_chunk=chunk-b\.js/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
   }
 })

--- a/utilityfog_frontend/frontend/scripts/check-bundle-budget.test.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-bundle-budget.test.mjs
@@ -12,6 +12,7 @@ import {
   summarize,
   checkBudgets,
   machineLine,
+  classifyAssets,
 } from './check-bundle-budget.mjs'
 
 // Populate a freshly created temp dir; on ANY setup failure the created
@@ -179,12 +180,200 @@ test('machine-readable line has the stable shape', () => {
     const line = machineLine(summary, checkBudgets(summary, { js_raw: 100, js_gzip: 100, css_raw: 100, css_gzip: 100 }))
     assert.match(
       line,
-      /^BUNDLE_BUDGET v1 js_raw=\d+ js_gzip=\d+ css_raw=\d+ css_gzip=\d+ total_raw=\d+ total_gzip=\d+ status=(PASS|FAIL)$/,
+      /^BUNDLE_BUDGET v2 js_raw=\d+ js_gzip=\d+ css_raw=\d+ css_gzip=\d+ total_raw=\d+ total_gzip=\d+ status=(PASS|FAIL)$/,
     )
     assert.match(line, /js_raw=40 /)
     assert.match(line, /css_raw=9 /)
     assert.match(line, /status=PASS$/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// v2: entry/chunk classification and budgets (Package AH).
+
+function v2Fixture(files, indexHtml) {
+  const dir = mkdtempSync(join(tmpdir(), 'budget-v2-'))
+  populateAssets(dir, files)
+  if (indexHtml !== null) writeFileSync(join(dir, 'index.html'), indexHtml)
+  return dir
+}
+const INDEX = (names) =>
+  '<!doctype html><html><head>' +
+  names.map((n) => `<script type="module" crossorigin src="/assets/${n}"></script>`).join('') +
+  '</head><body></body></html>'
+
+test('v2: single-chunk build classifies as entry-only (no async dimension)', () => {
+  const dir = v2Fixture({ 'index-abc.js': 'x'.repeat(100) }, INDEX(['index-abc.js']))
+  try {
+    const inv = inventoryAssets(join(dir, 'assets'))
+    const c = classifyAssets(dir, inv)
+    assert.deepEqual(c.entry.names, ['index-abc.js'])
+    assert.equal(c.entry.raw, 100)
+    assert.equal(c.asyncCount, 0)
+    assert.equal(c.largestAsync, null)
+    const result = checkBudgets(summarize(inv), undefined, c)
+    assert.equal(result.pass, true)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: several async chunks — largest identified by raw size', () => {
+  const dir = v2Fixture(
+    {
+      'index-e.js': 'e'.repeat(50),
+      'chunk-a.js': 'a'.repeat(200),
+      'chunk-b.js': 'b'.repeat(900),
+      'chunk-c.js': 'c'.repeat(400),
+    },
+    INDEX(['index-e.js']),
+  )
+  try {
+    const c = classifyAssets(dir, inventoryAssets(join(dir, 'assets')))
+    assert.equal(c.asyncCount, 3)
+    assert.equal(c.largestAsync.name, 'chunk-b.js')
+    assert.equal(c.largestAsync.raw, 900)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: missing index.html fails closed', () => {
+  const dir = v2Fixture({ 'index-e.js': 'e' }, null)
+  try {
+    assert.throws(
+      () => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))),
+      /missing built index\.html/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: index.html referencing a missing entry asset fails closed', () => {
+  const dir = v2Fixture({ 'chunk-a.js': 'a' }, INDEX(['index-gone.js']))
+  try {
+    assert.throws(
+      () => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))),
+      /references a missing asset: index-gone\.js/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: malformed script references fail closed', () => {
+  const dir = v2Fixture(
+    { 'index-e.js': 'e' },
+    '<script type="module" src="http://evil.example/outside.js"></script>',
+  )
+  try {
+    assert.throws(
+      () => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))),
+      /malformed script reference/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: index.html with no script reference at all fails closed', () => {
+  const dir = v2Fixture({ 'index-e.js': 'e' }, '<!doctype html><html><body></body></html>')
+  try {
+    assert.throws(
+      () => classifyAssets(dir, inventoryAssets(join(dir, 'assets'))),
+      /references no entry script/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: duplicate references to the same entry count once', () => {
+  const dir = v2Fixture(
+    { 'index-e.js': 'e'.repeat(60) },
+    INDEX(['index-e.js', 'index-e.js']),
+  )
+  try {
+    const c = classifyAssets(dir, inventoryAssets(join(dir, 'assets')))
+    assert.deepEqual(c.entry.names, ['index-e.js'])
+    assert.equal(c.entry.raw, 60)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: windows/posix path handling — classification works from a backslash dist path', () => {
+  const dir = v2Fixture({ 'index-e.js': 'e' }, INDEX(['index-e.js']))
+  try {
+    // join() produced the platform path; feeding an explicitly
+    // forward-slashed variant must classify identically (the HTML refs are
+    // always forward-slash).
+    const alt = dir.split('\\').join('/')
+    const c = classifyAssets(alt, inventoryAssets(join(dir, 'assets')))
+    assert.deepEqual(c.entry.names, ['index-e.js'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: exact limit passes and limit+1 fails, for entry and largest-async budgets', () => {
+  const budgets = {
+    js_raw: 10_000, js_gzip: 10_000, css_raw: 10_000, css_gzip: 10_000,
+    entry_raw: 100, entry_gzip: 10_000, largest_async_raw: 200, largest_async_gzip: 10_000,
+  }
+  const mk = (entryBytes, chunkBytes) => {
+    const dir = v2Fixture(
+      { 'index-e.js': 'e'.repeat(entryBytes), 'chunk-a.js': 'a'.repeat(chunkBytes) },
+      INDEX(['index-e.js']),
+    )
+    const inv = inventoryAssets(join(dir, 'assets'))
+    const result = checkBudgets(summarize(inv), budgets, classifyAssets(dir, inv))
+    rmSync(dir, { recursive: true, force: true })
+    return result
+  }
+  assert.equal(mk(100, 200).pass, true)   // both exactly at limit
+  const overEntry = mk(101, 200)
+  assert.equal(overEntry.pass, false)
+  assert.match(overEntry.failures.join(';'), /entry_raw 101 bytes exceeds budget 100/)
+  const overChunk = mk(100, 201)
+  assert.equal(overChunk.pass, false)
+  assert.match(overChunk.failures.join(';'), /largest_async_raw 201 bytes exceeds budget 200/)
+})
+
+test('v2: machine line is stable, versioned and carries the chunk dimensions', () => {
+  const dir = v2Fixture(
+    { 'index-e.js': 'e'.repeat(10), 'chunk-a.js': 'a'.repeat(20) },
+    INDEX(['index-e.js']),
+  )
+  try {
+    const inv = inventoryAssets(join(dir, 'assets'))
+    const c = classifyAssets(dir, inv)
+    const line = machineLine(summarize(inv), { pass: true }, c)
+    assert.match(
+      line,
+      /^BUNDLE_BUDGET v2 js_raw=\d+ js_gzip=\d+ css_raw=\d+ css_gzip=\d+ entry_raw=10 entry_gzip=\d+ async_chunks=1 largest_async_raw=20 largest_async_gzip=\d+ total_raw=\d+ total_gzip=\d+ status=PASS$/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('v2: gzip settings are deterministic (same bytes, same gzip size, twice)', () => {
+  const content = 'const x = 1;\n'.repeat(500)
+  const a = gzipSync(Buffer.from(content), { level: 9 }).length
+  const b = gzipSync(Buffer.from(content), { level: 9 }).length
+  assert.equal(a, b)
+  const dir1 = v2Fixture({ 'index-e.js': content }, INDEX(['index-e.js']))
+  const dir2 = v2Fixture({ 'index-e.js': content }, INDEX(['index-e.js']))
+  try {
+    const g1 = inventoryAssets(join(dir1, 'assets'))[0].gzip
+    const g2 = inventoryAssets(join(dir2, 'assets'))[0].gzip
+    assert.equal(g1, g2)
+  } finally {
+    rmSync(dir1, { recursive: true, force: true })
+    rmSync(dir2, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## PACKAGE AH — bundle budget v2 (refs #6 — no closing keyword)

**Stacked PR: base is `perf/frontend-lazy-views` (AG → main). Merge order AG → AH.**

### What
The Node-built-in checker now classifies the built output: **entry** = every module script referenced by the built `dist/index.html` (duplicates count once) · everything else = **async chunks** · the **largest chunk** budgeted individually · totals unchanged. **Fail-closed**: missing dist/assets, missing `index.html`, script-less `index.html`, malformed references, references to absent assets, empty JS output. Machine line → `BUNDLE_BUDGET v2` with entry/async/largest dimensions.

### Budget derivation (existing policy: measured +25% → next 16 KiB, 16 KiB floor)
| dimension | measured (AG build) | budget |
|---|---|---|
| entry raw / gzip | 155,478 / 50,240 | 196,608 / 65,536 |
| largest async raw / gzip | 826,250 / 223,412 | 1,048,576 / 294,912 |
| total JS raw / gzip | 986,638 / 275,640 | **1,228,800 / 344,064 — kept from v1** |
| CSS | 912 / 483 | 16,384 floor — kept |

**Totals deliberately kept: chunk splitting cannot disguise total growth.**

### Tests (11 → 22, all node:test synthetic fixtures)
single chunk · several async chunks · missing index · missing referenced entry · malformed references · script-less index · duplicate refs count once · windows/posix dist paths · **exact limit + limit+1** for entry and largest-async · stable versioned machine line · deterministic gzip.

### PERF_NOTES
v2 baseline table, mechanics, explicit **non-claims** (built sizes only — nothing about network, caching, or user-perceived latency), and the restated budget-change protocol (never widen to absorb unexplained growth).

Live receipt: `BUNDLE_BUDGET v2 … entry_raw=155478 … largest_async_raw=826250 … status=PASS`.

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)