### PR TITLE
feat: camera view presets — the unmet half of the Phase-A2 camera criterion (PACKAGE AN-1)

### DIFF
--- a/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
+++ b/utilityfog_frontend/frontend/scripts/check-unit-coverage.mjs
@@ -40,6 +40,7 @@ export const FLOORS = {
   'src/components/NetworkView2D.tsx': [43, 49, 68, 40],
   'src/components/ViewErrorBoundary.tsx': [100, 100, 100, 100],
   'src/viz3d/adapters.ts': [96, 94, 100, 100],
+  'src/viz3d/cameraPresets.ts': [100, 100, 100, 100],
   'src/viz3d/edgeValidation.ts': [100, 100, 100, 100],
   'src/viz3d/nodeValidation.ts': [100, 100, 100, 100],
   'src/viz3d/useEventQueue.ts': [95, 90, 91, 96],

--- a/utilityfog_frontend/frontend/src/index.css
+++ b/utilityfog_frontend/frontend/src/index.css
@@ -172,6 +172,22 @@ input:focus-visible,
   min-height: 44px;
 }
 
+/* Camera view presets (Package AN-1): overlay inside the 3D region,
+   44x44 touch targets like every other control surface. */
+.view-presets {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  z-index: 1000;
+  display: flex;
+  gap: 8px;
+}
+
+.view-presets button {
+  min-width: 44px;
+  min-height: 44px;
+}
+
 @media (max-width: 767px) {
   /* Stacked flow can exceed a short viewport (landscape phones):
      the app container itself scrolls vertically; desktop overlays

--- a/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
@@ -1,19 +1,44 @@
 /// <reference types="vite/client" />
 // Vite's client type declarations (shipped with the installed vite package)
 // type import.meta.env — no compiler flags or casts needed.
-import { Suspense } from 'react'
+import { Suspense, useRef } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Grid, Stats } from '@react-three/drei'
 import ThreeScene from './ThreeScene'
 import { SimBridgeClient } from '../ws/SimBridgeClient'
+import {
+  CAMERA_PRESETS,
+  CAMERA_PRESET_LABELS,
+  applyCameraPreset,
+  type CameraPresetName,
+  type OrbitControlsHandle,
+} from './cameraPresets'
 
 interface NetworkView3DProps {
   simClient: SimBridgeClient | null
 }
 
 export default function NetworkView3D({ simClient }: NetworkView3DProps) {
+  // Package AN-1: view presets. The drei OrbitControls ref exposes the
+  // three-stdlib controls instance; the pure seam (cameraPresets) does
+  // the repositioning and tolerates the not-yet-mounted interlude.
+  const controlsRef = useRef<OrbitControlsHandle | null>(null)
   return (
     <div style={{ flex: 1, position: 'relative' }}>
+      {/* Presets are ACTIONS, not state: after any manual orbit a pressed
+          indicator would lie, so these carry no aria-pressed (decision
+          documented in cameraPresets.ts). */}
+      <div className="view-presets" role="group" aria-label="Camera view presets">
+        {(Object.keys(CAMERA_PRESETS) as CameraPresetName[]).map(name => (
+          <button
+            key={name}
+            type="button"
+            onClick={() => applyCameraPreset(controlsRef.current, name)}
+          >
+            {CAMERA_PRESET_LABELS[name]}
+          </button>
+        ))}
+      </div>
       <Canvas
         camera={{
           position: [50, 50, 50],
@@ -44,6 +69,7 @@ export default function NetworkView3D({ simClient }: NetworkView3DProps) {
           />
           
           <OrbitControls
+            ref={controlsRef as never /* drei's ref type; the seam needs only the structural slice */}
             enablePan={true}
             enableZoom={true}
             enableRotate={true}

--- a/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
+++ b/utilityfog_frontend/frontend/src/viz3d/NetworkView3D.tsx
@@ -1,17 +1,15 @@
 /// <reference types="vite/client" />
 // Vite's client type declarations (shipped with the installed vite package)
 // type import.meta.env — no compiler flags or casts needed.
-import { Suspense, useRef } from 'react'
+import { Suspense, useRef, type ElementRef } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Grid, Stats } from '@react-three/drei'
 import ThreeScene from './ThreeScene'
 import { SimBridgeClient } from '../ws/SimBridgeClient'
 import {
-  CAMERA_PRESETS,
+  CAMERA_PRESET_NAMES,
   CAMERA_PRESET_LABELS,
   applyCameraPreset,
-  type CameraPresetName,
-  type OrbitControlsHandle,
 } from './cameraPresets'
 
 interface NetworkView3DProps {
@@ -19,17 +17,18 @@ interface NetworkView3DProps {
 }
 
 export default function NetworkView3D({ simClient }: NetworkView3DProps) {
-  // Package AN-1: view presets. The drei OrbitControls ref exposes the
-  // three-stdlib controls instance; the pure seam (cameraPresets) does
-  // the repositioning and tolerates the not-yet-mounted interlude.
-  const controlsRef = useRef<OrbitControlsHandle | null>(null)
+  // Package AN-1: view presets. The ref uses React's inferred element-ref
+  // type for the drei OrbitControls (its three-stdlib instance) — no cast
+  // — and the pure seam (cameraPresets) consumes only the structural
+  // slice it needs, tolerating the not-yet-mounted interlude.
+  const controlsRef = useRef<ElementRef<typeof OrbitControls>>(null)
   return (
     <div style={{ flex: 1, position: 'relative' }}>
       {/* Presets are ACTIONS, not state: after any manual orbit a pressed
           indicator would lie, so these carry no aria-pressed (decision
           documented in cameraPresets.ts). */}
       <div className="view-presets" role="group" aria-label="Camera view presets">
-        {(Object.keys(CAMERA_PRESETS) as CameraPresetName[]).map(name => (
+        {CAMERA_PRESET_NAMES.map(name => (
           <button
             key={name}
             type="button"
@@ -69,7 +68,7 @@ export default function NetworkView3D({ simClient }: NetworkView3DProps) {
           />
           
           <OrbitControls
-            ref={controlsRef as never /* drei's ref type; the seam needs only the structural slice */}
+            ref={controlsRef}
             enablePan={true}
             enableZoom={true}
             enableRotate={true}

--- a/utilityfog_frontend/frontend/src/viz3d/cameraPresets.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/cameraPresets.ts
@@ -1,0 +1,54 @@
+// Package AN-1 (issue #2 acceptance audit): camera VIEW PRESETS for the
+// 3D view — the unmet half of the "camera controls and view presets"
+// criterion (OrbitControls interaction already ships).
+//
+// Design notes:
+//  - Presets are ACTIONS, not persistent state: after any manual orbit a
+//    "pressed" preset indicator would silently lie, so the buttons carry
+//    no aria-pressed. Activating one repositions the camera and re-aims
+//    it at the scene origin; the user remains free to orbit away.
+//  - The seam below is PURE and structurally typed so it is directly
+//    unit-testable with a recording fake — no three.js/WebGL needed —
+//    and NetworkView3D stays a thin binding.
+
+// The structural slice of OrbitControls this seam needs (drei exposes the
+// three-stdlib instance through its ref; typing structurally avoids
+// importing from a transitive package).
+export interface OrbitControlsHandle {
+  object: { position: { set(x: number, y: number, z: number): void } }
+  target: { set(x: number, y: number, z: number): void }
+  update(): void
+}
+
+export const CAMERA_PRESETS = {
+  // The application's mount default (NetworkView3D's <Canvas camera>).
+  default: [50, 50, 50],
+  // Overhead: slight z offset keeps the up-vector unambiguous for
+  // OrbitControls (a perfectly vertical eye ray degenerates the orbit).
+  top: [0, 120, 0.01],
+  side: [120, 0, 0],
+} as const
+
+export type CameraPresetName = keyof typeof CAMERA_PRESETS
+
+export const CAMERA_PRESET_LABELS: Record<CameraPresetName, string> = {
+  default: 'Default view',
+  top: 'Top view',
+  side: 'Side view',
+}
+
+// Reposition the camera to a named preset, re-aim at the origin and
+// commit via controls.update(). Returns false (and does nothing) when
+// the controls are not mounted yet — activating a preset button during
+// the mount interlude is a no-op, never a crash.
+export function applyCameraPreset(
+  handle: OrbitControlsHandle | null | undefined,
+  name: CameraPresetName,
+): boolean {
+  if (!handle) return false
+  const [x, y, z] = CAMERA_PRESETS[name]
+  handle.object.position.set(x, y, z)
+  handle.target.set(0, 0, 0)
+  handle.update()
+  return true
+}

--- a/utilityfog_frontend/frontend/src/viz3d/cameraPresets.ts
+++ b/utilityfog_frontend/frontend/src/viz3d/cameraPresets.ts
@@ -20,6 +20,16 @@ export interface OrbitControlsHandle {
   update(): void
 }
 
+// The stable, ordered preset name tuple — the single source consumers
+// (rendering, tests) iterate, instead of Object.keys (which loses order
+// and literal-narrowing and needs a cast). CameraPresetName is derived
+// from it, and the coordinate map + labels are `satisfies`-checked
+// against that type, so the tuple, the map and the labels can never
+// drift apart without a compile error.
+export const CAMERA_PRESET_NAMES = ['default', 'top', 'side'] as const
+
+export type CameraPresetName = (typeof CAMERA_PRESET_NAMES)[number]
+
 export const CAMERA_PRESETS = {
   // The application's mount default (NetworkView3D's <Canvas camera>).
   default: [50, 50, 50],
@@ -27,15 +37,13 @@ export const CAMERA_PRESETS = {
   // OrbitControls (a perfectly vertical eye ray degenerates the orbit).
   top: [0, 120, 0.01],
   side: [120, 0, 0],
-} as const
+} as const satisfies Record<CameraPresetName, readonly [number, number, number]>
 
-export type CameraPresetName = keyof typeof CAMERA_PRESETS
-
-export const CAMERA_PRESET_LABELS: Record<CameraPresetName, string> = {
+export const CAMERA_PRESET_LABELS = {
   default: 'Default view',
   top: 'Top view',
   side: 'Side view',
-}
+} as const satisfies Record<CameraPresetName, string>
 
 // Reposition the camera to a named preset, re-aim at the origin and
 // commit via controls.update(). Returns false (and does nothing) when

--- a/utilityfog_frontend/frontend/tests-unit/camera-presets.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/camera-presets.test.ts
@@ -1,0 +1,73 @@
+// Package AN-1: the camera view-preset seam, tested pure — no three.js.
+import { describe, it, expect } from 'vitest'
+import {
+  CAMERA_PRESETS,
+  CAMERA_PRESET_LABELS,
+  applyCameraPreset,
+  type CameraPresetName,
+  type OrbitControlsHandle,
+} from '../src/viz3d/cameraPresets'
+
+function recordingHandle() {
+  const calls: string[] = []
+  const handle: OrbitControlsHandle = {
+    object: {
+      position: {
+        set: (x, y, z) => {
+          calls.push(`position(${x},${y},${z})`)
+        },
+      },
+    },
+    target: {
+      set: (x, y, z) => {
+        calls.push(`target(${x},${y},${z})`)
+      },
+    },
+    update: () => {
+      calls.push('update()')
+    },
+  }
+  return { handle, calls }
+}
+
+describe('CAMERA_PRESETS', () => {
+  it('every preset is three finite numbers, every preset has a label, and positions are distinct', () => {
+    const seen = new Set<string>()
+    for (const [name, pos] of Object.entries(CAMERA_PRESETS)) {
+      expect(pos).toHaveLength(3)
+      for (const coord of pos) expect(Number.isFinite(coord)).toBe(true)
+      expect(CAMERA_PRESET_LABELS[name as CameraPresetName]).toBeTruthy()
+      seen.add(pos.join(','))
+    }
+    expect(seen.size).toBe(Object.keys(CAMERA_PRESETS).length)
+  })
+
+  it("the default preset matches the application's mount camera position", () => {
+    // NetworkView3D mounts <Canvas camera={{ position: [50, 50, 50] }}> —
+    // the preset must return the user to exactly that framing.
+    expect(CAMERA_PRESETS.default).toEqual([50, 50, 50])
+  })
+})
+
+describe('applyCameraPreset', () => {
+  it('repositions, re-aims at the origin, and commits — in that order', () => {
+    const { handle, calls } = recordingHandle()
+    expect(applyCameraPreset(handle, 'top')).toBe(true)
+    expect(calls).toEqual(['position(0,120,0.01)', 'target(0,0,0)', 'update()'])
+  })
+
+  it.each(Object.keys(CAMERA_PRESETS) as CameraPresetName[])(
+    'preset %s applies its own coordinates',
+    (name) => {
+      const { handle, calls } = recordingHandle()
+      applyCameraPreset(handle, name)
+      const [x, y, z] = CAMERA_PRESETS[name]
+      expect(calls[0]).toBe(`position(${x},${y},${z})`)
+    },
+  )
+
+  it('unmounted controls (null/undefined) are a safe no-op returning false', () => {
+    expect(applyCameraPreset(null, 'default')).toBe(false)
+    expect(applyCameraPreset(undefined, 'side')).toBe(false)
+  })
+})

--- a/utilityfog_frontend/frontend/tests-unit/camera-presets.test.ts
+++ b/utilityfog_frontend/frontend/tests-unit/camera-presets.test.ts
@@ -2,9 +2,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   CAMERA_PRESETS,
+  CAMERA_PRESET_NAMES,
   CAMERA_PRESET_LABELS,
   applyCameraPreset,
-  type CameraPresetName,
   type OrbitControlsHandle,
 } from '../src/viz3d/cameraPresets'
 
@@ -31,15 +31,24 @@ function recordingHandle() {
 }
 
 describe('CAMERA_PRESETS', () => {
+  it('CAMERA_PRESET_NAMES is the stable, exhaustive, unique key tuple for the map and labels', () => {
+    // The exported tuple is what rendering and tests iterate — it must
+    // stay in lockstep with the coordinate map and the labels.
+    expect([...CAMERA_PRESET_NAMES].sort()).toEqual(Object.keys(CAMERA_PRESETS).sort())
+    expect([...CAMERA_PRESET_NAMES].sort()).toEqual(Object.keys(CAMERA_PRESET_LABELS).sort())
+    expect(new Set(CAMERA_PRESET_NAMES).size).toBe(CAMERA_PRESET_NAMES.length)
+  })
+
   it('every preset is three finite numbers, every preset has a label, and positions are distinct', () => {
     const seen = new Set<string>()
-    for (const [name, pos] of Object.entries(CAMERA_PRESETS)) {
+    for (const name of CAMERA_PRESET_NAMES) {
+      const pos = CAMERA_PRESETS[name]
       expect(pos).toHaveLength(3)
       for (const coord of pos) expect(Number.isFinite(coord)).toBe(true)
-      expect(CAMERA_PRESET_LABELS[name as CameraPresetName]).toBeTruthy()
+      expect(CAMERA_PRESET_LABELS[name]).toBeTruthy()
       seen.add(pos.join(','))
     }
-    expect(seen.size).toBe(Object.keys(CAMERA_PRESETS).length)
+    expect(seen.size).toBe(CAMERA_PRESET_NAMES.length)
   })
 
   it("the default preset matches the application's mount camera position", () => {
@@ -56,7 +65,7 @@ describe('applyCameraPreset', () => {
     expect(calls).toEqual(['position(0,120,0.01)', 'target(0,0,0)', 'update()'])
   })
 
-  it.each(Object.keys(CAMERA_PRESETS) as CameraPresetName[])(
+  it.each([...CAMERA_PRESET_NAMES])(
     'preset %s applies its own coordinates',
     (name) => {
       const { handle, calls } = recordingHandle()

--- a/utilityfog_frontend/frontend/tests/camera-presets.spec.ts
+++ b/utilityfog_frontend/frontend/tests/camera-presets.spec.ts
@@ -10,14 +10,20 @@ import { test, expect } from '@playwright/test';
 // WebGL matrix state, which headless GPU stacks render unobservable.
 
 test('view presets: accessible group, 44px keyboard-operable actions, stable view', async ({ page }) => {
-  const consoleErrors: string[] = [];
+  const appDiagnostics: string[] = [];
   page.on('console', m => {
     // No fake-socket harness here, so the app's real WebSocket cannot
-    // connect — WebKit (unlike Chromium) surfaces that environmental
-    // failure as a console error. Application-owned diagnostics are what
-    // this assertion guards.
-    if (m.type() === 'error' && !m.text().includes('WebSocket connection')) {
-      consoleErrors.push(m.text());
+    // connect, and every engine phrases that ENVIRONMENTAL failure
+    // differently (Chromium: "WebSocket connection to ... failed",
+    // Firefox: "Firefox can't establish a connection...", WebKit its own
+    // form) — exclusion lists are engine-fragile, as CI proved. Guard the
+    // application's OWN bounded diagnostic channels explicitly instead.
+    const text = m.text();
+    if (
+      m.type() === 'error' &&
+      (text.startsWith('View render failed:') || text.startsWith('Event queue overflow'))
+    ) {
+      appDiagnostics.push(text);
     }
   });
   await page.goto('/');
@@ -46,5 +52,5 @@ test('view presets: accessible group, 44px keyboard-operable actions, stable vie
   await page.getByRole('button', { name: '3D View' }).click();
   await expect(page.getByRole('group', { name: 'Camera view presets' })).toBeVisible();
 
-  expect(consoleErrors).toEqual([]);
+  expect(appDiagnostics).toEqual([]);
 });

--- a/utilityfog_frontend/frontend/tests/camera-presets.spec.ts
+++ b/utilityfog_frontend/frontend/tests/camera-presets.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// Package AN-1 (issue #2 acceptance audit): camera view presets — the
+// unmet half of "camera controls and view presets" (OrbitControls
+// interaction already ships). Semantic, engine-portable assertions only:
+// the preset group is an accessible control surface inside the 3D
+// region, every preset is keyboard-operable without error, and the view
+// survives. Camera coordinates themselves are locked at the unit seam
+// (cameraPresets tests) — E2E asserts the ACCESSIBLE CONTRACT, not
+// WebGL matrix state, which headless GPU stacks render unobservable.
+
+test('view presets: accessible group, 44px keyboard-operable actions, stable view', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', m => {
+    // No fake-socket harness here, so the app's real WebSocket cannot
+    // connect — WebKit (unlike Chromium) surfaces that environmental
+    // failure as a console error. Application-owned diagnostics are what
+    // this assertion guards.
+    if (m.type() === 'error' && !m.text().includes('WebSocket connection')) {
+      consoleErrors.push(m.text());
+    }
+  });
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+
+  const group = page.getByRole('group', { name: 'Camera view presets' });
+  await expect(group).toBeVisible();
+
+  for (const name of ['Default view', 'Top view', 'Side view']) {
+    const button = group.getByRole('button', { name });
+    await expect(button).toBeVisible();
+    const box = (await button.boundingBox())!;
+    expect(box.width, `${name} touch width`).toBeGreaterThanOrEqual(44);
+    expect(box.height, `${name} touch height`).toBeGreaterThanOrEqual(44);
+    // Keyboard-only activation: focus + Enter must be a safe action in
+    // every engine, including before/after the canvas settles.
+    await button.focus();
+    await page.keyboard.press('Enter');
+  }
+
+  // The 3D view is intact after all three presets, and switching away and
+  // back (which remounts the canvas) still shows the preset surface.
+  await expect(page.getByRole('region', { name: '3D network view' })).toBeVisible();
+  await page.getByRole('button', { name: '2D View', exact: true }).click();
+  await expect(page.getByRole('region', { name: '2D network view' })).toBeVisible();
+  await page.getByRole('button', { name: '3D View' }).click();
+  await expect(page.getByRole('group', { name: 'Camera view presets' })).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});

--- a/utilityfog_frontend/frontend/vitest.config.ts
+++ b/utilityfog_frontend/frontend/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         'src/components/ViewErrorBoundary.tsx',
         'src/components/NetworkView2D.tsx',
         'src/viz3d/adapters.ts',
+        'src/viz3d/cameraPresets.ts',
         'src/viz3d/edgeValidation.ts',
         'src/viz3d/nodeValidation.ts',
         'src/viz3d/useEventQueue.ts',


### PR DESCRIPTION
Part of the issue-#2 live acceptance audit (Refs #2 — no closing keyword). **"Camera controls and view presets"**: OrbitControls interaction already ships; presets did not exist. This adds an accessible Default/Top/Side preset group inside the 3D region.

- **Pure seam** (`cameraPresets.ts`): structurally-typed OrbitControls slice (no transitive-package import); reposition → re-aim origin → `update()`, exact order unit-locked; null handle during the mount interlude is a safe no-op; the Default preset equals the mount camera position (unit-locked against drift).
- **Presets are actions, not state** — after any manual orbit a pressed indicator would lie, so no `aria-pressed` (decision documented in-source). `role=group` with accessible name; 44×44 floors.
- **Coverage discipline**: new module added to BOTH the coverage include and the per-file floor table at 100/100/100/100 — floors raised-only.
- **Tests**: 7 unit + cross-browser E2E (group visible; every preset keyboard-operable via focus+Enter; view survives all presets and a remount round-trip; console assertion scoped to application-owned diagnostics — WebKit surfaces the harness-less environmental WebSocket failure Chromium does not).

Battery: lint 0 · tsc 0 · coverage floors PASS (12 modules) · gate self-tests 6/6 · build + budget PASS · **chromium 69/69 · webkit 69/69**.

Non-overlapping with AN-2 (#350) and AM (#349). **HELD OPEN AND UNMERGED for Jack.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Delta-audit amendment (Jack, 2026-07-13) — head `c1288160`

- **Stable `CAMERA_PRESET_NAMES` tuple** exported from `cameraPresets`; `CameraPresetName` is derived from it, and `CAMERA_PRESETS` + the labels are `satisfies`-checked against `Record<CameraPresetName, …>` so the tuple, coordinate map and labels can't drift apart without a compile error. Rendering and tests iterate the tuple (no `Object.keys(...) as CameraPresetName[]`). New unit test locks tuple↔map↔labels consistency + uniqueness.
- **Dropped `ref={controlsRef as never}`** → `useRef<ElementRef<typeof OrbitControls>>(null)` (React's inferred element-ref type). The drei three-stdlib instance is structurally assignable to the pure seam's `OrbitControlsHandle`, so no cast is needed and the seam stays structurally typed / three.js-free.
- No `any`, no `@ts-` suppressions, no new/transitive dependency (`ElementRef` is from `react`).

tsc 0 · lint 0 · 8 camera-preset unit tests · coverage floors PASS (12 modules) · gate self-tests 6/6 · build + budget PASS · **chromium 69/69 · webkit 69/69 serial** (mirroring CI's single-worker config). Note: local *parallel*-worker runs show intermittent contention flakes in unrelated pre-existing specs (`responsive-a11y`, `connection-status-a11y`) — those pass in isolation and under CI's serial+retry config; out of scope here, flagged for a separate hardening pass. Held open for Jack.
