### PR TITLE
test/ci: cross-browser ui-smoke — chromium/firefox/webkit matrix, portability audit (PACKAGE AJ)

### DIFF
--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -63,7 +63,16 @@ jobs:
       # bundle-budget gate.
 
       - name: Run smoke tests (${{ matrix.browser }})
-        run: npx playwright test --project=${{ matrix.browser }}
+        # Headless Firefox cannot create a WebGL context (the three.js 3D
+        # view needs one; Chromium/WebKit headless ship software GL).
+        # Firefox therefore runs HEADED under xvfb — xvfb-run is part of
+        # the ubuntu runner image; no extra installation.
+        run: |
+          if [ "${{ matrix.browser }}" = "firefox" ]; then
+            xvfb-run --auto-servernum npx playwright test --project=firefox --headed
+          else
+            npx playwright test --project=${{ matrix.browser }}
+          fi
 
       - name: Upload test report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -17,6 +17,14 @@ jobs:
   ui-smoke:
     runs-on: ubuntu-latest
 
+    # Cross-browser matrix (Package AJ, issue #2): the same semantic suite
+    # per engine. fail-fast off so one engine's failure still surfaces the
+    # other engines' results.
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
     defaults:
       run:
         working-directory: utilityfog_frontend/frontend
@@ -47,20 +55,20 @@ jobs:
       - name: Bundle budget check
         run: npm run check:budget
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browser (matrix engine only)
+        run: npx playwright install --with-deps ${{ matrix.browser }}
 
       # Playwright smoke tests still run against the Vite dev server (see
       # playwright.config.ts); the production build above exists to feed the
       # bundle-budget gate.
 
-      - name: Run smoke tests
-        run: npm run test:ui
+      - name: Run smoke tests (${{ matrix.browser }})
+        run: npx playwright test --project=${{ matrix.browser }}
 
       - name: Upload test report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: utilityfog_frontend/frontend/playwright-report/
           retention-days: 7

--- a/utilityfog_frontend/frontend/playwright.config.ts
+++ b/utilityfog_frontend/frontend/playwright.config.ts
@@ -14,10 +14,21 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
+  // Cross-browser matrix (Package AJ, issue #2): the same SEMANTIC tests
+  // run per engine — no screenshot/pixel comparisons, so engine rendering
+  // variance cannot create brittleness.
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
     },
   ],
 

--- a/utilityfog_frontend/frontend/tests-unit/wait-for-application-socket.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/wait-for-application-socket.test.ts
@@ -8,7 +8,8 @@ import { applicationSocketReady } from '../tests/helpers/waitForApplicationSocke
 
 type Registry = Array<{ url?: unknown; readyState?: unknown } | undefined>
 const install = (registry: Registry | undefined) => {
-  ;(window as unknown as { __fakeSockets?: Registry }).__fakeSockets = registry
+  const w = window as unknown as { __fakeSockets?: Registry }
+  w.__fakeSockets = registry
 }
 const ready = (minCount = 1, path = '/ws') => applicationSocketReady({ path, minCount })
 

--- a/utilityfog_frontend/frontend/tests-unit/wait-for-application-socket.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/wait-for-application-socket.test.ts
@@ -1,0 +1,74 @@
+// Package AJ (amendment): the shared readiness predicate is itself under
+// test. It executes in two hosts — serialized into the page by
+// waitForFunction, and directly under jsdom here — so its contract
+// (optional chaining everywhere, semantic "active application socket")
+// is locked at the pure-function seam both hosts share.
+import { describe, it, expect, afterEach } from 'vitest'
+import { applicationSocketReady } from '../tests/helpers/waitForApplicationSocket'
+
+type Registry = Array<{ url?: unknown; readyState?: unknown } | undefined>
+const install = (registry: Registry | undefined) => {
+  ;(window as unknown as { __fakeSockets?: Registry }).__fakeSockets = registry
+}
+const ready = (minCount = 1, path = '/ws') => applicationSocketReady({ path, minCount })
+
+afterEach(() => {
+  delete (window as unknown as { __fakeSockets?: Registry }).__fakeSockets
+})
+
+describe('applicationSocketReady', () => {
+  it('absent registry (init script not yet installed) is not-ready, never a crash', () => {
+    install(undefined)
+    expect(ready()).toBe(false)
+  })
+
+  it('empty registry (app has not constructed its socket) is not-ready', () => {
+    install([])
+    expect(ready()).toBe(false)
+  })
+
+  it('a registry with only NON-application sockets is not-ready', () => {
+    install([{ url: 'ws://localhost:5173/hmr', readyState: 1 }])
+    expect(ready()).toBe(false)
+  })
+
+  it('a STALE application socket (latest matching entry CLOSED) is not-ready', () => {
+    install([{ url: 'ws://localhost/ws', readyState: 3 }])
+    expect(ready()).toBe(false)
+  })
+
+  it('an active application socket is ready — CONNECTING counts (specs open it themselves)', () => {
+    install([{ url: 'ws://localhost/ws', readyState: 0 }])
+    expect(ready()).toBe(true)
+    install([{ url: 'ws://localhost/ws', readyState: 1 }])
+    expect(ready()).toBe(true)
+  })
+
+  it('the LATEST matching socket decides: closed-then-reopened is ready, open-then-closed is not', () => {
+    install([
+      { url: 'ws://localhost/ws', readyState: 3 },
+      { url: 'ws://localhost/ws', readyState: 0 },
+    ])
+    expect(ready()).toBe(true)
+    install([
+      { url: 'ws://localhost/ws', readyState: 1 },
+      { url: 'ws://localhost/ws', readyState: 3 },
+    ])
+    expect(ready()).toBe(false)
+  })
+
+  it('minCount gates reconnect scenarios: one socket does not satisfy minCount 2, two do', () => {
+    install([{ url: 'ws://localhost/ws', readyState: 3 }])
+    expect(ready(2)).toBe(false)
+    install([
+      { url: 'ws://localhost/ws', readyState: 3 },
+      { url: 'ws://localhost/ws', readyState: 0 },
+    ])
+    expect(ready(2)).toBe(true)
+  })
+
+  it('hostile registry shapes — holes and url-less entries — read as not-matching, never throw', () => {
+    install([undefined, { readyState: 1 }, { url: 42, readyState: 1 }])
+    expect(ready()).toBe(false)
+  })
+})

