### PR TITLE
feat/test: responsive + keyboard contracts — bounded mobile/a11y slice (PACKAGE AK)

### DIFF
--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { useState, useEffect, useRef, lazy, Suspense } from 'react'
+import { useState, useEffect, useRef, lazy } from 'react'
 import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
 import ViewErrorBoundary from './components/ViewErrorBoundary'
@@ -55,14 +55,16 @@ function App() {
     setView(target)
   }
 
-  // Predictable focus recovery (Package AK): after a successful Retry the
-  // Retry button unmounts, which would silently drop keyboard focus on
-  // <body>. The active view region (tabIndex=-1) receives focus instead —
-  // announced by its aria-label, stealing nothing during ordinary lazy
-  // loading (this runs only from the user-initiated Retry).
+  // Predictable focus recovery (Package AK, success-aware amendment):
+  // after a Retry the old button unmounts, which would silently drop
+  // keyboard focus on <body>. Focus moves to the labelled view region
+  // ONLY when the boundary reports a successful child commit
+  // (onRecovered) — a retry that fails again keeps focus on the new
+  // Retry button (boundary-owned), and ordinary lazy loading steals
+  // nothing (onRecovered never fires outside a retry cycle).
   const viewRegionRef = useRef<HTMLElement | null>(null)
-  const focusViewRegionAfterRetry = () => {
-    requestAnimationFrame(() => viewRegionRef.current?.focus())
+  const focusViewRegion = () => {
+    viewRegionRef.current?.focus()
   }
 
   useEffect(() => {
@@ -102,6 +104,10 @@ function App() {
           the same tree position, so WITHOUT it React reconciles them as one
           component and a failed boundary's state would survive the switch.
           Distinct keys force a remount — a fresh boundary per view. */}
+      {/* Layout comes from the .view-region CLASS contract (desktop
+          min-height 0 for flex overflow semantics; mobile enforces a
+          240px floor) — an inline min-height would silently defeat the
+          media-query floor, which is exactly the defect this replaced. */}
       {view === '3d' ? (
         <section
           key="view-3d"
@@ -109,27 +115,22 @@ function App() {
           tabIndex={-1}
           role="region"
           aria-label="3D network view"
-          style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
+          className="view-region"
         >
           <ViewErrorBoundary
             viewLabel="3D network view"
-            onRetry={() => {
-              setLazy3D(() => lazy(load3D))
-              focusViewRegionAfterRetry()
-            }}
+            onRetry={() => setLazy3D(() => lazy(load3D))}
+            onRecovered={focusViewRegion}
+            suspenseFallback={
+              /* The transient loading status is scoped inside the active
+                 region; steady-state keeps the badge as the only status
+                 region. */
+              <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
+                Loading 3D network view…
+              </div>
+            }
           >
-            {/* The transient loading status is scoped inside the active
-                region; steady-state keeps the badge as the only status
-                region. */}
-            <Suspense
-              fallback={
-                <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
-                  Loading 3D network view…
-                </div>
-              }
-            >
-              <Lazy3D simClient={simClient} />
-            </Suspense>
+            <Lazy3D simClient={simClient} />
           </ViewErrorBoundary>
         </section>
       ) : (
@@ -139,24 +140,19 @@ function App() {
           tabIndex={-1}
           role="region"
           aria-label="2D network view"
-          style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
+          className="view-region"
         >
           <ViewErrorBoundary
             viewLabel="2D network view"
-            onRetry={() => {
-              setLazy2D(() => lazy(load2D))
-              focusViewRegionAfterRetry()
-            }}
+            onRetry={() => setLazy2D(() => lazy(load2D))}
+            onRecovered={focusViewRegion}
+            suspenseFallback={
+              <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
+                Loading 2D network view…
+              </div>
+            }
           >
-            <Suspense
-              fallback={
-                <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
-                  Loading 2D network view…
-                </div>
-              }
-            >
-              <Lazy2D simClient={simClient} />
-            </Suspense>
+            <Lazy2D simClient={simClient} />
           </ViewErrorBoundary>
         </section>
       )}

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { useState, useEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, useRef, lazy, Suspense } from 'react'
 import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
 import ViewErrorBoundary from './components/ViewErrorBoundary'
@@ -55,6 +55,16 @@ function App() {
     setView(target)
   }
 
+  // Predictable focus recovery (Package AK): after a successful Retry the
+  // Retry button unmounts, which would silently drop keyboard focus on
+  // <body>. The active view region (tabIndex=-1) receives focus instead —
+  // announced by its aria-label, stealing nothing during ordinary lazy
+  // loading (this runs only from the user-initiated Retry).
+  const viewRegionRef = useRef<HTMLElement | null>(null)
+  const focusViewRegionAfterRetry = () => {
+    requestAnimationFrame(() => viewRegionRef.current?.focus())
+  }
+
   useEffect(() => {
     const client = new SimBridgeClient(WS_URL)
     
@@ -95,13 +105,18 @@ function App() {
       {view === '3d' ? (
         <section
           key="view-3d"
+          ref={viewRegionRef}
+          tabIndex={-1}
           role="region"
           aria-label="3D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
           <ViewErrorBoundary
             viewLabel="3D network view"
-            onRetry={() => setLazy3D(() => lazy(load3D))}
+            onRetry={() => {
+              setLazy3D(() => lazy(load3D))
+              focusViewRegionAfterRetry()
+            }}
           >
             {/* The transient loading status is scoped inside the active
                 region; steady-state keeps the badge as the only status
@@ -120,13 +135,18 @@ function App() {
       ) : (
         <section
           key="view-2d"
+          ref={viewRegionRef}
+          tabIndex={-1}
           role="region"
           aria-label="2D network view"
           style={{ flex: 1, display: 'flex', position: 'relative', minHeight: 0, minWidth: 0 }}
         >
           <ViewErrorBoundary
             viewLabel="2D network view"
-            onRetry={() => setLazy2D(() => lazy(load2D))}
+            onRetry={() => {
+              setLazy2D(() => lazy(load2D))
+              focusViewRegionAfterRetry()
+            }}
           >
             <Suspense
               fallback={

--- a/utilityfog_frontend/frontend/src/components/RecoveryProbe.tsx
+++ b/utilityfog_frontend/frontend/src/components/RecoveryProbe.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+// Package AK: commit probe for ViewErrorBoundary's success-aware focus
+// contract. Rendered INSIDE the boundary-owned suspense boundary, after
+// the real children — its effect can only run once the suspended
+// children have revealed, i.e. the child commit the focus contract keys
+// on. It fires on every subsequent commit too; the boundary gates on
+// its retry flag. Lives in its own module so the boundary file exports
+// only the boundary (react-refresh/only-export-components).
+export default function RecoveryProbe({ onCommit }: { onCommit: () => void }) {
+  useEffect(() => {
+    onCommit()
+  })
+  return null
+}

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import { Component, Suspense, createRef, useEffect } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 
 // Narrow error boundary for the REPLACEABLE 2D/3D view surface only — the
@@ -8,7 +8,10 @@ import type { ErrorInfo, ReactNode } from 'react'
 // validators guard against upstream; this is the last line).
 //
 // Containment contract:
-//  - When healthy, children render UNWRAPPED — zero layout impact.
+//  - When healthy, children render UNWRAPPED — zero layout impact —
+//    unless `suspenseFallback` is provided, in which case the boundary
+//    also owns the pending surface (children render inside Suspense with
+//    a commit probe reporting the reveal).
 //  - On failure: an accessible role="alert" fallback with a concise
 //    message and a Retry button that remounts ONLY the failed view.
 //  - Retry is user-initiated only — no automatic retry loop, no hidden
@@ -19,6 +22,31 @@ import type { ErrorInfo, ReactNode } from 'react'
 //  - Errors are not swallowed: each failure is reported exactly once
 //    through the established bounded diagnostic channel (console.error),
 //    alongside React's own development error output.
+//
+// Focus contract (Package AK amendment, success-aware):
+//  - Clicking Retry moves focus NOWHERE by itself. The old Retry button
+//    unmounts, and where focus lands next depends on the OUTCOME:
+//  - SUCCESS — the retried children COMMIT (in suspenseFallback mode:
+//    the suspense reveal, observed by the commit probe): `onRecovered`
+//    fires exactly once, and the owner moves focus (App focuses the
+//    labelled view region).
+//  - REPEATED FAILURE — the boundary catches again: focus is restored to
+//    the NEW Retry button, keeping a keyboard user inside the retry loop
+//    instead of dropping them on <body>.
+//  - A FIRST failure (no retry in flight) moves focus nowhere — the
+//    boundary self-focuses only inside a user-initiated retry cycle, so
+//    ordinary loads and first failures steal nothing.
+
+// Commit probe: rendered INSIDE the suspense boundary, after the real
+// children. Its effect can only run once the suspended children have
+// revealed — i.e. the child commit the focus contract keys on. It fires
+// on every subsequent commit too; the boundary gates on its retry flag.
+function RecoveryProbe({ onCommit }: { onCommit: () => void }) {
+  useEffect(() => {
+    onCommit()
+  })
+  return null
+}
 
 interface ViewErrorBoundaryProps {
   // Names the guarded surface in the fallback message ("3D network view").
@@ -27,6 +55,15 @@ interface ViewErrorBoundaryProps {
   // failed state — the owner can mint fresh lazy-loaded children so a
   // cached chunk-load rejection is retried (Package AG).
   onRetry?: () => void
+  // Success-aware recovery callback (Package AK): invoked exactly once
+  // when a user-initiated Retry is followed by a successful child commit.
+  // Never invoked for ordinary first loads.
+  onRecovered?: () => void
+  // When provided, the boundary owns the pending surface: children render
+  // inside <Suspense fallback={suspenseFallback}> with the commit probe.
+  // When absent, children render unwrapped (owners with their own
+  // Suspense keep exactly the old behavior; onRecovered stays silent).
+  suspenseFallback?: ReactNode
   children: ReactNode
 }
 
@@ -40,7 +77,14 @@ export default class ViewErrorBoundary extends Component<
 > {
   state: ViewErrorBoundaryState = { failed: false }
 
-  static getDerivedStateFromError(): ViewErrorBoundaryState {
+  // True from a Retry click until its outcome (success commit or repeated
+  // failure) is known. An instance field, not state: it must never cause
+  // a render of its own.
+  private retryPending = false
+
+  private retryButtonRef = createRef<HTMLButtonElement>()
+
+  static getDerivedStateFromError(): Partial<ViewErrorBoundaryState> {
     return { failed: true }
   }
 
@@ -51,36 +95,53 @@ export default class ViewErrorBoundary extends Component<
     console.error('View render failed:', error, info.componentStack)
   }
 
+  componentDidUpdate(_prevProps: ViewErrorBoundaryProps, prevState: ViewErrorBoundaryState): void {
+    // A failure that lands while a retry is in flight is a REPEATED
+    // failure: the fresh fallback has committed, so its new Retry button
+    // exists — restore keyboard focus there and close the cycle.
+    if (this.state.failed && !prevState.failed && this.retryPending) {
+      this.retryPending = false
+      this.retryButtonRef.current?.focus()
+    }
+  }
+
   handleRetry = (): void => {
+    this.retryPending = true
     this.props.onRetry?.()
     this.setState({ failed: false })
+  }
+
+  handleChildCommit = (): void => {
+    // The probe reports every commit of the revealed children; only the
+    // first one after a retry is the recovery event.
+    if (this.retryPending) {
+      this.retryPending = false
+      this.props.onRecovered?.()
+    }
   }
 
   render(): ReactNode {
     if (this.state.failed) {
       return (
-        <div
-          role="alert"
-          style={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '12px',
-            color: 'white',
-            backgroundColor: '#1a1a1a',
-          }}
-        >
-          <p style={{ margin: 0 }}>The {this.props.viewLabel} failed to render.</p>
+        <div role="alert" className="view-error-fallback">
+          <p>The {this.props.viewLabel} failed to render.</p>
           <button
             type="button"
-            style={{ minWidth: 44, minHeight: 44 }}
+            className="view-retry-button"
+            ref={this.retryButtonRef}
             onClick={this.handleRetry}
           >
             Retry {this.props.viewLabel}
           </button>
         </div>
+      )
+    }
+    if (this.props.suspenseFallback !== undefined) {
+      return (
+        <Suspense fallback={this.props.suspenseFallback}>
+          {this.props.children}
+          <RecoveryProbe onCommit={this.handleChildCommit} />
+        </Suspense>
       )
     }
     return this.props.children

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -73,7 +73,11 @@ export default class ViewErrorBoundary extends Component<
           }}
         >
           <p style={{ margin: 0 }}>The {this.props.viewLabel} failed to render.</p>
-          <button type="button" onClick={this.handleRetry}>
+          <button
+            type="button"
+            style={{ minWidth: 44, minHeight: 44 }}
+            onClick={this.handleRetry}
+          >
             Retry {this.props.viewLabel}
           </button>
         </div>

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -1,5 +1,6 @@
-import { Component, Suspense, createRef, useEffect } from 'react'
+import { Component, Suspense, createRef } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
+import RecoveryProbe from './RecoveryProbe'
 
 // Narrow error boundary for the REPLACEABLE 2D/3D view surface only — the
 // application shell (controls, event feed, connection badge) deliberately
@@ -37,16 +38,7 @@ import type { ErrorInfo, ReactNode } from 'react'
 //    boundary self-focuses only inside a user-initiated retry cycle, so
 //    ordinary loads and first failures steal nothing.
 
-// Commit probe: rendered INSIDE the suspense boundary, after the real
-// children. Its effect can only run once the suspended children have
-// revealed — i.e. the child commit the focus contract keys on. It fires
-// on every subsequent commit too; the boundary gates on its retry flag.
-function RecoveryProbe({ onCommit }: { onCommit: () => void }) {
-  useEffect(() => {
-    onCommit()
-  })
-  return null
-}
+// The commit probe lives in ./RecoveryProbe — see its header.
 
 interface ViewErrorBoundaryProps {
   // Names the guarded surface in the fallback message ("3D network view").

--- a/utilityfog_frontend/frontend/src/index.css
+++ b/utilityfog_frontend/frontend/src/index.css
@@ -74,3 +74,47 @@ body {
   right: 20px;
   z-index: 1000;
 }
+
+/* ------------------------------------------------------------------------
+   Responsive + keyboard contracts (Package AK, issue #2 slice).
+   Desktop keeps the overlay layout; below 768px the overlays become
+   stacked flow so the feed can never cover the controls or the view, and
+   the active view keeps a useful minimum height. */
+
+/* Touch targets: view controls and the boundary Retry meet 44x44 CSS px. */
+.controls button {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+/* A visible, engine-neutral focus indicator (some UA resets suppress the
+   default; keyboard users must always see where they are). */
+button:focus-visible,
+input:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+/* The replaceable view slot never collapses below a usable height. */
+.app-container > section {
+  min-height: 240px;
+}
+
+@media (max-width: 767px) {
+  .controls {
+    position: static;
+    padding: 12px 12px 0;
+  }
+  .event-feed {
+    position: static;
+    width: auto;
+    margin: 8px 12px;
+    max-height: 35vh;
+  }
+  .connection-badge {
+    position: static;
+    align-self: flex-start;
+    margin: 0 12px 8px;
+  }
+}

--- a/utilityfog_frontend/frontend/src/index.css
+++ b/utilityfog_frontend/frontend/src/index.css
@@ -88,7 +88,17 @@ body {
 }
 
 /* A visible, engine-neutral focus indicator (some UA resets suppress the
-   default; keyboard users must always see where they are). */
+   default; keyboard users must always see where they are).
+
+   DECISION (Package AK amendment, documented — not a bot default): the
+   programmatically focused tabIndex=-1 view region KEEPS this
+   :focus-visible rule. The UA's focus-visible heuristic then decides per
+   interaction: a keyboard-driven Retry shows the ring on the region (a
+   keyboard user needs to see where focus landed), while a pointer-driven
+   one typically does not (no ring flash for mouse users). We deliberately
+   neither suppress the indicator (outline: none on a focus target harms
+   keyboard users) nor force an always-on :focus ring (which would flash
+   at pointer users on every recovery). */
 button:focus-visible,
 input:focus-visible,
 [tabindex]:focus-visible {
@@ -96,12 +106,54 @@ input:focus-visible,
   outline-offset: 2px;
 }
 
-/* The replaceable view slot never collapses below a usable height. */
-.app-container > section {
-  min-height: 240px;
+/* View-region layout contract (Package AK amendment). A CLASS, not
+   inline styles: the previous inline min-height:0 silently defeated the
+   240px mobile floor below (inline always outranks a stylesheet rule).
+   Desktop: min-height 0 preserves flex overflow semantics inside the
+   fixed-height column. Mobile (<768px): the scrolling container makes a
+   real floor meaningful — see the media query. */
+.view-region {
+  flex: 1;
+  display: flex;
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Boundary fallback surface: an explicit class, NOT [role="alert"] —
+   the alert role is a semantic contract for assistive tech, not a
+   styling hook (a future alert elsewhere must not inherit view-slot
+   layout). Static Retry dimensions live here, not inline. */
+.view-error-fallback {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: white;
+  background-color: #1a1a1a;
+}
+
+.view-error-fallback p {
+  margin: 0;
+}
+
+.view-retry-button {
+  min-width: 44px;
+  min-height: 44px;
 }
 
 @media (max-width: 767px) {
+  /* Stacked flow can exceed a short viewport (landscape phones):
+     the app container itself scrolls vertically; desktop overlays
+     above 768px keep the fixed, non-scrolling column. */
+  .app-container {
+    overflow-y: auto;
+  }
+  .view-region {
+    min-height: 240px;
+  }
   .controls {
     position: static;
     padding: 12px 12px 0;

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -6,7 +6,7 @@
 // exercise the real ViewErrorBoundary inside the real App.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { StrictMode } from 'react'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import App from '../src/App'
 
 const failures = { v3d: false, v2d: false }
@@ -213,5 +213,32 @@ describe('AB audit amendments', () => {
     render(<App />)
     expect(await screen.findByRole('button', { name: 'Retry 3D network view' }))
       .toHaveAttribute('type', 'button')
+  })
+})
+
+describe('retry focus recovery (Package AK)', () => {
+  it('successful Retry moves focus to the recovered view region (never dropped on body)', async () => {
+    failures.v3d = true
+    render(<App />)
+    const retry = await screen.findByRole('button', { name: 'Retry 3D network view' })
+    retry.focus()
+    expect(retry).toHaveFocus()
+
+    failures.v3d = false
+    fireEvent.click(retry)
+    await screen.findByTestId('view-3d')
+    // The rAF-deferred focus lands on the labelled region.
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: '3D network view' })).toHaveFocus()
+    })
+  })
+
+  it('ordinary lazy loading steals no focus', async () => {
+    render(<App />)
+    const button2d = screen.getByRole('button', { name: '2D View' })
+    button2d.focus()
+    fireEvent.click(button2d)
+    await screen.findByTestId('view-2d')
+    expect(button2d).toHaveFocus() // load completed without focus theft
   })
 })

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -4,6 +4,8 @@
 // The WebGL-heavy views are mocked at the module seam (no real WebGL in
 // unit tests) with CONTROLLABLE failure flags, so genuine render throws
 // exercise the real ViewErrorBoundary inside the real App.
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { StrictMode } from 'react'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
@@ -216,7 +218,7 @@ describe('AB audit amendments', () => {
   })
 })
 
-describe('retry focus recovery (Package AK)', () => {
+describe('retry focus recovery (Package AK, success-aware amendment)', () => {
   it('successful Retry moves focus to the recovered view region (never dropped on body)', async () => {
     failures.v3d = true
     render(<App />)
@@ -227,7 +229,35 @@ describe('retry focus recovery (Package AK)', () => {
     failures.v3d = false
     fireEvent.click(retry)
     await screen.findByTestId('view-3d')
-    // The rAF-deferred focus lands on the labelled region.
+    // Success-aware focus: onRecovered fires from the post-reveal commit
+    // probe, so the region receives focus only after the view committed.
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: '3D network view' })).toHaveFocus()
+    })
+  })
+
+  it('a retry that FAILS AGAIN keeps focus on the new Retry button, not the region', async () => {
+    failures.v3d = true
+    render(<App />)
+    const retry = await screen.findByRole('button', { name: 'Retry 3D network view' })
+    retry.focus()
+    fireEvent.click(retry) // still failing: the old button unmounts, a new one renders
+    const retryAgain = await screen.findByRole('button', { name: 'Retry 3D network view' })
+    // The keyboard user must stay in the retry loop: focus is restored to
+    // the NEW Retry button, and the region is never focused (the view
+    // never committed).
+    await waitFor(() => expect(retryAgain).toHaveFocus())
+    expect(screen.queryByRole('region', { name: '3D network view' })).not.toHaveFocus()
+  })
+
+  it('eventual success after repeated failures: the region is focused exactly then', async () => {
+    failures.v3d = true
+    render(<App />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry 3D network view' }))
+    await screen.findByRole('alert') // first retry failed again
+    failures.v3d = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry 3D network view' }))
+    await screen.findByTestId('view-3d')
     await waitFor(() => {
       expect(screen.getByRole('region', { name: '3D network view' })).toHaveFocus()
     })
@@ -240,5 +270,53 @@ describe('retry focus recovery (Package AK)', () => {
     fireEvent.click(button2d)
     await screen.findByTestId('view-2d')
     expect(button2d).toHaveFocus() // load completed without focus theft
+  })
+
+  it('a FIRST failure (no retry involved) steals no focus either', async () => {
+    render(<App />)
+    await screen.findByTestId('view-3d')
+    const button2d = screen.getByRole('button', { name: '2D View' })
+    button2d.focus()
+    failures.v2d = true
+    fireEvent.click(button2d)
+    await screen.findByRole('alert')
+    // The boundary self-focuses its button ONLY inside a retry cycle.
+    expect(button2d).toHaveFocus()
+  })
+})
+
+describe('focus-indicator decision and fallback styling contracts (source-level)', () => {
+  // The stylesheet is the single owner of these decisions; :focus-visible
+  // matching on programmatic focus is deliberately left to each UA (see
+  // the DECISION comment in index.css), so the testable contract is that
+  // we neither removed the indicator nor styled by role. Read from the
+  // vitest root (`?raw` is intercepted empty by vitest's CSS pipeline;
+  // vitest always runs at the frontend root via the npm scripts) and
+  // strip comments — the assertions target RULES, and the documentation
+  // comments deliberately name the rejected patterns.
+  const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8').replace(
+    /\/\*[\s\S]*?\*\//g,
+    '',
+  )
+
+  it('the tabIndex=-1 view region keeps the :focus-visible indicator (documented decision, not suppressed)', () => {
+    expect(css).toContain('[tabindex]:focus-visible')
+    expect(css).not.toMatch(/outline:\s*none/)
+  })
+
+  it('fallback styling binds to the explicit class, never the alert ROLE', () => {
+    expect(css).toContain('.view-error-fallback')
+    expect(css).toContain('.view-retry-button')
+    expect(css).not.toMatch(/\[role=["']?alert["']?\]/)
+  })
+
+  it('the static Retry dimensions live in CSS, and the button carries the class', async () => {
+    expect(css).toMatch(/\.view-retry-button\s*\{[^}]*min-width:\s*44px/)
+    expect(css).toMatch(/\.view-retry-button\s*\{[^}]*min-height:\s*44px/)
+    failures.v3d = true
+    render(<App />)
+    const retry = await screen.findByRole('button', { name: 'Retry 3D network view' })
+    expect(retry).toHaveClass('view-retry-button')
+    expect(retry.getAttribute('style')).toBeNull() // no inline dimensions remain
   })
 })

--- a/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForApplicationSocket } from './helpers/waitForApplicationSocket';
 
 // Package AK: responsive + keyboard contracts (issue #2 slice). Semantic
 // measurements only — scrollWidth/clientWidth, bounding boxes, focus and
@@ -51,19 +52,20 @@ async function setupPage(page: Page) {
   });
   await page.goto('/');
   await expect(page.locator('#root')).toBeVisible();
-  await page.waitForFunction(() =>
-    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
-      String(s.url).includes('/ws'),
-    ),
-  );
-  await page.evaluate(
-    () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))),
-  );
+  // Portability (Package AJ): the SHARED semantic gate — active
+  // application socket plus the paint/effect turn.
+  await waitForApplicationSocket(page);
 }
 
 const VIEWPORTS = [
   { name: 'phone-320', width: 320, height: 568 },
   { name: 'phone-390', width: 390, height: 844 },
+  // Short-landscape phones (Package AK amendment): stacked flow CANNOT
+  // fit these heights, so the scrolling-container contract carries the
+  // reachability proof below.
+  { name: 'landscape-667', width: 667, height: 375 },
+  { name: 'landscape-740', width: 740, height: 360 },
+  { name: 'landscape-844', width: 844, height: 390 },
   { name: 'tablet-768', width: 768, height: 1024 },
   { name: 'desktop', width: 1280, height: 800 },
 ];
@@ -102,6 +104,37 @@ for (const viewport of VIEWPORTS) {
     const region = page.getByRole('region');
     const regionBox = (await region.boundingBox())!;
     expect(regionBox.height, `${viewport.name} view height`).toBeGreaterThanOrEqual(200);
+
+    // Reachability by scrolling (Package AK amendment): below 768px the
+    // app container is the vertical scroller. Short-landscape viewports
+    // CANNOT fit the stacked flow, so there the container must actually
+    // overflow — and every shell piece plus the active view must be
+    // reachable by scrolling it.
+    if (viewport.width < 768) {
+      const container = page.locator('.app-container');
+      const scroll = await container.evaluate(el => ({
+        scrollable: el.scrollHeight > el.clientHeight,
+        overflowY: getComputedStyle(el).overflowY,
+      }));
+      expect(scroll.overflowY, `${viewport.name} container overflow-y`).toBe('auto');
+      if (viewport.height < 500) {
+        expect(scroll.scrollable, `${viewport.name} short viewport must scroll`).toBe(true);
+      }
+      const reachables = [
+        ['controls', button3d],
+        ['feed', page.getByRole('log', { name: 'Event feed' })],
+        ['badge', page.getByRole('status').and(page.locator('[aria-atomic="true"]'))],
+        ['active view', region],
+      ] as const;
+      for (const [label, target] of reachables) {
+        await target.scrollIntoViewIfNeeded();
+        const box = (await target.boundingBox())!;
+        expect(box.y, `${viewport.name} ${label} reachable (top above fold)`).toBeLessThan(
+          viewport.height,
+        );
+        expect(box.y + box.height, `${viewport.name} ${label} reachable (bottom on screen)`).toBeGreaterThan(0);
+      }
+    }
 
     // Both regions reachable: switch to 2D and back.
     await button2d.click();
@@ -164,4 +197,49 @@ test('keyboard-only journey: tab order, visible focus, Enter/Space activation, t
 
   // Exactly one live status region after all the switching.
   await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toHaveCount(1);
+});
+
+test('keyboard-only retry loop: every repeated failure restores focus to the new Retry button; the keyboard escape route stays live', async ({ page }) => {
+  await setupPage(page);
+  await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
+
+  // Force the 2D chunk import to fail at the network seam.
+  //
+  // MEASURED PLATFORM LIMIT (this runway, request-log receipt): after a
+  // network-failed dynamic import, Chromium's module map caches the
+  // rejection for that URL — a later import() of the SAME specifier
+  // re-rejects instantly with NO new network request, even after the
+  // route is repaired. So "eventual success after network repair" is
+  // not stageable end-to-end in Chromium without a reload; the
+  // success-side focus contract (region focused only after the child
+  // commit) is locked at the unit seam instead, where fresh factories
+  // give real fresh imports. What IS provable in every engine — and is
+  // the part a stranded keyboard user needs — is the failure loop and
+  // the escape route below.
+  await page.route('**/NetworkView2D*', route => route.abort());
+  await page.getByRole('button', { name: '2D View' }).click();
+  await expect(page.getByRole('alert')).toContainText('The 2D network view failed to render.');
+
+  // Keyboard-only activation (focus() stands in for tab navigation to
+  // keep the journey engine-stable; the activation itself is a real
+  // keyboard Enter). Each retry fails again: the old Retry unmounts and
+  // focus must be RESTORED to the new Retry button — the keyboard user
+  // stays in the retry loop, never dropped on <body>.
+  const retry = page.getByRole('button', { name: 'Retry 2D network view' });
+  await retry.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('alert')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry 2D network view' })).toBeFocused();
+
+  // Second loop iteration behaves identically (bounded, user-paced).
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('alert')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry 2D network view' })).toBeFocused();
+
+  // The escape route works by keyboard: the already-loaded 3D view is
+  // reachable and healthy; the failed slot never trapped focus.
+  await page.getByRole('button', { name: '3D View' }).focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
+  await expect(page.getByRole('alert')).toHaveCount(0);
 });

--- a/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Package AK: responsive + keyboard contracts (issue #2 slice). Semantic
+// measurements only — scrollWidth/clientWidth, bounding boxes, focus and
+// pressed state; no pixel comparisons.
+
+interface FakeSocketHarness {
+  url: string;
+  readyState: number;
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: ((ev: unknown) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  _open: () => void;
+  _message: (obj: unknown) => void;
+}
+type HarnessWindow = Window & typeof globalThis & { __fakeSockets: FakeSocketHarness[] };
+
+async function setupPage(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as HarnessWindow;
+    w.__fakeSockets = [];
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      url: string;
+      readyState = 0;
+      onopen: ((ev: unknown) => void) | null = null;
+      onmessage: ((ev: { data: string }) => void) | null = null;
+      onclose: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      constructor(url: string) {
+        this.url = url;
+        w.__fakeSockets.push(this);
+      }
+      send() {}
+      close() {
+        this.readyState = 3;
+      }
+      _open() {
+        this.readyState = 1;
+        if (this.onopen) this.onopen({});
+      }
+      _message(obj: unknown) {
+        if (this.onmessage) this.onmessage({ data: JSON.stringify(obj) });
+      }
+    }
+    w.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+  await page.waitForFunction(() =>
+    (window as unknown as { __fakeSockets: Array<{ url: string }> }).__fakeSockets.some(s =>
+      String(s.url).includes('/ws'),
+    ),
+  );
+  await page.evaluate(
+    () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+  );
+}
+
+const VIEWPORTS = [
+  { name: 'phone-320', width: 320, height: 568 },
+  { name: 'phone-390', width: 390, height: 844 },
+  { name: 'tablet-768', width: 768, height: 1024 },
+  { name: 'desktop', width: 1280, height: 800 },
+];
+
+for (const viewport of VIEWPORTS) {
+  test(`responsive contract at ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await setupPage(page);
+
+    // No horizontal page overflow.
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scrollWidth, `${viewport.name} h-overflow`).toBeLessThanOrEqual(
+      overflow.clientWidth,
+    );
+
+    // Shell pieces visible and reachable.
+    const button3d = page.getByRole('button', { name: '3D View' });
+    const button2d = page.getByRole('button', { name: '2D View' });
+    await expect(button3d).toBeVisible();
+    await expect(button2d).toBeVisible();
+    await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toBeVisible();
+    await expect(page.getByRole('log', { name: 'Event feed' })).toBeVisible();
+
+    // 44x44 CSS-pixel touch targets for the view controls.
+    for (const control of [button3d, button2d]) {
+      const box = (await control.boundingBox())!;
+      expect(box.width, `${viewport.name} target width`).toBeGreaterThanOrEqual(44);
+      expect(box.height, `${viewport.name} target height`).toBeGreaterThanOrEqual(44);
+    }
+
+    // The active view region keeps a useful minimum height, and the
+    // controls do not cover it (their boxes are disjoint on mobile flow).
+    const region = page.getByRole('region');
+    const regionBox = (await region.boundingBox())!;
+    expect(regionBox.height, `${viewport.name} view height`).toBeGreaterThanOrEqual(200);
+
+    // Both regions reachable: switch to 2D and back.
+    await button2d.click();
+    await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();
+    await button3d.click();
+    await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
+
+    // EventFeed stays bounded and scrollable under load.
+    await page.evaluate(() => {
+      const w = window as unknown as { __fakeSockets: Array<{ url: string; _open: () => void; _message: (o: unknown) => void }> };
+      const socks = w.__fakeSockets.filter(s => String(s.url).includes('/ws'));
+      const live = socks[socks.length - 1];
+      live._open();
+      for (let i = 0; i < 55; i++) {
+        live._message({ type: 'node_update', payload: { id: `n${i}`, seq: i } });
+      }
+    });
+    const log = page.getByRole('log', { name: 'Event feed' });
+    await expect(log.locator('[data-event-channel]')).toHaveCount(50);
+    const bounded = await log.evaluate(el => ({
+      scrollable: el.scrollHeight > el.clientHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(bounded.scrollable, `${viewport.name} feed scrollable`).toBe(true);
+    expect(bounded.clientHeight, `${viewport.name} feed bounded`).toBeLessThanOrEqual(
+      viewport.height,
+    );
+  });
+}
+
+test('keyboard-only journey: tab order, visible focus, Enter/Space activation, truthful aria-pressed', async ({ page, browserName }) => {
+  await setupPage(page);
+  const button2d = page.getByRole('button', { name: '2D View' });
+  const button3d = page.getByRole('button', { name: '3D View' });
+
+  // Reach the 2D control with the keyboard alone (WebKit needs Alt+Tab
+  // for button focus on some platforms; plain Tab works in headless).
+  await page.keyboard.press('Tab');
+  const first = await page.evaluate(() => document.activeElement?.textContent ?? '');
+  expect(first, `first tab stop (${browserName})`).toBe('2D View');
+
+  // Visible focus indicator: the focus-visible outline is non-none.
+  const outline = await button2d.evaluate(el => getComputedStyle(el).outlineStyle);
+  expect(outline).not.toBe('none');
+
+  // Enter activates; aria-pressed stays truthful.
+  await page.keyboard.press('Enter');
+  await expect(button2d).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();
+
+  // Space activates the next control (tab to 3D, Space).
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Space');
+  await expect(button3d).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
+
+  // Lazy loading never steals focus: focus stays where the user put it.
+  const focusedNow = await page.evaluate(() => document.activeElement?.textContent ?? '');
+  expect(focusedNow).toBe('3D View');
+
+  // Exactly one live status region after all the switching.
+  await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toHaveCount(1);
+});

--- a/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
+++ b/utilityfog_frontend/frontend/tests/simbridge-lifecycle.spec.ts
@@ -175,10 +175,11 @@ test('unexpected close emits disconnected and schedules exactly one reconnect', 
   });
   expect(await events(page)).toEqual(['connected', 'disconnected']);
 
-  // Exactly one replacement socket after the injected delay — and still
-  // exactly one after another full delay (at most one reconnect per close).
-  await page.waitForTimeout(AFTER_RECONNECT_MS);
-  expect(await socketCount(page)).toBe(2);
+  // Exactly one replacement socket after the injected delay — POLLED for
+  // arrival (fixed sleeps flaked under WebKit timer jitter; Package AJ/AK
+  // portability audit) — and still exactly one after another full delay
+  // (at most one reconnect per close).
+  await expect.poll(() => socketCount(page), { timeout: 2000 }).toBe(2);
   await page.waitForTimeout(AFTER_RECONNECT_MS);
   expect(await socketCount(page)).toBe(2);
 
@@ -233,7 +234,7 @@ test('late callbacks from an obsolete socket cannot affect the current connectio
     h.sockets()[0]._open();
     h.sockets()[0]._close(); // drop → reconnect scheduled
   });
-  await page.waitForTimeout(AFTER_RECONNECT_MS);
+  await expect.poll(() => socketCount(page), { timeout: 2000 }).toBe(2);
   await page.evaluate(() => (window as HarnessWindow).__h.sockets()[1]._open());
   const before = await events(page);
 


### PR DESCRIPTION
## PACKAGE AK — responsive and keyboard contracts (refs #2, partial progress — no closing keyword)

**Stacked: base `test/frontend-cross-browser-smoke` (AJ → AH → AG → main). Merge order AG → AH → AJ → AK.**

### Smallest-change implementation
Mobile (<768px): the absolute overlays become **stacked flow** — nothing covers the view or controls; desktop untouched · **44×44** minimums for view controls + Retry · engine-neutral `:focus-visible` outline · 240px view-slot minimum, feed capped 35vh (bounded + scrollable) · **predictable Retry focus recovery**: the successful Retry's own unmount dropped focus on `body` — the labelled region (tabIndex −1) now receives it, only on the user-initiated Retry path (ordinary lazy loading steals nothing — unit-proven).

### Tests
`responsive-a11y.spec.ts` (all three engines via AJ's matrix): 320/390/768/desktop — **no horizontal overflow** (scrollWidth ≤ clientWidth), shell/status/feed visible, **bounding-box-measured 44px targets**, view minimum height, both regions reachable, **feed bounded+scrollable under 55 events** · keyboard journey — first tab stop, **visible focus outline**, Enter/Space activation, truthful `aria-pressed`, **no focus theft during lazy load**, single settled live region. Plus deterministic jsdom focus units.

### Receipts
chromium **66/66** · webkit **66/66** · unit **273/273** · lint+liveness clean · firefox via the AJ CI matrix (documented machine hard-stop).

Opened unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment (Jack runway, 2026-07-12 evening) — head `4af6fb32`, rebased onto amended AJ `3786825e`

**Rebase equivalence**: patch-preserving EXCEPT two hunks that dropped out by design — the inline readiness gates this branch had added to `node-update-resilience` and `connection-status-a11y` are superseded by AJ's shared `waitForApplicationSocket` helper (conflict resolved to the helper; everything else, incl. the lifecycle poll-for-arrival de-flake, applies unchanged).

**Mobile layout**: `.app-container` scrolls vertically below 768px (desktop overlays untouched). View-region layout moved from inline styles to the `.view-region` class contract — desktop `min-height: 0`, mobile a 240px floor. The replaced inline `min-height: 0` had been silently defeating the stylesheet floor (inline always outranks the media query) — exactly the flagged conflict. Matrix extended with short-landscape 667×375 / 740×360 / 844×390: the spec proves the container actually scrolls there and that controls, feed, badge and the active view are each REACHABLE by scrolling; no horizontal overflow across all 7 viewports.

**Success-aware retry focus**: clicking Retry focuses nothing by itself. `ViewErrorBoundary` owns the outcome: `onRecovered` fires exactly once when a user Retry is followed by a successful child commit (commit probe inside the boundary-owned Suspense reveal) → App focuses the labelled region only then. A retry that fails again RESTORES focus to the NEW Retry button (**failing-first receipt**: under the old rAF-region-focus implementation the new button did not receive focus). First failures and ordinary lazy loads steal nothing. Unit: repeated failure / eventual success / no-theft ×2; E2E keyboard-only loop ×2 iterations + live escape route.

**MEASURED PLATFORM LIMIT** (request-log receipt, documented in the spec): after a network-failed dynamic import, Chromium's module map caches the rejection — a later `import()` of the same specifier re-rejects with NO new network request even after the network is repaired. "Eventual success after network repair" is therefore locked at the unit seam (fresh factories = real fresh imports), not staged E2E.

**Styling**: Retry dimensions in CSS (`.view-retry-button`), fallback styled by explicit `.view-error-fallback` (never `[role="alert"]`). **Documented decision** (+ source-contract tests): the programmatically focused `tabIndex=-1` region KEEPS the `:focus-visible` rule — the UA heuristic decides per interaction; we neither suppress the outline nor force an always-on ring.

Battery at `4af6fb32`: lint 0 · tsc 0 · 287/287 unit · UNIT_COVERAGE PASS · chromium 65/65 · webkit 65/65 · build ✓ · BUNDLE_BUDGET v2 PASS (entry 156,070/50,437; both async maxima named).

**Amendment 2** — head is now `9ff56825`: (1) `RecoveryProbe` extracted to its own module — the overlay lab caught `react-refresh/only-export-components` flagging the in-file component under AI's ESLint 9 flat config (ESLint 8 on this branch does not surface it); behavior identical, boundary file exports only the boundary. (2) Rebased patch-preservingly onto amended AJ `2add13d7` (diff-of-diffs identical).