### PR TITLE
feat: WebGL capability fallback — accessible 2D recovery for the 3D view (PACKAGE AL)

### DIFF
--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
 import ViewErrorBoundary from './components/ViewErrorBoundary'
 import { SimBridgeClient } from './ws/SimBridgeClient'
+import { probeWebGLSupport } from './viz3d/webglSupport'
 
 // LAZY VIEW DELIVERY (Package AG): the heavy 3D/2D view modules are
 // code-split behind dynamic imports — the shell (controls, badge, feed)
@@ -67,6 +68,21 @@ function App() {
     viewRegionRef.current?.focus()
   }
 
+  // WebGL capability gate (Package AL): probed BEFORE the heavy 3D
+  // renderer mounts (and before its chunk is even fetched). null = not
+  // yet probed; probing happens at most once per 3D entry — the result
+  // is held in state, so switching views or rerendering NEVER re-probes
+  // (no probe loop, no log spam). The ONLY re-probe path is the explicit
+  // user-paced button in the fallback below. A successful probe does not
+  // guarantee Three.js will render — runtime renderer failures still
+  // belong to ViewErrorBoundary.
+  const [webglSupport, setWebglSupport] = useState<boolean | null>(null)
+  useEffect(() => {
+    if (view === '3d' && webglSupport === null) {
+      setWebglSupport(probeWebGLSupport())
+    }
+  }, [view, webglSupport])
+
   useEffect(() => {
     const client = new SimBridgeClient(WS_URL)
     
@@ -117,21 +133,48 @@ function App() {
           aria-label="3D network view"
           className="view-region"
         >
-          <ViewErrorBoundary
-            viewLabel="3D network view"
-            onRetry={() => setLazy3D(() => lazy(load3D))}
-            onRecovered={focusViewRegion}
-            suspenseFallback={
-              /* The transient loading status is scoped inside the active
-                 region; steady-state keeps the badge as the only status
-                 region. */
-              <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
-                Loading 3D network view…
-              </div>
-            }
-          >
-            <Lazy3D simClient={simClient} />
-          </ViewErrorBoundary>
+          {/* The capability gate replaces the renderer INSIDE the region:
+              shell, connection, feed and controls live above and stay
+              untouched, and no additional SimBridge connection exists on
+              this path. */}
+          {webglSupport === false ? (
+            <div className="webgl-fallback">
+              <p>
+                The 3D network view is unavailable: this browser or device
+                has no usable WebGL support.
+              </p>
+              <button
+                type="button"
+                className="webgl-use-2d-button"
+                onClick={() => selectView('2d')}
+              >
+                Use 2D view
+              </button>
+              <button
+                type="button"
+                className="webgl-reprobe-button"
+                onClick={() => setWebglSupport(probeWebGLSupport())}
+              >
+                Check 3D support again
+              </button>
+            </div>
+          ) : webglSupport === true ? (
+            <ViewErrorBoundary
+              viewLabel="3D network view"
+              onRetry={() => setLazy3D(() => lazy(load3D))}
+              onRecovered={focusViewRegion}
+              suspenseFallback={
+                /* The transient loading status is scoped inside the active
+                   region; steady-state keeps the badge as the only status
+                   region. */
+                <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
+                  Loading 3D network view…
+                </div>
+              }
+            >
+              <Lazy3D simClient={simClient} />
+            </ViewErrorBoundary>
+          ) : null /* probe pending: resolved by the effect within the same tick */}
         </section>
       ) : (
         <section

--- a/utilityfog_frontend/frontend/src/App.tsx
+++ b/utilityfog_frontend/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { useState, useEffect, useRef, lazy } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, lazy } from 'react'
 import ConnectionBadge from './components/ConnectionBadge'
 import EventFeed from './components/EventFeed'
 import ViewErrorBoundary from './components/ViewErrorBoundary'
@@ -76,12 +76,23 @@ function App() {
   // user-paced button in the fallback below. A successful probe does not
   // guarantee Three.js will render — runtime renderer failures still
   // belong to ViewErrorBoundary.
+  //
+  // useLayoutEffect (amendment): the probe resolves commit-synchronously,
+  // BEFORE the browser paints — the 3D region never paints an empty
+  // pending frame while a passive effect waits to run.
   const [webglSupport, setWebglSupport] = useState<boolean | null>(null)
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (view === '3d' && webglSupport === null) {
       setWebglSupport(probeWebGLSupport())
     }
   }, [view, webglSupport])
+
+  // Injected reload seam (Package AL amendment): the boundary presents
+  // "Reload application" for chunk-load failures and calls back through
+  // this — the boundary itself never touches a global.
+  const requestReload = () => {
+    window.location.reload()
+  }
 
   useEffect(() => {
     const client = new SimBridgeClient(WS_URL)
@@ -163,6 +174,7 @@ function App() {
               viewLabel="3D network view"
               onRetry={() => setLazy3D(() => lazy(load3D))}
               onRecovered={focusViewRegion}
+              onReloadRequest={requestReload}
               suspenseFallback={
                 /* The transient loading status is scoped inside the active
                    region; steady-state keeps the badge as the only status
@@ -189,6 +201,7 @@ function App() {
             viewLabel="2D network view"
             onRetry={() => setLazy2D(() => lazy(load2D))}
             onRecovered={focusViewRegion}
+            onReloadRequest={requestReload}
             suspenseFallback={
               <div role="status" style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'white' }}>
                 Loading 2D network view…

--- a/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
+++ b/utilityfog_frontend/frontend/src/components/ViewErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, Suspense, createRef } from 'react'
 import type { ErrorInfo, ReactNode } from 'react'
 import RecoveryProbe from './RecoveryProbe'
+import { isChunkLoadError } from './chunkLoadError'
 
 // Narrow error boundary for the REPLACEABLE 2D/3D view surface only — the
 // application shell (controls, event feed, connection badge) deliberately
@@ -13,71 +14,88 @@ import RecoveryProbe from './RecoveryProbe'
 //    unless `suspenseFallback` is provided, in which case the boundary
 //    also owns the pending surface (children render inside Suspense with
 //    a commit probe reporting the reveal).
-//  - On failure: an accessible role="alert" fallback with a concise
-//    message and a Retry button that remounts ONLY the failed view.
-//  - Retry is user-initiated only — no automatic retry loop, no hidden
-//    reconnect (the SimBridge client lives above this boundary and is
-//    untouched by view failures).
+//  - On failure the boundary CLASSIFIES the error (Package AL amendment):
+//    - RENDER failures get an accessible role="alert" fallback with a
+//      concise message and a user-paced Retry button that remounts ONLY
+//      the failed view.
+//    - CHUNK-LOAD failures (dynamic-import/network forms — see
+//      ./chunkLoadError) get a "Reload application" action instead:
+//      Chromium's module map caches a failed import URL, so a fresh
+//      lazy wrapper cannot recover it and a Retry button would be a
+//      false promise. The reload goes through the INJECTED
+//      onReloadRequest callback (no hardwired global), no recovery is
+//      guaranteed or claimed, and the same cached module URL is never
+//      re-imported. If no onReloadRequest is provided, the boundary
+//      falls back to the Retry presentation (legacy owners keep their
+//      old behavior).
+//  - Both actions are user-initiated only — no automatic retry loop, no
+//    hidden reconnect (the SimBridge client lives above this boundary
+//    and is untouched by view failures).
 //  - Switching views unmounts this boundary instance, so the replacement
 //    view always starts with a fresh, un-failed boundary.
 //  - Errors are not swallowed: each failure is reported exactly once
 //    through the established bounded diagnostic channel (console.error),
 //    alongside React's own development error output.
 //
-// Focus contract (Package AK amendment, success-aware):
-//  - Clicking Retry moves focus NOWHERE by itself. The old Retry button
-//    unmounts, and where focus lands next depends on the OUTCOME:
-//  - SUCCESS — the retried children COMMIT (in suspenseFallback mode:
-//    the suspense reveal, observed by the commit probe): `onRecovered`
-//    fires exactly once, and the owner moves focus (App focuses the
-//    labelled view region).
-//  - REPEATED FAILURE — the boundary catches again: focus is restored to
-//    the NEW Retry button, keeping a keyboard user inside the retry loop
-//    instead of dropping them on <body>.
+// Focus contract (success-aware, extended for chunk failures):
+//  - Clicking Retry moves focus NOWHERE by itself. Outcomes:
+//  - SUCCESS — the retried children COMMIT (suspense reveal observed by
+//    the commit probe): `onRecovered` fires exactly once and the owner
+//    moves focus (App focuses the labelled view region).
+//  - REPEATED FAILURE — the boundary catches again and focus is restored
+//    to the fresh fallback's action button: the new Retry for a render
+//    failure, or the Reload action when the retry outcome was a
+//    chunk-load failure. The keyboard user is never dropped on <body>.
 //  - A FIRST failure (no retry in flight) moves focus nowhere — the
 //    boundary self-focuses only inside a user-initiated retry cycle, so
 //    ordinary loads and first failures steal nothing.
-
-// The commit probe lives in ./RecoveryProbe — see its header.
 
 interface ViewErrorBoundaryProps {
   // Names the guarded surface in the fallback message ("3D network view").
   viewLabel: string
   // Invoked when the user clicks Retry, BEFORE the boundary clears its
   // failed state — the owner can mint fresh lazy-loaded children so a
-  // cached chunk-load rejection is retried (Package AG).
+  // cached render-failure rejection is retried (Package AG).
   onRetry?: () => void
   // Success-aware recovery callback (Package AK): invoked exactly once
   // when a user-initiated Retry is followed by a successful child commit.
   // Never invoked for ordinary first loads.
   onRecovered?: () => void
+  // Injected reload seam (Package AL): invoked when the user activates
+  // "Reload application" on a chunk-load failure. The owner decides what
+  // reloading means (App passes window.location.reload) — the boundary
+  // never touches a global, which keeps this path unit-testable.
+  onReloadRequest?: () => void
   // When provided, the boundary owns the pending surface: children render
   // inside <Suspense fallback={suspenseFallback}> with the commit probe.
-  // When absent, children render unwrapped (owners with their own
-  // Suspense keep exactly the old behavior; onRecovered stays silent).
   suspenseFallback?: ReactNode
   children: ReactNode
 }
 
+type FailureKind = 'render' | 'chunk-load'
+
 interface ViewErrorBoundaryState {
   failed: boolean
+  failureKind: FailureKind | null
 }
 
 export default class ViewErrorBoundary extends Component<
   ViewErrorBoundaryProps,
   ViewErrorBoundaryState
 > {
-  state: ViewErrorBoundaryState = { failed: false }
+  state: ViewErrorBoundaryState = { failed: false, failureKind: null }
 
   // True from a Retry click until its outcome (success commit or repeated
   // failure) is known. An instance field, not state: it must never cause
   // a render of its own.
   private retryPending = false
 
-  private retryButtonRef = createRef<HTMLButtonElement>()
+  // The fresh fallback's action button — Retry or Reload, whichever the
+  // classification rendered — for the repeated-failure focus restore.
+  private actionButtonRef = createRef<HTMLButtonElement>()
 
-  static getDerivedStateFromError(): Partial<ViewErrorBoundaryState> {
-    return { failed: true }
+  static getDerivedStateFromError(error: unknown): Partial<ViewErrorBoundaryState> {
+    return { failed: true, failureKind: isChunkLoadError(error) ? 'chunk-load' : 'render' }
   }
 
   componentDidCatch(error: unknown, info: ErrorInfo): void {
@@ -87,20 +105,27 @@ export default class ViewErrorBoundary extends Component<
     console.error('View render failed:', error, info.componentStack)
   }
 
-  componentDidUpdate(_prevProps: ViewErrorBoundaryProps, prevState: ViewErrorBoundaryState): void {
+  componentDidUpdate(): void {
     // A failure that lands while a retry is in flight is a REPEATED
-    // failure: the fresh fallback has committed, so its new Retry button
-    // exists — restore keyboard focus there and close the cycle.
-    if (this.state.failed && !prevState.failed && this.retryPending) {
+    // failure: the fresh fallback has committed, so its action button
+    // (Retry or Reload per classification) exists — restore keyboard
+    // focus there and close the cycle. Guarded by the retry flag, NOT a
+    // failed:false→true state transition: a synchronously-throwing child
+    // fails during the retry's own render pass, so the intermediate
+    // healthy tree never commits and no transition is observable. The
+    // flag cannot false-positive — failed can only be true again once an
+    // outcome (a catch) exists, and success clears the flag in the
+    // commit probe instead.
+    if (this.state.failed && this.retryPending) {
       this.retryPending = false
-      this.retryButtonRef.current?.focus()
+      this.actionButtonRef.current?.focus()
     }
   }
 
   handleRetry = (): void => {
     this.retryPending = true
     this.props.onRetry?.()
-    this.setState({ failed: false })
+    this.setState({ failed: false, failureKind: null })
   }
 
   handleChildCommit = (): void => {
@@ -114,13 +139,35 @@ export default class ViewErrorBoundary extends Component<
 
   render(): ReactNode {
     if (this.state.failed) {
+      const chunkPath =
+        this.state.failureKind === 'chunk-load' && this.props.onReloadRequest !== undefined
+      if (chunkPath) {
+        return (
+          <div role="alert" className="view-error-fallback">
+            <p>
+              Part of the application failed to download, so the{' '}
+              {this.props.viewLabel} cannot be shown. Retrying the same
+              download cannot recover it in this browser session — reloading
+              the application may help.
+            </p>
+            <button
+              type="button"
+              className="view-reload-button"
+              ref={this.actionButtonRef}
+              onClick={this.props.onReloadRequest}
+            >
+              Reload application
+            </button>
+          </div>
+        )
+      }
       return (
         <div role="alert" className="view-error-fallback">
           <p>The {this.props.viewLabel} failed to render.</p>
           <button
             type="button"
             className="view-retry-button"
-            ref={this.retryButtonRef}
+            ref={this.actionButtonRef}
             onClick={this.handleRetry}
           >
             Retry {this.props.viewLabel}

--- a/utilityfog_frontend/frontend/src/components/chunkLoadError.ts
+++ b/utilityfog_frontend/frontend/src/components/chunkLoadError.ts
@@ -1,0 +1,25 @@
+// Package AL (amendment): chunk-load-error classifier.
+//
+// MEASURED PLATFORM LIMIT (request-log receipt on #345): after a
+// network-failed dynamic import, Chromium's module map caches the
+// rejection for that URL — a later import() of the SAME specifier
+// re-rejects instantly with no new network request. A fresh React.lazy
+// wrapper therefore cannot recover such a failure, and advertising a
+// Retry action for it would be a false promise. The boundary uses this
+// classifier to offer "Reload application" instead.
+//
+// The patterns are the ACTUAL dynamic-import failure message forms of
+// the three engines in the test matrix — deliberately narrow so that
+// ordinary render errors (including a bare fetch()'s "Failed to fetch")
+// are never misclassified:
+//  - Chromium: TypeError: Failed to fetch dynamically imported module: <url>
+//  - Firefox:  TypeError: error loading dynamically imported module: <url>
+//  - WebKit:   TypeError: Importing a module script failed.
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return (
+    /Failed to fetch dynamically imported module/i.test(error.message) ||
+    /error loading dynamically imported module/i.test(error.message) ||
+    /Importing a module script failed/i.test(error.message)
+  )
+}

--- a/utilityfog_frontend/frontend/src/index.css
+++ b/utilityfog_frontend/frontend/src/index.css
@@ -139,7 +139,8 @@ input:focus-visible,
   margin: 0;
 }
 
-.view-retry-button {
+.view-retry-button,
+.view-reload-button {
   min-width: 44px;
   min-height: 44px;
 }

--- a/utilityfog_frontend/frontend/src/index.css
+++ b/utilityfog_frontend/frontend/src/index.css
@@ -144,6 +144,33 @@ input:focus-visible,
   min-height: 44px;
 }
 
+/* WebGL capability fallback (Package AL): rendered inside the 3D view
+   region when the probe finds no usable WebGL. Same explicit-class
+   discipline as the boundary fallback; both action buttons meet the
+   44x44 CSS-pixel touch-target floor. */
+.webgl-fallback {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: white;
+  background-color: #1a1a1a;
+  text-align: center;
+  padding: 0 16px;
+}
+
+.webgl-fallback p {
+  margin: 0;
+}
+
+.webgl-use-2d-button,
+.webgl-reprobe-button {
+  min-width: 44px;
+  min-height: 44px;
+}
+
 @media (max-width: 767px) {
   /* Stacked flow can exceed a short viewport (landscape phones):
      the app container itself scrolls vertically; desktop overlays

--- a/utilityfog_frontend/frontend/src/viz3d/webglSupport.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/webglSupport.ts
@@ -7,6 +7,9 @@
 // fetching its chunk.
 //
 // Contract:
+//  - Probes the renderer's own context set, in the renderer's preference
+//    order: webgl2, then webgl, then experimental-webgl (the prefixed id
+//    older engines expose; Three.js accepts a context of that kind too).
 //  - NEVER throws: any hostile/broken canvas API reads as "unsupported".
 //  - Does not retain the probe canvas or context: the context is
 //    explicitly released where the platform provides WEBGL_lose_context,
@@ -16,13 +19,28 @@
 //    guarantee the Three.js renderer will initialize or render (driver
 //    blacklists, context-loss at mount time and renderer failures remain
 //    possible; those still belong to ViewErrorBoundary).
+
+// experimental-webgl resolves through the string overload of getContext,
+// which is typed as the broad RenderingContext union — narrow structurally
+// (a WebGL context of any vintage exposes getExtension) instead of
+// asserting a concrete class.
+function isReleasableWebGLContext(
+  ctx: NonNullable<ReturnType<HTMLCanvasElement['getContext']>>,
+): ctx is WebGLRenderingContext | WebGL2RenderingContext {
+  return typeof (ctx as { getExtension?: unknown }).getExtension === 'function'
+}
+
 export function probeWebGLSupport(): boolean {
   try {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl')
+    const gl =
+      canvas.getContext('webgl2') ??
+      canvas.getContext('webgl') ??
+      canvas.getContext('experimental-webgl')
     if (!gl) return false
-    const lose = (gl as WebGLRenderingContext).getExtension('WEBGL_lose_context')
-    lose?.loseContext()
+    if (isReleasableWebGLContext(gl)) {
+      gl.getExtension('WEBGL_lose_context')?.loseContext()
+    }
     return true
   } catch {
     return false

--- a/utilityfog_frontend/frontend/src/viz3d/webglSupport.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/webglSupport.ts
@@ -1,0 +1,30 @@
+// Package AL: narrow WebGL capability probe for the 3D view.
+//
+// A browser/device without usable WebGL previously hit the raw
+// canvas/context failure inside the heavy renderer (the CI Firefox
+// headless run died with "Error creating WebGL context"). The probe lets
+// the application decide BEFORE mounting the renderer — and before even
+// fetching its chunk.
+//
+// Contract:
+//  - NEVER throws: any hostile/broken canvas API reads as "unsupported".
+//  - Does not retain the probe canvas or context: the context is
+//    explicitly released where the platform provides WEBGL_lose_context,
+//    and every reference is dropped either way (the detached canvas is
+//    garbage once this returns).
+//  - A successful probe means a context could be CREATED — it does NOT
+//    guarantee the Three.js renderer will initialize or render (driver
+//    blacklists, context-loss at mount time and renderer failures remain
+//    possible; those still belong to ViewErrorBoundary).
+export function probeWebGLSupport(): boolean {
+  try {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl')
+    if (!gl) return false
+    const lose = (gl as WebGLRenderingContext).getExtension('WEBGL_lose_context')
+    lose?.loseContext()
+    return true
+  } catch {
+    return false
+  }
+}

--- a/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/app-view-switching.test.tsx
@@ -17,6 +17,11 @@ vi.mock('../src/components/NetworkView2D', () => ({
   default: () => <div data-testid="view-2d" />,
 }))
 
+// Package AL: jsdom has no WebGL, so the capability gate would fail
+// closed and block the mocked 3D view. These suites test view
+// lifecycle, not capability - the probe is pinned supported here.
+vi.mock('../src/viz3d/webglSupport', () => ({ probeWebGLSupport: () => true }))
+
 class FakeWebSocket {
   static CONNECTING = 0
   static OPEN = 1

--- a/utilityfog_frontend/frontend/tests-unit/chunk-load-recovery.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/chunk-load-recovery.test.tsx
@@ -1,0 +1,149 @@
+// Package AL (amendment): chunk-load failure classification and the
+// Reload recovery path. The classifier is tested at its seam against the
+// MEASURED engine message forms; the boundary is driven directly with a
+// controllable failing child, an injected reload callback and real focus.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { isChunkLoadError } from '../src/components/chunkLoadError'
+import ViewErrorBoundary from '../src/components/ViewErrorBoundary'
+
+describe('isChunkLoadError classifier', () => {
+  it.each([
+    [
+      'Chromium',
+      new TypeError(
+        'Failed to fetch dynamically imported module: http://localhost:4173/src/components/NetworkView2D.tsx',
+      ),
+    ],
+    ['Firefox', new TypeError('error loading dynamically imported module: http://x/NetworkView2D.js')],
+    ['WebKit', new TypeError('Importing a module script failed.')],
+  ])('classifies the %s dynamic-import failure form', (_engine, error) => {
+    expect(isChunkLoadError(error)).toBe(true)
+  })
+
+  it.each([
+    ['a bare fetch() network error', new TypeError('Failed to fetch')],
+    ['an ordinary render error', new Error('Cannot read properties of undefined')],
+    ['a synthetic view failure', new Error('synthetic 3D render failure')],
+    ['a harness rejection', new Error('chunk load failed')],
+    ['an import-adjacent but different message', new Error('module evaluation failed')],
+  ])('does NOT misclassify %s (false-positive guard)', (_label, error) => {
+    expect(isChunkLoadError(error)).toBe(false)
+  })
+
+  it.each([
+    ['a string', 'Failed to fetch dynamically imported module: x'],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object with a message field', { message: 'Importing a module script failed.' }],
+  ])('rejects non-Error values: %s', (_label, value) => {
+    expect(isChunkLoadError(value)).toBe(false)
+  })
+})
+
+// Direct boundary harness: a child whose failure MODE is controllable.
+// The REAL Chromium message form is thrown here. React dev re-reports
+// boundary-caught errors on the window error channel, and vitest sniffs
+// exactly these engine messages as its OWN module-import failures
+// (aborting collection) — so the hooks below mark the window event
+// handled (preventDefault), the standard error-boundary test recipe.
+const CHUNK_ERROR = new TypeError(
+  'Failed to fetch dynamically imported module: http://localhost:4173/src/x.tsx',
+)
+const mode: { current: 'ok' | 'render-fail' | 'chunk-fail' } = { current: 'ok' }
+function Failing() {
+  if (mode.current === 'render-fail') throw new Error('ordinary render failure')
+  if (mode.current === 'chunk-fail') throw CHUNK_ERROR
+  return <div data-testid="healthy-child" />
+}
+
+function Harness({ onReload, onRetry }: { onReload?: () => void; onRetry?: () => void }) {
+  const [nonce, setNonce] = useState(0)
+  return (
+    <ViewErrorBoundary
+      viewLabel="test view"
+      onRetry={() => {
+        onRetry?.()
+        setNonce(n => n + 1)
+      }}
+      onReloadRequest={onReload}
+      suspenseFallback={<div role="status">Loading…</div>}
+    >
+      <Failing key={nonce} />
+    </ViewErrorBoundary>
+  )
+}
+
+const swallowWindowError = (e: ErrorEvent) => e.preventDefault()
+
+beforeEach(() => {
+  mode.current = 'ok'
+  window.addEventListener('error', swallowWindowError)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  window.removeEventListener('error', swallowWindowError)
+  vi.restoreAllMocks()
+})
+
+describe('ViewErrorBoundary chunk-load recovery', () => {
+  it('a chunk-load failure presents Reload application — and does NOT advertise Retry', async () => {
+    mode.current = 'chunk-fail'
+    render(<Harness onReload={() => {}} />)
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('failed to download')
+    expect(alert).toHaveTextContent('Retrying the same download cannot recover it')
+    const reload = screen.getByRole('button', { name: 'Reload application' })
+    expect(reload).toHaveClass('view-reload-button') // 44x44 floor lives in CSS
+    expect(screen.queryByRole('button', { name: /Retry/ })).not.toBeInTheDocument()
+  })
+
+  it('Reload invokes the INJECTED callback exactly once — no hardwired global', async () => {
+    const onReload = vi.fn()
+    mode.current = 'chunk-fail'
+    render(<Harness onReload={onReload} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Reload application' }))
+    expect(onReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('an ordinary render failure keeps the user-paced Retry path (kind is per-error)', async () => {
+    mode.current = 'render-fail'
+    render(<Harness onReload={() => {}} />)
+    expect(await screen.findByRole('button', { name: 'Retry test view' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reload application' })).not.toBeInTheDocument()
+    mode.current = 'ok'
+    fireEvent.click(screen.getByRole('button', { name: 'Retry test view' }))
+    expect(await screen.findByTestId('healthy-child')).toBeInTheDocument()
+  })
+
+  it('a Retry whose outcome is a CHUNK failure focuses the Reload action (cycle closes there)', async () => {
+    mode.current = 'render-fail'
+    render(<Harness onReload={() => {}} />)
+    const retry = await screen.findByRole('button', { name: 'Retry test view' })
+    retry.focus()
+    mode.current = 'chunk-fail' // the fresh import attempt hits the cached-URL failure
+    fireEvent.click(retry)
+    const reload = await screen.findByRole('button', { name: 'Reload application' })
+    expect(reload).toHaveFocus()
+  })
+
+  it('a FIRST chunk failure steals no focus (self-focus only inside a retry cycle)', async () => {
+    mode.current = 'chunk-fail'
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    outside.focus()
+    render(<Harness onReload={() => {}} />)
+    await screen.findByRole('button', { name: 'Reload application' })
+    expect(outside).toHaveFocus()
+    outside.remove()
+  })
+
+  it('without an injected reload callback the boundary falls back to Retry (legacy owners)', async () => {
+    mode.current = 'chunk-fail'
+    render(<Harness />)
+    expect(await screen.findByRole('button', { name: 'Retry test view' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reload application' })).not.toBeInTheDocument()
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/lazy-view-delivery.test.tsx
@@ -21,6 +21,11 @@ vi.mock('../src/components/NetworkView2D', () => ({
   default: () => <div data-testid="view-2d" />,
 }))
 
+// Package AL: jsdom has no WebGL, so the capability gate would fail
+// closed and block the mocked 3D view. These suites test view
+// lifecycle, not capability - the probe is pinned supported here.
+vi.mock('../src/viz3d/webglSupport', () => ({ probeWebGLSupport: () => true }))
+
 class FakeWebSocket {
   static CONNECTING = 0
   static OPEN = 1

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -26,6 +26,11 @@ vi.mock('../src/components/NetworkView2D', () => ({
   },
 }))
 
+// Package AL: jsdom has no WebGL, so the capability gate would fail
+// closed and block the mocked 3D view. These suites test view
+// lifecycle, not capability - the probe is pinned supported here.
+vi.mock('../src/viz3d/webglSupport', () => ({ probeWebGLSupport: () => true }))
+
 class FakeWebSocket {
   static CONNECTING = 0
   static OPEN = 1

--- a/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/view-error-containment.test.tsx
@@ -11,10 +11,11 @@ import { StrictMode } from 'react'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import App from '../src/App'
 
-const failures = { v3d: false, v2d: false }
+const failures = { v3d: false, v2d: false, v3dError: null as Error | null }
 
 vi.mock('../src/viz3d/NetworkView3D', () => ({
   default: () => {
+    if (failures.v3dError) throw failures.v3dError
     if (failures.v3d) throw new Error('synthetic 3D render failure')
     return <div data-testid="view-3d" />
   },
@@ -71,6 +72,7 @@ const reportCount = () => boundaryReports().length
 beforeEach(() => {
   failures.v3d = false
   failures.v2d = false
+  failures.v3dError = null
   vi.stubGlobal('WebSocket', FakeWebSocket)
   FakeWebSocket.instances = []
   vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -290,6 +292,42 @@ describe('retry focus recovery (Package AK, success-aware amendment)', () => {
   })
 })
 
+
+describe('chunk-load failure recovery at the App seam (Package AL amendment)', () => {
+  const chunkError = () =>
+    new TypeError('Failed to fetch dynamically imported module: http://localhost:4173/x.tsx')
+
+  // vitest sniffs the engine import-failure messages as its OWN module
+  // failures when React dev re-reports them on the window channel — mark
+  // them handled for this describe (see chunk-load-recovery.test.tsx).
+  const swallowWindowError = (e: ErrorEvent) => e.preventDefault()
+  beforeEach(() => window.addEventListener('error', swallowWindowError))
+  afterEach(() => window.removeEventListener('error', swallowWindowError))
+
+  it('a chunk-shaped failure presents Reload application, advertises NO Retry, and the shell survives', async () => {
+    failures.v3dError = chunkError()
+    render(<App />)
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('failed to download')
+    expect(screen.getByRole('button', { name: 'Reload application' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Retry/ })).not.toBeInTheDocument()
+    shellAlive()
+  })
+
+  it('switch-away/back: the healthy view works, the fresh boundary re-classifies, one socket throughout', async () => {
+    failures.v3dError = chunkError()
+    render(<App />)
+    await screen.findByRole('button', { name: 'Reload application' })
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    expect(await screen.findByRole('button', { name: 'Reload application' })).toBeInTheDocument()
+    shellAlive()
+    expect(FakeWebSocket.instances).toHaveLength(1) // no hidden reconnect
+  })
+})
+
 describe('focus-indicator decision and fallback styling contracts (source-level)', () => {
   // The stylesheet is the single owner of these decisions; :focus-visible
   // matching on programmatic focus is deliberately left to each UA (see
@@ -316,8 +354,8 @@ describe('focus-indicator decision and fallback styling contracts (source-level)
   })
 
   it('the static Retry dimensions live in CSS, and the button carries the class', async () => {
-    expect(css).toMatch(/\.view-retry-button\s*\{[^}]*min-width:\s*44px/)
-    expect(css).toMatch(/\.view-retry-button\s*\{[^}]*min-height:\s*44px/)
+    expect(css).toMatch(/\.view-retry-button[^{]*\{[^}]*min-width:\s*44px/)
+    expect(css).toMatch(/\.view-retry-button[^{]*\{[^}]*min-height:\s*44px/)
     failures.v3d = true
     render(<App />)
     const retry = await screen.findByRole('button', { name: 'Retry 3D network view' })

--- a/utilityfog_frontend/frontend/tests-unit/webgl-gate.test.tsx
+++ b/utilityfog_frontend/frontend/tests-unit/webgl-gate.test.tsx
@@ -1,0 +1,123 @@
+// Package AL: the App-level WebGL capability gate. The probe module is
+// mocked at its seam (controllable result + call counter); the views are
+// mocked like the containment suite so the REAL App, gate, boundary and
+// region structure are exercised.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../src/App'
+
+const probe = { result: false, calls: 0 }
+
+vi.mock('../src/viz3d/webglSupport', () => ({
+  probeWebGLSupport: () => {
+    probe.calls++
+    return probe.result
+  },
+}))
+
+vi.mock('../src/viz3d/NetworkView3D', () => ({
+  default: () => <div data-testid="view-3d" />,
+}))
+vi.mock('../src/components/NetworkView2D', () => ({
+  default: () => <div data-testid="view-2d" />,
+}))
+
+class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: FakeWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+  send() {}
+  close() {
+    this.readyState = 3
+  }
+}
+
+beforeEach(() => {
+  probe.result = false
+  probe.calls = 0
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  FakeWebSocket.instances = []
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  FakeWebSocket.instances = []
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('WebGL capability gate', () => {
+  it('unsupported: an accessible message and a Use 2D view button render INSIDE the 3D region; the renderer never mounts', async () => {
+    render(<App />)
+    const region = screen.getByRole('region', { name: '3D network view' })
+    expect(region).toHaveTextContent('no usable WebGL support')
+    const use2d = screen.getByRole('button', { name: 'Use 2D view' })
+    expect(use2d).toHaveClass('webgl-use-2d-button') // 44x44 floor lives in CSS
+    expect(screen.queryByTestId('view-3d')).not.toBeInTheDocument()
+    // Shell alive: controls, badge, feed.
+    expect(screen.getByRole('button', { name: '2D View' })).toBeInTheDocument()
+    expect(screen.getAllByRole('status')).toHaveLength(1)
+    expect(screen.getAllByRole('log')).toHaveLength(1)
+  })
+
+  it('unsupported: exactly ONE probe — rerenders and view switches never re-probe (no loop, no spam)', async () => {
+    render(<App />)
+    screen.getByRole('button', { name: 'Use 2D view' })
+    expect(probe.calls).toBe(1)
+    fireEvent.click(screen.getByRole('button', { name: '2D View' }))
+    await screen.findByTestId('view-2d')
+    fireEvent.click(screen.getByRole('button', { name: '3D View' }))
+    screen.getByRole('button', { name: 'Use 2D view' }) // fallback again, from held state
+    expect(probe.calls).toBe(1) // still the single probe
+    expect(vi.mocked(console.error).mock.calls).toHaveLength(0) // no log spam
+  })
+
+  it('no additional SimBridge connection exists on the fallback path', () => {
+    render(<App />)
+    screen.getByRole('button', { name: 'Use 2D view' })
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
+  it('Use 2D view switches to a working, stable 2D view over the SAME connection', async () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Use 2D view' }))
+    expect(await screen.findByTestId('view-2d')).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: '2D network view' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '2D View' })).toHaveAttribute('aria-pressed', 'true')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    // Stable: a rerender-provoking interaction leaves it in place.
+    fireEvent.click(screen.getByRole('button', { name: '2D View' })) // active no-op
+    expect(screen.getByTestId('view-2d')).toBeInTheDocument()
+  })
+
+  it('supported: the 3D renderer mounts inside its boundary as before', async () => {
+    probe.result = true
+    render(<App />)
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Use 2D view' })).not.toBeInTheDocument()
+    expect(probe.calls).toBe(1)
+  })
+
+  it('explicit re-probe is user-paced: Check 3D support again recovers when support appears', async () => {
+    render(<App />)
+    screen.getByRole('button', { name: 'Use 2D view' })
+    expect(probe.calls).toBe(1)
+    probe.result = true
+    fireEvent.click(screen.getByRole('button', { name: 'Check 3D support again' }))
+    expect(await screen.findByTestId('view-3d')).toBeInTheDocument()
+    expect(probe.calls).toBe(2) // exactly one more probe, on the user's click
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/webgl-support.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/webgl-support.test.ts
@@ -45,6 +45,34 @@ describe('probeWebGLSupport', () => {
     expect(getContext).toHaveBeenCalledWith('webgl')
   })
 
+  it('probes the RENDERER context set in order: webgl2, webgl, experimental-webgl', () => {
+    const getContext = vi.fn((_type: string) => null)
+    stubCanvas(getContext)
+    expect(probeWebGLSupport()).toBe(false)
+    expect(getContext.mock.calls.map(args => args[0])).toEqual([
+      'webgl2',
+      'webgl',
+      'experimental-webgl',
+    ])
+  })
+
+  it('supported via experimental-webgl ONLY (older engines), context still released', () => {
+    const loseContext = vi.fn()
+    const getContext = vi.fn((type: string) =>
+      type === 'experimental-webgl'
+        ? { getExtension: (name: string) => (name === 'WEBGL_lose_context' ? { loseContext } : null) }
+        : null,
+    )
+    stubCanvas(getContext)
+    expect(probeWebGLSupport()).toBe(true)
+    expect(loseContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('an experimental-webgl context WITHOUT getExtension still probes true (release is best-effort)', () => {
+    stubCanvas((type: string) => (type === 'experimental-webgl' ? {} : null))
+    expect(probeWebGLSupport()).toBe(true)
+  })
+
   it('supported even when WEBGL_lose_context is unavailable (release is best-effort)', () => {
     stubCanvas(() => ({ getExtension: () => null }))
     expect(probeWebGLSupport()).toBe(true)

--- a/utilityfog_frontend/frontend/tests-unit/webgl-support.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/webgl-support.test.ts
@@ -1,0 +1,80 @@
+// Package AL: the WebGL capability probe's own contract — supported,
+// unsupported and THROWING canvas APIs, plus the no-retained-context
+// guarantee, exercised through a controlled document.createElement seam.
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { probeWebGLSupport } from '../src/viz3d/webglSupport'
+
+type GetContext = (type: string) => unknown
+
+function stubCanvas(getContext: GetContext) {
+  const createElement = document.createElement.bind(document)
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') {
+      return { getContext } as unknown as HTMLCanvasElement
+    }
+    return createElement(tag)
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('probeWebGLSupport', () => {
+  it('supported: a webgl2 context probes true and is explicitly released, not retained', () => {
+    const loseContext = vi.fn()
+    const getExtension = vi.fn((name: string) =>
+      name === 'WEBGL_lose_context' ? { loseContext } : null,
+    )
+    const getContext = vi.fn((type: string) =>
+      type === 'webgl2' ? { getExtension } : null,
+    )
+    stubCanvas(getContext)
+    expect(probeWebGLSupport()).toBe(true)
+    expect(getExtension).toHaveBeenCalledWith('WEBGL_lose_context')
+    expect(loseContext).toHaveBeenCalledTimes(1) // the probe context is released
+  })
+
+  it('supported via webgl1 when webgl2 is absent', () => {
+    const getContext = vi.fn((type: string) =>
+      type === 'webgl' ? { getExtension: () => null } : null,
+    )
+    stubCanvas(getContext)
+    expect(probeWebGLSupport()).toBe(true)
+    expect(getContext).toHaveBeenCalledWith('webgl2')
+    expect(getContext).toHaveBeenCalledWith('webgl')
+  })
+
+  it('supported even when WEBGL_lose_context is unavailable (release is best-effort)', () => {
+    stubCanvas(() => ({ getExtension: () => null }))
+    expect(probeWebGLSupport()).toBe(true)
+  })
+
+  it('unsupported: both context types null probes false', () => {
+    const getContext = vi.fn(() => null)
+    stubCanvas(getContext)
+    expect(probeWebGLSupport()).toBe(false)
+  })
+
+  it('throwing probe: a hostile getContext is contained as unsupported, never thrown', () => {
+    stubCanvas(() => {
+      throw new Error('hostile canvas API')
+    })
+    expect(probeWebGLSupport()).toBe(false)
+  })
+
+  it('throwing probe: a hostile getExtension is contained too', () => {
+    stubCanvas(() => ({
+      getExtension: () => {
+        throw new Error('hostile extension API')
+      },
+    }))
+    expect(probeWebGLSupport()).toBe(false)
+  })
+
+  it('jsdom reality check: no WebGL here, so the UNSTUBBED probe reports false', () => {
+    // jsdom has no WebGL implementation — the same environment the gate
+    // tests rely on. If this ever flips, the gate tests must be revisited.
+    expect(probeWebGLSupport()).toBe(false)
+  })
+})

--- a/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
+++ b/utilityfog_frontend/frontend/tests/responsive-a11y.spec.ts
@@ -199,47 +199,35 @@ test('keyboard-only journey: tab order, visible focus, Enter/Space activation, t
   await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toHaveCount(1);
 });
 
-test('keyboard-only retry loop: every repeated failure restores focus to the new Retry button; the keyboard escape route stays live', async ({ page }) => {
+test('keyboard journey for an unrecoverable chunk failure: Reload application is offered — never a false Retry', async ({ page }) => {
   await setupPage(page);
   await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
 
-  // Force the 2D chunk import to fail at the network seam.
-  //
-  // MEASURED PLATFORM LIMIT (this runway, request-log receipt): after a
-  // network-failed dynamic import, Chromium's module map caches the
-  // rejection for that URL — a later import() of the SAME specifier
-  // re-rejects instantly with NO new network request, even after the
-  // route is repaired. So "eventual success after network repair" is
-  // not stageable end-to-end in Chromium without a reload; the
-  // success-side focus contract (region focused only after the child
-  // commit) is locked at the unit seam instead, where fresh factories
-  // give real fresh imports. What IS provable in every engine — and is
-  // the part a stranded keyboard user needs — is the failure loop and
-  // the escape route below.
+  // Force the 2D chunk import to fail at the network seam. MEASURED
+  // (request-log receipt): Chromium's module map caches this failed URL,
+  // so a fresh lazy wrapper cannot recover it — the boundary must offer
+  // reload, not a Retry it cannot honor.
   await page.route('**/NetworkView2D*', route => route.abort());
-  await page.getByRole('button', { name: '2D View' }).click();
-  await expect(page.getByRole('alert')).toContainText('The 2D network view failed to render.');
+  await page.getByRole('button', { name: '2D View', exact: true }).click();
+  const alert = page.getByRole('alert');
+  await expect(alert).toContainText('failed to download');
+  await expect(page.getByRole('button', { name: /Retry/ })).toHaveCount(0);
+  const reload = page.getByRole('button', { name: 'Reload application' });
+  await expect(reload).toBeVisible();
+  const box = (await reload.boundingBox())!;
+  expect(box.width).toBeGreaterThanOrEqual(44);
+  expect(box.height).toBeGreaterThanOrEqual(44);
 
-  // Keyboard-only activation (focus() stands in for tab navigation to
-  // keep the journey engine-stable; the activation itself is a real
-  // keyboard Enter). Each retry fails again: the old Retry unmounts and
-  // focus must be RESTORED to the new Retry button — the keyboard user
-  // stays in the retry loop, never dropped on <body>.
-  const retry = page.getByRole('button', { name: 'Retry 2D network view' });
-  await retry.focus();
+  // Keyboard-only activation. The network is repaired FIRST so the
+  // reloaded document can boot — reload is a recovery ATTEMPT, and the
+  // fallback copy makes no guarantee.
+  await page.unroute('**/NetworkView2D*');
+  await reload.focus();
   await page.keyboard.press('Enter');
-  await expect(page.getByRole('alert')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Retry 2D network view' })).toBeFocused();
-
-  // Second loop iteration behaves identically (bounded, user-paced).
-  await page.keyboard.press('Enter');
-  await expect(page.getByRole('alert')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Retry 2D network view' })).toBeFocused();
-
-  // The escape route works by keyboard: the already-loaded 3D view is
-  // reachable and healthy; the failed slot never trapped focus.
-  await page.getByRole('button', { name: '3D View' }).focus();
-  await page.keyboard.press('Enter');
+  await page.waitForLoadState('load');
+  await expect(page.locator('#root')).toBeVisible();
   await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
-  await expect(page.getByRole('alert')).toHaveCount(0);
+  // The previously failed view loads in the fresh session.
+  await page.getByRole('button', { name: '2D View', exact: true }).click();
+  await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();
 });

--- a/utilityfog_frontend/frontend/tests/webgl-fallback.spec.ts
+++ b/utilityfog_frontend/frontend/tests/webgl-fallback.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Package AL: forced no-WebGL journey, run in EVERY engine of the
+// project matrix. The init script nulls out webgl/webgl2 context
+// creation semantically (and counts probe attempts), so the same
+// journey is deterministic in Chromium, Firefox and WebKit regardless
+// of the machine's real GPU stack.
+
+interface ProbeWindow extends Window {
+  __webglContextRequests: number;
+}
+
+async function setupNoWebGL(page: Page) {
+  await page.addInitScript(() => {
+    const w = window as unknown as ProbeWindow;
+    w.__webglContextRequests = 0;
+    const original = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (
+      this: HTMLCanvasElement,
+      type: string,
+      ...rest: unknown[]
+    ) {
+      if (String(type).includes('webgl')) {
+        w.__webglContextRequests++;
+        return null;
+      }
+      return (original as (this: HTMLCanvasElement, t: string, ...r: unknown[]) => unknown).call(
+        this,
+        type,
+        ...rest,
+      );
+    } as typeof HTMLCanvasElement.prototype.getContext;
+  });
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+}
+
+const contextRequests = (page: Page) =>
+  page.evaluate(() => (window as unknown as ProbeWindow).__webglContextRequests);
+
+test('no-WebGL: shell stays alive, the 3D region carries an accessible fallback with a 44px Use 2D view button', async ({ page }) => {
+  await setupNoWebGL(page);
+
+  const region = page.getByRole('region', { name: '3D network view' });
+  await expect(region).toContainText('no usable WebGL support');
+
+  // Shell alive around the gated region: controls, badge, feed.
+  await expect(page.getByRole('button', { name: '2D View', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: '3D View' })).toBeVisible();
+  await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toBeVisible();
+  await expect(page.getByRole('log', { name: 'Event feed' })).toBeVisible();
+
+  // The recovery control meets the 44x44 CSS-pixel floor.
+  const use2d = page.getByRole('button', { name: 'Use 2D view' });
+  await expect(use2d).toBeVisible();
+  const box = (await use2d.boundingBox())!;
+  expect(box.width).toBeGreaterThanOrEqual(44);
+  expect(box.height).toBeGreaterThanOrEqual(44);
+});
+
+test('no-WebGL: probing is bounded — view switches and time never re-probe', async ({ page }) => {
+  await setupNoWebGL(page);
+  await expect(page.getByRole('button', { name: 'Use 2D view' })).toBeVisible();
+
+  // The single mount-time probe issues at most two context requests
+  // (webgl2 then webgl); StrictMode's dev double-effect can at most
+  // double that. The load-bearing assertion is STABILITY below.
+  const initial = await contextRequests(page);
+  expect(initial).toBeGreaterThanOrEqual(1);
+  expect(initial).toBeLessThanOrEqual(4);
+
+  await page.getByRole('button', { name: '2D View', exact: true }).click();
+  await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();
+  await page.getByRole('button', { name: '3D View' }).click();
+  await expect(page.getByRole('button', { name: 'Use 2D view' })).toBeVisible();
+  await page.waitForTimeout(500);
+  expect(await contextRequests(page), 'no re-probe on switches or over time').toBe(initial);
+});
+
+test('no-WebGL: Use 2D view switches to a working, stable 2D view with no extra churn', async ({ page }) => {
+  await setupNoWebGL(page);
+  await page.getByRole('button', { name: 'Use 2D view' }).click();
+
+  const region2d = page.getByRole('region', { name: '2D network view' });
+  await expect(region2d).toBeVisible();
+  await expect(page.getByRole('button', { name: '2D View', exact: true })).toHaveAttribute('aria-pressed', 'true');
+  // The 2D view renders on a 2d canvas context — unaffected by the gate.
+  await expect(region2d.locator('canvas')).toBeVisible();
+
+  // Stable: still standing after a settle window, shell intact.
+  await page.waitForTimeout(500);
+  await expect(region2d).toBeVisible();
+  await expect(page.getByRole('log', { name: 'Event feed' })).toBeVisible();
+  await expect(page.getByRole('status').and(page.locator('[aria-atomic="true"]'))).toBeVisible();
+});

--- a/utilityfog_frontend/frontend/tests/webgl-fallback.spec.ts
+++ b/utilityfog_frontend/frontend/tests/webgl-fallback.spec.ts
@@ -62,12 +62,13 @@ test('no-WebGL: probing is bounded — view switches and time never re-probe', a
   await setupNoWebGL(page);
   await expect(page.getByRole('button', { name: 'Use 2D view' })).toBeVisible();
 
-  // The single mount-time probe issues at most two context requests
-  // (webgl2 then webgl); StrictMode's dev double-effect can at most
-  // double that. The load-bearing assertion is STABILITY below.
+  // The single mount-time probe issues at most three context requests
+  // (webgl2, webgl, experimental-webgl — the amended renderer context
+  // set); StrictMode's dev double-effect can at most double that. The
+  // load-bearing assertion is STABILITY below.
   const initial = await contextRequests(page);
   expect(initial).toBeGreaterThanOrEqual(1);
-  expect(initial).toBeLessThanOrEqual(4);
+  expect(initial).toBeLessThanOrEqual(6);
 
   await page.getByRole('button', { name: '2D View', exact: true }).click();
   await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();


### PR DESCRIPTION
## PACKAGE AL — WebGL capability fallback for the 3D view

**Stacked on amended AK (`4af6fb32`, #345).** Merge order: AG #341 → AH #342 → AJ #344 → AK #345 → this.

Refs #2 (partial progress — capability-gated 3D with an accessible 2D recovery path; not a close).

### Problem
A browser or device without usable WebGL previously hit the raw canvas/context failure inside the heavy renderer — the exact failure CI Firefox-headless surfaced ("Error creating WebGL context") before AJ moved it to headed-under-xvfb. The user got a crashed view instead of a recovery path.

### Change
- **`src/viz3d/webglSupport.ts`** — `probeWebGLSupport()`: tries `webgl2` then `webgl` on a detached canvas. NEVER throws (hostile canvas APIs read as unsupported). Does not retain the probe canvas/context — explicit `WEBGL_lose_context` release where available, references dropped either way. **Non-claim, documented in source**: a successful probe means a context could be *created*; it does NOT guarantee the Three.js renderer will initialize or render. Runtime renderer failures still belong to `ViewErrorBoundary`.
- **App gate** — probed at most once per 3D entry, result held in state: view switches and rerenders never re-probe (no probe loop, no log spam). When unsupported, the 3D region (shell, connection, feed, controls all alive around it) renders a concise accessible message, a **44×44 "Use 2D view"** button, and a **user-paced** "Check 3D support again" re-probe. No additional SimBridge connection exists on this path.

### Evidence
- **Unit (13 new)**: probe supported / webgl1-fallback / unsupported / throwing `getContext` / throwing `getExtension` / missing lose-context / jsdom reality check; gate fallback-in-region / single-probe-across-switches / one-socket / Use-2D-stable / supported-mounts-renderer / user-paced re-probe. Lifecycle suites pin the probe supported (jsdom has no WebGL; they test lifecycle, not capability).
- **E2E (`tests/webgl-fallback.spec.ts`, every engine in the matrix)**: forced no-WebGL via init-script `getContext` nulling with a request counter — shell-alive + 44px fallback journey; **bounded probing** (context-request count stable across view switches and time); Use-2D switch to a working, stable canvas view.

### Battery at `4c175197`
lint 0 · tsc 0 · **300/300 unit** · UNIT_COVERAGE PASS · **chromium 68/68 · webkit 68/68** (firefox via CI headed-under-xvfb) · build ✓ · BUNDLE_BUDGET v2 PASS (entry 156,776 raw / 50,664 gzip; both async maxima named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebase note** — head is now `b905a7f9`: rebased patch-preservingly (diff-of-diffs identical) onto amended AK `9ff56825`, which extracted `RecoveryProbe` into its own module after the overlay lab caught an ESLint-9-only `react-refresh/only-export-components` warning.

---

## Amendment (final seal runway, 2026-07-12 late) — head `2844dc74`, rebased onto FINAL main `907f7ff9`

**Rebase**: retargeted to `main` (auto, verified) and rebased patch-preservingly (diff-of-diffs identical) after the six-PR seal train.

**Probe (narrowed + strengthened claims)**:
- Initial probe runs in `useLayoutEffect` — commit-synchronous, so the 3D region never paints an empty pending frame.
- Probe set = the renderer's context set, in order: `webgl2`, `webgl`, `experimental-webgl`. Typing narrowed via a structural guard for the string-overload union; the previously redundant concrete-class cast is removed. Context still released via `WEBGL_lose_context` where supported (best-effort).
- New tests: probe order · experimental-webgl-only (release still happens) · extension-less context · throwing `getContext`/`getExtension` · jsdom reality check.

**Chunk-load recovery (honest claims — supersedes the earlier Retry-centric wording)**:
- MEASURED limit (receipts on #345): Chromium's module map caches a failed dynamic-import URL; a fresh `React.lazy` wrapper does **not** issue another request. **A Retry action cannot honor its promise for this failure class, so it is no longer advertised there.**
- New narrowly-tested classifier (`chunkLoadError.ts`) for the actual Chromium/Firefox/WebKit dynamic-import message forms, with false-positive guards (bare `fetch()` errors, ordinary render errors, harness rejections, non-Error values).
- `ViewErrorBoundary` stores the failure **kind** in state. Render failures: unchanged user-paced Retry. Chunk failures: accessible **"Reload application"** via the **injected** `onReloadRequest` callback (App passes `window.location.reload`; the boundary never touches a global) — fallback copy claims an *attempt*, never a guarantee; the cached URL is never re-imported; callback-less legacy owners keep Retry.
- Focus: repeated render failure → new Retry; successful render retry → view region (commit probe); retry whose outcome is a chunk failure → Reload action; first failures steal nothing. **Defect fixed en route**: the focus restore keyed on a `failed:false→true` transition that synchronously-throwing children never produce (their healthy tree never commits) — the retry flag is the correct guard, direct-harness-locked.
- One SimBridge connection on every path (test-locked). E2E journey rewritten to the honest contract in every engine; bounded-probe E2E updated for the 3-context set.

**Battery at `2844dc74`**: lint 0 · tsc 0 · **345/345 unit** · UNIT_COVERAGE PASS · build ✓ · BUNDLE_BUDGET v2 PASS (entry 157,768/50,967) · **chromium 68/68 · webkit 68/68** (firefox via CI headed-under-xvfb).

**DO NOT MERGE — held open for Jack's audit.**