--- a/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/connection-status-a11y.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForApplicationSocket } from './helpers/waitForApplicationSocket';
 
 // ---------------------------------------------------------------------------
 // Typed test-harness surface (no `any`): the in-page fake socket and the
@@ -105,6 +106,11 @@ async function setupPage(page: Page) {
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
+  // Portability (Package AJ): #root alone left activeSocket() racing the
+  // app's socket construction (its descriptive throw was the observable
+  // flake). The SHARED semantic gate waits for the active application
+  // socket plus the paint/effect turn — see tests/helpers/.
+  await waitForApplicationSocket(page);
 }
 
 const activeSocket = (page: Page, action: '_open' | '_close') =>

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -105,6 +105,23 @@ async function setupPage(page: Page) {
   await page.goto('/');
   // The app's client(s) exist once the root renders; the active one is last.
   await expect(page.locator('#root')).toBeVisible();
+  // Portability (Package AJ): waiting for #root alone raced the
+  // subscription effects — Chromium happened to win the race, WebKit lost
+  // it (events emitted before EventFeed subscribed were silently missed).
+  // Semantic readiness: the app socket must exist AND two paint ticks must
+  // pass so the post-commit subscription effects have flushed, in every
+  // engine.
+  await page.waitForFunction(() =>
+    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
+      String(s.url).includes('/ws'),
+    ),
+  );
+  await page.evaluate(
+    () =>
+      new Promise(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      ),
+  );
 }
 
 // Inject one already-parsed-shape message on the app's active socket.

--- a/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-contract.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForApplicationSocket } from './helpers/waitForApplicationSocket';
 
 // ---------------------------------------------------------------------------
 // Typed test-harness surface (no `any`): the in-page fake socket and the
@@ -105,23 +106,10 @@ async function setupPage(page: Page) {
   await page.goto('/');
   // The app's client(s) exist once the root renders; the active one is last.
   await expect(page.locator('#root')).toBeVisible();
-  // Portability (Package AJ): waiting for #root alone raced the
-  // subscription effects — Chromium happened to win the race, WebKit lost
-  // it (events emitted before EventFeed subscribed were silently missed).
-  // Semantic readiness: the app socket must exist AND two paint ticks must
-  // pass so the post-commit subscription effects have flushed, in every
-  // engine.
-  await page.waitForFunction(() =>
-    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
-      String(s.url).includes('/ws'),
-    ),
-  );
-  await page.evaluate(
-    () =>
-      new Promise(resolve =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve)),
-      ),
-  );
+  // Portability (Package AJ): #root alone raced the subscription effects.
+  // The SHARED semantic gate waits for the active application socket plus
+  // the paint/effect turn — see tests/helpers/waitForApplicationSocket.ts.
+  await waitForApplicationSocket(page);
 }
 
 // Inject one already-parsed-shape message on the app's active socket.

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -107,6 +107,23 @@ async function setupPage(page: Page) {
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
+  // Portability (Package AJ): waiting for #root alone raced the
+  // subscription effects — Chromium happened to win the race, WebKit lost
+  // it (events emitted before EventFeed subscribed were silently missed).
+  // Semantic readiness: the app socket must exist AND two paint ticks must
+  // pass so the post-commit subscription effects have flushed, in every
+  // engine.
+  await page.waitForFunction(() =>
+    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
+      String(s.url).includes('/ws'),
+    ),
+  );
+  await page.evaluate(
+    () =>
+      new Promise(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      ),
+  );
 }
 
 const inject = (page: Page, type: string, payload: unknown) =>

