### PR TITLE
feat: deterministic next-event baselines over nextness logs (PACKAGE NP1)

### DIFF
--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -72,9 +72,22 @@ fallback is visible.
 - **Strictly increasing generations** over accepted rows: duplicates and
   out-of-order rows are rejected and counted, never silently reordered
   (sorting could hide train/holdout leakage; refusing cannot).
-- Bounded work: `max_rows` (default 100 000, ceiling 1 000 000) and
-  `max_line_bytes` (default 65 536); oversized lines are rejected and
-  counted.
+- Bounded raw work: `max_rows` (default 100 000, ceiling 1 000 000)
+  counts **every physical input record** — accepted, rejected and blank
+  alike — so a blank-line flood cannot buy unbounded reading. Blank
+  records are neither observations nor violations: they consume row
+  budget but appear in no rejection count, so `rows_read ≥
+  rows_accepted + rows_rejected`, with `rows_accepted` the
+  accepted-observation count.
+- Bounded line size (pre-allocation guard): records are `\n`-delimited
+  and read via bounded `readline` calls of at most `max_line_bytes + 2`
+  bytes (default `max_line_bytes` 65 536), so an oversized or
+  unterminated record is **never materialized in full**. A record whose
+  content (raw bytes; LF or CRLF terminator excluded) exceeds
+  `max_line_bytes` is counted `oversized_line` and **terminates
+  ingestion — fail closed**: skipping past it would require unbounded
+  scanning for the next record boundary. Total read work is bounded by
+  `max_rows × (max_line_bytes + 2)` bytes.
 - Every rejection is accounted by a fixed reason vocabulary; the report
   carries **counts only** — row payloads are never copied anywhere.
 
@@ -96,6 +109,21 @@ is checked against a **64 KiB ceiling — fail closed** (`ReportTooLargeError`).
 - No network, HTTP, ZMQ, Ollama or model calls anywhere in the module
   (statically auditable: the only imports are stdlib + `TOKEN_NAMES` /
   `WriteOutsideLogDirError` from `scripts.nextness_observer`).
+
+## CLI exit codes
+
+Expected failures print one concise `error:` line to stderr — **never a
+traceback**. Only the expected error types are caught; unexpected
+programming errors propagate loudly rather than masquerade as clean
+exits.
+
+| Code | Meaning |
+|---|---|
+| 0 | success |
+| 2 | validation failure: missing log file or out-of-bounds configuration (argparse usage errors also exit 2) |
+| 3 | insufficient history for a train/holdout split |
+| 4 | output-path failure: write-boundary violation or unwritable target |
+| 5 | serialized report exceeds the 64 KiB ceiling (fail closed) |
 
 ## Relationship to what comes next
 

--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -1,0 +1,105 @@
+# Nextness Prediction Baseline (NP1)
+
+**Module**: `scripts/nextness_predictor.py` · **Tests**: `tests/test_nextness_predictor.py`
+**Schema**: `nextness-predictor-v1` · **Status**: baseline instrument, offline-only
+
+## What this is
+
+The first measurable capacity on the "functional self-awareness" ladder:
+**can the system anticipate what happens next?** — asked in the most
+honest way available: three transparent baselines over the existing
+Nextness Observer log, so that any future, cleverer predictor has
+something falsifiable to beat.
+
+It reads `nextness_runs.jsonl` rows (never raw snapshots, never live
+engine state), reduces each row to its **dominant vocabulary token**
+(maximal count; ties broken by canonical `TOKEN_NAMES` order), and
+evaluates next-token prediction on a **chronological holdout**.
+
+## Non-claims (load-bearing)
+
+- This measures **sequence regularity in observer logs**, nothing more.
+  No intelligence, awareness, understanding or performance-victory claim
+  is made or implied.
+- A simple baseline outperforming a complex model is an **expected,
+  fully-reported outcome** — that is what baselines are for.
+- Dominant-token reduction discards within-row distribution detail by
+  design; a future instrument may predict full distributions.
+
+## The three baselines
+
+All three emit a full-vocabulary probability distribution using the same
+additive (Laplace) smoothing `α` (default 1.0, bounded (0, 1000]), so
+their likelihoods are directly comparable.
+
+| Model | P(next = t) | Notes |
+|---|---|---|
+| `empirical_prior` | (train count of t + α) / (train rows + 16α) | ignores the previous token |
+| `persistence` | (1[t = prev] + α) / (1 + 16α) | "tomorrow equals today" |
+| `first_order` | (C[prev][t] + α) / (ΣC[prev] + 16α) | Markov transition counts from consecutive train pairs |
+
+**First-order fallback**: a previous token never seen as a transition
+*source* in training has no row to smooth. The model falls back to the
+`empirical_prior` distribution (never an invented uniform row), and the
+report carries `first_order_unseen_source_count` so the frequency of
+fallback is visible.
+
+## Evaluation protocol
+
+- **Chronological split only**: first `floor(N·(1−h))` accepted rows
+  train (`h` = holdout fraction, default 0.25, bounded [0.05, 0.5]); the
+  remainder is holdout. Nothing is shuffled; models never see a holdout
+  token before predicting it. The first holdout target's "previous
+  token" is the last training token (known at prediction time).
+- **Metrics** (all deterministic):
+  - `nll_bits` — mean −log₂ P(actual); base-2 to match the repository's
+    bits-everywhere convention.
+  - `brier` — mean multiclass Brier score Σ_t (p_t − 1[t=actual])².
+  - `top1_accuracy` — argmax prediction, canonical-order tie-break.
+  - `ece` — expected calibration error over **10 fixed equal-width
+    confidence bins** (final bin closed above), bin-size weighted.
+- Every exact-metric test fixture is calculated independently in the
+  test file from these formulas — the module is never asked to verify
+  itself.
+
+## Input contract (defensive by construction)
+
+- Built-in `dict` rows only; `generation` must be a non-bool `int`;
+  `token_counts` must be a built-in `dict`.
+- **Known vocabulary only** — any unknown key rejects the row.
+- Counts must be real, finite, non-negative numbers; `bool` is rejected
+  explicitly (schema violation, not a count of one).
+- **Strictly increasing generations** over accepted rows: duplicates and
+  out-of-order rows are rejected and counted, never silently reordered
+  (sorting could hide train/holdout leakage; refusing cannot).
+- Bounded work: `max_rows` (default 100 000, ceiling 1 000 000) and
+  `max_line_bytes` (default 65 536); oversized lines are rejected and
+  counted.
+- Every rejection is accounted by a fixed reason vocabulary; the report
+  carries **counts only** — row payloads are never copied anywhere.
+
+## Report contract
+
+Deterministic JSON: sorted keys, fixed separators, `schema` +
+configuration echo + row/rejection accounting + split boundary +
+per-model metrics + explicit non-claims. **No wall-clock timestamps.**
+Byte-identical across repeated runs on the same input. Serialized size
+is checked against a **64 KiB ceiling — fail closed** (`ReportTooLargeError`).
+
+## Write boundary
+
+- Default output is **stdout**.
+- `--output` must resolve **inside the input-log directory** (mirrors
+  `nextness_metrics`; `WriteOutsideLogDirError` otherwise) and must
+  **never** resolve inside the repository `data/` tree — even when the
+  input log itself lives there. Reports about `data/` logs go to stdout.
+- No network, HTTP, ZMQ, Ollama or model calls anywhere in the module
+  (statically auditable: the only imports are stdlib + `TOKEN_NAMES` /
+  `WriteOutsideLogDirError` from `scripts.nextness_observer`).
+
+## Relationship to what comes next
+
+NP2 (`nextness_monitor`) consumes this instrument's outputs to measure
+*when the predictor should not be trusted* (uncertainty, surprise,
+calibration drift, abstention). Neither package changes observer
+semantics, vocabulary, or the engine.

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -31,9 +31,16 @@ Safety contract (Lane B, mirrors nextness_observer/nextness_metrics):
   rejected and counted, never silently reordered (sorting could hide
   leakage; refusing cannot).
 - Defensive parsing: built-in ``dict`` rows only, known vocabulary only,
-  finite non-negative numeric counts only (bools rejected explicitly),
-  bounded row count and line length; every rejection is counted by
-  reason. Row payloads are never copied into the report — only counts.
+  finite non-negative numeric counts only (bools rejected explicitly);
+  every rejection is counted by reason. Row payloads are never copied
+  into the report — only counts.
+- Bounded raw work: ``max_rows`` counts every physical input record
+  (blank, rejected and accepted alike) and records are read with bounded
+  ``readline`` calls so no more than ``max_line_bytes + 2`` bytes of a
+  record are ever materialized; the first oversized record is counted
+  and terminates ingestion (fail closed). CLI failures for expected
+  invalid input exit with documented nonzero codes and concise stderr —
+  never a traceback.
 - Deterministic output: sorted keys, fixed schema/version, no wall-clock
   timestamps, canonical-order tie-breaking, fixed ECE bins; the same
   input file always produces byte-identical reports.
