### PR TITLE
feat: metacognitive calibration receipt over NP1 (PACKAGE NP2)

### DIFF
--- a/docs/NEXTNESS_MONITOR_CONTRACT.md
+++ b/docs/NEXTNESS_MONITOR_CONTRACT.md
@@ -34,7 +34,7 @@ only part that can be tested.
 | `mean_confidence` | float | mean top-1 probability |
 | `mean_surprise_bits` | float | mean −log₂ P(actual), bounded ≤1000 (underflow guard) |
 | `rolling_calibration_error` | float | fixed-bin ECE over the last `window` observations (same 10-bin scheme as NP1) |
-| `distribution_drift_bits` | float | Jensen-Shannon divergence (bits), recent window vs training reference — **reuses `nextness_metrics.js_divergence`**, no new divergence code |
+| `distribution_drift_bits` | float | Jensen-Shannon divergence (bits), recent window vs training reference — **reuses `nextness_metrics.js_divergence`**, no new divergence code. The bridge's recent counts cover **exactly the latest `window` holdout observations** (never the whole holdout, so an older stable prefix cannot dilute a late regime change) |
 | `sufficiency` | enum | `sufficient` / `insufficient` |
 | `abstain` | bool | see decision procedure |
 | `abstain_reason` | enum | fixed vocabulary below |
@@ -69,13 +69,30 @@ float thresholds ∈ (0, 1)).
 - Observations must be built-in dicts with exactly the allowlisted
   fields `confidence`, `hit`, `p_actual`, `prev_seen`; unknown fields
   are discarded and honestly counted (`input_reduced`); missing or
-  invalid required fields **fail closed** with a typed error.
+  invalid required fields **fail closed** with a typed error. All four
+  fields are required — a missing `prev_seen` is **never defaulted to
+  `True`** (that would mask `unseen_state` abstention).
+- Numbers must be **exact builtin `int`/`float`**: bools, non-finite
+  values and custom numeric subclasses are rejected through
+  `MonitorInputError` *before* any conversion hook
+  (`__float__`/`__index__`) can run.
 - Container guards: dict subclasses, hostile `__str__`/`__float__`
   objects, bools-as-numbers, NaN/inf, out-of-range probabilities and
   astronomically large integers are all rejected *before* any
   stringification or arithmetic can touch them.
 - Reference/recent token counts: built-in dicts, known vocabulary only,
   non-negative built-in ints.
+- Configuration: `min_history` and `window` must be **exact builtin
+  ints** within their documented ranges (bool/float/subclasses rejected);
+  the bridge's inherited NP1 options (`smoothing`, `holdout_fraction`)
+  keep NP1's exact bounds and fail closed on violation.
+
+## CLI expected-failure contract (inherited from NP1)
+
+`0` success · `2` validation failure (missing log file or out-of-bounds
+options) · `3` insufficient history. Every expected failure prints one
+concise `error:` line to stderr — never a traceback. The monitor writes
+no files on any path, success or failure.
 
 ## A finding worth keeping (from the test suite)
 

--- a/docs/NEXTNESS_MONITOR_CONTRACT.md
+++ b/docs/NEXTNESS_MONITOR_CONTRACT.md
@@ -1,0 +1,96 @@
+# Nextness Monitor Contract (NP2)
+
+**Module**: `scripts/nextness_monitor.py` · **Tests**: `tests/test_nextness_monitor.py`
+**Schema**: `nextness-monitor-v1` · **Status**: functional metacognition only — measures, never acts
+
+## What this is
+
+The second rung of the functional-self-awareness ladder: **can the
+system detect when its own predictor should not be trusted?** The
+monitor consumes NP1's bounded prediction observations and emits one
+deterministic receipt saying how confident the predictor was, how
+surprised it turned out to be, whether it is inside its calibrated
+regime, and — centrally — whether its current output should be
+**abstained from**.
+
+**"Abstain" means exactly one thing**: *do not treat this prediction as
+evidence.* It triggers no action, no tuning, no orchestration, nothing.
+The receipt is a statement about trustworthiness, not a control signal.
+
+## Explicit non-claim (load-bearing, embedded in every receipt)
+
+Nothing here is, or is evidence of, awareness, sentience or phenomenal
+experience. It is bookkeeping about a counting model's error statistics
+— the functional shadow of "knowing you might be wrong", which is the
+only part that can be tested.
+
+## Receipt fields (closed allowlist)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema` | const | `nextness-monitor-v1` |
+| `model` | enum | one of `empirical_prior` / `persistence` / `first_order` (fixed allowlist; fail closed) |
+| `observation_count` | int | validated observations consumed |
+| `mean_confidence` | float | mean top-1 probability |
+| `mean_surprise_bits` | float | mean −log₂ P(actual), bounded ≤1000 (underflow guard) |
+| `rolling_calibration_error` | float | fixed-bin ECE over the last `window` observations (same 10-bin scheme as NP1) |
+| `distribution_drift_bits` | float | Jensen-Shannon divergence (bits), recent window vs training reference — **reuses `nextness_metrics.js_divergence`**, no new divergence code |
+| `sufficiency` | enum | `sufficient` / `insufficient` |
+| `abstain` | bool | see decision procedure |
+| `abstain_reason` | enum | fixed vocabulary below |
+| `input_reduced` | bool | unknown observation fields were discarded |
+| `discarded_field_count` | int | how many |
+| `config` | object | bounded threshold echo |
+| `non_claim` | const | the statement above |
+
+No free-form text, no internal monologue, no prompt text, no source
+payloads — numbers, enums and booleans only. Sorted-key deterministic
+JSON, no wall-clock timestamps, byte-identical across runs, **64 KiB
+fail-closed ceiling**.
+
+## Abstention decision (fixed precedence; first match wins)
+
+1. `insufficient_history` — fewer than `min_history` observations.
+2. `unseen_state` — the latest previous token was never seen in
+   training (for `first_order`: never a transition source).
+3. `low_confidence` — latest top-1 probability below threshold.
+4. `calibration_drift` — rolling ECE above threshold.
+5. `distribution_shift` — JS divergence (recent vs reference) above
+   threshold.
+6. `none` — no abstention; the prediction may be treated as evidence.
+
+**Thresholds are configuration, not constants of nature**: every one is
+bounded, documented, echoed in the receipt, and none is claimed to be
+universal (`min_history` ∈ [5, 10000], `window` ∈ [5, 10000], the three
+float thresholds ∈ (0, 1)).
+
+## Input contract
+
+- Observations must be built-in dicts with exactly the allowlisted
+  fields `confidence`, `hit`, `p_actual`, `prev_seen`; unknown fields
+  are discarded and honestly counted (`input_reduced`); missing or
+  invalid required fields **fail closed** with a typed error.
+- Container guards: dict subclasses, hostile `__str__`/`__float__`
+  objects, bools-as-numbers, NaN/inf, out-of-range probabilities and
+  astronomically large integers are all rejected *before* any
+  stringification or arithmetic can touch them.
+- Reference/recent token counts: built-in dicts, known vocabulary only,
+  non-negative built-in ints.
+
+## A finding worth keeping (from the test suite)
+
+With NP1's default Laplace smoothing (α = 1.0 over 16 tokens), a
+predictor that is *perfectly right* on an alternating sequence still
+states only ≈0.605 confidence — systematically under-confident — and
+the monitor correctly reports that gap as `calibration_drift`. The
+metacognition layer catching its own predictor's smoothing bias on day
+one is precisely the kind of receipt this package exists to produce
+(and why thresholds are configuration: light smoothing removes the
+gap). Kept as a permanent regression test.
+
+## Safety
+
+No tuning, orchestration, engine, Swarm Hunter or Lane-A imports (only
+`nextness_predictor`, `nextness_metrics`, `nextness_observer` and
+stdlib). Offline; no network. The monitor **writes no files** — the
+receipt goes to the caller or stdout.

--- a/scripts/nextness_monitor.py
+++ b/scripts/nextness_monitor.py
@@ -26,7 +26,14 @@ Receipt contract (``nextness-monitor-v1``):
   is claimed to be universal.
 - Unknown observation fields are DISCARDED and honestly counted
   (``discarded_field_count`` + ``input_reduced``); malformed