--- a/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
+++ b/utilityfog_frontend/frontend/tests/event-feed-operations.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForApplicationSocket } from './helpers/waitForApplicationSocket';
 
 // ---------------------------------------------------------------------------
 // Typed test-harness surface (no `any`): the in-page fake socket and the
@@ -107,23 +108,10 @@ async function setupPage(page: Page) {
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
-  // Portability (Package AJ): waiting for #root alone raced the
-  // subscription effects — Chromium happened to win the race, WebKit lost
-  // it (events emitted before EventFeed subscribed were silently missed).
-  // Semantic readiness: the app socket must exist AND two paint ticks must
-  // pass so the post-commit subscription effects have flushed, in every
-  // engine.
-  await page.waitForFunction(() =>
-    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
-      String(s.url).includes('/ws'),
-    ),
-  );
-  await page.evaluate(
-    () =>
-      new Promise(resolve =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve)),
-      ),
-  );
+  // Portability (Package AJ): #root alone raced the subscription effects.
+  // The SHARED semantic gate waits for the active application socket plus
+  // the paint/effect turn — see tests/helpers/waitForApplicationSocket.ts.
+  await waitForApplicationSocket(page);
 }
 
 const inject = (page: Page, type: string, payload: unknown) =>

--- a/utilityfog_frontend/frontend/tests/helpers/waitForApplicationSocket.ts
+++ b/utilityfog_frontend/frontend/tests/helpers/waitForApplicationSocket.ts
@@ -1,0 +1,62 @@
+// Package AJ (amendment): the ONE shared readiness gate for every spec
+// that drives the application through a fake-socket registry.
+//
+// Why this exists (portability audit receipt): waiting for #root alone
+// raced the post-commit subscription effects — Chromium happened to win
+// the race, WebKit lost it (events injected before EventFeed subscribed
+// were silently missed), and a bootstrap that dereferenced
+// `socks[socks.length - 1]` straight after #root could observe an
+// ABSENT registry entry and throw. Semantic readiness is two-phase:
+//   1. the application's CURRENT socket exists in the registry (the
+//      active-application-socket predicate below), and
+//   2. two paint ticks have passed, so the subscription effects that
+//      attach onmessage handlers have flushed in every engine.
+import type { Page } from '@playwright/test'
+
+// PAGE-CONTEXT predicate — fully self-contained (references only its
+// argument and window) so Playwright can serialize it into the page for
+// waitForFunction, and vitest can call it directly under jsdom. Optional
+// chaining throughout: an absent or empty registry, or a hole in it, is
+// simply "not ready yet" — never a crash.
+//
+// "Active application socket": at least `minCount` registry entries whose
+// url contains `path`, and the LATEST such entry (the application's
+// current socket) is not CLOSED. Sockets begin CONNECTING (0) and the
+// specs open them explicitly, so the predicate deliberately requires
+// "not CLOSED (3)", not "OPEN (1)".
+export function applicationSocketReady(arg: { path: string; minCount: number }): boolean {
+  const w = window as unknown as {
+    __fakeSockets?: Array<{ url?: unknown; readyState?: unknown } | undefined>
+  }
+  const matching = (w.__fakeSockets ?? []).filter(s =>
+    String(s?.url ?? '').includes(arg.path),
+  )
+  if (matching.length < arg.minCount) return false
+  const current = matching[matching.length - 1]
+  return current?.readyState !== 3
+}
+
+export interface WaitForApplicationSocketOptions {
+  // Substring identifying application sockets in the registry.
+  path?: string
+  // For reconnect scenarios: wait until this many application sockets
+  // have been created (the newest is the active one).
+  minCount?: number
+}
+
+export async function waitForApplicationSocket(
+  page: Page,
+  options?: WaitForApplicationSocketOptions,
+): Promise<void> {
+  const arg = { path: options?.path ?? '/ws', minCount: options?.minCount ?? 1 }
+  await page.waitForFunction(applicationSocketReady, arg)
+  // The required paint/effect turn: two rAF ticks after the socket
+  // exists guarantee the commit that created it has painted and its
+  // subscription effects have run before any test injects traffic.
+  await page.evaluate(
+    () =>
+      new Promise(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve)),
+      ),
+  )
+}