@@ -157,8 +164,24 @@ def read_dominant_sequence(
     """Parse the JSONL log into a chronological dominant-token sequence.
 
     Returns ``(sequence, rejections, rows_read)`` where ``rejections``
-    maps every reason in REJECT_REASONS to a count. Rows beyond
-    ``max_rows`` raw lines are not read at all (bounded work).
+    maps every reason in REJECT_REASONS to a count.
+
+    Raw-work bound: ``rows_read`` counts every PHYSICAL input record
+    consumed — accepted, rejected and blank alike — so ``max_rows``
+    bounds raw input work, not just observations. Blank records are
+    neither observations nor violations: they consume row budget without
+    appearing in ``rejections``. The accepted-observation count is
+    ``len(sequence)`` (reported as ``rows_accepted``).
+
+    Pre-allocation line-size bound: records are ``\\n``-delimited and read
+    with bounded ``readline`` calls of at most ``max_line_bytes + 2``
+    bytes, so an oversized or unterminated record is never materialized
+    in full. A record whose content (raw bytes; LF or CRLF terminator
+    excluded) exceeds ``max_line_bytes`` is counted ``oversized_line``
+    and TERMINATES ingestion (fail closed): skipping past it would
+    require unbounded scanning for the next record boundary. Total read
+    work is therefore bounded by ``max_rows * (max_line_bytes + 2)``
+    bytes.
 
     Chronology contract: ``generation`` must be strictly increasing over
     ACCEPTED rows. A row whose generation equals the last accepted one is
@@ -175,18 +198,30 @@ def read_dominant_sequence(
     rows_read = 0
     last_generation: int | None = None
 
-    with log_path.open("r", encoding="utf-8", errors="replace") as f:
-        for line in f:
-            if rows_read >= max_rows:
-                break
+    with log_path.open("rb") as f:
+        while rows_read < max_rows:
+            chunk = f.readline(max_line_bytes + 2)
+            if not chunk:
+                break  # EOF
             rows_read += 1
-            if len(line.encode("utf-8", errors="replace")) > max_line_bytes:
+            if chunk.endswith(b"\n"):
+                # LF or CRLF terminator — excluded from the content bound
+                # (a record of exactly max_line_bytes content plus either
+                # terminator fits in the max_line_bytes + 2 probe).
+                content = chunk[:-2] if chunk.endswith(b"\r\n") else chunk[:-1]
+            else:
+                # EOF-unterminated record, or a probe that hit the read
+                # limit mid-record (already past the bound either way).
+                content = chunk
+            if len(content) > max_line_bytes:
+                # Fail closed: count and stop — never drain or
+                # resynchronize past an oversized record.
                 rejections["oversized_line"] += 1
-                continue
-            stripped = line.strip()
+                break
+            stripped = content.decode("utf-8", errors="replace").strip()
             if not stripped:
-                # Blank lines are not observations and not violations.
-                rows_read -= 1
+                # Blank records are not observations and not violations,
+                # but they still consume raw-row budget (bounded work).
                 continue
             try:
                 row = json.loads(stripped)
@@ -541,13 +576,30 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit-code contract (documented, tested):
+
+    - ``0`` success
+    - ``2`` validation failure — missing log file or out-of-bounds
+      configuration (argparse's own usage errors also exit 2)
+    - ``3`` insufficient history for a train/holdout split
+    - ``4`` output-path failure — write-boundary violation or an
+      unwritable target
+    - ``5`` report exceeds MAX_REPORT_BYTES (fail closed)
+
+    Every expected failure prints one concise ``error:`` line to stderr —
+    never a traceback. Only the expected error types above are caught;
+    unexpected programming errors propagate loudly rather than
+    masquerade as clean exits.
+    """
     args = _build_parser().parse_args(argv)
     if not args.log_path.is_file():
         print(f"error: log file not found: {args.log_path}", file=sys.stderr)
         return 2
-    if args.output is not None:
-        validate_output_path(args.output, args.log_path)
     try:
+        if args.output is not None:
+            validate_output_path(args.output, args.log_path)
         report = build_report(
             args.log_path,
             smoothing=args.smoothing,
@@ -555,12 +607,25 @@ def main(argv: list[str] | None = None) -> int:
             max_rows=args.max_rows,
             max_line_bytes=args.max_line_bytes,
         )
+    except WriteOutsideLogDirError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 4
     except InsufficientHistoryError as e:
         print(f"error: {e}", file=sys.stderr)
         return 3
+    except ReportTooLargeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 5
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
     serialized = serialize_report(report)
     if args.output is not None:
-        args.output.write_text(serialized, encoding="utf-8")
+        try:
+            args.output.write_text(serialized, encoding="utf-8")
+        except OSError as e:
+            print(f"error: cannot write report to {args.output}: {e}", file=sys.stderr)
+            return 4
     else:
         sys.stdout.write(serialized)
     return 0

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -1,0 +1,570 @@
+"""Deterministic next-event baselines over Nextness Observer logs (NP1).
+
+Reads existing ``nextness_runs.jsonl`` rows — never raw snapshots, never
+live engine state — and evaluates three transparent baseline predictors
+of the *next dominant vocabulary token*:
+
+1. ``empirical_prior``   — smoothed frequency of dominant tokens in the
+   training prefix; ignores the previous token entirely.
+2. ``persistence``       — predicts "the next dominant token equals the
+   previous one", smoothed over the full vocabulary.
+3. ``first_order``       — first-order Markov transition model with
+   additive (Laplace) smoothing; unseen previous tokens fall back to the
+   empirical prior (documented below).
+
+SCOPE OF CLAIM (deliberate, narrow): these are *baselines* whose job is
+to make future claims falsifiable. Reporting includes every model, and a
+simple baseline winning is a fully expected, fully reported outcome.
+Nothing here measures or implies intelligence, awareness or performance
+victory. This module contains no learning beyond counting.
+
+Safety contract (Lane B, mirrors nextness_observer/nextness_metrics):
+
+- Offline only: no network, HTTP, ZMQ, Ollama or model calls; the only
+  I/O is reading one JSONL file and (optionally) writing one report next
+  to it.
+- Writes are permitted ONLY inside the resolved input-log directory
+  (``WriteOutsideLogDirError`` otherwise) and NEVER inside the
+  repository ``data/`` tree — reports about ``data/`` logs go to stdout.
+- Chronological evaluation only: rows must arrive in strictly increasing
+  ``generation`` order; out-of-order and duplicate generations are
+  rejected and counted, never silently reordered (sorting could hide
+  leakage; refusing cannot).
+- Defensive parsing: built-in ``dict`` rows only, known vocabulary only,
+  finite non-negative numeric counts only (bools rejected explicitly),
+  bounded row count and line length; every rejection is counted by
+  reason. Row payloads are never copied into the report — only counts.
+- Deterministic output: sorted keys, fixed schema/version, no wall-clock
+  timestamps, canonical-order tie-breaking, fixed ECE bins; the same
+  input file always produces byte-identical reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from scripts.nextness_observer import TOKEN_NAMES, WriteOutsideLogDirError
+
+# ---------------------------------------------------------------------------
+# Fixed contract constants
+# ---------------------------------------------------------------------------
+
+REPORT_SCHEMA: Final[str] = "nextness-predictor-v1"
+
+#: Canonical index for deterministic dominant-token tie-breaking: among
+#: tied maximal counts the token EARLIEST in TOKEN_NAMES order wins.
+_TOKEN_INDEX: Final[dict[str, int]] = {t: i for i, t in enumerate(TOKEN_NAMES)}
+
+#: Hard input bounds (accidental-unbounded-work guards, not tuning knobs).
+MAX_ROWS_DEFAULT: Final[int] = 100_000
+MAX_ROWS_CEILING: Final[int] = 1_000_000
+MAX_LINE_BYTES_DEFAULT: Final[int] = 65_536
+
+#: Additive (Laplace) smoothing pseudo-count, shared by all three models
+#: so their likelihoods are comparable. Documented in the baseline doc;
+#: configurable but bounded — smoothing is a floor against log(0), not a
+#: fitted parameter.
+SMOOTHING_DEFAULT: Final[float] = 1.0
+SMOOTHING_MAX: Final[float] = 1_000.0
+
+#: Chronological holdout fraction (tail of the sequence). Bounded so a
+#: degenerate split cannot silently produce an empty side.
+HOLDOUT_FRACTION_DEFAULT: Final[float] = 0.25
+HOLDOUT_FRACTION_MIN: Final[float] = 0.05
+HOLDOUT_FRACTION_MAX: Final[float] = 0.5
+
+#: Fixed deterministic ECE binning: 10 equal-width confidence bins over
+#: [0, 1]; the final bin is closed above.
+ECE_BINS: Final[int] = 10
+
+#: Report size ceiling — fail closed rather than emit an unbounded blob.
+MAX_REPORT_BYTES: Final[int] = 64 * 1024
+
+#: Rejection reasons (fixed vocabulary; the report carries ONLY counts).
+REJECT_REASONS: Final[tuple[str, ...]] = (
+    "oversized_line",
+    "malformed_json",
+    "not_object",
+    "missing_generation",
+    "invalid_generation",
+    "out_of_order_generation",
+    "duplicate_generation",
+    "missing_token_counts",
+    "invalid_token_counts",
+    "unknown_token",
+    "invalid_count_value",
+    "no_dominant_token",
+)
+
+
+class ReportTooLargeError(RuntimeError):
+    """Serialized report exceeded MAX_REPORT_BYTES (fail closed)."""
+
+
+class InsufficientHistoryError(RuntimeError):
+    """Too few accepted rows to form a train/holdout split."""
+
+
+# ---------------------------------------------------------------------------
+# Defensive row parsing
+# ---------------------------------------------------------------------------
+
+
+def _valid_count(value: Any) -> bool:
+    """A usable token count: real int/float, finite, non-negative.
+
+    ``bool`` is an ``int`` subclass in Python and is rejected explicitly —
+    ``True`` counts are a schema violation, not a count of one.
+    """
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, (int, float)):
+        return False
+    if isinstance(value, float) and not math.isfinite(value):
+        return False
+    return value >= 0
+
+
+def dominant_token(token_counts: Mapping[str, Any]) -> str | None:
+    """The maximal-count token, ties broken by canonical TOKEN_NAMES order.
+
+    Returns ``None`` when no token has a strictly positive count (an
+    all-zero row has no dominant event and is rejected upstream). The
+    caller is responsible for having validated keys/values first.
+    """
+    best: str | None = None
+    best_count = 0.0
+    for token in TOKEN_NAMES:  # canonical order makes ties deterministic
+        count = token_counts.get(token, 0)
+        if count > best_count:
+            best = token
+            best_count = count
+    return best
+
+
+def read_dominant_sequence(
+    log_path: pathlib.Path,
+    *,
+    max_rows: int = MAX_ROWS_DEFAULT,
+    max_line_bytes: int = MAX_LINE_BYTES_DEFAULT,
+) -> tuple[list[str], dict[str, int], int]:
+    """Parse the JSONL log into a chronological dominant-token sequence.
+
+    Returns ``(sequence, rejections, rows_read)`` where ``rejections``
+    maps every reason in REJECT_REASONS to a count. Rows beyond
+    ``max_rows`` raw lines are not read at all (bounded work).
+
+    Chronology contract: ``generation`` must be strictly increasing over
+    ACCEPTED rows. A row whose generation equals the last accepted one is
+    counted ``duplicate_generation``; a smaller one is counted
+    ``out_of_order_generation``. Neither is silently reordered.
+    """
+    if not 0 < max_rows <= MAX_ROWS_CEILING:
+        raise ValueError(f"max_rows must be in (0, {MAX_ROWS_CEILING}], got {max_rows}")
+    if max_line_bytes <= 0:
+        raise ValueError(f"max_line_bytes must be positive, got {max_line_bytes}")
+
+    sequence: list[str] = []
+    rejections: dict[str, int] = {reason: 0 for reason in REJECT_REASONS}
+    rows_read = 0
+    last_generation: int | None = None
+
+    with log_path.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            if rows_read >= max_rows:
+                break
+            rows_read += 1
+            if len(line.encode("utf-8", errors="replace")) > max_line_bytes:
+                rejections["oversized_line"] += 1
+                continue
+            stripped = line.strip()
+            if not stripped:
+                # Blank lines are not observations and not violations.
+                rows_read -= 1
+                continue
+            try:
+                row = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                rejections["malformed_json"] += 1
+                continue
+            # Built-in dict rows only — json.loads only ever produces
+            # dicts for objects, so this rejects arrays/scalars, and, for
+            # rows injected programmatically in tests, hostile mappings.
+            if type(row) is not dict:
+                rejections["not_object"] += 1
+                continue
+            if "generation" not in row:
+                rejections["missing_generation"] += 1
+                continue
+            generation = row["generation"]
+            if isinstance(generation, bool) or not isinstance(generation, int):
+                rejections["invalid_generation"] += 1
+                continue
+            if "token_counts" not in row:
+                rejections["missing_token_counts"] += 1
+                continue
+            token_counts = row["token_counts"]
+            if type(token_counts) is not dict:
+                rejections["invalid_token_counts"] += 1
+                continue
+            if any(key not in _TOKEN_INDEX for key in token_counts):
+                rejections["unknown_token"] += 1
+                continue
+            if any(not _valid_count(v) for v in token_counts.values()):
+                rejections["invalid_count_value"] += 1
+                continue
+            # Chronology AFTER shape validation so a malformed row can
+            # never advance the generation cursor.
+            if last_generation is not None:
+                if generation == last_generation:
+                    rejections["duplicate_generation"] += 1
+                    continue
+                if generation < last_generation:
+                    rejections["out_of_order_generation"] += 1
+                    continue
+            dominant = dominant_token(token_counts)
+            if dominant is None:
+                rejections["no_dominant_token"] += 1
+                continue
+            last_generation = generation
+            sequence.append(dominant)
+
+    return sequence, rejections, rows_read
+
+
+# ---------------------------------------------------------------------------
+# The three baselines: each returns P(next token) as a dict over the FULL
+# canonical vocabulary, always summing to 1.0 (within float precision).
+# ---------------------------------------------------------------------------
+
+
+def _normalized(weights: Sequence[float]) -> dict[str, float]:
+    total = sum(weights)
+    return {t: w / total for t, w in zip(TOKEN_NAMES, weights)}
+
+
+def empirical_prior_distribution(
+    train: Sequence[str], smoothing: float
+) -> dict[str, float]:
+    """Smoothed frequency of dominant tokens in the training prefix."""
+    counts = {t: 0 for t in TOKEN_NAMES}
+    for token in train:
+        counts[token] += 1
+    return _normalized([counts[t] + smoothing for t in TOKEN_NAMES])
+
+
+def persistence_distribution(previous: str, smoothing: float) -> dict[str, float]:
+    """All mass on the previous token, smoothed over the vocabulary."""
+    return _normalized(
+        [(1.0 if t == previous else 0.0) + smoothing for t in TOKEN_NAMES]
+    )
+
+
+def transition_counts(train: Sequence[str]) -> dict[str, dict[str, int]]:
+    """First-order transition counts over consecutive training pairs."""
+    table: dict[str, dict[str, int]] = {}
+    for prev, nxt in zip(train, train[1:]):
+        row = table.setdefault(prev, {t: 0 for t in TOKEN_NAMES})
+        row[nxt] += 1
+    return table
+
+
+def first_order_distribution(
+    previous: str,
+    table: Mapping[str, Mapping[str, int]],
+    prior: Mapping[str, float],
+    smoothing: float,
+) -> dict[str, float]:
+    """Smoothed transition row for ``previous``; falls back to the prior.
+
+    Fallback contract (documented in the baseline doc): a previous token
+    never seen as a transition SOURCE in training has no row to smooth —
+    the model abstains to the empirical prior rather than inventing a
+    uniform row, and the evaluation records how often that happened via
+    the model's own metrics (the fallback is the prior, so the comparison
+    stays honest).
+    """
+    row = table.get(previous)
+    if row is None:
+        return dict(prior)
+    return _normalized([row[t] + smoothing for t in TOKEN_NAMES])
+
+
+# ---------------------------------------------------------------------------
+# Metrics: NLL (bits), multiclass Brier, top-1 accuracy, fixed-bin ECE
+# ---------------------------------------------------------------------------
+
+
+def evaluate_predictions(
+    predictions: Sequence[Mapping[str, float]],
+    actuals: Sequence[str],
+) -> dict[str, float]:
+    """Deterministic holdout metrics for one model.
+
+    - ``nll_bits``: mean −log₂ P(actual). Base-2 to match the repo's
+      entropy/divergence convention (bits everywhere).
+    - ``brier``: mean multiclass Brier score Σ_t (p_t − 1[t=actual])².
+    - ``top1_accuracy``: argmax with canonical-order tie-breaking.
+    - ``ece``: expected calibration error over ECE_BINS fixed equal-width
+      confidence bins (final bin closed above), weighted by bin size.
+    """
+    if len(predictions) != len(actuals) or not predictions:
+        raise ValueError("predictions and actuals must be equal-length and non-empty")
+    n = len(predictions)
+    nll_total = 0.0
+    brier_total = 0.0
+    correct = 0
+    bin_confidence = [0.0] * ECE_BINS
+    bin_accuracy = [0.0] * ECE_BINS
+    bin_count = [0] * ECE_BINS
+    for dist, actual in zip(predictions, actuals):
+        p_actual = dist[actual]
+        nll_total += -math.log2(max(p_actual, 1e-300))
+        brier_total += sum(
+            (dist[t] - (1.0 if t == actual else 0.0)) ** 2 for t in TOKEN_NAMES
+        )
+        # argmax with canonical tie-break (first maximal in TOKEN_NAMES).
+        top_token = max(TOKEN_NAMES, key=lambda t: (dist[t], -_TOKEN_INDEX[t]))
+        confidence = dist[top_token]
+        hit = top_token == actual
+        correct += 1 if hit else 0
+        bin_idx = min(int(confidence * ECE_BINS), ECE_BINS - 1)
+        bin_confidence[bin_idx] += confidence
+        bin_accuracy[bin_idx] += 1.0 if hit else 0.0
+        bin_count[bin_idx] += 1
+    ece = 0.0
+    for b in range(ECE_BINS):
+        if bin_count[b] == 0:
+            continue
+        avg_conf = bin_confidence[b] / bin_count[b]
+        avg_acc = bin_accuracy[b] / bin_count[b]
+        ece += (bin_count[b] / n) * abs(avg_conf - avg_acc)
+    return {
+        "nll_bits": nll_total / n,
+        "brier": brier_total / n,
+        "top1_accuracy": correct / n,
+        "ece": ece,
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end evaluation
+# ---------------------------------------------------------------------------
+
+
+def run_evaluation(
+    sequence: Sequence[str],
+    *,
+    smoothing: float = SMOOTHING_DEFAULT,
+    holdout_fraction: float = HOLDOUT_FRACTION_DEFAULT,
+) -> dict[str, Any]:
+    """Chronological train/holdout evaluation of all three baselines.
+
+    The split is a single chronological cut: the first
+    ``floor(N · (1 − holdout_fraction))`` dominant tokens train, the rest
+    are holdout targets. Each holdout position is predicted from the
+    TRUE previous token (available at prediction time; the first holdout
+    target's previous token is the last training token) — models never
+    see a holdout token before predicting it, and nothing is shuffled.
+    """
+    if not 0.0 < smoothing <= SMOOTHING_MAX:
+        raise ValueError(f"smoothing must be in (0, {SMOOTHING_MAX}], got {smoothing}")
+    if not HOLDOUT_FRACTION_MIN <= holdout_fraction <= HOLDOUT_FRACTION_MAX:
+        raise ValueError(
+            f"holdout_fraction must be in [{HOLDOUT_FRACTION_MIN}, "
+            f"{HOLDOUT_FRACTION_MAX}], got {holdout_fraction}"
+        )
+    n = len(sequence)
+    split = math.floor(n * (1.0 - holdout_fraction))
+    train = list(sequence[:split])
+    holdout = list(sequence[split:])
+    if len(train) < 2 or len(holdout) < 1:
+        raise InsufficientHistoryError(
+            f"need >=2 train and >=1 holdout rows; got train={len(train)}, "
+            f"holdout={len(holdout)} from {n} accepted rows"
+        )
+
+    prior = empirical_prior_distribution(train, smoothing)
+    table = transition_counts(train)
+
+    previous_tokens = [train[-1]] + holdout[:-1]
+    models: dict[str, list[dict[str, float]]] = {
+        "empirical_prior": [dict(prior) for _ in holdout],
+        "persistence": [
+            persistence_distribution(prev, smoothing) for prev in previous_tokens
+        ],
+        "first_order": [
+            first_order_distribution(prev, table, prior, smoothing)
+            for prev in previous_tokens
+        ],
+    }
+    unseen_sources = sum(1 for prev in previous_tokens if prev not in table)
+
+    metrics = {
+        name: evaluate_predictions(preds, holdout) for name, preds in models.items()
+    }
+    return {
+        "train_rows": len(train),
+        "holdout_rows": len(holdout),
+        "split_index": split,
+        "first_order_unseen_source_count": unseen_sources,
+        "models": metrics,
+    }
+
+
+def build_report(
+    log_path: pathlib.Path,
+    *,
+    smoothing: float = SMOOTHING_DEFAULT,
+    holdout_fraction: float = HOLDOUT_FRACTION_DEFAULT,
+    max_rows: int = MAX_ROWS_DEFAULT,
+    max_line_bytes: int = MAX_LINE_BYTES_DEFAULT,
+) -> dict[str, Any]:
+    """Full deterministic report for one log file.
+
+    Contains configuration echoes, row/rejection accounting, the split
+    boundary and per-model metrics. Never contains row payloads, file
+    contents or wall-clock timestamps. Keys serialize sorted; the same
+    input yields a byte-identical report.
+    """
+    sequence, rejections, rows_read = read_dominant_sequence(
+        log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
+    )
+    evaluation = run_evaluation(
+        sequence, smoothing=smoothing, holdout_fraction=holdout_fraction
+    )
+    report: dict[str, Any] = {
+        "schema": REPORT_SCHEMA,
+        "config": {
+            "smoothing": smoothing,
+            "holdout_fraction": holdout_fraction,
+            "max_rows": max_rows,
+            "max_line_bytes": max_line_bytes,
+            "ece_bins": ECE_BINS,
+            "vocabulary_size": len(TOKEN_NAMES),
+        },
+        "input": {
+            "rows_read": rows_read,
+            "rows_accepted": len(sequence),
+            "rows_rejected": sum(rejections.values()),
+            "rejections": rejections,
+        },
+        "evaluation": evaluation,
+        "non_claims": [
+            "Baselines only: no intelligence, awareness or performance-victory claim.",
+            "A simple baseline outperforming a complex one is an expected, reported outcome.",
+        ],
+    }
+    serialized = serialize_report(report)
+    if len(serialized.encode("utf-8")) > MAX_REPORT_BYTES:
+        raise ReportTooLargeError(
+            f"report would exceed {MAX_REPORT_BYTES} bytes; refusing to emit"
+        )
+    return report
+
+
+def serialize_report(report: Mapping[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, newline."""
+    return json.dumps(report, sort_keys=True, separators=(",", ": "), indent=1) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Write-boundary guard: inside the input-log directory only, never data/
+# ---------------------------------------------------------------------------
+
+
+def _repo_data_dir() -> pathlib.Path:
+    return (pathlib.Path(__file__).resolve().parent.parent / "data").resolve()
+
+
+def validate_output_path(out_path: pathlib.Path, log_path: pathlib.Path) -> None:
+    """Enforce the NP1 write contract for --output.
+
+    The report may land ONLY inside the resolved input-log directory
+    (mirroring nextness_metrics), and NEVER inside the repository
+    ``data/`` tree — even when the input log itself lives there. Reports
+    about ``data/`` logs go to stdout instead.
+    """
+    log_dir_resolved = log_path.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(log_dir_resolved)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write predictor report outside the input-log "
+            f"directory: {out_resolved} is not inside {log_dir_resolved}"
+        ) from e
+    data_dir = _repo_data_dir()
+    if out_resolved == data_dir or data_dir in out_resolved.parents:
+        raise WriteOutsideLogDirError(
+            f"refusing to write predictor report inside the repository data/ "
+            f"tree: {out_resolved}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deterministic next-dominant-token baselines over a Nextness "
+            "Observer JSONL log (offline; see module docstring for the "
+            "full safety contract)."
+        )
+    )
+    parser.add_argument("log_path", type=pathlib.Path, help="path to nextness_runs.jsonl")
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=None,
+        help=(
+            "optional report path; must resolve inside the input log's "
+            "directory and outside the repository data/ tree (default: stdout)"
+        ),
+    )
+    parser.add_argument("--smoothing", type=float, default=SMOOTHING_DEFAULT)
+    parser.add_argument(
+        "--holdout-fraction", type=float, default=HOLDOUT_FRACTION_DEFAULT
+    )
+    parser.add_argument("--max-rows", type=int, default=MAX_ROWS_DEFAULT)
+    parser.add_argument("--max-line-bytes", type=int, default=MAX_LINE_BYTES_DEFAULT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.log_path.is_file():
+        print(f"error: log file not found: {args.log_path}", file=sys.stderr)
+        return 2
+    if args.output is not None:
+        validate_output_path(args.output, args.log_path)
+    try:
+        report = build_report(
+            args.log_path,
+            smoothing=args.smoothing,
+            holdout_fraction=args.holdout_fraction,
+            max_rows=args.max_rows,
+            max_line_bytes=args.max_line_bytes,
+        )
+    except InsufficientHistoryError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+    serialized = serialize_report(report)
+    if args.output is not None:
+        args.output.write_text(serialized, encoding="utf-8")
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -1,0 +1,383 @@
+"""NP1: deterministic next-event baselines — contract + adversarial tests.
+
+Every exact metric fixture below is calculated INDEPENDENTLY in the test
+(explicit arithmetic from the documented formulas), never by calling the
+module's own helpers — so a formula regression cannot hide behind its own
+reflection.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+
+import pytest
+
+from scripts.nextness_observer import TOKEN_NAMES, WriteOutsideLogDirError
+from scripts.nextness_predictor import (
+    ECE_BINS,
+    InsufficientHistoryError,
+    MAX_REPORT_BYTES,
+    REJECT_REASONS,
+    REPORT_SCHEMA,
+    build_report,
+    dominant_token,
+    empirical_prior_distribution,
+    first_order_distribution,
+    main,
+    persistence_distribution,
+    read_dominant_sequence,
+    run_evaluation,
+    serialize_report,
+    transition_counts,
+    validate_output_path,
+)
+
+A = "void_static"      # canonical index 0
+B = "compute_static"   # canonical index 1
+K = len(TOKEN_NAMES)   # 16
+
+
+def _row(generation: int, counts: dict[str, int]) -> str:
+    return json.dumps({"generation": generation, "token_counts": counts})
+
+
+def _write_log(tmp_path: pathlib.Path, lines: list[str]) -> pathlib.Path:
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return log
+
+
+def _dominant_rows(tokens: list[str]) -> list[str]:
+    return [_row(i, {tok: 3}) for i, tok in enumerate(tokens)]
+
+
+# ---------------------------------------------------------------------------
+# Dominant-token extraction
+# ---------------------------------------------------------------------------
+
+
+def test_dominant_token_ties_break_by_canonical_order() -> None:
+    # A (index 0) and B (index 1) tied: canonical order wins, not dict order.
+    assert dominant_token({B: 2, A: 2}) == A
+    assert dominant_token({"phase_boundary": 5, "energy_pulse": 5}) == "energy_pulse"
+
+
+def test_dominant_token_all_zero_is_none() -> None:
+    assert dominant_token({A: 0, B: 0}) is None
+    assert dominant_token({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Defensive parsing: every rejection reason, individually accounted
+# ---------------------------------------------------------------------------
+
+
+def test_rejections_are_counted_by_reason_and_never_crash(tmp_path) -> None:
+    payload_sentinel = "SENTINEL_PAYLOAD_MUST_NOT_APPEAR_IN_REPORT"
+    lines = [
+        _row(1, {A: 3}),                                        # accepted
+        "{not json" + payload_sentinel,                          # malformed_json
+        json.dumps([1, 2, 3]),                                   # not_object
+        json.dumps({"token_counts": {A: 1}}),                    # missing_generation
+        json.dumps({"generation": True, "token_counts": {A: 1}}),   # invalid_generation (bool)
+        json.dumps({"generation": 1.5, "token_counts": {A: 1}}),    # invalid_generation (float)
+        json.dumps({"generation": 2}),                           # missing_token_counts
+        json.dumps({"generation": 3, "token_counts": [A]}),      # invalid_token_counts
+        json.dumps({"generation": 4, "token_counts": {"tok_not_in_vocab": 1}}),  # unknown_token
+        json.dumps({"generation": 5, "token_counts": {A: float("nan")}}),   # invalid_count_value
+        json.dumps({"generation": 6, "token_counts": {A: -1}}),  # invalid_count_value
+        json.dumps({"generation": 7, "token_counts": {A: True}}),  # invalid_count_value (bool)
+        json.dumps({"generation": 8, "token_counts": {A: 0}}),   # no_dominant_token
+        _row(9, {B: 2}),                                         # accepted
+        _row(9, {A: 2}),                                         # duplicate_generation
+        _row(4, {A: 2}),                                         # out_of_order_generation
+    ]
+    # NaN survives json.dumps? No — json.dumps(nan) emits NaN which loads
+    # back via json.loads as float('nan') under the default parser. Good.
+    log = _write_log(tmp_path, lines)
+    seq, rej, rows_read = read_dominant_sequence(log)
+    assert seq == [A, B]
+    assert rej["malformed_json"] == 1
+    assert rej["not_object"] == 1
+    assert rej["missing_generation"] == 1
+    assert rej["invalid_generation"] == 2
+    assert rej["missing_token_counts"] == 1
+    assert rej["invalid_token_counts"] == 1
+    assert rej["unknown_token"] == 1
+    assert rej["invalid_count_value"] == 3
+    assert rej["no_dominant_token"] == 1
+    assert rej["duplicate_generation"] == 1
+    assert rej["out_of_order_generation"] == 1
+    assert rej["oversized_line"] == 0
+    assert sum(rej.values()) == 14
+    assert rows_read == len(lines)
+    assert set(rej) == set(REJECT_REASONS)
+
+
+def test_huge_line_is_rejected_not_parsed(tmp_path) -> None:
+    huge = json.dumps({"generation": 1, "token_counts": {A: 1}, "pad": "x" * 70_000})
+    log = _write_log(tmp_path, [huge, _row(2, {A: 1})])
+    seq, rej, _ = read_dominant_sequence(log)
+    assert rej["oversized_line"] == 1
+    assert seq == [A]
+
+
+def test_max_rows_bounds_work(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows([A] * 50))
+    seq, _, rows_read = read_dominant_sequence(log, max_rows=10)
+    assert rows_read == 10
+    assert len(seq) == 10
+
+
+def test_out_of_order_rows_never_reorder_silently(tmp_path) -> None:
+    log = _write_log(
+        tmp_path, [_row(1, {A: 1}), _row(3, {B: 1}), _row(2, {A: 1}), _row(4, {A: 1})]
+    )
+    seq, rej, _ = read_dominant_sequence(log)
+    assert seq == [A, B, A]  # gen 2 rejected, NOT inserted between 1 and 3
+    assert rej["out_of_order_generation"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Exact metric fixtures — independently calculated
+#
+# Setup: train = A B A B A B A B (8), holdout = A B A (3), smoothing = 1,
+# holdout_fraction = 0.25 (floor(11 * 0.75) = 8). Transition counts from
+# train pairs: A->B x4, B->A x3. Previous tokens for the holdout are
+# [B (last train), A, B].
+# ---------------------------------------------------------------------------
+
+_FIXTURE_SEQUENCE = [A, B, A, B, A, B, A, B, A, B, A]
+
+
+def _fixture_report(tmp_path) -> dict:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    return build_report(log)
+
+
+def test_fixture_split_and_transition_bookkeeping(tmp_path) -> None:
+    ev = _fixture_report(tmp_path)["evaluation"]
+    assert ev["train_rows"] == 8
+    assert ev["holdout_rows"] == 3
+    assert ev["split_index"] == 8
+    assert ev["first_order_unseen_source_count"] == 0
+
+
+def test_fixture_first_order_exact_metrics(tmp_path) -> None:
+    # Row A: P(B|A) = (4+1)/(4+16) = 0.25, others 1/20.
+    # Row B: P(A|B) = (3+1)/(3+16) = 4/19, others 1/19.
+    # Holdout (prev -> actual): (B->A), (A->B), (B->A); all top-1 hits.
+    m = _fixture_report(tmp_path)["evaluation"]["models"]["first_order"]
+    nll = (2 * math.log2(19 / 4) + math.log2(20 / 5)) / 3
+    brier_b_row = (1 - 4 / 19) ** 2 + 15 * (1 / 19) ** 2
+    brier_a_row = (1 - 5 / 20) ** 2 + 15 * (1 / 20) ** 2
+    brier = (2 * brier_b_row + brier_a_row) / 3
+    # Confidences 4/19, 5/20, 4/19 all land in bin [0.2, 0.3); acc 1.0.
+    ece = abs((2 * (4 / 19) + 0.25) / 3 - 1.0)
+    assert m["top1_accuracy"] == pytest.approx(1.0)
+    assert m["nll_bits"] == pytest.approx(nll, rel=1e-12)
+    assert m["brier"] == pytest.approx(brier, rel=1e-12)
+    assert m["ece"] == pytest.approx(ece, rel=1e-12)
+
+
+def test_fixture_persistence_exact_metrics(tmp_path) -> None:
+    # Persistence dist: prev gets 2/17, all others 1/17. The alternating
+    # holdout means the actual token is NEVER the previous one: 0 hits.
+    m = _fixture_report(tmp_path)["evaluation"]["models"]["persistence"]
+    assert m["top1_accuracy"] == pytest.approx(0.0)
+    assert m["nll_bits"] == pytest.approx(math.log2(17), rel=1e-12)
+    brier = (2 / 17) ** 2 + (1 - 1 / 17) ** 2 + 14 * (1 / 17) ** 2
+    assert m["brier"] == pytest.approx(brier, rel=1e-12)
+    assert m["ece"] == pytest.approx(2 / 17, rel=1e-12)  # conf 2/17, acc 0
+
+
+def test_fixture_empirical_prior_exact_metrics(tmp_path) -> None:
+    # Train counts: A=4, B=4 -> P(A)=P(B)=5/24, others 1/24. Argmax ties
+    # A/B; canonical order predicts A every time -> 2/3 accuracy on A,B,A.
+    m = _fixture_report(tmp_path)["evaluation"]["models"]["empirical_prior"]
+    assert m["top1_accuracy"] == pytest.approx(2 / 3, rel=1e-12)
+    assert m["nll_bits"] == pytest.approx(math.log2(24 / 5), rel=1e-12)
+    brier = (1 - 5 / 24) ** 2 + (5 / 24) ** 2 + 14 * (1 / 24) ** 2
+    assert m["brier"] == pytest.approx(brier, rel=1e-12)
+    assert m["ece"] == pytest.approx(abs(5 / 24 - 2 / 3), rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral shape tests: constant, alternation, unseen tokens, fallback
+# ---------------------------------------------------------------------------
+
+
+def test_constant_sequence_every_model_predicts_it(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows([A] * 12))
+    models = build_report(log)["evaluation"]["models"]
+    for name in ("empirical_prior", "persistence", "first_order"):
+        assert models[name]["top1_accuracy"] == pytest.approx(1.0), name
+
+
+def test_alternation_rewards_transition_and_punishes_persistence(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows([A, B] * 10))
+    models = build_report(log)["evaluation"]["models"]
+    assert models["first_order"]["top1_accuracy"] == pytest.approx(1.0)
+    assert models["persistence"]["top1_accuracy"] == pytest.approx(0.0)
+
+
+def test_unseen_holdout_token_is_survivable_and_costly(tmp_path) -> None:
+    # 'energy_pulse' first appears in the holdout: every model still emits
+    # a full-vocabulary distribution (no crash), it just pays a large NLL.
+    seq = [A, B] * 6 + ["energy_pulse", A, B, A]
+    log = _write_log(tmp_path, _dominant_rows(seq))
+    report = build_report(log)
+    for name, m in report["evaluation"]["models"].items():
+        assert math.isfinite(m["nll_bits"]), name
+        assert m["nll_bits"] > 0.0, name
+
+
+def test_first_order_unseen_source_falls_back_to_prior() -> None:
+    train = [A, B, A, B]
+    prior = empirical_prior_distribution(train, smoothing=1.0)
+    table = transition_counts(train)
+    fallback = first_order_distribution("energy_pulse", table, prior, smoothing=1.0)
+    assert fallback == prior  # documented fallback: the empirical prior
+
+
+def test_unseen_source_count_is_reported(tmp_path) -> None:
+    seq = [A, B] * 5 + ["energy_pulse", A]  # 'energy_pulse' is a holdout prev
+    log = _write_log(tmp_path, _dominant_rows(seq))
+    ev = build_report(log)["evaluation"]
+    assert ev["first_order_unseen_source_count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Leakage, distributions, insufficiency
+# ---------------------------------------------------------------------------
+
+
+def test_no_holdout_leakage_into_training_prior(tmp_path) -> None:
+    # 'sensor_alert' exists ONLY in the holdout. If the prior were built
+    # over the full sequence it would carry frequency mass; built over the
+    # train prefix only, its probability is exactly the smoothing floor.
+    seq = [A, B] * 6 + ["sensor_alert", "sensor_alert", "sensor_alert"]
+    split = math.floor(len(seq) * 0.75)
+    assert all(t != "sensor_alert" for t in seq[:split])
+    prior = empirical_prior_distribution(seq[:split], smoothing=1.0)
+    assert prior["sensor_alert"] == pytest.approx(1.0 / (split + K), rel=1e-12)
+
+
+def test_distributions_are_full_vocabulary_and_normalized() -> None:
+    for dist in (
+        empirical_prior_distribution([A, B, A], 1.0),
+        persistence_distribution(A, 1.0),
+        first_order_distribution(A, transition_counts([A, B, A]),
+                                 empirical_prior_distribution([A, B], 1.0), 1.0),
+    ):
+        assert set(dist) == set(TOKEN_NAMES)
+        assert sum(dist.values()) == pytest.approx(1.0, rel=1e-12)
+        assert all(p > 0 for p in dist.values())
+
+
+def test_insufficient_history_fails_closed(tmp_path) -> None:
+    with pytest.raises(InsufficientHistoryError):
+        run_evaluation([A, B])  # train=1 after split: too small
+    log = _write_log(tmp_path, _dominant_rows([A]))
+    with pytest.raises(InsufficientHistoryError):
+        build_report(log)
+
+
+def test_minimum_viable_history_works() -> None:
+    ev = run_evaluation([A, B, A])  # train 2, holdout 1
+    assert ev["train_rows"] == 2 and ev["holdout_rows"] == 1
+
+
+def test_config_bounds_are_enforced() -> None:
+    with pytest.raises(ValueError):
+        run_evaluation([A] * 10, smoothing=0.0)
+    with pytest.raises(ValueError):
+        run_evaluation([A] * 10, holdout_fraction=0.9)
+    with pytest.raises(ValueError):
+        read_dominant_sequence(pathlib.Path("x"), max_rows=0)
+
+
+# ---------------------------------------------------------------------------
+# Report determinism, hygiene and bounds
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_byte_identical_across_repeated_runs(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    first = serialize_report(build_report(log))
+    second = serialize_report(build_report(log))
+    assert first == second
+
+
+def test_report_hygiene_no_timestamps_no_payloads(tmp_path) -> None:
+    sentinel = "SENTINEL_PAYLOAD_MUST_NOT_APPEAR_IN_REPORT"
+    lines = _dominant_rows(_FIXTURE_SEQUENCE) + ["{broken " + sentinel]
+    log = _write_log(tmp_path, lines)
+    report = build_report(log)
+    serialized = serialize_report(report)
+    assert report["schema"] == REPORT_SCHEMA
+    assert sentinel not in serialized              # payloads never copied
+    assert '"ts"' not in serialized                # no wall-clock fields
+    assert len(serialized.encode("utf-8")) <= MAX_REPORT_BYTES
+    # sorted-keys canonical form
+    assert serialized == json.dumps(
+        json.loads(serialized), sort_keys=True, separators=(",", ": "), indent=1
+    ) + "\n"
+    assert report["input"]["rows_rejected"] == 1
+    assert report["config"]["ece_bins"] == ECE_BINS
+
+
+# ---------------------------------------------------------------------------
+# Write boundary: inside the input-log directory only, never data/
+# ---------------------------------------------------------------------------
+
+
+def test_output_inside_log_directory_is_allowed(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    validate_output_path(tmp_path / "report.json", log)  # no raise
+
+
+def test_output_outside_log_directory_is_refused(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(tmp_path.parent / "escape.json", log)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(tmp_path / ".." / "escape.json", log)
+
+
+def test_output_inside_repo_data_tree_is_refused() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    data_log = repo_root / "data" / "nextness_logs" / "nextness_runs.jsonl"
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(data_log.parent / "report.json", data_log)
+    # Pure path logic: nothing was created or written.
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end (offline, tmp-dir only)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_writes_deterministic_report_inside_log_dir(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "report.json"
+    assert main([str(log), "--output", str(out)]) == 0
+    text_one = out.read_text(encoding="utf-8")
+    assert main([str(log)]) == 0  # stdout path
+    stdout = capsys.readouterr().out
+    assert stdout == text_one
+    assert json.loads(text_one)["schema"] == REPORT_SCHEMA
+
+
+def test_cli_refuses_output_escape(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    with pytest.raises(WriteOutsideLogDirError):
+        main([str(log), "--output", str(tmp_path.parent / "escape.json")])
+
+
+def test_cli_missing_file_and_insufficient_history_exit_codes(tmp_path) -> None:
+    assert main([str(tmp_path / "absent.jsonl")]) == 2
+    log = _write_log(tmp_path, _dominant_rows([A]))
+    assert main([str(log)]) == 3

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -14,10 +14,12 @@ import pathlib
 
 import pytest
 
+import scripts.nextness_predictor as nextness_predictor
 from scripts.nextness_observer import TOKEN_NAMES, WriteOutsideLogDirError
 from scripts.nextness_predictor import (
     ECE_BINS,
     InsufficientHistoryError,
+    MAX_LINE_BYTES_DEFAULT,
     MAX_REPORT_BYTES,
     REJECT_REASONS,
     REPORT_SCHEMA,
@@ -51,6 +53,22 @@ def _write_log(tmp_path: pathlib.Path, lines: list[str]) -> pathlib.Path:
 
 def _dominant_rows(tokens: list[str]) -> list[str]:
     return [_row(i, {tok: 3}) for i, tok in enumerate(tokens)]
+
+
+def _padded_row(generation: int, counts: dict[str, int], content_bytes: int) -> str:
+    """A valid row padded to EXACTLY content_bytes bytes (terminator excluded).
+
+    json.dumps here is pure ASCII, so byte length == character length and
+    each pad character grows the record by exactly one byte.
+    """
+    base = json.dumps({"generation": generation, "token_counts": counts, "pad": ""})
+    deficit = content_bytes - len(base)
+    assert deficit >= 0, "content_bytes too small for the base row"
+    padded = json.dumps(
+        {"generation": generation, "token_counts": counts, "pad": "x" * deficit}
+    )
+    assert len(padded.encode("utf-8")) == content_bytes
+    return padded
 
 
 # ---------------------------------------------------------------------------
@@ -116,12 +134,90 @@ def test_rejections_are_counted_by_reason_and_never_crash(tmp_path) -> None:
     assert set(rej) == set(REJECT_REASONS)
 
 
-def test_huge_line_is_rejected_not_parsed(tmp_path) -> None:
+def test_huge_line_is_rejected_and_terminates_ingestion(tmp_path) -> None:
+    # Fail-closed contract: the first oversized record is counted and ends
+    # ingestion — skipping past it would require unbounded scanning for
+    # the next record boundary, so the row after it is never read.
     huge = json.dumps({"generation": 1, "token_counts": {A: 1}, "pad": "x" * 70_000})
     log = _write_log(tmp_path, [huge, _row(2, {A: 1})])
-    seq, rej, _ = read_dominant_sequence(log)
+    seq, rej, rows_read = read_dominant_sequence(log)
     assert rej["oversized_line"] == 1
-    assert seq == [A]
+    assert seq == []
+    assert rows_read == 1
+
+
+def test_line_content_exactly_at_byte_bound_is_accepted(tmp_path) -> None:
+    # The bound is on record CONTENT (LF or CRLF terminator excluded): a
+    # record of exactly max_line_bytes bytes is still a valid observation.
+    for terminator in (b"\n", b"\r\n"):
+        log = tmp_path / "nextness_runs.jsonl"
+        log.write_bytes(
+            _padded_row(1, {A: 3}, 200).encode("utf-8") + terminator
+            + _row(2, {B: 2}).encode("utf-8") + terminator
+        )
+        seq, rej, rows_read = read_dominant_sequence(log, max_line_bytes=200)
+        assert rej["oversized_line"] == 0, terminator
+        assert seq == [A, B], terminator
+        assert rows_read == 2, terminator
+
+
+def test_line_one_byte_over_bound_is_oversized_and_terminal(tmp_path) -> None:
+    for terminator in (b"\n", b"\r\n"):
+        log = tmp_path / "nextness_runs.jsonl"
+        log.write_bytes(
+            _padded_row(1, {A: 3}, 201).encode("utf-8") + terminator
+            + _row(2, {B: 2}).encode("utf-8") + terminator
+        )
+        seq, rej, rows_read = read_dominant_sequence(log, max_line_bytes=200)
+        assert rej["oversized_line"] == 1, terminator
+        assert seq == [], terminator  # fail closed: nothing after it is read
+        assert rows_read == 1, terminator
+
+
+def test_unterminated_giant_record_reads_bounded_bytes(tmp_path, monkeypatch) -> None:
+    # Pre-allocation guard: a 4 MB unterminated record must be DETECTED as
+    # oversized without ever being materialized in full. The counting
+    # wrapper measures the bytes actually pulled from the file.
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_bytes(b"x" * 4_000_000)  # one physical record, no terminator
+    counted = {"bytes": 0}
+    real_open = pathlib.Path.open
+
+    class _CountingFile:
+        def __init__(self, raw):
+            self._raw = raw
+
+        def readline(self, limit=-1):
+            chunk = self._raw.readline(limit)
+            counted["bytes"] += len(chunk)
+            return chunk
+
+        def __iter__(self):
+            for line in self._raw:
+                counted["bytes"] += len(line)
+                yield line
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._raw.__exit__(*exc)
+
+        def __getattr__(self, name):
+            return getattr(self._raw, name)
+
+    def counting_open(self, *args, **kwargs):
+        raw = real_open(self, *args, **kwargs)
+        return _CountingFile(raw) if self == log else raw
+
+    monkeypatch.setattr(pathlib.Path, "open", counting_open)
+    seq, rej, rows_read = read_dominant_sequence(log)
+    assert rej["oversized_line"] == 1
+    assert seq == []
+    assert rows_read == 1
+    # Bounded read: at most one max_line_bytes-sized probe plus slack —
+    # never the full 4 MB record.
+    assert counted["bytes"] <= MAX_LINE_BYTES_DEFAULT + 4096
 
 
 def test_max_rows_bounds_work(tmp_path) -> None:
@@ -129,6 +225,43 @@ def test_max_rows_bounds_work(tmp_path) -> None:
     seq, _, rows_read = read_dominant_sequence(log, max_rows=10)
     assert rows_read == 10
     assert len(seq) == 10
+
+
+def test_max_rows_exact_limit_and_one_over(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows([A] * 10))
+    seq, _, rows_read = read_dominant_sequence(log, max_rows=10)
+    assert (len(seq), rows_read) == (10, 10)   # exact limit: everything read
+    log11 = _write_log(tmp_path, _dominant_rows([A] * 11))
+    seq11, _, rows_read11 = read_dominant_sequence(log11, max_rows=10)
+    assert (len(seq11), rows_read11) == (10, 10)  # limit+1: the 11th is untouched
+
+
+def test_max_rows_counts_blank_physical_records(tmp_path) -> None:
+    # max_rows is a RAW-work bound: blank physical records consume budget
+    # even though they are neither observations nor violations.
+    log = _write_log(tmp_path, ["", "", ""] + _dominant_rows([A, B, A]))
+    seq, rej, rows_read = read_dominant_sequence(log, max_rows=5)
+    assert rows_read == 5
+    assert seq == [A, B]      # 3 blanks + 2 rows exhaust the budget of 5
+    assert sum(rej.values()) == 0
+
+
+def test_blank_line_flood_terminates_within_budget(tmp_path) -> None:
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text("\n" * 10_000, encoding="utf-8")
+    seq, rej, rows_read = read_dominant_sequence(log, max_rows=50)
+    assert rows_read == 50    # bounded raw work, NOT 10,000 refunded reads
+    assert seq == []
+    assert sum(rej.values()) == 0
+
+
+def test_report_rows_read_counts_blank_records(tmp_path) -> None:
+    rows = _dominant_rows(_FIXTURE_SEQUENCE)
+    log = _write_log(tmp_path, rows[:3] + [""] + rows[3:7] + [""] + rows[7:])
+    report = build_report(log)
+    assert report["input"]["rows_read"] == len(_FIXTURE_SEQUENCE) + 2
+    assert report["input"]["rows_accepted"] == len(_FIXTURE_SEQUENCE)
+    assert report["input"]["rows_rejected"] == 0
 
 
 def test_out_of_order_rows_never_reorder_silently(tmp_path) -> None:
@@ -371,13 +504,64 @@ def test_cli_writes_deterministic_report_inside_log_dir(tmp_path, capsys) -> Non
     assert json.loads(text_one)["schema"] == REPORT_SCHEMA
 
 
-def test_cli_refuses_output_escape(tmp_path) -> None:
-    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
-    with pytest.raises(WriteOutsideLogDirError):
-        main([str(log), "--output", str(tmp_path.parent / "escape.json")])
+# Expected-failure contract: documented nonzero exit + one concise
+# ``error:`` stderr line, never a traceback; unexpected programming
+# errors are NOT converted into clean exits.
 
 
-def test_cli_missing_file_and_insufficient_history_exit_codes(tmp_path) -> None:
-    assert main([str(tmp_path / "absent.jsonl")]) == 2
+def _expect_cli_failure(capsys, argv: list[str], code: int) -> str:
+    assert main(argv) == code, argv
+    captured = capsys.readouterr()
+    assert captured.err.startswith("error:"), argv
+    assert "Traceback" not in captured.err, argv
+    return captured.err
+
+
+def test_cli_missing_file_and_insufficient_history_exit_codes(tmp_path, capsys) -> None:
+    _expect_cli_failure(capsys, [str(tmp_path / "absent.jsonl")], 2)
     log = _write_log(tmp_path, _dominant_rows([A]))
-    assert main([str(log)]) == 3
+    _expect_cli_failure(capsys, [str(log)], 3)
+
+
+def test_cli_validation_errors_are_concise_exit_2(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    for extra in (
+        ["--smoothing", "0"],
+        ["--smoothing", "1001"],
+        ["--holdout-fraction", "0.9"],
+        ["--max-rows", "0"],
+        ["--max-rows", "2000000"],
+        ["--max-line-bytes", "0"],
+    ):
+        _expect_cli_failure(capsys, [str(log), *extra], 2)
+
+
+def test_cli_output_escape_is_concise_exit_4(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    escape = tmp_path.parent / "escape.json"
+    _expect_cli_failure(capsys, [str(log), "--output", str(escape)], 4)
+    assert not escape.exists()
+
+
+def test_cli_unwritable_output_is_concise_exit_4(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    # The log's own directory passes the boundary check but cannot be
+    # opened for writing on any platform.
+    _expect_cli_failure(capsys, [str(log), "--output", str(tmp_path)], 4)
+
+
+def test_cli_report_too_large_is_concise_exit_5(tmp_path, capsys, monkeypatch) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    monkeypatch.setattr(nextness_predictor, "MAX_REPORT_BYTES", 10)
+    _expect_cli_failure(capsys, [str(log)], 5)
+
+
+def test_cli_unexpected_errors_are_not_hidden(tmp_path, monkeypatch) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("unexpected programming error")
+
+    monkeypatch.setattr(nextness_predictor, "build_report", boom)
+    with pytest.raises(RuntimeError, match="unexpected programming error"):
+        main([str(log)])


### PR DESCRIPTION
First package of the **Medusa nextness + metacognitive foundation** runway (Kev-authorized 2026-07-13): the "can she anticipate what happens next?" rung, asked honestly — three transparent baselines over the existing Nextness Observer JSONL so any future predictor has something falsifiable to beat.

**Models** (shared Laplace smoothing, directly comparable likelihoods): `empirical_prior` · `persistence` · `first_order` (unseen transition sources fall back to the prior — documented + counted in the report).

**Evaluation**: chronological holdout only, nothing shuffled; NLL (bits), multiclass Brier, top-1 (canonical tie-break), ECE (10 fixed bins). Every model reported, **including when a simple baseline wins — no intelligence claims** (non-claims embedded in the report itself).

**Safety contract**: offline-only (no network/ZMQ/Ollama/model calls — statically auditable imports); reads observer logs, never snapshots or live engine; writes only inside the resolved input-log dir (`WriteOutsideLogDirError` reused) and **never** inside `data/`; strictly-increasing generation chronology (rejects, never reorders); bounded rows/line-length; fixed rejection-reason vocabulary carrying counts only; deterministic sorted-key report, no timestamps, byte-identical across runs, 64 KiB fail-closed ceiling.

**Tests (28)**: exact metric fixtures calculated *independently in the test* (closed forms, e.g. persistence NLL = log₂17 on the alternating fixture), no-leakage proof (holdout-only token sits at exactly the smoothing floor in the trained prior), all 12 rejection reasons individually accounted, unseen tokens/sources, ties, bounds, hygiene, write-boundary refusals, CLI round-trip.

**Receipts**: `py_compile` OK · 28/28 targeted · full maintained Python suite **875 passed / 27 skipped / 0 failed**.

No dependencies added. No engine/observer/vocabulary changes. **HELD OPEN AND UNMERGED for Jack.** NP2 (metacognitive monitor) stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Kev-authorized corrections (2026-07-14, one commit: `f519256b122beaf70b0e6eafaec8b675541c6b60`)

Bounded correction pass, personally authorized by Kev: heads `0c551a3e` → `f519256b`; files touched = the module, its tests, its contract doc only.

**1. Raw-line work bound** — `max_rows` now counts **every physical input record** (blank, rejected and accepted alike); the blank-line refund (`rows_read -= 1`) that let a blank-line flood buy unbounded reading is gone. `rows_accepted` remains the accepted-observation count, so `rows_read ≥ rows_accepted + rows_rejected`. Tested at the exact limit, limit+1, and a 10,000-blank-line flood (budget 50 → exactly 50 records consumed).

**2. Pre-allocation line-size bound** — records are read via bounded `readline` probes of at most `max_line_bytes + 2` bytes, so an oversized or unterminated record is **never materialized in full** (receipt: a 4 MB unterminated record triggers ≤ 65 538 + slack bytes of actual reads, measured by a counting file wrapper). The bound is on record **content** (LF or CRLF terminator excluded). Documented fail-closed behavior: the first oversized record is counted `oversized_line` and **terminates ingestion** — skipping past it would require unbounded scanning for the next record boundary; total read work ≤ `max_rows × (max_line_bytes + 2)` bytes. Tested at exact size, one byte over (both terminators), and the 4 MB unterminated case.

**3. Expected CLI failures** — documented exit-code contract, all tested: `2` validation (missing file, out-of-bounds smoothing/holdout/max-rows/max-line-bytes), `3` insufficient history, `4` output-path (boundary violation or unwritable target), `5` report-too-large. Each prints one concise `error:` stderr line — never a traceback; only the expected error types are caught, so unexpected programming errors still propagate (tested).

**Failing-first receipts** — the new/updated tests were run against the *old* implementation first: **11 failed, 28 passed** (`test_max_rows_counts_blank_physical_records`, `test_blank_line_flood_terminates_within_budget`, `test_report_rows_read_counts_blank_records`, `test_huge_line_is_rejected_and_terminates_ingestion`, `test_line_content_exactly_at_byte_bound_is_accepted`, `test_line_one_byte_over_bound_is_oversized_and_terminal`, `test_unterminated_giant_record_reads_bounded_bytes`, `test_cli_validation_errors_are_concise_exit_2`, `test_cli_output_escape_is_concise_exit_4`, `test_cli_unwritable_output_is_concise_exit_4`, `test_cli_report_too_large_is_concise_exit_5`). After the fix: **39/39 targeted**, full maintained suite **886 passed / 27 skipped / 0 failed**, `py_compile` OK.

**Intentional output differences** (deterministic behavior otherwise preserved — blank-free, within-bounds logs produce byte-identical reports, locked by the existing byte-identity test):
- `input.rows_read` now includes blank physical records (was: blanks refunded).
- Content of exactly `max_line_bytes` bytes is now accepted (old check charged the line terminator against the bound and measured re-encoded characters; new check measures raw content bytes, terminator excluded).
- A log containing an oversized record now yields a report over the rows accepted *before* it (fail-closed stop) instead of skipping the record after full materialization.
- Expected CLI failures exit 2/4/5 with concise stderr instead of raw tracebacks.

**Review-finding dispositions** (threads deliberately left open and unreplied for Jack): gemini `max_rows` blank-line bypass → addressed by correction 1 · codex P2 "count blank lines against the raw-line cap" → addressed by correction 1 · codex P2 "enforce line-size limits before allocating the line" → addressed by correction 2 · gemini "CLI crashes with raw traceback on expected errors" → addressed by correction 3.

**Still HELD OPEN AND UNMERGED for Jack.**