-  observations fail closed with a typed error.
+  observations fail closed with a typed error. All four allowlisted
+  fields are REQUIRED (a missing ``prev_seen`` is never defaulted);
+  numbers must be exact builtin ``int``/``float`` (bools and custom
+  numeric subclasses are rejected before any conversion hook can run)
+  and ``min_history``/``window`` exact builtin ints.
+- Distribution drift compares the training reference against exactly
+  the LATEST ``window`` holdout observations — an older stable holdout
+  prefix cannot dilute a late regime change.
 
 Safety: no tuning, orchestration, engine, Swarm Hunter or Lane-A
 imports; offline; no network; writes nothing (receipt goes to the
@@ -45,13 +52,16 @@ from dataclasses import dataclass
 from typing import Any, Final
 
 from scripts.nextness_metrics import js_divergence
-from scripts.nextness_observer import TOKEN_NAMES
+from scripts.nextness_observer import TOKEN_INDEX, TOKEN_NAMES
 from scripts.nextness_predictor import (
     ECE_BINS,
     HOLDOUT_FRACTION_DEFAULT,
+    HOLDOUT_FRACTION_MAX,
+    HOLDOUT_FRACTION_MIN,
     MAX_LINE_BYTES_DEFAULT,
     MAX_ROWS_DEFAULT,
     SMOOTHING_DEFAULT,
+    SMOOTHING_MAX,
     InsufficientHistoryError,
     empirical_prior_distribution,
     first_order_distribution,
@@ -111,6 +121,8 @@ class MonitorConfig:
     drift_threshold_bits: float = 0.15          # JS divergence, [0, 1] bits
 
     def validate(self) -> None:
+        _require_exact_int("min_history", self.min_history)
+        _require_exact_int("window", self.window)
         if not 5 <= self.min_history <= 10_000:
             raise ValueError(f"min_history out of bounds [5, 10000]: {self.min_history}")
         if not 5 <= self.window <= 10_000:
@@ -129,12 +141,25 @@ class MonitorConfig:
 # ---------------------------------------------------------------------------
 
 
+def _require_exact_int(name: str, value: Any) -> None:
+    """Exact builtin ``int`` only — bool, float and int subclasses are
+    configuration errors, not values to coerce."""
+    if type(value) is not int:
+        raise ValueError(
+            f"{name} must be a builtin int, got {type(value).__name__}"
+        )
+
+
 def _bounded_float(value: Any, field: str, low: float, high: float) -> float:
-    """Accept real, finite numerics inside [low, high]; reject everything
-    else (bools, hostile objects with __float__/__str__, NaN/inf,
-    astronomically large ints) with a typed error."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise MonitorInputError(f"{field}: expected a real number, got {type(value).__name__}")
+    """Accept exact builtin ``int``/``float`` finite values inside
+    [low, high]; reject everything else (bools, custom numeric subclasses,
+    hostile objects with __float__/__str__, NaN/inf, astronomically large
+    ints) with a typed error. Exact-type checks run FIRST so no custom
+    conversion hook (__float__/__index__) is ever invoked."""
+    if type(value) is not int and type(value) is not float:
+        raise MonitorInputError(
+            f"{field}: expected a builtin real number, got {type(value).__name__}"
+        )
     try:
         as_float = float(value)
     except (OverflowError, ValueError) as e:  # e.g. int(10**400) -> inf
@@ -172,7 +197,11 @@ def validate_observations(
         hit = record.get("hit")
         if type(hit) is not bool:
             raise MonitorInputError(f"observation {i}: hit must be a builtin bool")
-        prev_seen = record.get("prev_seen", True)
+        if "prev_seen" not in record:
+            # Fail closed — defaulting a missing prev_seen to True would
+            # silently mask unseen_state abstention.
+            raise MonitorInputError(f"observation {i}: missing field 'prev_seen'")
+        prev_seen = record["prev_seen"]
         if type(prev_seen) is not bool:
             raise MonitorInputError(f"observation {i}: prev_seen must be a builtin bool")
         observations.append(
@@ -208,7 +237,11 @@ def rolling_ece(observations: Sequence[Mapping[str, Any]]) -> float:
     ece = 0.0
     for b in range(ECE_BINS):
         if bin_count[b]:
-            ece += (bin_count[b] / n) * abs(bin_conf[b] / bin_count[b] - bin_acc[b] / bin_count[b])
+            # Algebraically identical to the textbook
+            # (count/n)·|conf/count − acc/count| form — the bin count
+            # cancels; equivalence is locked by a boundary+seeded fixture
+            # test against the unsimplified reference.
+            ece += abs(bin_conf[b] - bin_acc[b]) / n
     return ece
 
 
@@ -217,6 +250,13 @@ def surprise_bits(p_actual: float) -> float:
     if p_actual <= 0.0:
         return _MAX_SURPRISE_BITS
     return min(-math.log2(p_actual), _MAX_SURPRISE_BITS)
+
+
+def canonical_top(dist: Mapping[str, float]) -> str:
+    """Argmax over the canonical vocabulary, ties broken by TOKEN_INDEX
+    (the token EARLIEST in TOKEN_NAMES order wins) — the same constant-time
+    lookup NP1's ``evaluate_predictions`` uses."""
+    return max(TOKEN_NAMES, key=lambda t: (dist[t], -TOKEN_INDEX[t]))
 
 
 # ---------------------------------------------------------------------------
@@ -349,16 +389,33 @@ def observations_from_log(
     holdout_fraction: float = HOLDOUT_FRACTION_DEFAULT,
     max_rows: int = MAX_ROWS_DEFAULT,
     max_line_bytes: int = MAX_LINE_BYTES_DEFAULT,
+    window: int = MonitorConfig.window,
 ) -> tuple[list[dict[str, Any]], dict[str, int], dict[str, int]]:
     """Replay NP1's chronological holdout as monitor observations.
 
     Returns ``(observations, reference_counts, recent_counts)`` where the
-    reference is the training prefix's dominant-token counts and the
-    recent window is the holdout's. Uses exactly NP1's split and model
-    definitions — this bridge adds no new prediction semantics.
+    reference is the training prefix's dominant-token counts and
+    ``recent_counts`` covers exactly the LATEST ``window`` holdout
+    observations (an older stable holdout prefix must not dilute a late
+    regime change; pass the same ``window`` the receipt's MonitorConfig
+    uses). Uses exactly NP1's split, option bounds and model definitions —
+    this bridge adds no new prediction semantics.
     """
     if model not in MODEL_ALLOWLIST:
         raise MonitorInputError(f"model {model!r} not in fixed allowlist {MODEL_ALLOWLIST}")
+    # Inherited NP1 option bounds (same messages as run_evaluation) —
+    # out-of-bounds options must fail closed here too, never reach the
+    # distribution builders as silent garbage.
+    if not 0.0 < smoothing <= SMOOTHING_MAX:
+        raise ValueError(f"smoothing must be in (0, {SMOOTHING_MAX}], got {smoothing}")
+    if not HOLDOUT_FRACTION_MIN <= holdout_fraction <= HOLDOUT_FRACTION_MAX:
+        raise ValueError(
+            f"holdout_fraction must be in [{HOLDOUT_FRACTION_MIN}, "
+            f"{HOLDOUT_FRACTION_MAX}], got {holdout_fraction}"
+        )
+    _require_exact_int("window", window)
+    if not 5 <= window <= 10_000:
+        raise ValueError(f"window out of bounds [5, 10000]: {window}")
     sequence, _rejections, _rows = read_dominant_sequence(
         log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
     )
@@ -386,7 +443,7 @@ def observations_from_log(
         else:
             dist = first_order_distribution(prev, table, prior, smoothing)
             prev_seen = prev in table
-        top = max(TOKEN_NAMES, key=lambda t: (dist[t], -TOKEN_NAMES.index(t)))
+        top = canonical_top(dist)
         observations.append(
             {
                 "confidence": dist[top],
@@ -402,7 +459,7 @@ def observations_from_log(
             out[t] = out.get(t, 0) + 1
         return out
 
-    return observations, _counts(train), _counts(holdout)
+    return observations, _counts(train), _counts(holdout[-window:])
 
 
 # ---------------------------------------------------------------------------
@@ -426,26 +483,44 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit-code contract (inherited from NP1's expected-failure contract):
+
+    - ``0`` success
+    - ``2`` validation failure — missing log file or out-of-bounds
+      options (argparse's own usage errors also exit 2)
+    - ``3`` insufficient history for a train/holdout split
+
+    Every expected failure prints one concise ``error:`` line to stderr —
+    never a traceback. Unexpected programming errors propagate loudly.
+    """
     args = _build_parser().parse_args(argv)
     if not args.log_path.is_file():
         print(f"error: log file not found: {args.log_path}", file=sys.stderr)
         return 2
+    config = MonitorConfig()
     try:
         observations, reference, recent = observations_from_log(
             args.log_path,
             args.model,
             smoothing=args.smoothing,
             holdout_fraction=args.holdout_fraction,
+            window=config.window,
         )
         receipt = build_receipt(
             model=args.model,
             observations=observations,
             reference_counts=reference,
             recent_counts=recent,
+            config=config,
         )
     except InsufficientHistoryError as e:
         print(f"error: {e}", file=sys.stderr)
         return 3
+    except ValueError as e:  # includes MonitorInputError (its subclass)
+        print(f"error: {e}", file=sys.stderr)
+        return 2
     sys.stdout.write(serialize_receipt(receipt))
     return 0
 

--- a/scripts/nextness_monitor.py
+++ b/scripts/nextness_monitor.py
@@ -1,0 +1,454 @@
+"""Metacognitive calibration receipt over NP1 predictions (NP2).
+
+Functional metacognition ONLY: this module measures when the NP1
+predictor is uncertain, surprised, drifting out of its calibrated
+regime, or short of history — and says so in a fixed, bounded,
+deterministic receipt. It does not act on anything. "Abstain" means
+exactly "do not treat this prediction as evidence"; it triggers no
+tuning, no orchestration, no engine or observer behavior of any kind.
+
+EXPLICIT NON-CLAIM (load-bearing): nothing here is, or is evidence of,
+awareness, sentience or phenomenal experience. It is bookkeeping about
+a counting model's error statistics — the *functional* shadow of
+"knowing that you might be wrong", which is the only part we can test.
+
+Receipt contract (``nextness-monitor-v1``):
+
+- Only allowlisted, bounded fields; the model identifier comes from a
+  fixed allowlist; the abstention reason from a fixed vocabulary
+  (``insufficient_history``, ``unseen_state``, ``low_confidence``,
+  ``calibration_drift``, ``distribution_shift``, ``none``).
+- No free-form text, no internal monologue, no prompt text, no source
+  payloads — numbers, enums and booleans only.
+- Plain deterministic JSON: sorted keys, fixed rounding, no wall-clock
+  timestamps, byte-identical across repeated runs, ≤64 KiB fail-closed.
+- Every threshold is bounded, documented configuration — none of them
+  is claimed to be universal.
+- Unknown observation fields are DISCARDED and honestly counted
+  (``discarded_field_count`` + ``input_reduced``); malformed
+  observations fail closed with a typed error.
+
+Safety: no tuning, orchestration, engine, Swarm Hunter or Lane-A
+imports; offline; no network; writes nothing (receipt goes to the
+caller / stdout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final
+
+from scripts.nextness_metrics import js_divergence
+from scripts.nextness_observer import TOKEN_NAMES
+from scripts.nextness_predictor import (
+    ECE_BINS,
+    HOLDOUT_FRACTION_DEFAULT,
+    MAX_LINE_BYTES_DEFAULT,
+    MAX_ROWS_DEFAULT,
+    SMOOTHING_DEFAULT,
+    InsufficientHistoryError,
+    empirical_prior_distribution,
+    first_order_distribution,
+    persistence_distribution,
+    read_dominant_sequence,
+    transition_counts,
+)
+
+RECEIPT_SCHEMA: Final[str] = "nextness-monitor-v1"
+
+#: The only model identifiers a receipt may carry (fail closed otherwise).
+MODEL_ALLOWLIST: Final[tuple[str, ...]] = (
+    "empirical_prior",
+    "persistence",
+    "first_order",
+)
+
+#: Fixed abstention vocabulary, in DECISION PRECEDENCE order (first
+#: matching reason wins; documented in NEXTNESS_MONITOR_CONTRACT.md).
+ABSTAIN_REASONS: Final[tuple[str, ...]] = (
+    "insufficient_history",
+    "unseen_state",
+    "low_confidence",
+    "calibration_drift",
+    "distribution_shift",
+    "none",
+)
+
+#: Allowlisted observation-record fields (anything else is discarded and
+#: counted; the receipt then carries input_reduced=true).
+OBSERVATION_FIELDS: Final[frozenset[str]] = frozenset(
+    {"confidence", "hit", "p_actual", "prev_seen"}
+)
+
+MAX_RECEIPT_BYTES: Final[int] = 64 * 1024
+_ROUND: Final[int] = 6  # fixed decimal rounding for deterministic floats
+_MAX_SURPRISE_BITS: Final[float] = 1_000.0  # bound against p_actual underflow
+
+
+class MonitorInputError(ValueError):
+    """A malformed observation record (fail closed, typed)."""
+
+
+class ReceiptTooLargeError(RuntimeError):
+    """Serialized receipt exceeded MAX_RECEIPT_BYTES (fail closed)."""
+
+
+@dataclass(frozen=True)
+class MonitorConfig:
+    """Bounded, documented thresholds. None of these is universal; they
+    are operating-regime configuration and the receipt echoes them."""
+
+    min_history: int = 30            # observations needed for sufficiency
+    window: int = 50                 # rolling window for ECE + drift
+    low_confidence_threshold: float = 0.30
+    calibration_error_threshold: float = 0.20   # rolling ECE, [0, 1]
+    drift_threshold_bits: float = 0.15          # JS divergence, [0, 1] bits
+
+    def validate(self) -> None:
+        if not 5 <= self.min_history <= 10_000:
+            raise ValueError(f"min_history out of bounds [5, 10000]: {self.min_history}")
+        if not 5 <= self.window <= 10_000:
+            raise ValueError(f"window out of bounds [5, 10000]: {self.window}")
+        for name, value in (
+            ("low_confidence_threshold", self.low_confidence_threshold),
+            ("calibration_error_threshold", self.calibration_error_threshold),
+            ("drift_threshold_bits", self.drift_threshold_bits),
+        ):
+            if not (isinstance(value, float) and 0.0 < value < 1.0):
+                raise ValueError(f"{name} must be a float in (0, 1): {value!r}")
+
+
+# ---------------------------------------------------------------------------
+# Observation validation (container guards + bounded normalization)
+# ---------------------------------------------------------------------------
+
+
+def _bounded_float(value: Any, field: str, low: float, high: float) -> float:
+    """Accept real, finite numerics inside [low, high]; reject everything
+    else (bools, hostile objects with __float__/__str__, NaN/inf,
+    astronomically large ints) with a typed error."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MonitorInputError(f"{field}: expected a real number, got {type(value).__name__}")
+    try:
+        as_float = float(value)
+    except (OverflowError, ValueError) as e:  # e.g. int(10**400) -> inf
+        raise MonitorInputError(f"{field}: not representable as a finite float") from e
+    if not math.isfinite(as_float):
+        raise MonitorInputError(f"{field}: not finite")
+    if not low <= as_float <= high:
+        raise MonitorInputError(f"{field}: {as_float} outside [{low}, {high}]")
+    return as_float
+
+
+def validate_observations(
+    records: Sequence[Any],
+) -> tuple[list[dict[str, Any]], int]:
+    """Normalize observation records into owned, bounded dicts.
+
+    Returns ``(observations, discarded_field_count)``. Each record must
+    be a built-in dict carrying the allowlisted fields; unknown fields
+    are discarded (counted), missing/invalid required fields fail
+    closed. Values are read exactly once into owned plain objects — no
+    caller container is retained.
+    """
+    observations: list[dict[str, Any]] = []
+    discarded = 0
+    for i, record in enumerate(records):
+        if type(record) is not dict:
+            raise MonitorInputError(f"observation {i}: expected builtin dict")
+        unknown = set(record) - OBSERVATION_FIELDS
+        discarded += len(unknown)
+        try:
+            confidence = _bounded_float(record["confidence"], "confidence", 0.0, 1.0)
+            p_actual = _bounded_float(record["p_actual"], "p_actual", 0.0, 1.0)
+        except KeyError as e:
+            raise MonitorInputError(f"observation {i}: missing field {e.args[0]!r}") from e
+        hit = record.get("hit")
+        if type(hit) is not bool:
+            raise MonitorInputError(f"observation {i}: hit must be a builtin bool")
+        prev_seen = record.get("prev_seen", True)
+        if type(prev_seen) is not bool:
+            raise MonitorInputError(f"observation {i}: prev_seen must be a builtin bool")
+        observations.append(
+            {
+                "confidence": confidence,
+                "hit": hit,
+                "p_actual": p_actual,
+                "prev_seen": prev_seen,
+            }
+        )
+    return observations, discarded
+
+
+# ---------------------------------------------------------------------------
+# Rolling statistics (all deterministic, all bounded)
+# ---------------------------------------------------------------------------
+
+
+def rolling_ece(observations: Sequence[Mapping[str, Any]]) -> float:
+    """Fixed-bin expected calibration error over the given observations —
+    the same ECE_BINS deterministic binning NP1 uses."""
+    if not observations:
+        return 0.0
+    n = len(observations)
+    bin_conf = [0.0] * ECE_BINS
+    bin_acc = [0.0] * ECE_BINS
+    bin_count = [0] * ECE_BINS
+    for ob in observations:
+        b = min(int(ob["confidence"] * ECE_BINS), ECE_BINS - 1)
+        bin_conf[b] += ob["confidence"]
+        bin_acc[b] += 1.0 if ob["hit"] else 0.0
+        bin_count[b] += 1
+    ece = 0.0
+    for b in range(ECE_BINS):
+        if bin_count[b]:
+            ece += (bin_count[b] / n) * abs(bin_conf[b] / bin_count[b] - bin_acc[b] / bin_count[b])
+    return ece
+
+
+def surprise_bits(p_actual: float) -> float:
+    """Realised surprise −log₂ P(actual), bounded above (underflow guard)."""
+    if p_actual <= 0.0:
+        return _MAX_SURPRISE_BITS
+    return min(-math.log2(p_actual), _MAX_SURPRISE_BITS)
+
+
+# ---------------------------------------------------------------------------
+# Receipt construction
+# ---------------------------------------------------------------------------
+
+
+def decide_abstention(
+    *,
+    observation_count: int,
+    latest_confidence: float | None,
+    latest_prev_seen: bool,
+    rolling_calibration_error: float,
+    drift_bits: float,
+    config: MonitorConfig,
+) -> tuple[bool, str]:
+    """Deterministic abstention decision, fixed precedence order.
+
+    Precedence (first match wins): insufficient_history → unseen_state →
+    low_confidence → calibration_drift → distribution_shift → none.
+    """
+    if observation_count < config.min_history:
+        return True, "insufficient_history"
+    if not latest_prev_seen:
+        return True, "unseen_state"
+    if latest_confidence is not None and latest_confidence < config.low_confidence_threshold:
+        return True, "low_confidence"
+    if rolling_calibration_error > config.calibration_error_threshold:
+        return True, "calibration_drift"
+    if drift_bits > config.drift_threshold_bits:
+        return True, "distribution_shift"
+    return False, "none"
+
+
+def build_receipt(
+    *,
+    model: str,
+    observations: Sequence[Any],
+    reference_counts: Mapping[str, int],
+    recent_counts: Mapping[str, int],
+    config: MonitorConfig | None = None,
+) -> dict[str, Any]:
+    """One deterministic ``nextness-monitor-v1`` receipt.
+
+    ``reference_counts``/``recent_counts`` are dominant-token count
+    mappings (training reference vs the recent window) whose smoothed
+    Jensen-Shannon divergence — reusing ``nextness_metrics`` — is the
+    drift measure. All fields are allowlisted and bounded; see the
+    module docstring for the full contract.
+    """
+    cfg = config or MonitorConfig()
+    cfg.validate()
+    if model not in MODEL_ALLOWLIST:
+        raise MonitorInputError(f"model {model!r} not in fixed allowlist {MODEL_ALLOWLIST}")
+    for name, counts in (("reference_counts", reference_counts), ("recent_counts", recent_counts)):
+        if type(counts) is not dict:
+            raise MonitorInputError(f"{name}: expected builtin dict")
+        if any(k not in TOKEN_NAMES for k in counts):
+            raise MonitorInputError(f"{name}: unknown token key")
+        for v in counts.values():
+            if isinstance(v, bool) or not isinstance(v, int) or v < 0:
+                raise MonitorInputError(f"{name}: counts must be non-negative builtin ints")
+
+    validated, discarded = validate_observations(observations)
+    window = validated[-cfg.window :]
+    n = len(validated)
+
+    mean_confidence = sum(ob["confidence"] for ob in validated) / n if n else 0.0
+    mean_surprise = sum(surprise_bits(ob["p_actual"]) for ob in validated) / n if n else 0.0
+    ece = rolling_ece(window)
+    drift = js_divergence(reference_counts, recent_counts)
+
+    abstain, reason = decide_abstention(
+        observation_count=n,
+        latest_confidence=validated[-1]["confidence"] if validated else None,
+        latest_prev_seen=validated[-1]["prev_seen"] if validated else True,
+        rolling_calibration_error=ece,
+        drift_bits=drift,
+        config=cfg,
+    )
+
+    receipt: dict[str, Any] = {
+        "schema": RECEIPT_SCHEMA,
+        "model": model,
+        "observation_count": n,
+        "mean_confidence": round(mean_confidence, _ROUND),
+        "mean_surprise_bits": round(mean_surprise, _ROUND),
+        "rolling_calibration_error": round(ece, _ROUND),
+        "distribution_drift_bits": round(drift, _ROUND),
+        "sufficiency": "sufficient" if n >= cfg.min_history else "insufficient",
+        "abstain": abstain,
+        "abstain_reason": reason,
+        "input_reduced": discarded > 0,
+        "discarded_field_count": discarded,
+        "config": {
+            "min_history": cfg.min_history,
+            "window": cfg.window,
+            "low_confidence_threshold": round(cfg.low_confidence_threshold, _ROUND),
+            "calibration_error_threshold": round(cfg.calibration_error_threshold, _ROUND),
+            "drift_threshold_bits": round(cfg.drift_threshold_bits, _ROUND),
+        },
+        "non_claim": (
+            "functional-metacognition-only: no awareness, sentience or "
+            "phenomenal-experience claim"
+        ),
+    }
+    serialized = serialize_receipt(receipt)
+    if len(serialized.encode("utf-8")) > MAX_RECEIPT_BYTES:
+        raise ReceiptTooLargeError(
+            f"receipt would exceed {MAX_RECEIPT_BYTES} bytes; refusing to emit"
+        )
+    return receipt
+
+
+def serialize_receipt(receipt: Mapping[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, newline."""
+    return json.dumps(receipt, sort_keys=True, separators=(",", ": "), indent=1) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# NP1 bridge: derive observations for one model over one JSONL log
+# ---------------------------------------------------------------------------
+
+
+def observations_from_log(
+    log_path: pathlib.Path,
+    model: str,
+    *,
+    smoothing: float = SMOOTHING_DEFAULT,
+    holdout_fraction: float = HOLDOUT_FRACTION_DEFAULT,
+    max_rows: int = MAX_ROWS_DEFAULT,
+    max_line_bytes: int = MAX_LINE_BYTES_DEFAULT,
+) -> tuple[list[dict[str, Any]], dict[str, int], dict[str, int]]:
+    """Replay NP1's chronological holdout as monitor observations.
+
+    Returns ``(observations, reference_counts, recent_counts)`` where the
+    reference is the training prefix's dominant-token counts and the
+    recent window is the holdout's. Uses exactly NP1's split and model
+    definitions — this bridge adds no new prediction semantics.
+    """
+    if model not in MODEL_ALLOWLIST:
+        raise MonitorInputError(f"model {model!r} not in fixed allowlist {MODEL_ALLOWLIST}")
+    sequence, _rejections, _rows = read_dominant_sequence(
+        log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
+    )
+    n = len(sequence)
+    split = math.floor(n * (1.0 - holdout_fraction))
+    train, holdout = list(sequence[:split]), list(sequence[split:])
+    if len(train) < 2 or len(holdout) < 1:
+        raise InsufficientHistoryError(
+            f"need >=2 train and >=1 holdout rows; got train={len(train)}, "
+            f"holdout={len(holdout)}"
+        )
+    prior = empirical_prior_distribution(train, smoothing)
+    table = transition_counts(train)
+    train_tokens = set(train)
+    previous_tokens = [train[-1]] + holdout[:-1]
+
+    observations: list[dict[str, Any]] = []
+    for prev, actual in zip(previous_tokens, holdout):
+        if model == "empirical_prior":
+            dist = prior
+            prev_seen = prev in train_tokens
+        elif model == "persistence":
+            dist = persistence_distribution(prev, smoothing)
+            prev_seen = prev in train_tokens
+        else:
+            dist = first_order_distribution(prev, table, prior, smoothing)
+            prev_seen = prev in table
+        top = max(TOKEN_NAMES, key=lambda t: (dist[t], -TOKEN_NAMES.index(t)))
+        observations.append(
+            {
+                "confidence": dist[top],
+                "hit": top == actual,
+                "p_actual": dist[actual],
+                "prev_seen": prev_seen,
+            }
+        )
+
+    def _counts(tokens: Sequence[str]) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for t in tokens:
+            out[t] = out.get(t, 0) + 1
+        return out
+
+    return observations, _counts(train), _counts(holdout)
+
+
+# ---------------------------------------------------------------------------
+# CLI (stdout only — the monitor writes no files)
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Metacognitive calibration receipt over NP1 predictions "
+            "(functional metacognition only; stdout only; see module "
+            "docstring for the full contract)."
+        )
+    )
+    parser.add_argument("log_path", type=pathlib.Path, help="path to nextness_runs.jsonl")
+    parser.add_argument("--model", choices=MODEL_ALLOWLIST, default="first_order")
+    parser.add_argument("--smoothing", type=float, default=SMOOTHING_DEFAULT)
+    parser.add_argument("--holdout-fraction", type=float, default=HOLDOUT_FRACTION_DEFAULT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.log_path.is_file():
+        print(f"error: log file not found: {args.log_path}", file=sys.stderr)
+        return 2
+    try:
+        observations, reference, recent = observations_from_log(
+            args.log_path,
+            args.model,
+            smoothing=args.smoothing,
+            holdout_fraction=args.holdout_fraction,
+        )
+        receipt = build_receipt(
+            model=args.model,
+            observations=observations,
+            reference_counts=reference,
+            recent_counts=recent,
+        )
+    except InsufficientHistoryError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+    sys.stdout.write(serialize_receipt(receipt))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -336,3 +336,273 @@ def test_cli_exit_codes(tmp_path) -> None:
     assert main([str(tmp_path / "absent.jsonl")]) == 2
     log = _write_log(tmp_path, [A])
     assert main([str(log)]) == 3
+
+
+# ---------------------------------------------------------------------------
+# NP2 corrections (delta audit): exact-type guards, required prev_seen,
+# windowed drift, canonical tie-break equivalence, gated ECE simplification,
+# inherited NP1 reader behavior, abstention-only outcomes.
+# ---------------------------------------------------------------------------
+
+
+class _IntSubclass(int):
+    pass
+
+
+def test_config_min_history_and_window_must_be_exact_builtin_ints() -> None:
+    # Correction A: bool, float and numeric subclasses are rejected even
+    # when their numeric value sits inside the documented range.
+    for bad in (True, 30.0, _IntSubclass(30)):
+        with pytest.raises(ValueError):
+            MonitorConfig(min_history=bad).validate()
+    for bad in (True, 50.0, _IntSubclass(50)):
+        with pytest.raises(ValueError):
+            MonitorConfig(window=bad).validate()
+    MonitorConfig(min_history=30, window=50).validate()  # exact ints still fine
+
+
+def test_numeric_subclasses_rejected_without_invoking_conversion_hooks() -> None:
+    # Correction B: only exact builtin int/float are supported observation
+    # numbers; custom subclasses are rejected through MonitorInputError
+    # BEFORE any conversion hook (__float__/__index__) can run.
+    hook_calls: list[str] = []
+
+    class _HookedFloat(float):
+        def __float__(self) -> float:
+            hook_calls.append("float.__float__")
+            return 0.5
+
+    class _HookedInt(int):
+        def __float__(self) -> float:
+            hook_calls.append("int.__float__")
+            return 0.5
+
+        def __index__(self) -> int:
+            hook_calls.append("int.__index__")
+            return 0
+
+    for bad in (_HookedFloat(0.5), _HookedInt(0)):
+        for field in ("confidence", "p_actual"):
+            with pytest.raises(MonitorInputError):
+                validate_observations([{**_ob(0.5, True, 0.5), field: bad}])
+    assert hook_calls == []  # rejection happened before conversion
+
+
+def test_missing_prev_seen_fails_closed_and_never_defaults_to_true() -> None:
+    # Correction C: prev_seen is REQUIRED; a missing value must not be
+    # silently defaulted to True (that would mask unseen_state abstention).
+    record = {"confidence": 0.9, "hit": True, "p_actual": 0.9}  # no prev_seen
+    with pytest.raises(MonitorInputError):
+        validate_observations([record])
+    for bad in (None, 1, 0, "true"):
+        with pytest.raises(MonitorInputError):
+            validate_observations([{**_ob(0.9, True, 0.9), "prev_seen": bad}])
+
+
+def test_recent_counts_use_exactly_the_latest_window_observations(tmp_path) -> None:
+    # Correction D: 60 train + 20 holdout; the older half of the holdout
+    # continues the training regime, the last `window`=10 observations are
+    # a hard regime change to all-B. Whole-holdout counting dilutes the
+    # shift below the drift threshold; windowed counting must not.
+    tokens = [A, B] * 30 + [A, B] * 5 + [B] * 10
+    log = _write_log(tmp_path, tokens)
+    obs, reference, recent = observations_from_log(
+        log, "persistence", smoothing=0.01, window=10
+    )
+    assert reference == {A: 30, B: 30}
+    assert recent == {B: 10}  # exactly the latest window, not {A: 5, B: 15}
+
+    # Expected drift derived independently of the bridge: hand-built count
+    # dicts through the shared metric, cross-checked against the hand
+    # calculation JS((.5,.5),(0,1)) = 1 - 0.75*log2(3) + 0.5*log2(2) ~ 0.3113.
+    from scripts.nextness_metrics import js_divergence
+
+    expected_drift = js_divergence({A: 30, B: 30}, {B: 10})
+    diluted_drift = js_divergence({A: 30, B: 30}, {A: 5, B: 15})
+    assert expected_drift == pytest.approx(0.3113, abs=2e-3)
+    assert diluted_drift < 0.15 < expected_drift  # dilution hid the shift
+
+    receipt = build_receipt(
+        model="persistence",
+        observations=obs,
+        reference_counts=reference,
+        recent_counts=recent,
+        config=MonitorConfig(min_history=10, window=10),
+    )
+    assert receipt["distribution_drift_bits"] == round(expected_drift, 6)
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "distribution_shift"
+
+
+def test_default_window_bounds_recent_counts(tmp_path) -> None:
+    # Correction D at the default window: holdout 100 > window 50 must
+    # yield exactly 50 recent counts, not the entire holdout.
+    log = _write_log(tmp_path, [A, B] * 150 + [B] * 100)
+    _obs, reference, recent = observations_from_log(log, "persistence")
+    assert sum(reference.values()) == 300
+    assert recent == {B: 50}
+
+
+def test_bridge_window_must_be_exact_builtin_int_in_bounds(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 8)
+    for bad in (True, 10.0, _IntSubclass(10), 4, 10_001):
+        with pytest.raises(ValueError):
+            observations_from_log(log, "persistence", window=bad)
+
+
+def test_canonical_top_matches_legacy_token_names_index_tie_break() -> None:
+    # Correction E equivalence proof: TOKEN_INDEX tie-breaking selects the
+    # same token as the legacy TOKEN_NAMES.index expression on uniform,
+    # pairwise-tied and coarsely-quantized (tie-rich) distributions.
+    from scripts.nextness_monitor import canonical_top
+
+    dists = [{t: 1.0 / len(TOKEN_NAMES) for t in TOKEN_NAMES}]
+    for i in range(len(TOKEN_NAMES)):
+        for j in range(i + 1, len(TOKEN_NAMES)):
+            d = {t: 0.01 for t in TOKEN_NAMES}
+            d[TOKEN_NAMES[i]] = 0.4
+            d[TOKEN_NAMES[j]] = 0.4
+            dists.append(d)
+    rng = random.Random(4242)
+    for _ in range(500):
+        dists.append({t: round(rng.random() * 5) / 5.0 for t in TOKEN_NAMES})
+    for d in dists:
+        legacy = max(TOKEN_NAMES, key=lambda t: (d[t], -TOKEN_NAMES.index(t)))
+        assert canonical_top(d) == legacy
+
+
+def _rolling_ece_reference(observations) -> float:
+    # The pre-simplification form, kept VERBATIM as the equivalence oracle
+    # for correction F: (count/n) * |conf/count - acc/count| per bin.
+    from scripts.nextness_predictor import ECE_BINS
+
+    if not observations:
+        return 0.0
+    n = len(observations)
+    bin_conf = [0.0] * ECE_BINS
+    bin_acc = [0.0] * ECE_BINS
+    bin_count = [0] * ECE_BINS
+    for ob in observations:
+        b = min(int(ob["confidence"] * ECE_BINS), ECE_BINS - 1)
+        bin_conf[b] += ob["confidence"]
+        bin_acc[b] += 1.0 if ob["hit"] else 0.0
+        bin_count[b] += 1
+    ece = 0.0
+    for b in range(ECE_BINS):
+        if bin_count[b]:
+            ece += (bin_count[b] / n) * abs(
+                bin_conf[b] / bin_count[b] - bin_acc[b] / bin_count[b]
+            )
+    return ece
+
+
+def test_ece_simplification_equivalent_on_boundary_and_seeded_fixtures() -> None:
+    # Correction F gate: exact bin-boundary confidences (0.0, 0.1, ..., 1.0),
+    # the recorded exact fixture, degenerate cases and seeded traces must
+    # agree with the pre-simplification form to 1e-12 AND serialize
+    # identically after the receipt's fixed 6-decimal rounding.
+    fixtures = [
+        [_ob(round(k * 0.1, 1), k % 2 == 0, 0.5) for k in range(11)],
+        [_ob(0.85, True, 0.85), _ob(0.85, False, 0.1)],
+        [],
+        [_ob(1.0, True, 1.0)] * 7,
+        [_ob(0.0, False, 0.0)] * 3,
+    ]
+    for seed in (7, 77, 777, 4242):
+        rng = random.Random(seed)
+        fixtures.append(
+            [_ob(rng.random(), rng.random() < 0.5, rng.random()) for _ in range(97)]
+        )
+    for obs in fixtures:
+        simplified = rolling_ece(obs)
+        reference = _rolling_ece_reference(obs)
+        assert simplified == pytest.approx(reference, abs=1e-12)
+        assert round(simplified, 6) == round(reference, 6)
+
+
+def test_blank_records_consume_raw_row_budget_through_the_bridge(tmp_path) -> None:
+    # Inherited NP1 reader contract: blank records are neither observations
+    # nor violations, but they consume max_rows budget (bounded raw work).
+    rows = [
+        json.dumps({"generation": i, "token_counts": {(A if i % 2 == 0 else B): 3}})
+        for i in range(40)
+    ]
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text("\n\n\n" + "\n".join(rows) + "\n", encoding="utf-8")
+    obs, reference, recent = observations_from_log(log, "persistence", max_rows=40)
+    # 3 blanks + 37 data rows fit the budget: split floor(37*0.75)=27/10.
+    assert sum(reference.values()) == 27
+    assert len(obs) == 10
+
+
+def test_oversized_record_stops_ingestion_through_the_bridge(tmp_path) -> None:
+    # Inherited NP1 reader contract: the first oversized record is counted
+    # and TERMINATES ingestion with bounded reads (fail closed) — rows
+    # after it never become observations.
+    rows = [
+        json.dumps({"generation": i, "token_counts": {(A if i % 2 == 0 else B): 3}})
+        for i in range(30)
+    ]
+    big = json.dumps({"generation": 98, "token_counts": {A: 3}, "pad": "x" * 5000})
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text(
+        "\n".join(rows[:20]) + "\n" + big + "\n" + "\n".join(rows[20:]) + "\n",
+        encoding="utf-8",
+    )
+    obs, reference, recent = observations_from_log(
+        log, "persistence", max_line_bytes=256
+    )
+    # Exactly the 20 pre-oversize rows: split floor(20*0.75)=15/5.
+    assert sum(reference.values()) == 15
+    assert len(obs) == 5
+
+
+def test_invalid_inherited_predictor_options_fail_closed(tmp_path) -> None:
+    # Inherited NP1 option bounds must hold on the bridge too — never
+    # silently produce distributions from out-of-bounds smoothing or a
+    # degenerate holdout fraction.
+    log = _write_log(tmp_path, [A, B] * 30)
+    for kwargs in (
+        {"smoothing": -1.0},
+        {"smoothing": 0.0},
+        {"smoothing": 1e9},
+        {"holdout_fraction": 0.01},
+        {"holdout_fraction": 0.9},
+    ):
+        with pytest.raises(ValueError):
+            observations_from_log(log, "first_order", **kwargs)
+
+
+def test_cli_invalid_options_exit_concisely_and_write_nothing(tmp_path, capsys) -> None:
+    # Inherited expected-failure CLI contract: concise `error:` line on
+    # stderr, exit 2, no traceback, no files written.
+    log = _write_log(tmp_path, [A, B] * 30)
+    before = sorted(p.name for p in tmp_path.iterdir())
+    assert main([str(log), "--smoothing", "-1"]) == 2
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+    assert main([str(log), "--holdout-fraction", "0.9"]) == 2
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+def test_rejected_evidence_yields_typed_failure_or_documented_abstention() -> None:
+    # Abstention contract: rejected predictor evidence is a typed input
+    # failure (no receipt at all); insufficient evidence is a documented
+    # abstention receipt whose fields stay inside the closed allowlist —
+    # never an action, tuning, orchestration or write signal.
+    with pytest.raises(MonitorInputError):
+        _receipt([{**_ob(0.5, True, 0.5), "p_actual": float("nan")}])
+    receipt = _receipt([_ob(0.9, True, 0.9)] * 3)
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "insufficient_history"
+    assert set(receipt) == {
+        "schema", "model", "observation_count", "mean_confidence",
+        "mean_surprise_bits", "rolling_calibration_error",
+        "distribution_drift_bits", "sufficiency", "abstain",
+        "abstain_reason", "input_reduced", "discarded_field_count",
+        "config", "non_claim",
+    }

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -1,0 +1,338 @@
+"""NP2: metacognitive calibration receipt — contract + adversarial tests."""
+
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+import random
+
+import pytest
+
+from scripts.nextness_observer import TOKEN_NAMES
+from scripts.nextness_monitor import (
+    ABSTAIN_REASONS,
+    MAX_RECEIPT_BYTES,
+    MODEL_ALLOWLIST,
+    RECEIPT_SCHEMA,
+    MonitorConfig,
+    MonitorInputError,
+    build_receipt,
+    decide_abstention,
+    main,
+    observations_from_log,
+    rolling_ece,
+    serialize_receipt,
+    surprise_bits,
+    validate_observations,
+)
+
+A = "void_static"
+B = "compute_static"
+
+
+def _ob(confidence: float, hit: bool, p_actual: float, prev_seen: bool = True) -> dict:
+    return {"confidence": confidence, "hit": hit, "p_actual": p_actual, "prev_seen": prev_seen}
+
+
+def _receipt(observations, *, model="first_order", reference=None, recent=None, config=None):
+    return build_receipt(
+        model=model,
+        observations=observations,
+        reference_counts=reference if reference is not None else {A: 10, B: 10},
+        recent_counts=recent if recent is not None else {A: 5, B: 5},
+        config=config,
+    )
+
+
+def _write_log(tmp_path: pathlib.Path, tokens: list[str]) -> pathlib.Path:
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text(
+        "\n".join(
+            json.dumps({"generation": i, "token_counts": {t: 3}}) for i, t in enumerate(tokens)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Regression scenarios (the six named regimes)
+# ---------------------------------------------------------------------------
+
+
+def test_calibrated_regime_does_not_abstain(tmp_path) -> None:
+    # Perfect alternation with LIGHT smoothing: first_order is confident
+    # (~0.995), right, calibrated, and train/holdout distributions match
+    # -> abstain=false, reason none.
+    log = _write_log(tmp_path, [A, B] * 30)
+    observations, reference, recent = observations_from_log(
+        log, "first_order", smoothing=0.01
+    )
+    receipt = _receipt(observations, reference=reference, recent=recent,
+                       config=MonitorConfig(min_history=10))
+    assert receipt["abstain"] is False
+    assert receipt["abstain_reason"] == "none"
+    assert receipt["sufficiency"] == "sufficient"
+
+
+def test_monitor_detects_np1_default_smoothing_underconfidence(tmp_path) -> None:
+    # FINDING (kept deliberately): with NP1's default Laplace alpha=1.0
+    # over 16 tokens, a perfect alternation predictor STATES ~0.605
+    # confidence while ACHIEVING 1.0 accuracy — systematically
+    # under-confident, and the monitor honestly reports that gap as
+    # calibration drift. Metacognition catching its own predictor's
+    # smoothing bias is exactly the receipt this package exists to give.
+    log = _write_log(tmp_path, [A, B] * 30)
+    observations, reference, recent = observations_from_log(log, "first_order")
+    receipt = _receipt(observations, reference=reference, recent=recent,
+                       config=MonitorConfig(min_history=10))
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "calibration_drift"
+    assert receipt["mean_confidence"] < 0.7
+    assert receipt["rolling_calibration_error"] > 0.3
+
+
+def test_under_confident_regime_abstains_on_low_confidence() -> None:
+    # Confidence sits below the threshold while accuracy is fine.
+    obs = [_ob(0.2, True, 0.2) for _ in range(40)]
+    receipt = _receipt(obs, config=MonitorConfig(min_history=10))
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "low_confidence"
+
+
+def test_over_confident_regime_abstains_on_calibration_drift() -> None:
+    # Confident (0.9) but wrong half the time: rolling ECE ~= 0.4+ .
+    obs = [_ob(0.9, i % 2 == 0, 0.45) for i in range(40)]
+    receipt = _receipt(obs, config=MonitorConfig(min_history=10))
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "calibration_drift"
+    assert receipt["rolling_calibration_error"] > 0.2
+
+
+def test_shifted_regime_abstains_on_distribution_drift() -> None:
+    # Healthy predictions, but the recent window's token mix diverges
+    # hard from the training reference -> distribution_shift.
+    obs = [_ob(0.8, True, 0.8) for _ in range(40)]
+    receipt = _receipt(
+        obs,
+        reference={A: 30},
+        recent={B: 30},
+        config=MonitorConfig(min_history=10),
+    )
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "distribution_shift"
+    assert receipt["distribution_drift_bits"] > 0.15
+
+
+def test_unseen_state_abstains(tmp_path) -> None:
+    # The latest previous token was never a training transition source.
+    obs = [_ob(0.8, True, 0.8) for _ in range(39)] + [_ob(0.8, False, 0.05, prev_seen=False)]
+    receipt = _receipt(obs, config=MonitorConfig(min_history=10))
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "unseen_state"
+
+
+def test_insufficient_history_abstains_first() -> None:
+    obs = [_ob(0.9, True, 0.9) for _ in range(5)]
+    receipt = _receipt(obs)  # default min_history=30
+    assert receipt["abstain"] is True
+    assert receipt["abstain_reason"] == "insufficient_history"
+    assert receipt["sufficiency"] == "insufficient"
+
+
+def test_abstention_precedence_is_fixed() -> None:
+    # All triggers simultaneously true -> the FIRST in precedence wins.
+    abstain, reason = decide_abstention(
+        observation_count=1,               # insufficient
+        latest_confidence=0.01,            # low confidence too
+        latest_prev_seen=False,            # unseen too
+        rolling_calibration_error=0.9,     # drifted too
+        drift_bits=0.9,                    # shifted too
+        config=MonitorConfig(),
+    )
+    assert (abstain, reason) == (True, "insufficient_history")
+    assert list(ABSTAIN_REASONS)[0] == "insufficient_history"
+    assert list(ABSTAIN_REASONS)[-1] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Container guards / adversarial input
+# ---------------------------------------------------------------------------
+
+
+class _HostileStr:
+    def __str__(self) -> str:  # pragma: no cover - must never be called
+        raise RuntimeError("hostile __str__ escaped into the receipt path")
+
+
+class _DictSubclass(dict):
+    pass
+
+
+def test_non_builtin_dict_observations_fail_closed() -> None:
+    with pytest.raises(MonitorInputError):
+        validate_observations([_DictSubclass(_ob(0.5, True, 0.5))])
+    with pytest.raises(MonitorInputError):
+        validate_observations(["not a dict"])
+
+
+def test_hostile_values_fail_closed_before_any_stringification() -> None:
+    for bad in (_HostileStr(), float("nan"), float("inf"), 10**400, True, "0.5"):
+        with pytest.raises(MonitorInputError):
+            validate_observations([{**_ob(0.5, True, 0.5), "confidence": bad}])
+    with pytest.raises(MonitorInputError):
+        validate_observations([{**_ob(0.5, True, 0.5), "hit": 1}])  # int, not bool
+
+
+def test_out_of_range_probabilities_fail_closed() -> None:
+    for bad in (-0.1, 1.5):
+        with pytest.raises(MonitorInputError):
+            validate_observations([_ob(bad, True, 0.5)])
+        with pytest.raises(MonitorInputError):
+            validate_observations([_ob(0.5, True, bad)])
+
+
+def test_unknown_fields_are_discarded_and_honestly_flagged() -> None:
+    obs = [{**_ob(0.9, True, 0.9), "monologue": "should never survive", "extra": 1}
+           for _ in range(35)]
+    receipt = _receipt(obs, config=MonitorConfig(min_history=10))
+    assert receipt["input_reduced"] is True
+    assert receipt["discarded_field_count"] == 70
+    assert "monologue" not in serialize_receipt(receipt)
+    assert "should never survive" not in serialize_receipt(receipt)
+
+
+def test_model_and_count_allowlists_fail_closed() -> None:
+    obs = [_ob(0.9, True, 0.9)]
+    with pytest.raises(MonitorInputError):
+        _receipt(obs, model="clever_new_model")
+    with pytest.raises(MonitorInputError):
+        _receipt(obs, reference={"not_a_token": 3})
+    with pytest.raises(MonitorInputError):
+        _receipt(obs, recent={A: True})
+    with pytest.raises(MonitorInputError):
+        _receipt(obs, recent={A: -1})
+    assert set(MODEL_ALLOWLIST) == {"empirical_prior", "persistence", "first_order"}
+
+
+def test_config_bounds_fail_closed() -> None:
+    with pytest.raises(ValueError):
+        MonitorConfig(min_history=1).validate()
+    with pytest.raises(ValueError):
+        MonitorConfig(window=100_000).validate()
+    with pytest.raises(ValueError):
+        MonitorConfig(low_confidence_threshold=1.0).validate()
+
+
+# ---------------------------------------------------------------------------
+# Numeric helpers
+# ---------------------------------------------------------------------------
+
+
+def test_surprise_is_bounded_against_underflow() -> None:
+    assert surprise_bits(0.0) == 1_000.0
+    assert surprise_bits(0.5) == pytest.approx(1.0)
+    assert surprise_bits(1.0) == pytest.approx(0.0)
+
+
+def test_rolling_ece_exact_fixture() -> None:
+    # Two observations at confidence 0.85 (bin 8), one hit one miss:
+    # ECE = |0.85 - 0.5| = 0.35 exactly.
+    obs = [_ob(0.85, True, 0.85), _ob(0.85, False, 0.1)]
+    assert rolling_ece(obs) == pytest.approx(0.35, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Receipt hygiene, determinism, bounds
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_is_deterministic_and_canonical() -> None:
+    obs = [_ob(0.7, True, 0.7) for _ in range(35)]
+    first = serialize_receipt(_receipt(obs, config=MonitorConfig(min_history=10)))
+    second = serialize_receipt(_receipt(obs, config=MonitorConfig(min_history=10)))
+    assert first == second
+    assert first == json.dumps(
+        json.loads(first), sort_keys=True, separators=(",", ": "), indent=1
+    ) + "\n"
+    assert '"ts"' not in first
+    assert len(first.encode("utf-8")) <= MAX_RECEIPT_BYTES
+
+
+def test_receipt_fields_are_exactly_the_allowlisted_set() -> None:
+    obs = [_ob(0.7, True, 0.7) for _ in range(35)]
+    receipt = _receipt(obs, config=MonitorConfig(min_history=10))
+    assert set(receipt) == {
+        "schema", "model", "observation_count", "mean_confidence",
+        "mean_surprise_bits", "rolling_calibration_error",
+        "distribution_drift_bits", "sufficiency", "abstain",
+        "abstain_reason", "input_reduced", "discarded_field_count",
+        "config", "non_claim",
+    }
+    assert receipt["schema"] == RECEIPT_SCHEMA
+    assert receipt["abstain_reason"] in ABSTAIN_REASONS
+    assert "awareness" in receipt["non_claim"]  # the non-claim is embedded
+
+
+# ---------------------------------------------------------------------------
+# Property-style seeded traces (stdlib random only — no new dependency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", [7, 77, 777])
+def test_seeded_trace_receipts_are_bounded_and_deterministic(seed: int, tmp_path) -> None:
+    rng = random.Random(seed)
+    tokens = [rng.choice([A, B, "energy_pulse", "sensor_alert"]) for _ in range(120)]
+    log = _write_log(tmp_path, tokens)
+    for model in MODEL_ALLOWLIST:
+        obs, reference, recent = observations_from_log(log, model)
+        r1 = build_receipt(model=model, observations=obs,
+                           reference_counts=reference, recent_counts=recent)
+        r2 = build_receipt(model=model, observations=obs,
+                           reference_counts=reference, recent_counts=recent)
+        assert serialize_receipt(r1) == serialize_receipt(r2)
+        assert r1["abstain_reason"] in ABSTAIN_REASONS
+        assert 0.0 <= r1["mean_confidence"] <= 1.0
+        assert 0.0 <= r1["rolling_calibration_error"] <= 1.0
+        assert 0.0 <= r1["distribution_drift_bits"] <= 1.0 + 1e-9
+        assert math.isfinite(r1["mean_surprise_bits"])
+        assert len(serialize_receipt(r1).encode("utf-8")) <= MAX_RECEIPT_BYTES
+
+
+# ---------------------------------------------------------------------------
+# NP1 bridge + CLI
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_replays_np1_split_without_new_semantics(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 8)  # 16 rows -> split 12/4
+    obs, reference, recent = observations_from_log(log, "first_order")
+    assert len(obs) == 4
+    assert sum(reference.values()) == 12
+    assert sum(recent.values()) == 4
+    assert all(set(ob) == {"confidence", "hit", "p_actual", "prev_seen"} for ob in obs)
+
+
+def test_bridge_insufficient_history_fails_closed(tmp_path) -> None:
+    from scripts.nextness_predictor import InsufficientHistoryError
+    log = _write_log(tmp_path, [A])
+    with pytest.raises(InsufficientHistoryError):
+        observations_from_log(log, "persistence")
+
+
+def test_cli_emits_receipt_to_stdout_only(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    before = sorted(p.name for p in tmp_path.iterdir())
+    assert main([str(log), "--model", "first_order"]) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["schema"] == RECEIPT_SCHEMA
+    after = sorted(p.name for p in tmp_path.iterdir())
+    assert before == after  # the monitor writes NO files
+
+
+def test_cli_exit_codes(tmp_path) -> None:
+    assert main([str(tmp_path / "absent.jsonl")]) == 2
+    log = _write_log(tmp_path, [A])
+    assert main([str(log)]) == 3


### PR DESCRIPTION
**Stacked on NP1 (#354).** Second rung of the runway: functional metacognition ONLY — the system measures when its predictor is uncertain, surprised or outside its calibrated regime. **It does not act.** "Abstain" = *do not treat this prediction as evidence*; the receipt is a trustworthiness statement, never a control signal.

**Receipt** (`nextness-monitor-v1`): closed field allowlist — model id (fixed allowlist), observation count, mean confidence, realised surprise (bits, underflow-bounded), rolling fixed-bin ECE, recent-vs-reference drift (**reuses `nextness_metrics.js_divergence`**), sufficiency, abstain + fixed-precedence reason (`insufficient_history → unseen_state → low_confidence → calibration_drift → distribution_shift → none`). No free-form text/monologue/prompts/payloads. Deterministic sorted-key JSON, no timestamps, 64 KiB fail-closed. Every threshold is bounded, documented config echoed in the receipt — none claimed universal. Unknown fields discarded with honest `input_reduced` flag; malformed input fails closed (typed error). The monitor **writes no files**.

**Explicit non-claim, embedded in every receipt**: nothing here is awareness, sentience or phenomenal experience — it's bookkeeping about a counting model's error statistics.

**Tests (25)**: all six named regimes · fixed-precedence proof · adversarial containers (dict subclass, hostile `__str__`, 10⁴⁰⁰ ints, NaN/inf, bool-as-number) rejected before any stringification · exact ECE fixture · property-style seeded traces (seeds 7/77/777 × 3 models, stdlib `random` — no new dependency) · NP1-bridge fidelity · CLI stdout-only proof.

**Finding kept as a permanent regression test**: with NP1's default Laplace α=1.0, a perfectly-right alternation predictor states only ≈0.605 confidence — the monitor correctly flags its own predictor's smoothing bias as `calibration_drift` on day one. That's the receipt this package exists to give.

**Receipts**: `py_compile` OK · 25/25 targeted · full maintained suite **900 passed / 27 skipped / 0 failed**.

No new dependencies. No tuning/orchestration/engine/Swarm-Hunter/Lane-A imports. **HELD OPEN AND UNMERGED for Jack.**

---

## Delta-audit corrections (rebase onto amended NP1 + bounded corrections A–F)

*(Supersedes the test/suite totals above: targeted corpus is now **38**, full suite **924/27/0**.)*

### Heads & rebase-equivalence proof

| | commit |
|---|---|
| Old head (pre-rebase) | `4b7e52fc9859ad6147bf434131e1bfde88d9133d` |
| New base (amended NP1, #354) | `f519256b122beaf70b0e6eafaec8b675541c6b60` |
| Rebased head (pre-correction) | `58b05521d4d7fb5e5724fe851ee0133362560441` |
| **New head (corrections)** | `54440cf2bb547040d9d01f78bc4da81769ef0181` |

Equivalence: the original three-file patch (`docs/NEXTNESS_MONITOR_CONTRACT.md`, `scripts/nextness_monitor.py`, `tests/test_nextness_monitor.py`, 888 insertions) was preserved **byte-identically** across the rebase — `git diff 0c551a3..4b7e52fc` and `git diff f519256b..58b05521` both hash SHA-256 `6afc39523c9ae266fb621c1584d653a93f05fda99fcbcf2cbbd9bc29d414a1ff`; `git range-diff` reports `1: 4b7e52f = 1: 58b0552`. Lease-safe pushes pinned to the expected prior head at each step.

### Corrections (each failing-first)

- **A — config types**: `min_history`/`window` must be exact builtin `int`s in range; bool, float and int subclasses rejected cleanly (`_require_exact_int`).
- **B — observation numbers**: only exact builtin `int`/`float` accepted; bools, non-finite values and custom numeric subclasses fail through `MonitorInputError` **before any conversion hook runs** (test proves `__float__`/`__index__` are never invoked).
- **C — required `prev_seen`**: missing or wrong-type `prev_seen` fails closed; the silent default-to-`True` (which masked `unseen_state` abstention) is gone.
- **D — recent-window drift**: bridge `recent_counts` now cover exactly the latest `config.window` holdout observations. Long-holdout fixture (60 train / 20 holdout, last 10 a hard regime change): expected drift derived independently in the test from hand-built count dicts + hand calculation (JS((.5,.5),(0,1)) ≈ 0.3113 bits); the old whole-holdout counting diluted it to 0.049 — below the 0.15 threshold.
- **E — deterministic lookup**: canonical tie-break via `TOKEN_INDEX` O(1) lookup (`canonical_top`), matching NP1's `evaluate_predictions`. Ordering proven unchanged over uniform, all pairwise-tied and 500 quantized tie-rich seeded distributions, plus byte-identical receipts (below).
- **F — ECE simplification**: applied **only after** equivalence testing across exact bin-boundary fixtures (0.0…1.0), the recorded exact fixture, degenerate cases and seeded traces (7/77/777/4242) against the verbatim pre-simplification reference. **Measured floating difference: 0.0 on every fixture** — no floating-serialization difference exists (6-decimal receipt rounding also asserted identical).

### RED → GREEN receipts

RED (tests written first, run against the rebased pre-correction module): **9 failed / 29 passed** —
`test_config_min_history_and_window_must_be_exact_builtin_ints` · `test_numeric_subclasses_rejected_without_invoking_conversion_hooks` · `test_missing_prev_seen_fails_closed_and_never_defaults_to_true` · `test_recent_counts_use_exactly_the_latest_window_observations` · `test_default_window_bounds_recent_counts` · `test_bridge_window_must_be_exact_builtin_int_in_bounds` · `test_canonical_top_matches_legacy_token_names_index_tie_break` · `test_invalid_inherited_predictor_options_fail_closed` · `test_cli_invalid_options_exit_concisely_and_write_nothing`. The RED CLI run surfaced the live defect: `--smoothing -1` reached the distribution builders and produced `confidence: 3.5` garbage. The ECE-equivalence gate passed against the *old* form first (its "before" leg), then again after the simplification.

GREEN: **38/38 targeted** · full maintained Python suite **924 passed / 27 skipped / 0 failed** · `py_compile` OK.

### Inherited #354 reader behavior (confirmed through the bridge)

- Blank records consume raw-row budget (3 blanks + 40 rows under `max_rows=40` → exactly 37 observations ingested).
- Oversized records stop ingestion with bounded reads (rows after the first oversized record never become observations).
- Invalid inherited predictor options (`smoothing`, `holdout_fraction`) now fail closed at the bridge with NP1's exact bounds and exit the CLI with one concise `error:` line, code 2 — never a traceback, never a write.

### Abstention verified

Insufficient or rejected predictor evidence yields the documented abstention receipt or a typed `MonitorInputError` — never an action, tuning, orchestration or write; receipt fields stay inside the closed allowlist on every path.

### Intentional output changes (complete list)

1. **Drift on long holdouts** (correction D): receipts for logs whose holdout exceeds `window` change — 480-token fixture: `distribution_drift_bits` `0.033029 → 0.311278` (single-line receipt diff; recent counts `120 → 50` observations). Short-holdout receipts are **byte-identical**: 12/12 pre/post captures (alternating + seeds 7/77/777 × 3 models) compared equal.
2. **CLI expected-failure contract** (inherited): out-of-bounds `--smoothing`/`--holdout-fraction` now exit 2 with a concise error instead of tracebacking or emitting a garbage receipt.
3. Nothing else: corrections A/B/C tighten rejection (previously-invalid inputs now fail typed), E/F are proven output-neutral.

### CI (conclusive, head `54440cf2`)

All conclusive SUCCESS: `agent-safety` · `verify-python` ×2 · `frontend-quality` ×2 — the full required set (`agent-safety`, `verify-python`, `frontend-quality`) green.

Review threads: all 7 left open and unreplied (dispositions in the seat report). **HELD OPEN AND UNMERGED for Jack.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