--- a/utilityfog_frontend/frontend/tests/node-update-resilience.spec.ts
+++ b/utilityfog_frontend/frontend/tests/node-update-resilience.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForApplicationSocket } from './helpers/waitForApplicationSocket';
 
 // ---------------------------------------------------------------------------
 // Typed test-harness surface (no `any`): the in-page fake socket and the
@@ -116,6 +117,11 @@ async function setupPage(page: Page) {
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
+  // Portability (Package AJ): #root alone raced socket construction — the
+  // _open() below dereferenced the newest registry entry, which could be
+  // ABSENT in a losing engine. The SHARED semantic gate waits for the
+  // active application socket plus the paint/effect turn first.
+  await waitForApplicationSocket(page);
   await page.evaluate(() => {
     const w = window as HarnessWindow;
     const socks = w.__fakeSockets.filter((s) => String(s.url).includes('/ws'));


### PR DESCRIPTION
## PACKAGE AJ — cross-browser smoke (refs #2, partial progress — no closing keyword)

**Stacked: base `ci/frontend-chunk-budgets` (AH → AG → main). Merge order AG → AH → AJ.**

### What
Playwright **firefox + webkit projects** beside chromium (same semantic tests — no pixel comparisons) · **ui-smoke browser matrix** (fail-fast off, one engine per job via the official `playwright install --with-deps <engine>` path, browser-qualified artifacts, pins/permissions unchanged, frontend-quality untouched).

### Portability audit (full suite per engine, locally)
**One genuine defect found and fixed**: the event-feed specs raced the post-commit subscription effects by waiting only for `#root` — Chromium won the race, **WebKit lost it (10 failures, events silently missed)**. Fixed with semantic readiness (app-socket existence + two paint ticks). Animation computed-styles, fake-WS behavior, reduced-motion emulation and export handling audited clean.

### Receipts
Local: **chromium 56/56 · webkit 56/56**. **Firefox hard stop honored**: Playwright's firefox build fails to launch on this machine (side-by-side configuration error — a machine-level VC++ runtime the official install path cannot supply; system installs are fenced). Firefox receipts come from this PR's own **CI matrix** (ubuntu `--with-deps`). Error-boundary recovery remains unit-owned (documented — E2E would need app test hooks).

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment (Jack runway, 2026-07-12 evening) — head `3786825e`

**One shared, typed readiness helper** — `tests/helpers/waitForApplicationSocket.ts` — now owns fake-socket readiness across the COMPLETE Playwright corpus:

- `applicationSocketReady` is a self-contained page-context predicate (optional chaining throughout; absent/empty/hostile registries read as "not ready", never a crash). Semantics: ≥ `minCount` application sockets (url contains the app path) and the LATEST one is not CLOSED — CONNECTING counts, because specs open sockets themselves.
- `waitForApplicationSocket` = predicate wait + the required paint/effect turn (two rAF ticks) so post-commit subscription effects are live in every engine before traffic injection.
- The predicate runs in BOTH hosts — serialized into the page by `waitForFunction`, and directly under jsdom in vitest — and is unit-tested at that shared seam: **absent registry, empty registry, non-app sockets, stale (latest closed), active, latest-decides, minCount reconnect gating, hostile shapes** (8 tests).

**Untruncated sweep receipt** (`__fakeSockets` / `_open()` / "active socket" / `#root`-only waits, all 6 specs):

| Spec | Finding | Action |
|---|---|---|
| event-feed-operations | inline AJ gate | replaced with shared helper |
| event-feed-contract | inline AJ gate | replaced with shared helper |
| node-update-resilience | `#root`-only bootstrap dereferenced the newest registry entry for `_open()` with no existence wait | helper inserted before `_open()` |
| connection-status-a11y | `#root`-only bootstrap left `activeSocket()` racing socket construction (its descriptive throw was the flake surface) | helper inserted in bootstrap |
| simbridge-lifecycle | drives its OWN in-page client synchronously inside `evaluate` — no app-socket race exists | out of scope, documented |
| smoke | no fake sockets; `#root` visibility IS the test | out of scope, documented |

No `any`; typed Window/harness augmentation retained. Battery at `3786825e`: lint 0 · tsc 0 · unit 279/279 (incl. 8 new helper tests) · chromium 56/56 · webkit 56/56 · firefox via CI (headed-under-xvfb; local FF = known SxS machine dep).

**Amendment 2 (CI-caught)** — head is now `2add13d7`: the ASI-guard semicolon in the helper unit test tripped ESLint 8's `no-extra-semi` in CI (ESLint 9, used by the overlay lab, removed the rule — which is why overlay lint stayed silent). Restructured to a plain narrowing binding; 8/8 helper tests green, bare lint exit 0. Process lesson re-banked: gating commands are never piped (`| tail` masks the exit code).