### PR TITLE
feat: deterministic evaluation layer over recorded NP1/NP2 artifacts (PACKAGE NP5)

### DIFF
--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -1,0 +1,213 @@
+# Nextness Evaluator Contract (NP5)
+
+**Module**: `scripts/nextness_evaluator.py` · **Tests**: `tests/test_nextness_evaluator.py`
+**Schema**: `nextness-evaluation-v1` · **Status**: offline artifact evaluator — observes and scores recordings, never acts
+
+## What this is
+
+The first evaluation layer above NP1 and NP2: a deterministic, offline
+reader of **recorded artifacts** — NP1 predictor reports
+(`nextness-predictor-v1`) and NP2 monitor receipts
+(`nextness-monitor-v1`, singly or as a recorded series) — that answers
+one question honestly:
+
+> What can these artifacts establish about prediction, uncertainty,
+> abstention and recovery after surprise — and what remains
+> uncomputable from them?
+
+It never tunes, actuates, selects engine rules, invokes a model,
+contacts a service, or writes into the engine or observer. Its only
+inputs are artifact files; its only output is one deterministic JSON
+evaluation.
+
+## Non-claims (load-bearing, embedded in every evaluation)
+
+- No awareness, consciousness, phenomenology or biological-equivalence
+  claim is made or implied by any value here.
+- A `not_computable` result is a statement about the **artifacts'
+  evidence**, never about the underlying system.
+- No "improvement" or "victory" language: model comparisons are
+  reported as gaps and rankings with fixed tie-breaks, nothing more.
+
+## The result envelope (the honest core)
+
+Every metric is exactly one of:
+
+```json
+{"status": "computed", "value": ...}
+{"status": "not_computable", "reason": "<fixed code>", "requires": "<missing evidence>"}
+```
+
+Fixed reason vocabulary: `artifact_absent` · `field_not_recorded` ·
+`series_too_short` · `order_not_witnessed` · `no_covering_receipt`.
+Uncomputability is typed and first-class — absent evidence is never
+guessed around.
+
+## What is computable, and why
+
+| Question | Evidence | Result |
+|---|---|---|
+| Prediction error vs the uniform reference | NP1 report: per-model `nll_bits`, fixed vocabulary size | `nll_gap_to_uniform_bits` per model (`log2(16) = 4` bits reference) |
+| Model ordering | NP1 report metrics | deterministic rankings (ties broken in fixed model order) + do the two proper scores agree |
+| Ingestion health | NP1 report accounting | rejection rate, unseen-transition-source rate |
+| Calibration magnitude | either artifact's ECE fields | echoes + series max; series "latest" only when order is witnessed |
+| Abstention behaviour | NP2 series | abstention rate, fixed-vocabulary reason histogram, config-stability flag |
+| Receipt internal consistency | NP2 recorded fields | tri-state verdicts per fixed check (below) |
+| Recovery/reorientation | NP2 **ordered** series | abstention onsets, reorientations, completed run lengths (in receipts), unresolved trailing run |
+| Inter-receipt dynamics | NP2 ordered series + prefix assumption | per-block means recovered algebraically, **with propagated error bounds** |
+| Cross-artifact agreement | report + a covering receipt | ECE and surprise/NLL matches under a stated assumption |
+
+## What is *not* computable, and why (typed in the output)
+
+- **Full abstention-decision verification** — the v1 receipt does not
+  record the latest observation's `confidence` or `prev_seen`, the two
+  inputs that the `low_confidence` and `unseen_state` reasons (and part
+  of `none`) depend on. Those clauses are `unverifiable` by
+  construction.
+- **Abstention quality** (was abstaining warranted?) — receipts record
+  aggregates only; per-observation outcomes during abstained spans are
+  absent (`field_not_recorded`).
+- **Miscalibration direction** — both artifacts record absolute-gap
+  ECE; signed per-bin gaps are absent, so over- vs under-confidence
+  cannot be distinguished (`field_not_recorded`).
+- **Metric-difference significance** — the report records holdout means
+  only; no variance estimate is possible (`field_not_recorded`).
+- **Per-observation recovery** — recovery is resolvable at receipt
+  granularity only (`field_not_recorded`).
+- **Series order, when unwitnessed** — see chronology below
+  (`order_not_witnessed`).
+
+## Consistency verdicts (tri-state, tolerance-guarded)
+
+Four fixed checks per receipt: `abstain_flag_matches_reason`,
+`sufficiency_matches_history`, `higher_precedence_excluded`,
+`stated_reason_trigger`. Verdicts are `consistent` / `contradicted` /
+`unverifiable`, aggregated per check with bounded contradiction-index
+lists (explicit `truncated` flag, never silent).
+
+**Tolerance derivation**: NP2 rounds receipt floats to 6 decimal
+places, so a recorded value is within 5e-7 of the true value. Comparing
+two recorded values ⇒ worst-case combined error 1e-6 ⇒
+`CONTRADICTION_TOLERANCE = 2e-6` (2× margin). Comparing a recorded
+value against an unrounded report value ⇒ worst case 5e-7 ⇒
+`CROSS_CHECK_TOLERANCE = 1e-6`. A declared contradiction can therefore
+never be a rounding artifact.
+
+## Chronology witness
+
+Receipts carry no timestamps (by emitter design). Series order is
+trusted **iff `observation_count` strictly increases** — each receipt
+saw more observations than its predecessor. Equal counts are ambiguous
+(a deterministic emitter produces byte-identical receipts for identical
+inputs, so an equal-count neighbour adds no ordering evidence) and fail
+the witness. A failed witness degrades order-dependent metrics to
+`order_not_witnessed`; order-free metrics still compute.
+
+## Stated assumptions (emitted only when used)
+
+- **prefix-extension** — inter-receipt block means assume consecutive
+  receipts are cumulative snapshots of one growing stream. The block
+  mean over the `n2 − n1` new observations is `(n2·m2 − n1·m1)/(n2 −
+  n1)`, with propagated rounding-error bound `(n1 + n2)·5e-7/(n2 −
+  n1)` reported beside every value (it grows without bound as blocks
+  shrink). A block mean outside the field's possible range by more than
+  its bound **falsifies the assumption** — reported per block and rolled
+  up as `all_within_bounds`.
+- **same-source** — cross-checks assume the receipts came from the same
+  log and NP1 options as the report; neither artifact records this, so
+  cross-check verdicts are explicitly conditional. A receipt "covers"
+  the report when `observation_count == holdout_rows` and
+  `config.window >= holdout_rows`; then its rolling ECE is the same
+  computation as the report's holdout ECE and its mean surprise is the
+  report's `nll_bits`. **Divergent-cap witness**: the emitters record
+  extreme per-observation surprise differently (NP1 floors P(actual) at
+  1e-300 ≈ 996.58 bits; NP2 caps at 1000 bits), and per-observation
+  surprises are non-negative, so `mean × count < 996.58 bits` witnesses
+  that no observation was in the divergent regime. One floored
+  observation forces **both** recorded totals above that line, so the
+  surprise/NLL comparison is `unverifiable` exactly when both totals
+  clear `-log2(1e-300) − 1` bit (margin failing toward unverifiable);
+  otherwise it is genuine evidence.
+
+## Input contract (defensive by construction)
+
+- Bounded read **before** parse: at most `MAX_INPUT_BYTES` (1 MiB) + 1
+  probe byte ever materialized; larger files fail closed.
+- Series bounded at `MAX_SERIES_RECEIPTS` (256); empty series fail
+  closed.
+- Exact-type, fail-closed validation at every field: builtin
+  `dict`/`list`/`str`/`bool`/`int`/`float` only; bools are never
+  numbers; no conversion hook (`__float__`/`__index__`) is ever
+  invoked; non-finite and overflow-scale numbers are rejected;
+  **exact key sets** (unknown keys = unknown variant = rejected;
+  missing keys = rejected); unknown `schema` strings rejected.
+- NP1 internal-accounting identities re-checked (rejections sum,
+  row-count inequality, split arithmetic): an artifact violating them
+  is not a v1 report, whatever its schema string says.
+- Receipt internal *consistency* is deliberately **not** a load error —
+  a well-formed receipt that contradicts itself is exactly the evidence
+  the abstention section exists to report.
+
+## Output contract
+
+Deterministic JSON: sorted keys, fixed separators, newline-terminated —
+the same canonical serialization as NP1/NP2. **No wall-clock
+timestamps, no random identifiers, no absolute paths**; provenance is
+the SHA-256 and byte count of each input artifact's raw bytes, which is
+sufficient to reproduce every calculation. Byte-identical across
+repeated runs, and `--output` files are written LF-only on every
+platform (no newline translation), so a recorded evaluation's own
+sha256 does not depend on the producing operating system. Every
+per-item detail list — contradiction indices, block means, run lengths,
+cross-check results — is capped at `MAX_DETAIL_ITEMS` (128) with
+explicit `truncated` flags and full counts, never silently. Serialized
+size is checked against a **64 KiB ceiling — fail closed**
+(`EvaluationTooLargeError`), proven in tests at the maximum series
+length in both saturation directions (receipts-only, and report plus a
+fully-covering series).
+
+## Write boundary
+
+Default output is **stdout**. `--output` must resolve inside the
+primary input artifact's directory (the `--report` file when provided,
+else the `--receipts` file) and **never** inside the repository `data/`
+tree — the same convention as `nextness_predictor`.
+
+## CLI exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | success |
+| 2 | validation failure: missing/oversized/malformed artifact, unknown variant, or no artifact provided (argparse usage errors also exit 2) |
+| 4 | output-path failure: write-boundary violation or unwritable target |
+| 5 | serialized evaluation exceeds the 64 KiB ceiling (fail closed) |
+
+There is deliberately no exit-3: "not enough evidence" is never a CLI
+failure — it is a typed `not_computable` result inside a successful
+evaluation. Expected failures print one concise `error:` line to
+stderr, never a traceback; unexpected programming errors propagate
+loudly.
+
+## Safety
+
+Offline; no network; no tuning, orchestration, engine, Swarm Hunter or
+Lane-A imports (only `nextness_predictor`, `nextness_monitor`,
+`nextness_observer` and stdlib — statically auditable). Reads only the
+artifact files named on the command line; writes only under the
+documented boundary.
+
+## Relationship to what comes next
+
+Planned follow-ups in this runway (not yet part of the repository until
+their own packages land): a replay laboratory for per-step abstention
+trajectories over recorded logs, and a test-owned contract guard
+locking the artifact schemas against silent drift. Nothing in this
+package changes observer, predictor or monitor semantics, and nothing
+in the runway touches the engine.
+
+One boundary note for a future package (out of scope here, as it
+requires touching NP1): `nextness_predictor`'s own `--output` writes
+with platform newline translation, so an NP1 report file's sha256
+differs between Windows and Linux even when its content is identical;
+this evaluator hashes whatever bytes it is given and is unaffected, but
+cross-platform golden-fixture work should account for it.

--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -39,7 +39,8 @@ Every metric is exactly one of:
 ```
 
 Fixed reason vocabulary: `artifact_absent` · `field_not_recorded` ·
-`series_too_short` · `order_not_witnessed` · `no_covering_receipt`.
+`series_too_short` · `order_not_witnessed` · `no_covering_receipt` ·
+`model_not_stable` · `config_not_stable`.
 Uncomputability is typed and first-class — absent evidence is never
 guessed around.
 
@@ -85,6 +86,26 @@ Four fixed checks per receipt: `abstain_flag_matches_reason`,
 `unverifiable`, aggregated per check with bounded contradiction-index
 lists (explicit `truncated` flag, never silent).
 
+**Higher-precedence truth table.** The decision precedence is
+`insufficient_history > unseen_state > low_confidence >
+calibration_drift > distribution_shift > none`, but the v1 receipt
+records neither the latest observation's `prev_seen` (the
+`unseen_state` trigger) nor its `confidence` (the `low_confidence`
+trigger). A recorded earlier trigger firing yields `contradicted`;
+otherwise, if an unrecorded earlier trigger *could* have fired, the
+verdict is `unverifiable` — never `consistent`:
+
+| Stated reason | Recorded earlier clauses (checked) | If a recorded clause fired | Otherwise |
+|---|---|---|---|
+| `insufficient_history` | none (nothing precedes it) | — | `consistent` |
+| `unseen_state` | history sufficiency | `contradicted` | `consistent` |
+| `low_confidence` | history sufficiency | `contradicted` | `unverifiable` (unseen_state unrecorded) |
+| `calibration_drift` | history sufficiency | `contradicted` | `unverifiable` (unseen_state, low_confidence unrecorded) |
+| `distribution_shift` | history sufficiency, calibration ≤ threshold | `contradicted` | `unverifiable` (unseen_state, low_confidence unrecorded) |
+| `none` | history sufficiency, calibration ≤ threshold, drift ≤ threshold | `contradicted` | `unverifiable` (unseen_state, low_confidence unrecorded) |
+
+All recorded-value comparisons carry the rounding tolerance below.
+
 **Tolerance derivation**: NP2 rounds receipt floats to 6 decimal
 places, so a recorded value is within 5e-7 of the true value. Comparing
 two recorded values ⇒ worst-case combined error 1e-6 ⇒
@@ -93,7 +114,7 @@ value against an unrounded report value ⇒ worst case 5e-7 ⇒
 `CROSS_CHECK_TOLERANCE = 1e-6`. A declared contradiction can therefore
 never be a rounding artifact.
 
-## Chronology witness
+## Chronology witness and series comparability (separate contracts)
 
 Receipts carry no timestamps (by emitter design). Series order is
 trusted **iff `observation_count` strictly increases** — each receipt
@@ -102,6 +123,25 @@ saw more observations than its predecessor. Equal counts are ambiguous
 inputs, so an equal-count neighbour adds no ordering evidence) and fail
 the witness. A failed witness degrades order-dependent metrics to
 `order_not_witnessed`; order-free metrics still compute.
+
+**Comparability is deliberately not conflated with chronology**: a
+well-ordered series can still mix regimes. Both stability facts are
+recorded per receipt, so they are checked, never assumed, and reported
+as `series_comparability` (`model_stable` / `config_stable`):
+
+- **Cumulative surprise/confidence blocks** additionally require one
+  stable predictor `model` — means from different models cannot be
+  combined into inter-receipt blocks (`model_not_stable` otherwise).
+  The monitor configuration does *not* gate blocks: the recorded means
+  aggregate the model's own observations and are config-independent.
+- **Abstention transitions** additionally require one stable monitor
+  `config` — decisions under different thresholds are not one monitor's
+  trajectory (`config_not_stable` otherwise; a mixed-model series
+  already fails at `model_not_stable`).
+
+Gate precedence (the typed reason names the first failed gate):
+`order_not_witnessed` > `series_too_short` > `model_not_stable` >
+`config_not_stable`.
 
 ## Stated assumptions (emitted only when used)
 
@@ -112,7 +152,10 @@ the witness. A failed witness degrades order-dependent metrics to
   n1)` reported beside every value (it grows without bound as blocks
   shrink). A block mean outside the field's possible range by more than
   its bound **falsifies the assumption** — reported per block and rolled
-  up as `all_within_bounds`.
+  up as `all_within_bounds`. The assumption is appended to the output's
+  `assumptions` list **only when block recovery actually ran**, i.e.
+  when its complete preconditions held: witnessed chronology, at least
+  two receipts, and a stable model.
 - **same-source** — cross-checks assume the receipts came from the same
   log and NP1 options as the report; neither artifact records this, so
   cross-check verdicts are explicitly conditional. A receipt "covers"
@@ -155,9 +198,10 @@ the same canonical serialization as NP1/NP2. **No wall-clock
 timestamps, no random identifiers, no absolute paths**; provenance is
 the SHA-256 and byte count of each input artifact's raw bytes, which is
 sufficient to reproduce every calculation. Byte-identical across
-repeated runs, and `--output` files are written LF-only on every
-platform (no newline translation), so a recorded evaluation's own
-sha256 does not depend on the producing operating system. Every
+repeated runs, and `--output` files are written as raw UTF-8 bytes
+(LF-only, no newline translation, no dependence on newer
+`Path.write_text` parameters), so a recorded evaluation's own bytes and
+sha256 do not depend on the producing interpreter or operating system. Every
 per-item detail list — contradiction indices, block means, run lengths,
 cross-check results — is capped at `MAX_DETAIL_ITEMS` (128) with
 explicit `truncated` flags and full counts, never silently. Serialized

--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -147,6 +147,8 @@ NOT_COMPUTABLE_REASONS: Final[tuple[str, ...]] = (
     "series_too_short",       # the computation needs more receipts than exist
     "order_not_witnessed",    # observation_count is not strictly increasing
     "no_covering_receipt",    # no receipt satisfies the cross-check precondition
+    "model_not_stable",       # the series mixes predictor models
+    "config_not_stable",      # the series mixes monitor configurations
 )
 
 #: Tri-state consistency verdicts (fixed vocabulary).
@@ -571,6 +573,24 @@ def chronology_witness(receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     return {"witnessed": True, "first_violation_index": None}
 
 
+def series_comparability(receipts: Sequence[Mapping[str, Any]]) -> dict[str, bool]:
+    """Order-free stability facts, deliberately SEPARATE from chronology.
+
+    A strictly increasing observation_count says the receipts are
+    ordered — it does not say they describe one regime. Cumulative
+    block recovery is only meaningful over one predictor model
+    (the recorded means are model-derived), and abstention transitions
+    are only meaningful when both the model and the monitor
+    configuration (the thresholds the decisions were made under) held
+    still. Both facts ARE recorded per receipt, so they are checked,
+    never assumed.
+    """
+    return {
+        "model_stable": all(r["model"] == receipts[0]["model"] for r in receipts),
+        "config_stable": all(r["config"] == receipts[0]["config"] for r in receipts),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Section: prediction (NP1 report evidence)
 # ---------------------------------------------------------------------------
@@ -743,18 +763,37 @@ def check_receipt_consistency(receipt: Mapping[str, Any]) -> dict[str, str]:
         else "contradicted"
     )
 
-    # Higher-precedence exclusion: every VERIFIABLE reason above the
-    # stated one must not have fired (decision precedence is fixed:
-    # insufficient_history > unseen_state > low_confidence >
-    # calibration_drift > distribution_shift > none).
-    excluded = "consistent"
-    if reason != "insufficient_history" and not history_ok:
-        excluded = "contradicted"
-    if reason == "distribution_shift" and _cmp_recorded(ece, cal_thr) > 0:
-        excluded = "contradicted"  # calibration_drift should have fired first
-    if reason == "none":
-        if _cmp_recorded(ece, cal_thr) > 0 or _cmp_recorded(drift, drift_thr) > 0:
-            excluded = "contradicted"
+    # Higher-precedence exclusion, honest truth table. Decision
+    # precedence is fixed (insufficient_history > unseen_state >
+    # low_confidence > calibration_drift > distribution_shift > none),
+    # but the v1 receipt records neither the latest observation's
+    # prev_seen (unseen_state trigger) nor its confidence
+    # (low_confidence trigger). So:
+    #   - a RECORDED earlier trigger firing => contradicted;
+    #   - otherwise, if an UNRECORDED earlier trigger could have fired,
+    #     the verdict is unverifiable — never consistent;
+    #   - "consistent" survives only where every earlier clause is
+    #     recorded and shown not to fire (insufficient_history, which
+    #     has no earlier clause, and unseen_state, whose only earlier
+    #     clause is the recorded history check).
+    if reason == "insufficient_history":
+        excluded = "consistent"
+    elif not history_ok:
+        excluded = "contradicted"  # recorded higher trigger fired
+    elif reason == "unseen_state":
+        excluded = "consistent"
+    elif reason == "distribution_shift" and _cmp_recorded(ece, cal_thr) > 0:
+        excluded = "contradicted"  # recorded calibration_drift should have fired
+    elif reason == "none" and (
+        _cmp_recorded(ece, cal_thr) > 0 or _cmp_recorded(drift, drift_thr) > 0
+    ):
+        excluded = "contradicted"  # recorded drift/calibration should have fired
+    else:
+        # low_confidence / calibration_drift / distribution_shift / none
+        # with no recorded contradiction: unseen_state (and, below
+        # low_confidence, the confidence trigger) is unrecorded and
+        # could have fired.
+        excluded = "unverifiable"
     verdicts["higher_precedence_excluded"] = excluded
 
     # The stated reason's own trigger, where the receipt records it.
@@ -881,6 +920,7 @@ def _recovery_section(
         absent = _not_computable("artifact_absent", _REQUIRES_RECEIPTS)
         return {
             "chronology": absent,
+            "series_comparability": absent,
             "abstention_transitions": absent,
             "surprise_blocks": absent,
             "confidence_blocks": absent,
@@ -889,8 +929,17 @@ def _recovery_section(
             ),
         }
     assert order is not None
-    section: dict[str, Any] = {"chronology": _computed(dict(order))}
+    comparability = series_comparability(receipts)
+    section: dict[str, Any] = {
+        "chronology": _computed(dict(order)),
+        "series_comparability": _computed(dict(comparability)),
+    }
 
+    # Gate precedence (first failed gate names the typed reason):
+    # order_not_witnessed > series_too_short > model_not_stable >
+    # config_not_stable. Chronology and comparability are separate
+    # contracts — a well-ordered series over mixed regimes is still
+    # incomparable, and vice versa.
     if not order["witnessed"]:
         blocked = _not_computable(
             "order_not_witnessed",
@@ -906,6 +955,32 @@ def _recovery_section(
         section["abstention_transitions"] = short
         section["surprise_blocks"] = short
         section["confidence_blocks"] = short
+    elif not comparability["model_stable"]:
+        mixed = _not_computable(
+            "model_not_stable",
+            "a single predictor model across the series (cumulative means "
+            "from different models cannot be combined into blocks, and "
+            "their abstention decisions describe different predictors)",
+        )
+        section["abstention_transitions"] = mixed
+        section["surprise_blocks"] = mixed
+        section["confidence_blocks"] = mixed
+    elif not comparability["config_stable"]:
+        # Cumulative means are config-independent (they aggregate the
+        # model's own observations), so blocks stay computable; the
+        # abstention decisions were made under different thresholds, so
+        # transitions between them are not one monitor reorienting.
+        section["abstention_transitions"] = _not_computable(
+            "config_not_stable",
+            "a single monitor configuration across the series (decisions "
+            "under different thresholds are not one monitor's trajectory)",
+        )
+        section["surprise_blocks"] = _computed(
+            _block_means(receipts, "mean_surprise_bits", 0.0, SURPRISE_BITS_MAX)
+        )
+        section["confidence_blocks"] = _computed(
+            _block_means(receipts, "mean_confidence", 0.0, 1.0)
+        )
     else:
         onsets = 0          # abstain False -> True between neighbours
         reorientations = 0  # abstain True -> False between neighbours
@@ -1078,9 +1153,11 @@ def evaluate(
     cross = _cross_check_section(report, receipts)
 
     # Assumptions are listed IFF a computed value in this evaluation
-    # depends on them (deterministic function of the inputs).
+    # depends on them (deterministic function of the inputs). The
+    # prefix-extension assumption is used exactly when block recovery
+    # actually ran — i.e. when its complete preconditions held.
     assumptions: list[str] = []
-    if receipts is not None and order is not None and order["witnessed"] and len(receipts) >= 2:
+    if recovery["surprise_blocks"]["status"] == "computed":
         assumptions.append(ASSUMPTION_PREFIX_EXTENSION)
     if cross["ece_match"]["status"] == "computed":
         assumptions.append(ASSUMPTION_SAME_SOURCE)
@@ -1265,11 +1342,12 @@ def main(argv: list[str] | None = None) -> int:
     serialized = serialize_evaluation(evaluation)
     if args.output is not None:
         try:
-            # newline="" disables platform newline translation so the
-            # recorded artifact is byte-identical (LF-only) on every
-            # platform — a written evaluation's sha256 must not depend
-            # on the operating system that produced it.
-            args.output.write_text(serialized, encoding="utf-8", newline="")
+            # Raw byte write: no platform newline translation, no
+            # dependence on Path.write_text's newline= parameter (which
+            # only exists on newer Pythons) — a recorded evaluation's
+            # bytes and sha256 must not depend on the producing
+            # interpreter or operating system.
+            args.output.write_bytes(serialized.encode("utf-8"))
         except OSError as e:
             print(f"error: cannot write evaluation to {args.output}: {e}", file=sys.stderr)
             return 4

--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -1,0 +1,1282 @@
+"""Deterministic offline evaluator over recorded NP1/NP2 artifacts (NP5).
+
+Reads artifacts that already exist on disk — NP1 predictor reports
+(``nextness-predictor-v1``) and NP2 monitor receipts
+(``nextness-monitor-v1``), singly or as a recorded series — and answers
+one question honestly: *what can these artifacts establish about
+prediction, uncertainty, abstention and recovery after surprise, and
+what remains uncomputable from them?*
+
+SCOPE OF CLAIM (deliberate, narrow): this module observes and scores
+recorded artifacts. It never tunes, actuates, selects engine rules,
+invokes a model, contacts a service, or writes into the engine or the
+observer. Nothing here is, or is evidence of, awareness, consciousness,
+phenomenology or biological equivalence — see ``NON_CLAIMS``.
+
+The honest core is the RESULT ENVELOPE: every metric is emitted either
+as ``{"status": "computed", "value": ...}`` or as ``{"status":
+"not_computable", "reason": <fixed code>, "requires": <what evidence is
+missing>}``. Uncomputability is a first-class, typed result — the
+evaluator never substitutes a guess for absent evidence.
+
+Three structural facts about the v1 artifacts drive the design:
+
+1. An NP2 receipt does not record the latest observation's confidence
+   or ``prev_seen`` — the two inputs that two of the six abstention
+   reasons depend on. Full abstention-decision verification is therefore
+   PROVABLY not computable from receipts; the evaluator instead emits
+   per-clause tri-state verdicts (``consistent`` / ``contradicted`` /
+   ``unverifiable``) for exactly the clauses the recorded fields can
+   witness.
+2. Receipts carry no timestamps (by emitter design). Series order is
+   witnessed only by strictly increasing ``observation_count``; when the
+   witness fails, order-dependent metrics return a typed
+   ``order_not_witnessed`` result while order-free metrics still
+   compute.
+3. Receipt floats are rounded to 6 decimal places by the emitter, so
+   every comparison against them carries a derived tolerance
+   (documented at the constants below) — a contradiction is only
+   declared when it exceeds worst-case rounding error.
+
+Safety contract (Lane B, mirrors nextness_predictor/nextness_monitor):
+
+- Offline only: no network, HTTP, ZMQ, Ollama or model calls; the only
+  I/O is reading the artifact files named on the command line and
+  (optionally) writing one evaluation next to them.
+- Bounded input: artifact files are read through a hard pre-parse size
+  ceiling (``MAX_INPUT_BYTES``) — at most ``MAX_INPUT_BYTES + 1`` bytes
+  are ever materialized; receipt series are bounded by
+  ``MAX_SERIES_RECEIPTS``. Exact-type, fail-closed validation runs
+  before any arithmetic; unknown schemas, unknown keys and missing keys
+  are all rejected (unknown variants never pass silently).
+- Writes are permitted ONLY inside the directory of the primary input
+  artifact (``WriteOutsideLogDirError`` otherwise) and NEVER inside the
+  repository ``data/`` tree — the same convention as nextness_predictor.
+- Deterministic output: sorted keys, fixed schema, no wall-clock
+  timestamps, no random identifiers, no absolute paths (provenance is
+  the SHA-256 of each artifact's raw bytes); the same input bytes always
+  produce a byte-identical evaluation, checked against a 64 KiB
+  fail-closed ceiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import pathlib
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from scripts.nextness_monitor import (
+    ABSTAIN_REASONS,
+    MODEL_ALLOWLIST,
+    RECEIPT_SCHEMA,
+)
+from scripts.nextness_observer import TOKEN_NAMES, WriteOutsideLogDirError
+from scripts.nextness_predictor import (
+    ECE_BINS,
+    HOLDOUT_FRACTION_MAX,
+    HOLDOUT_FRACTION_MIN,
+    MAX_ROWS_CEILING,
+    REJECT_REASONS,
+    REPORT_SCHEMA,
+    SMOOTHING_MAX,
+)
+
+# ---------------------------------------------------------------------------
+# Fixed contract constants
+# ---------------------------------------------------------------------------
+
+EVALUATION_SCHEMA: Final[str] = "nextness-evaluation-v1"
+
+#: Pre-parse input ceiling: at most this many bytes of an artifact file
+#: are ever read (the loader probes one extra byte to detect overflow,
+#: so peak materialization is MAX_INPUT_BYTES + 1). A realistic receipt
+#: is ~1 KiB, so a full 256-receipt series fits comfortably.
+MAX_INPUT_BYTES: Final[int] = 1_048_576
+
+#: Hard bound on receipts per recorded series (fail closed above).
+MAX_SERIES_RECEIPTS: Final[int] = 256
+
+#: Evaluation size ceiling — fail closed rather than emit an unbounded
+#: blob (same 64 KiB convention as NP1 reports and NP2 receipts).
+MAX_EVALUATION_BYTES: Final[int] = 64 * 1024
+
+#: Detailed per-item lists (block means, run lengths, contradiction
+#: indices) are capped at this many entries WITH an explicit
+#: ``truncated`` flag — never silently — so the evaluation stays inside
+#: MAX_EVALUATION_BYTES for a full 256-receipt series.
+MAX_DETAIL_ITEMS: Final[int] = 128
+
+#: NP2 rounds every receipt float to 6 decimal places, so a recorded
+#: value differs from the true value by at most 5e-7. Comparing two
+#: recorded values therefore carries a worst-case combined rounding
+#: error of 1e-6; comparing one recorded value against one unrounded
+#: value carries 5e-7. Each tolerance below is twice its worst case, so
+#: a declared contradiction can never be a rounding artifact.
+CONTRADICTION_TOLERANCE: Final[float] = 2e-6   # recorded vs recorded
+CROSS_CHECK_TOLERANCE: Final[float] = 1e-6     # recorded vs unrounded
+
+#: Kept manually in sync with nextness_monitor's surprise underflow cap
+#: (its private ``_MAX_SURPRISE_BITS = 1000.0``).
+SURPRISE_BITS_MAX: Final[float] = 1_000.0
+
+#: Mirrors NP1's log floor: evaluate_predictions clamps P(actual) at
+#: 1e-300, so a single observation's surprise never exceeds
+#: -log2(1e-300) in the report.
+NLL_BITS_MAX: Final[float] = -math.log2(1e-300)
+
+#: NP1's nll_bits is a naive float sum divided by n, so a genuine
+#: all-floored report overshoots NLL_BITS_MAX by accumulated rounding
+#: (measured up to ~1.5e-8 at n = 1e6). Validation allows this small
+#: slack above the exact bound; fabricated out-of-range values are
+#: still rejected.
+_NLL_BITS_VALIDATION_MAX: Final[float] = NLL_BITS_MAX + 1e-6
+
+#: Multiclass Brier score over a full probability distribution is
+#: bounded by 2 (all mass on one wrong token).
+BRIER_MAX: Final[float] = 2.0
+
+#: Fixed vocabulary for typed not-computable results.
+NOT_COMPUTABLE_REASONS: Final[tuple[str, ...]] = (
+    "artifact_absent",        # the artifact carrying the evidence was not provided
+    "field_not_recorded",     # the v1 schema does not record the required evidence
+    "series_too_short",       # the computation needs more receipts than exist
+    "order_not_witnessed",    # observation_count is not strictly increasing
+    "no_covering_receipt",    # no receipt satisfies the cross-check precondition
+)
+
+#: Tri-state consistency verdicts (fixed vocabulary).
+VERDICTS: Final[tuple[str, ...]] = ("consistent", "contradicted", "unverifiable")
+
+#: Per-receipt consistency checks (fixed vocabulary; aggregated in the
+#: abstention section).
+CONSISTENCY_CHECKS: Final[tuple[str, ...]] = (
+    "abstain_flag_matches_reason",
+    "sufficiency_matches_history",
+    "higher_precedence_excluded",
+    "stated_reason_trigger",
+)
+
+#: Assumptions are only ever emitted when a metric that depends on them
+#: is actually computed, and they are fixed strings (deterministic).
+ASSUMPTION_PREFIX_EXTENSION: Final[str] = (
+    "receipt-series-prefix-extension: consecutive receipts are cumulative "
+    "snapshots of one growing observation stream"
+)
+ASSUMPTION_SAME_SOURCE: Final[str] = (
+    "cross-check-same-source: the receipts were derived from the same log "
+    "and NP1 options as the report (not recorded in either artifact)"
+)
+
+NON_CLAIMS: Final[tuple[str, ...]] = (
+    "Evaluates recorded artifacts only: observes and scores, never tunes, "
+    "actuates, selects rules, invokes a model or contacts a service.",
+    "No awareness, consciousness, phenomenology or biological-equivalence "
+    "claim is made or implied by any value in this evaluation.",
+    "A not_computable result is a statement about the artifacts' evidence, "
+    "not about the underlying system.",
+)
+
+#: Expected key sets — exact match required (unknown variants fail closed).
+_REPORT_KEYS: Final[frozenset[str]] = frozenset(
+    {"schema", "config", "input", "evaluation", "non_claims"}
+)
+_REPORT_CONFIG_KEYS: Final[frozenset[str]] = frozenset(
+    {"smoothing", "holdout_fraction", "max_rows", "max_line_bytes",
+     "ece_bins", "vocabulary_size"}
+)
+_REPORT_INPUT_KEYS: Final[frozenset[str]] = frozenset(
+    {"rows_read", "rows_accepted", "rows_rejected", "rejections"}
+)
+_REPORT_EVALUATION_KEYS: Final[frozenset[str]] = frozenset(
+    {"train_rows", "holdout_rows", "split_index",
+     "first_order_unseen_source_count", "models"}
+)
+_MODEL_METRIC_KEYS: Final[frozenset[str]] = frozenset(
+    {"nll_bits", "brier", "top1_accuracy", "ece"}
+)
+_RECEIPT_KEYS: Final[frozenset[str]] = frozenset(
+    {"schema", "model", "observation_count", "mean_confidence",
+     "mean_surprise_bits", "rolling_calibration_error",
+     "distribution_drift_bits", "sufficiency", "abstain", "abstain_reason",
+     "input_reduced", "discarded_field_count", "config", "non_claim"}
+)
+_RECEIPT_CONFIG_KEYS: Final[frozenset[str]] = frozenset(
+    {"min_history", "window", "low_confidence_threshold",
+     "calibration_error_threshold", "drift_threshold_bits"}
+)
+
+_MAX_NON_CLAIM_CHARS: Final[int] = 500
+_MAX_NON_CLAIMS_ITEMS: Final[int] = 16
+
+
+class EvaluatorInputError(ValueError):
+    """A malformed, hostile or unknown-variant artifact (fail closed)."""
+
+
+class EvaluationTooLargeError(RuntimeError):
+    """Serialized evaluation exceeded MAX_EVALUATION_BYTES (fail closed)."""
+
+
+# ---------------------------------------------------------------------------
+# Result envelope: every metric is computed or typed-not-computable
+# ---------------------------------------------------------------------------
+
+
+def _computed(value: Any) -> dict[str, Any]:
+    return {"status": "computed", "value": value}
+
+
+def _not_computable(reason: str, requires: str) -> dict[str, Any]:
+    if reason not in NOT_COMPUTABLE_REASONS:  # internal invariant, not input
+        raise ValueError(f"unknown not-computable reason: {reason!r}")
+    return {"status": "not_computable", "reason": reason, "requires": requires}
+
+
+# ---------------------------------------------------------------------------
+# Exact-type validators (hostile input boundary; no conversion hooks,
+# no stringification, no traversal before the type is proven)
+# ---------------------------------------------------------------------------
+
+
+def _exact_str(value: Any, field: str) -> str:
+    if type(value) is not str:
+        raise EvaluatorInputError(f"{field}: expected builtin str, got {type(value).__name__}")
+    return value
+
+
+def _exact_bool(value: Any, field: str) -> bool:
+    if type(value) is not bool:
+        raise EvaluatorInputError(f"{field}: expected builtin bool, got {type(value).__name__}")
+    return value
+
+
+def _exact_int(value: Any, field: str, low: int, high: int | None = None) -> int:
+    if type(value) is not int:
+        raise EvaluatorInputError(f"{field}: expected builtin int, got {type(value).__name__}")
+    if value < low or (high is not None and value > high):
+        bound = f"[{low}, {high}]" if high is not None else f">= {low}"
+        raise EvaluatorInputError(f"{field}: {value} outside {bound}")
+    return value
+
+
+def _exact_float(
+    value: Any,
+    field: str,
+    low: float,
+    high: float,
+) -> float:
+    """Exact builtin int/float, finite, inside [low, high].
+
+    Exact-type checks run FIRST, so no custom __float__/__index__ hook is
+    ever invoked (same posture as nextness_monitor's _bounded_float).
+    """
+    if type(value) is not int and type(value) is not float:
+        raise EvaluatorInputError(
+            f"{field}: expected a builtin real number, got {type(value).__name__}"
+        )
+    try:
+        as_float = float(value)
+    except (OverflowError, ValueError) as e:  # e.g. int(10**400) -> inf
+        raise EvaluatorInputError(f"{field}: not representable as a finite float") from e
+    if not math.isfinite(as_float):
+        raise EvaluatorInputError(f"{field}: not finite")
+    if not low <= as_float <= high:
+        raise EvaluatorInputError(f"{field}: {as_float} outside [{low}, {high}]")
+    return as_float
+
+
+def _exact_dict(value: Any, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    """Builtin dict with EXACTLY the given key set (unknown keys are an
+    unknown variant; missing keys are missing evidence — both fail closed)."""
+    if type(value) is not dict:
+        raise EvaluatorInputError(f"{field}: expected builtin dict, got {type(value).__name__}")
+    present = set(value)
+    if present != keys:
+        # Non-str keys are named by type only — never repr'd/str'd, so a
+        # hostile key's __repr__ can never run in the error path.
+        unknown = sorted(k if type(k) is str else f"<{type(k).__name__}>" for k in present - keys)
+        missing = sorted(keys - present)
+        raise EvaluatorInputError(
+            f"{field}: key set mismatch (unknown={unknown}, missing={missing})"
+        )
+    return value
+
+
+def _bounded_text(value: Any, field: str) -> str:
+    text = _exact_str(value, field)
+    if not text or len(text) > _MAX_NON_CLAIM_CHARS:
+        raise EvaluatorInputError(
+            f"{field}: length must be in [1, {_MAX_NON_CLAIM_CHARS}]"
+        )
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Artifact loading (size limit BEFORE parse) and validation
+# ---------------------------------------------------------------------------
+
+
+def load_json_artifact(path: pathlib.Path, *, max_bytes: int = MAX_INPUT_BYTES) -> tuple[Any, str, int]:
+    """Bounded read + parse of one artifact file.
+
+    Returns ``(parsed, sha256_hex, byte_count)``. At most ``max_bytes + 1``
+    bytes are read (the extra byte only detects overflow); a larger file
+    fails closed before any parsing or hashing of the full content.
+    """
+    with path.open("rb") as f:
+        raw = f.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise EvaluatorInputError(
+            f"artifact exceeds {max_bytes} bytes; refusing to parse"
+        )
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as e:
+        raise EvaluatorInputError(f"artifact is not valid UTF-8: {e.reason}") from e
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError) as e:
+        raise EvaluatorInputError(f"artifact is not valid JSON: {e}") from e
+    except RecursionError as e:
+        # A pathologically nested artifact (e.g. one megabyte of "[")
+        # exhausts the parser's recursion budget — fail closed like any
+        # other malformed artifact instead of propagating a traceback.
+        raise EvaluatorInputError("artifact nesting exceeds the parser's depth limit") from e
+    return parsed, hashlib.sha256(raw).hexdigest(), len(raw)
+
+
+def validate_report(obj: Any) -> dict[str, Any]:
+    """Exact-type, fail-closed validation of one nextness-predictor-v1
+    report. Returns an owned normalized dict (no caller container is
+    retained). Internal-accounting identities established by NP1's own
+    construction are re-checked — an artifact violating them is not a
+    v1 report, whatever its schema string says."""
+    outer = _exact_dict(obj, "report", _REPORT_KEYS)
+    schema = _exact_str(outer["schema"], "report.schema")
+    if schema != REPORT_SCHEMA:
+        raise EvaluatorInputError(
+            f"report.schema: unknown variant {schema!r} (expected {REPORT_SCHEMA!r})"
+        )
+
+    cfg = _exact_dict(outer["config"], "report.config", _REPORT_CONFIG_KEYS)
+    smoothing = _exact_float(cfg["smoothing"], "report.config.smoothing", 0.0, SMOOTHING_MAX)
+    if smoothing <= 0.0:
+        raise EvaluatorInputError("report.config.smoothing: must be > 0")
+    holdout_fraction = _exact_float(
+        cfg["holdout_fraction"], "report.config.holdout_fraction",
+        HOLDOUT_FRACTION_MIN, HOLDOUT_FRACTION_MAX,
+    )
+    max_rows = _exact_int(cfg["max_rows"], "report.config.max_rows", 1, MAX_ROWS_CEILING)
+    max_line_bytes = _exact_int(cfg["max_line_bytes"], "report.config.max_line_bytes", 1)
+    ece_bins = _exact_int(cfg["ece_bins"], "report.config.ece_bins", 1)
+    if ece_bins != ECE_BINS:
+        raise EvaluatorInputError(
+            f"report.config.ece_bins: unknown variant {ece_bins} (v1 uses {ECE_BINS})"
+        )
+    vocabulary_size = _exact_int(cfg["vocabulary_size"], "report.config.vocabulary_size", 2)
+    if vocabulary_size != len(TOKEN_NAMES):
+        raise EvaluatorInputError(
+            f"report.config.vocabulary_size: unknown variant {vocabulary_size} "
+            f"(v1 vocabulary has {len(TOKEN_NAMES)} tokens)"
+        )
+
+    inp = _exact_dict(outer["input"], "report.input", _REPORT_INPUT_KEYS)
+    rows_read = _exact_int(inp["rows_read"], "report.input.rows_read", 0, MAX_ROWS_CEILING)
+    rows_accepted = _exact_int(inp["rows_accepted"], "report.input.rows_accepted", 0, MAX_ROWS_CEILING)
+    rows_rejected = _exact_int(inp["rows_rejected"], "report.input.rows_rejected", 0, MAX_ROWS_CEILING)
+    rejections_raw = _exact_dict(
+        inp["rejections"], "report.input.rejections", frozenset(REJECT_REASONS)
+    )
+    rejections = {
+        reason: _exact_int(rejections_raw[reason], f"report.input.rejections.{reason}", 0, MAX_ROWS_CEILING)
+        for reason in REJECT_REASONS
+    }
+    if sum(rejections.values()) != rows_rejected:
+        raise EvaluatorInputError(
+            "report.input: rejections do not sum to rows_rejected"
+        )
+    if rows_read < rows_accepted + rows_rejected:
+        raise EvaluatorInputError(
+            "report.input: rows_read < rows_accepted + rows_rejected"
+        )
+
+    ev = _exact_dict(outer["evaluation"], "report.evaluation", _REPORT_EVALUATION_KEYS)
+    train_rows = _exact_int(ev["train_rows"], "report.evaluation.train_rows", 2, MAX_ROWS_CEILING)
+    holdout_rows = _exact_int(ev["holdout_rows"], "report.evaluation.holdout_rows", 1, MAX_ROWS_CEILING)
+    split_index = _exact_int(ev["split_index"], "report.evaluation.split_index", 2, MAX_ROWS_CEILING)
+    if split_index != train_rows:
+        raise EvaluatorInputError("report.evaluation: split_index != train_rows")
+    if train_rows + holdout_rows != rows_accepted:
+        raise EvaluatorInputError(
+            "report.evaluation: train_rows + holdout_rows != rows_accepted"
+        )
+    unseen = _exact_int(
+        ev["first_order_unseen_source_count"],
+        "report.evaluation.first_order_unseen_source_count", 0, holdout_rows,
+    )
+    models_raw = _exact_dict(
+        ev["models"], "report.evaluation.models", frozenset(MODEL_ALLOWLIST)
+    )
+    models: dict[str, dict[str, float]] = {}
+    for name in MODEL_ALLOWLIST:
+        metrics = _exact_dict(
+            models_raw[name], f"report.evaluation.models.{name}", _MODEL_METRIC_KEYS
+        )
+        models[name] = {
+            "nll_bits": _exact_float(metrics["nll_bits"], f"{name}.nll_bits", 0.0, _NLL_BITS_VALIDATION_MAX),
+            "brier": _exact_float(metrics["brier"], f"{name}.brier", 0.0, BRIER_MAX),
+            "top1_accuracy": _exact_float(metrics["top1_accuracy"], f"{name}.top1_accuracy", 0.0, 1.0),
+            "ece": _exact_float(metrics["ece"], f"{name}.ece", 0.0, 1.0),
+        }
+
+    non_claims = outer["non_claims"]
+    if type(non_claims) is not list or not non_claims or len(non_claims) > _MAX_NON_CLAIMS_ITEMS:
+        raise EvaluatorInputError(
+            f"report.non_claims: expected a non-empty list of at most "
+            f"{_MAX_NON_CLAIMS_ITEMS} strings"
+        )
+    for i, item in enumerate(non_claims):
+        _bounded_text(item, f"report.non_claims[{i}]")
+
+    return {
+        "smoothing": smoothing,
+        "holdout_fraction": holdout_fraction,
+        "max_rows": max_rows,
+        "max_line_bytes": max_line_bytes,
+        "vocabulary_size": vocabulary_size,
+        "rows_read": rows_read,
+        "rows_accepted": rows_accepted,
+        "rows_rejected": rows_rejected,
+        "rejections": rejections,
+        "train_rows": train_rows,
+        "holdout_rows": holdout_rows,
+        "first_order_unseen_source_count": unseen,
+        "models": models,
+    }
+
+
+def validate_receipt(obj: Any, field: str) -> dict[str, Any]:
+    """Exact-type, fail-closed validation of one nextness-monitor-v1
+    receipt. Returns an owned normalized dict.
+
+    NOTE: internal CONSISTENCY (e.g. the abstain flag versus the stated
+    reason) is deliberately NOT validated here — a well-formed receipt
+    that contradicts itself is exactly the evidence the abstention
+    section exists to report, so it must load successfully.
+    """
+    outer = _exact_dict(obj, field, _RECEIPT_KEYS)
+    schema = _exact_str(outer["schema"], f"{field}.schema")
+    if schema != RECEIPT_SCHEMA:
+        raise EvaluatorInputError(
+            f"{field}.schema: unknown variant {schema!r} (expected {RECEIPT_SCHEMA!r})"
+        )
+    model = _exact_str(outer["model"], f"{field}.model")
+    if model not in MODEL_ALLOWLIST:
+        raise EvaluatorInputError(f"{field}.model: {model!r} not in fixed allowlist")
+    sufficiency = _exact_str(outer["sufficiency"], f"{field}.sufficiency")
+    if sufficiency not in ("sufficient", "insufficient"):
+        raise EvaluatorInputError(f"{field}.sufficiency: unknown variant {sufficiency!r}")
+    reason = _exact_str(outer["abstain_reason"], f"{field}.abstain_reason")
+    if reason not in ABSTAIN_REASONS:
+        raise EvaluatorInputError(f"{field}.abstain_reason: unknown variant {reason!r}")
+
+    cfg = _exact_dict(outer["config"], f"{field}.config", _RECEIPT_CONFIG_KEYS)
+    # The emitter validates thresholds in the OPEN interval (0, 1) but
+    # echoes them rounded to 6 dp, so a recorded echo can legitimately
+    # be exactly 0.0 or 1.0 (e.g. 1e-9 rounds to 0.0) — the evaluator
+    # accepts the CLOSED interval for the recorded echo.
+    config = {
+        "min_history": _exact_int(cfg["min_history"], f"{field}.config.min_history", 5, 10_000),
+        "window": _exact_int(cfg["window"], f"{field}.config.window", 5, 10_000),
+        "low_confidence_threshold": _exact_float(
+            cfg["low_confidence_threshold"], f"{field}.config.low_confidence_threshold", 0.0, 1.0
+        ),
+        "calibration_error_threshold": _exact_float(
+            cfg["calibration_error_threshold"], f"{field}.config.calibration_error_threshold", 0.0, 1.0
+        ),
+        "drift_threshold_bits": _exact_float(
+            cfg["drift_threshold_bits"], f"{field}.config.drift_threshold_bits", 0.0, 1.0
+        ),
+    }
+
+    return {
+        "model": model,
+        "observation_count": _exact_int(
+            outer["observation_count"], f"{field}.observation_count", 0, MAX_ROWS_CEILING
+        ),
+        "mean_confidence": _exact_float(
+            outer["mean_confidence"], f"{field}.mean_confidence", 0.0, 1.0
+        ),
+        "mean_surprise_bits": _exact_float(
+            outer["mean_surprise_bits"], f"{field}.mean_surprise_bits", 0.0, SURPRISE_BITS_MAX
+        ),
+        "rolling_calibration_error": _exact_float(
+            outer["rolling_calibration_error"], f"{field}.rolling_calibration_error", 0.0, 1.0
+        ),
+        "distribution_drift_bits": _exact_float(
+            outer["distribution_drift_bits"], f"{field}.distribution_drift_bits", 0.0, 1.0
+        ),
+        "sufficiency": sufficiency,
+        "abstain": _exact_bool(outer["abstain"], f"{field}.abstain"),
+        "abstain_reason": reason,
+        "input_reduced": _exact_bool(outer["input_reduced"], f"{field}.input_reduced"),
+        "discarded_field_count": _exact_int(
+            outer["discarded_field_count"], f"{field}.discarded_field_count", 0
+        ),
+        "non_claim": _bounded_text(outer["non_claim"], f"{field}.non_claim"),
+        "config": config,
+    }
+
+
+def validate_receipt_series(obj: Any) -> list[dict[str, Any]]:
+    """A recorded series: a JSON array of receipts (order = array order)
+    or a single receipt object (a series of one). Bounded, fail closed."""
+    if type(obj) is dict:
+        return [validate_receipt(obj, "receipts[0]")]
+    if type(obj) is not list:
+        raise EvaluatorInputError(
+            f"receipts: expected a receipt object or an array of receipts, "
+            f"got {type(obj).__name__}"
+        )
+    if not obj:
+        raise EvaluatorInputError("receipts: series is empty (no evidence to evaluate)")
+    if len(obj) > MAX_SERIES_RECEIPTS:
+        raise EvaluatorInputError(
+            f"receipts: series has {len(obj)} receipts, exceeding the "
+            f"{MAX_SERIES_RECEIPTS} bound"
+        )
+    return [validate_receipt(item, f"receipts[{i}]") for i, item in enumerate(obj)]
+
+
+# ---------------------------------------------------------------------------
+# Chronology witness
+# ---------------------------------------------------------------------------
+
+
+def chronology_witness(receipts: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Series order is only trusted if observation_count strictly
+    increases (each receipt saw more observations than the one before).
+    Equal counts are ambiguous — a deterministic emitter produces
+    byte-identical receipts for identical inputs, so an equal-count
+    neighbour adds no ordering evidence — and are treated as a failed
+    witness, not an error."""
+    for i in range(1, len(receipts)):
+        if receipts[i]["observation_count"] <= receipts[i - 1]["observation_count"]:
+            return {"witnessed": False, "first_violation_index": i}
+    return {"witnessed": True, "first_violation_index": None}
+
+
+# ---------------------------------------------------------------------------
+# Section: prediction (NP1 report evidence)
+# ---------------------------------------------------------------------------
+
+_REQUIRES_REPORT: Final[str] = "an NP1 nextness-predictor-v1 report artifact"
+_REQUIRES_RECEIPTS: Final[str] = "an NP2 nextness-monitor-v1 receipt series artifact"
+
+
+def _ranking(models: Mapping[str, Mapping[str, float]], metric: str, *, descending: bool) -> list[str]:
+    """Deterministic model ranking; ties broken by canonical
+    MODEL_ALLOWLIST order (the enumeration index)."""
+    order = {name: i for i, name in enumerate(MODEL_ALLOWLIST)}
+    return sorted(
+        MODEL_ALLOWLIST,
+        key=lambda name: (
+            -models[name][metric] if descending else models[name][metric],
+            order[name],
+        ),
+    )
+
+
+def _prediction_section(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if report is None:
+        absent = _not_computable("artifact_absent", _REQUIRES_REPORT)
+        return {
+            "uniform_nll_bits": absent,
+            "models": absent,
+            "rankings": absent,
+            "proper_score_rankings_agree": absent,
+            "ingestion": absent,
+            "metric_difference_significance": _not_computable(
+                "artifact_absent", _REQUIRES_REPORT
+            ),
+        }
+    models = report["models"]
+    uniform_nll = math.log2(report["vocabulary_size"])
+    per_model = {
+        name: {
+            "nll_bits": _computed(models[name]["nll_bits"]),
+            # "gap", not "improvement": the sign says which side of the
+            # uniform reference the model landed on, nothing more.
+            "nll_gap_to_uniform_bits": _computed(uniform_nll - models[name]["nll_bits"]),
+            "brier": _computed(models[name]["brier"]),
+            "top1_accuracy": _computed(models[name]["top1_accuracy"]),
+        }
+        for name in MODEL_ALLOWLIST
+    }
+    rankings = {
+        "by_nll_bits": _ranking(models, "nll_bits", descending=False),
+        "by_brier": _ranking(models, "brier", descending=False),
+        "by_top1_accuracy": _ranking(models, "top1_accuracy", descending=True),
+    }
+    return {
+        "uniform_nll_bits": _computed(uniform_nll),
+        "models": per_model,
+        "rankings": _computed(rankings),
+        "proper_score_rankings_agree": _computed(
+            rankings["by_nll_bits"] == rankings["by_brier"]
+        ),
+        "ingestion": _computed(
+            {
+                "rows_read": report["rows_read"],
+                "rows_accepted": report["rows_accepted"],
+                "rejection_rate": report["rows_rejected"] / report["rows_read"],
+                "train_rows": report["train_rows"],
+                "holdout_rows": report["holdout_rows"],
+                "first_order_unseen_source_rate": (
+                    report["first_order_unseen_source_count"] / report["holdout_rows"]
+                ),
+            }
+        ),
+        "metric_difference_significance": _not_computable(
+            "field_not_recorded",
+            "per-observation outcomes (the report records holdout means only, "
+            "so no variance estimate or significance statement is possible)",
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: calibration (either artifact)
+# ---------------------------------------------------------------------------
+
+
+def _calibration_section(
+    report: Mapping[str, Any] | None,
+    receipts: Sequence[Mapping[str, Any]] | None,
+    order: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    section: dict[str, Any] = {}
+    if report is None:
+        section["holdout_ece_by_model"] = _not_computable("artifact_absent", _REQUIRES_REPORT)
+        section["ece_bin_width"] = _not_computable("artifact_absent", _REQUIRES_REPORT)
+    else:
+        section["holdout_ece_by_model"] = _computed(
+            {name: report["models"][name]["ece"] for name in MODEL_ALLOWLIST}
+        )
+        section["ece_bin_width"] = _computed(1.0 / ECE_BINS)
+    if receipts is None:
+        section["max_rolling_calibration_error"] = _not_computable(
+            "artifact_absent", _REQUIRES_RECEIPTS
+        )
+        section["latest_rolling_calibration_error"] = _not_computable(
+            "artifact_absent", _REQUIRES_RECEIPTS
+        )
+    else:
+        # max over the series is order-free; "latest" needs the witness.
+        section["max_rolling_calibration_error"] = _computed(
+            max(r["rolling_calibration_error"] for r in receipts)
+        )
+        if order is not None and order["witnessed"]:
+            section["latest_rolling_calibration_error"] = _computed(
+                receipts[-1]["rolling_calibration_error"]
+            )
+        else:
+            section["latest_rolling_calibration_error"] = _not_computable(
+                "order_not_witnessed",
+                "strictly increasing observation_count across the series",
+            )
+    section["miscalibration_direction"] = _not_computable(
+        "field_not_recorded",
+        "signed per-bin confidence-accuracy gaps (both artifacts record "
+        "absolute-gap ECE only, so over- versus under-confidence cannot be "
+        "distinguished)",
+    )
+    return section
+
+
+# ---------------------------------------------------------------------------
+# Section: abstention (NP2 receipt evidence; tri-state consistency)
+# ---------------------------------------------------------------------------
+
+
+def _cmp_recorded(a: float, b: float) -> int:
+    """Compare two RECORDED (6-dp-rounded) values with the derived
+    tolerance: returns -1 (a definitely below b), 1 (definitely above),
+    0 (indistinguishable within worst-case rounding error)."""
+    if a <= b - CONTRADICTION_TOLERANCE:
+        return -1
+    if a >= b + CONTRADICTION_TOLERANCE:
+        return 1
+    return 0
+
+
+def check_receipt_consistency(receipt: Mapping[str, Any]) -> dict[str, str]:
+    """Per-receipt tri-state verdicts for the fixed CONSISTENCY_CHECKS.
+
+    Only clauses witnessed by RECORDED fields can be judged; a clause
+    depending on the unrecorded latest observation (its confidence or
+    prev_seen flag) is ``unverifiable`` — that is the honest limit of
+    the v1 receipt schema, not a defect of the receipt.
+    """
+    n = receipt["observation_count"]
+    cfg = receipt["config"]
+    reason = receipt["abstain_reason"]
+    ece = receipt["rolling_calibration_error"]
+    drift = receipt["distribution_drift_bits"]
+    cal_thr = cfg["calibration_error_threshold"]
+    drift_thr = cfg["drift_threshold_bits"]
+    history_ok = n >= cfg["min_history"]
+
+    verdicts: dict[str, str] = {}
+
+    verdicts["abstain_flag_matches_reason"] = (
+        "consistent" if receipt["abstain"] == (reason != "none") else "contradicted"
+    )
+    verdicts["sufficiency_matches_history"] = (
+        "consistent"
+        if (receipt["sufficiency"] == "sufficient") == history_ok
+        else "contradicted"
+    )
+
+    # Higher-precedence exclusion: every VERIFIABLE reason above the
+    # stated one must not have fired (decision precedence is fixed:
+    # insufficient_history > unseen_state > low_confidence >
+    # calibration_drift > distribution_shift > none).
+    excluded = "consistent"
+    if reason != "insufficient_history" and not history_ok:
+        excluded = "contradicted"
+    if reason == "distribution_shift" and _cmp_recorded(ece, cal_thr) > 0:
+        excluded = "contradicted"  # calibration_drift should have fired first
+    if reason == "none":
+        if _cmp_recorded(ece, cal_thr) > 0 or _cmp_recorded(drift, drift_thr) > 0:
+            excluded = "contradicted"
+    verdicts["higher_precedence_excluded"] = excluded
+
+    # The stated reason's own trigger, where the receipt records it.
+    if reason == "insufficient_history":
+        trigger = "consistent" if not history_ok else "contradicted"
+    elif reason == "calibration_drift":
+        trigger = "contradicted" if _cmp_recorded(ece, cal_thr) < 0 else "consistent"
+    elif reason == "distribution_shift":
+        trigger = "contradicted" if _cmp_recorded(drift, drift_thr) < 0 else "consistent"
+    else:
+        # unseen_state and low_confidence depend on the latest
+        # observation's prev_seen / confidence; "none" additionally
+        # asserts both non-triggers. None of those fields is recorded.
+        trigger = "unverifiable"
+    verdicts["stated_reason_trigger"] = trigger
+
+    return verdicts
+
+
+def _abstention_section(receipts: Sequence[Mapping[str, Any]] | None) -> dict[str, Any]:
+    if receipts is None:
+        absent = _not_computable("artifact_absent", _REQUIRES_RECEIPTS)
+        return {
+            "receipt_count": absent,
+            "abstention_rate": absent,
+            "reason_counts": absent,
+            "configurations_identical": absent,
+            "consistency": absent,
+            "abstention_quality": _not_computable("artifact_absent", _REQUIRES_RECEIPTS),
+        }
+    n = len(receipts)
+    reason_counts = {reason: 0 for reason in ABSTAIN_REASONS}
+    abstained = 0
+    for r in receipts:
+        reason_counts[r["abstain_reason"]] += 1
+        abstained += 1 if r["abstain"] else 0
+
+    consistency: dict[str, Any] = {}
+    for check in CONSISTENCY_CHECKS:
+        tallies = {verdict: 0 for verdict in VERDICTS}
+        contradicted_indices: list[int] = []
+        for i, r in enumerate(receipts):
+            verdict = check_receipt_consistency(r)[check]
+            tallies[verdict] += 1
+            if verdict == "contradicted":
+                contradicted_indices.append(i)
+        consistency[check] = {
+            "verdicts": tallies,
+            "contradicted_indices": contradicted_indices[:MAX_DETAIL_ITEMS],
+            "contradicted_indices_truncated": len(contradicted_indices) > MAX_DETAIL_ITEMS,
+        }
+
+    return {
+        "receipt_count": _computed(n),
+        "abstention_rate": _computed(abstained / n),
+        "reason_counts": _computed(reason_counts),
+        # Mixed configurations mean the reason histogram aggregates
+        # different operating regimes — flagged, not forbidden.
+        "configurations_identical": _computed(
+            all(r["config"] == receipts[0]["config"] for r in receipts)
+        ),
+        "consistency": _computed(consistency),
+        "abstention_quality": _not_computable(
+            "field_not_recorded",
+            "per-observation outcomes during abstained spans (receipts record "
+            "aggregates only, so whether an abstention was warranted cannot be "
+            "established from the artifacts)",
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section: recovery after surprise (ordered NP2 series evidence)
+# ---------------------------------------------------------------------------
+
+
+def _block_means(
+    receipts: Sequence[Mapping[str, Any]], field: str, low: float, high: float
+) -> dict[str, Any]:
+    """Recover the mean of FIELD over each inter-receipt observation
+    block, with propagated rounding-error bounds.
+
+    Under the prefix-extension assumption, receipt i's mean over n_i
+    observations and receipt i+1's mean over n_{i+1} observations
+    algebraically determine the mean over the (n_{i+1} - n_i) NEW
+    observations: (n2*m2 - n1*m1) / (n2 - n1). Each recorded mean
+    carries at most 5e-7 rounding error, so the recovered block mean
+    carries at most (n1 + n2) * 5e-7 / (n2 - n1) — reported alongside
+    every value, because it grows without bound as blocks shrink
+    relative to the running total.
+
+    A block mean outside [low, high] by more than its error bound is
+    impossible for per-observation values bounded in [low, high], so it
+    FALSIFIES the prefix-extension assumption for this series — reported
+    as ``within_bounds`` per block and rolled up by the caller.
+    """
+    blocks: list[dict[str, float | bool]] = []
+    for prev, curr in zip(receipts, receipts[1:]):
+        n1, n2 = prev["observation_count"], curr["observation_count"]
+        m1, m2 = prev[field], curr[field]
+        width = n2 - n1  # witness guarantees width >= 1
+        mean = (n2 * m2 - n1 * m1) / width
+        bound = (n1 + n2) * 5e-7 / width
+        blocks.append(
+            {
+                "block_mean": mean,
+                "error_bound": bound,
+                "within_bounds": (low - bound) <= mean <= (high + bound),
+            }
+        )
+    return {
+        "blocks": blocks[:MAX_DETAIL_ITEMS],
+        "blocks_truncated": len(blocks) > MAX_DETAIL_ITEMS,
+        "block_count": len(blocks),
+        "all_within_bounds": all(b["within_bounds"] for b in blocks),
+    }
+
+
+def _recovery_section(
+    receipts: Sequence[Mapping[str, Any]] | None,
+    order: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if receipts is None:
+        absent = _not_computable("artifact_absent", _REQUIRES_RECEIPTS)
+        return {
+            "chronology": absent,
+            "abstention_transitions": absent,
+            "surprise_blocks": absent,
+            "confidence_blocks": absent,
+            "per_observation_recovery": _not_computable(
+                "artifact_absent", _REQUIRES_RECEIPTS
+            ),
+        }
+    assert order is not None
+    section: dict[str, Any] = {"chronology": _computed(dict(order))}
+
+    if not order["witnessed"]:
+        blocked = _not_computable(
+            "order_not_witnessed",
+            "strictly increasing observation_count across the series",
+        )
+        section["abstention_transitions"] = blocked
+        section["surprise_blocks"] = blocked
+        section["confidence_blocks"] = blocked
+    elif len(receipts) < 2:
+        short = _not_computable(
+            "series_too_short", "at least two chronologically witnessed receipts"
+        )
+        section["abstention_transitions"] = short
+        section["surprise_blocks"] = short
+        section["confidence_blocks"] = short
+    else:
+        onsets = 0          # abstain False -> True between neighbours
+        reorientations = 0  # abstain True -> False between neighbours
+        run_lengths: list[int] = []  # completed abstaining runs, in receipts
+        current_run = 1 if receipts[0]["abstain"] else 0
+        for prev, curr in zip(receipts, receipts[1:]):
+            if not prev["abstain"] and curr["abstain"]:
+                onsets += 1
+                current_run = 1
+            elif prev["abstain"] and curr["abstain"]:
+                current_run += 1
+            elif prev["abstain"] and not curr["abstain"]:
+                reorientations += 1
+                run_lengths.append(current_run)
+                current_run = 0
+        trailing = current_run if receipts[-1]["abstain"] else None
+        section["abstention_transitions"] = _computed(
+            {
+                "abstention_onsets": onsets,
+                "reorientations": reorientations,
+                "completed_abstention_run_lengths_receipts": run_lengths[:MAX_DETAIL_ITEMS],
+                "run_lengths_truncated": len(run_lengths) > MAX_DETAIL_ITEMS,
+                "unresolved_trailing_abstention_receipts": trailing,
+            }
+        )
+        section["surprise_blocks"] = _computed(
+            _block_means(receipts, "mean_surprise_bits", 0.0, SURPRISE_BITS_MAX)
+        )
+        section["confidence_blocks"] = _computed(
+            _block_means(receipts, "mean_confidence", 0.0, 1.0)
+        )
+
+    section["per_observation_recovery"] = _not_computable(
+        "field_not_recorded",
+        "per-observation surprise values (receipts record cumulative means "
+        "only; recovery is resolvable at receipt granularity, never at "
+        "observation granularity)",
+    )
+    return section
+
+
+# ---------------------------------------------------------------------------
+# Section: cross-artifact check (conditional on an unrecordable premise)
+# ---------------------------------------------------------------------------
+
+
+def _capped_results(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Cross-check result lists follow the same explicit-truncation
+    convention as every other detail list: capped at MAX_DETAIL_ITEMS
+    (series order is the deterministic selection rule), full count kept."""
+    return {
+        "results": results[:MAX_DETAIL_ITEMS],
+        "results_truncated": len(results) > MAX_DETAIL_ITEMS,
+        "covering_receipt_count": len(results),
+    }
+
+
+def _cross_check_section(
+    report: Mapping[str, Any] | None,
+    receipts: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    if report is None or receipts is None:
+        missing = _REQUIRES_REPORT if report is None else _REQUIRES_RECEIPTS
+        return {
+            "assumption": ASSUMPTION_SAME_SOURCE,
+            "ece_match": _not_computable("artifact_absent", missing),
+            "surprise_nll_match": _not_computable("artifact_absent", missing),
+        }
+    holdout_rows = report["holdout_rows"]
+    # A receipt "covers" the report's evaluation when it saw exactly the
+    # full holdout AND its rolling window spans the whole holdout — then
+    # (under the same-source assumption) its rolling ECE is the same
+    # computation as the report's holdout ECE, and its mean surprise is
+    # the report's nll_bits.
+    covering = [
+        r
+        for r in receipts
+        if r["observation_count"] == holdout_rows and r["config"]["window"] >= holdout_rows
+    ]
+    if not covering:
+        blocked = _not_computable(
+            "no_covering_receipt",
+            f"a receipt with observation_count == {holdout_rows} (the report's "
+            f"holdout_rows) and config.window >= {holdout_rows}",
+        )
+        return {
+            "assumption": ASSUMPTION_SAME_SOURCE,
+            "ece_match": blocked,
+            "surprise_nll_match": blocked,
+        }
+
+    ece_results: list[dict[str, Any]] = []
+    surprise_results: list[dict[str, Any]] = []
+    for r in covering:
+        model = r["model"]
+        report_ece = report["models"][model]["ece"]
+        ece_results.append(
+            {
+                "model": model,
+                "report_ece": report_ece,
+                "receipt_rolling_calibration_error": r["rolling_calibration_error"],
+                "verdict": (
+                    "consistent"
+                    if abs(report_ece - r["rolling_calibration_error"]) <= CROSS_CHECK_TOLERANCE
+                    else "contradicted"
+                ),
+            }
+        )
+        report_nll = report["models"][model]["nll_bits"]
+        surprise = r["mean_surprise_bits"]
+        # The two emitters record extreme per-observation surprise
+        # differently: for P(actual) < 1e-300 NP1 floors at exactly
+        # NLL_BITS_MAX bits while NP2 records up to 1000 bits, so the
+        # two MEANS legitimately diverge by up to (1000 - NLL_BITS_MAX)/n
+        # — far beyond the tolerance. The divergence is only POSSIBLE if
+        # some single observation reached the floor, and per-observation
+        # surprises are non-negative, so max per-obs <= mean * n: if a
+        # recorded mean-times-count stays below NLL_BITS_MAX, that
+        # artifact witnesses that NO observation was in the divergent
+        # regime. One floored observation forces BOTH totals above
+        # NLL_BITS_MAX (minus <=0.5 receipt rounding at n <= 1e6), so
+        # the comparison is unverifiable only when BOTH totals clear the
+        # threshold (1.0-bit margin, failing toward "unverifiable").
+        n_receipt = r["observation_count"]
+        cap_possible = (
+            report_nll * holdout_rows >= NLL_BITS_MAX - 1.0
+            and surprise * n_receipt >= NLL_BITS_MAX - 1.0
+        )
+        if cap_possible:
+            verdict = "unverifiable"
+        else:
+            verdict = (
+                "consistent"
+                if abs(report_nll - surprise) <= CROSS_CHECK_TOLERANCE
+                else "contradicted"
+            )
+        surprise_results.append(
+            {
+                "model": model,
+                "report_nll_bits": report_nll,
+                "receipt_mean_surprise_bits": surprise,
+                "verdict": verdict,
+            }
+        )
+    return {
+        "assumption": ASSUMPTION_SAME_SOURCE,
+        "ece_match": _computed(_capped_results(ece_results)),
+        "surprise_nll_match": _computed(_capped_results(surprise_results)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate(
+    *,
+    report: Mapping[str, Any] | None = None,
+    receipts: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """One deterministic evaluation over already-VALIDATED artifacts
+    (see validate_report / validate_receipt_series). At least one
+    artifact is required — with neither there is no evidence at all."""
+    if report is None and receipts is None:
+        raise EvaluatorInputError("no artifacts provided: nothing to evaluate")
+
+    order = chronology_witness(receipts) if receipts is not None else None
+    recovery = _recovery_section(receipts, order)
+    cross = _cross_check_section(report, receipts)
+
+    # Assumptions are listed IFF a computed value in this evaluation
+    # depends on them (deterministic function of the inputs).
+    assumptions: list[str] = []
+    if receipts is not None and order is not None and order["witnessed"] and len(receipts) >= 2:
+        assumptions.append(ASSUMPTION_PREFIX_EXTENSION)
+    if cross["ece_match"]["status"] == "computed":
+        assumptions.append(ASSUMPTION_SAME_SOURCE)
+
+    return {
+        "schema": EVALUATION_SCHEMA,
+        "config": {
+            "max_input_bytes": MAX_INPUT_BYTES,
+            "max_series_receipts": MAX_SERIES_RECEIPTS,
+            "max_detail_items": MAX_DETAIL_ITEMS,
+            "contradiction_tolerance": CONTRADICTION_TOLERANCE,
+            "cross_check_tolerance": CROSS_CHECK_TOLERANCE,
+            "max_evaluation_bytes": MAX_EVALUATION_BYTES,
+        },
+        "assumptions": assumptions,
+        "prediction": _prediction_section(report),
+        "calibration": _calibration_section(report, receipts, order),
+        "abstention": _abstention_section(receipts),
+        "recovery": recovery,
+        "cross_check": cross,
+        "non_claims": list(NON_CLAIMS),
+    }
+
+
+def build_evaluation(
+    *,
+    report_path: pathlib.Path | None = None,
+    receipts_path: pathlib.Path | None = None,
+) -> dict[str, Any]:
+    """Load, validate and evaluate artifact files, attaching SHA-256
+    provenance (of the raw bytes — sufficient to reproduce every
+    calculation, with no paths, timestamps or environment leakage)."""
+    report = None
+    receipts = None
+    artifacts: dict[str, Any] = {
+        "report": {"provided": False},
+        "receipts": {"provided": False},
+    }
+    if report_path is not None:
+        parsed, digest, size = load_json_artifact(report_path)
+        report = validate_report(parsed)
+        artifacts["report"] = {
+            "provided": True,
+            "sha256": digest,
+            "bytes": size,
+            "schema": REPORT_SCHEMA,
+        }
+    if receipts_path is not None:
+        parsed, digest, size = load_json_artifact(receipts_path)
+        receipts = validate_receipt_series(parsed)
+        artifacts["receipts"] = {
+            "provided": True,
+            "sha256": digest,
+            "bytes": size,
+            "schema": RECEIPT_SCHEMA,
+            "receipt_count": len(receipts),
+        }
+    evaluation = evaluate(report=report, receipts=receipts)
+    evaluation["artifacts"] = artifacts
+    serialized = serialize_evaluation(evaluation)
+    if len(serialized.encode("utf-8")) > MAX_EVALUATION_BYTES:
+        raise EvaluationTooLargeError(
+            f"evaluation would exceed {MAX_EVALUATION_BYTES} bytes; refusing to emit"
+        )
+    return evaluation
+
+
+def serialize_evaluation(evaluation: Mapping[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, newline
+    (identical convention to NP1 reports and NP2 receipts)."""
+    return json.dumps(evaluation, sort_keys=True, separators=(",", ": "), indent=1) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Write-boundary guard (mirrors nextness_predictor's convention)
+# ---------------------------------------------------------------------------
+
+
+def _repo_data_dir() -> pathlib.Path:
+    return (pathlib.Path(__file__).resolve().parent.parent / "data").resolve()
+
+
+def validate_output_path(out_path: pathlib.Path, primary_input: pathlib.Path) -> None:
+    """--output may land ONLY inside the primary input artifact's
+    directory (the --report file when provided, else the --receipts
+    file), and NEVER inside the repository ``data/`` tree — the same
+    rule nextness_predictor enforces for its own reports."""
+    input_dir_resolved = primary_input.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(input_dir_resolved)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write evaluation outside the primary input "
+            f"artifact's directory: {out_resolved} is not inside {input_dir_resolved}"
+        ) from e
+    data_dir = _repo_data_dir()
+    if out_resolved == data_dir or data_dir in out_resolved.parents:
+        raise WriteOutsideLogDirError(
+            f"refusing to write evaluation inside the repository data/ tree: {out_resolved}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deterministic offline evaluation of recorded NP1 reports and "
+            "NP2 receipt series (observes and scores artifacts only; see "
+            "module docstring for the full contract)."
+        )
+    )
+    parser.add_argument(
+        "--report", type=pathlib.Path, default=None,
+        help="path to a recorded nextness-predictor-v1 report (JSON)",
+    )
+    parser.add_argument(
+        "--receipts", type=pathlib.Path, default=None,
+        help=(
+            "path to a recorded nextness-monitor-v1 receipt or JSON array "
+            "of receipts (array order = series order)"
+        ),
+    )
+    parser.add_argument(
+        "--output", type=pathlib.Path, default=None,
+        help=(
+            "optional evaluation path; must resolve inside the primary "
+            "input artifact's directory and outside the repository data/ "
+            "tree (default: stdout)"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit-code contract (mirrors NP1's expected-failure contract):
+
+    - ``0`` success
+    - ``2`` validation failure — missing/oversized/malformed artifact,
+      unknown schema variant, or no artifact provided (argparse's own
+      usage errors also exit 2)
+    - ``4`` output-path failure — write-boundary violation or an
+      unwritable target
+    - ``5`` evaluation exceeds MAX_EVALUATION_BYTES (fail closed)
+
+    There is no exit-3: "not enough evidence" is never a CLI failure
+    here — it is a typed not_computable result inside a successful
+    evaluation. Every expected failure prints one concise ``error:``
+    line to stderr — never a traceback; unexpected programming errors
+    propagate loudly.
+    """
+    args = _build_parser().parse_args(argv)
+    if args.report is None and args.receipts is None:
+        print("error: provide --report and/or --receipts", file=sys.stderr)
+        return 2
+    for label, path in (("report", args.report), ("receipts", args.receipts)):
+        if path is not None and not path.is_file():
+            print(f"error: {label} artifact not found: {path}", file=sys.stderr)
+            return 2
+    primary = args.report if args.report is not None else args.receipts
+    try:
+        if args.output is not None:
+            validate_output_path(args.output, primary)
+        evaluation = build_evaluation(
+            report_path=args.report, receipts_path=args.receipts
+        )
+    except WriteOutsideLogDirError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 4
+    except EvaluationTooLargeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 5
+    except EvaluatorInputError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    serialized = serialize_evaluation(evaluation)
+    if args.output is not None:
+        try:
+            # newline="" disables platform newline translation so the
+            # recorded artifact is byte-identical (LF-only) on every
+            # platform — a written evaluation's sha256 must not depend
+            # on the operating system that produced it.
+            args.output.write_text(serialized, encoding="utf-8", newline="")
+        except OSError as e:
+            print(f"error: cannot write evaluation to {args.output}: {e}", file=sys.stderr)
+            return 4
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -201,15 +201,17 @@ def test_report_absent_prediction_is_typed_not_computable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_reason_none_is_consistent_but_trigger_unverifiable() -> None:
+def test_reason_none_flag_and_sufficiency_consistent_rest_unverifiable() -> None:
     verdicts = check_receipt_consistency(
         validate_receipt(_make_receipt(reason="none"), "r")
     )
     assert verdicts["abstain_flag_matches_reason"] == "consistent"
     assert verdicts["sufficiency_matches_history"] == "consistent"
-    assert verdicts["higher_precedence_excluded"] == "consistent"
-    # The "none" claim also asserts confidence and prev_seen non-triggers,
-    # neither of which the receipt records.
+    # "none" asserts that NO reason fired — but the unseen_state and
+    # low_confidence triggers are unrecorded, so with no recorded
+    # contradiction the exclusion verdict is honestly unverifiable,
+    # and so is the stated-reason trigger.
+    assert verdicts["higher_precedence_excluded"] == "unverifiable"
     assert verdicts["stated_reason_trigger"] == "unverifiable"
 
 
@@ -303,6 +305,142 @@ def test_insufficient_history_trigger_verifiable() -> None:
         "r",
     )
     assert check_receipt_consistency(lying)["stated_reason_trigger"] == "contradicted"
+
+
+# ---------------------------------------------------------------------------
+# Higher-precedence truth table (exhaustive, table-driven)
+# ---------------------------------------------------------------------------
+#
+# The v1 receipt does not record the latest observation's prev_seen or
+# confidence, so unseen_state and low_confidence triggers are invisible.
+# The exclusion check may only say "consistent" when EVERY higher-
+# precedence trigger is recorded and shown not to fire; when an
+# unrecorded higher trigger could have fired, the honest verdict is
+# "unverifiable". A recorded earlier trigger always yields
+# "contradicted".
+
+
+@pytest.mark.parametrize(
+    "reason,history_ok,ece_fired,drift_fired,expected",
+    [
+        # insufficient_history: nothing above it — verify normally.
+        ("insufficient_history", False, False, False, "consistent"),
+        ("insufficient_history", True, False, False, "consistent"),
+        # unseen_state: the only higher clause (history) is recorded.
+        ("unseen_state", True, False, False, "consistent"),
+        ("unseen_state", False, False, False, "contradicted"),
+        # low_confidence: unseen_state is unrecorded above it.
+        ("low_confidence", True, False, False, "unverifiable"),
+        ("low_confidence", False, False, False, "contradicted"),
+        # calibration_drift: unseen_state + low_confidence unrecorded.
+        ("calibration_drift", True, False, False, "unverifiable"),
+        ("calibration_drift", False, False, False, "contradicted"),
+        # distribution_shift: calibration IS recorded (checkable), the
+        # two unrecorded clauses still cap the verdict at unverifiable.
+        ("distribution_shift", True, False, False, "unverifiable"),
+        ("distribution_shift", True, True, False, "contradicted"),
+        ("distribution_shift", False, False, False, "contradicted"),
+        # none: calibration + drift recorded, two clauses unrecorded.
+        ("none", True, False, False, "unverifiable"),
+        ("none", True, True, False, "contradicted"),
+        ("none", True, False, True, "contradicted"),
+        ("none", False, False, False, "contradicted"),
+    ],
+)
+def test_higher_precedence_truth_table(
+    reason, history_ok, ece_fired, drift_fired, expected
+) -> None:
+    receipt = validate_receipt(
+        _make_receipt(
+            reason=reason,
+            observation_count=40 if history_ok else 10,
+            min_history=30,
+            sufficiency="sufficient" if history_ok else "insufficient",
+            ece=0.25 if ece_fired else 0.1,
+            cal_threshold=0.2,
+            drift=0.2 if drift_fired else 0.05,
+            drift_threshold=0.15,
+        ),
+        "r",
+    )
+    assert check_receipt_consistency(receipt)["higher_precedence_excluded"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Series comparability (model/config stability gates for recovery)
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_model_series_blocks_and_transitions_not_computable() -> None:
+    # Jack's canonical case: first_order n=10 then empirical_prior n=20.
+    # Cumulative block recovery across two different predictors is
+    # meaningless; it must degrade to a typed result, never a number.
+    receipts = _series(
+        [
+            _make_receipt(observation_count=10, min_history=5, model="first_order"),
+            _make_receipt(observation_count=20, min_history=5, model="empirical_prior"),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    comparability = ev["recovery"]["series_comparability"]["value"]
+    assert comparability["model_stable"] is False
+    for key in ("surprise_blocks", "confidence_blocks", "abstention_transitions"):
+        assert ev["recovery"][key]["status"] == "not_computable"
+        assert ev["recovery"][key]["reason"] == "model_not_stable"
+    # The prefix-extension assumption's preconditions do NOT hold.
+    assert ASSUMPTION_PREFIX_EXTENSION not in ev["assumptions"]
+    # Order itself was fine — chronology is a separate, unconflated fact.
+    assert ev["recovery"]["chronology"]["value"]["witnessed"] is True
+
+
+def test_changed_config_blocks_computable_transitions_not() -> None:
+    # Stable model, changed monitor configuration: cumulative means are
+    # config-independent so blocks stay computable, but abstention
+    # transitions compare decisions made under different thresholds.
+    receipts = _series(
+        [
+            _make_receipt(observation_count=10, min_history=5),
+            _make_receipt(observation_count=20, min_history=6),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    comparability = ev["recovery"]["series_comparability"]["value"]
+    assert comparability["model_stable"] is True
+    assert comparability["config_stable"] is False
+    assert ev["recovery"]["surprise_blocks"]["status"] == "computed"
+    assert ev["recovery"]["confidence_blocks"]["status"] == "computed"
+    assert ev["recovery"]["abstention_transitions"]["status"] == "not_computable"
+    assert ev["recovery"]["abstention_transitions"]["reason"] == "config_not_stable"
+    assert ASSUMPTION_PREFIX_EXTENSION in ev["assumptions"]  # blocks used it
+
+
+def test_stable_series_remains_fully_computable() -> None:
+    receipts = _series(
+        [
+            _make_receipt(observation_count=10, min_history=5),
+            _make_receipt(observation_count=20, min_history=5),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    comparability = ev["recovery"]["series_comparability"]["value"]
+    assert comparability == {"model_stable": True, "config_stable": True}
+    assert ev["recovery"]["surprise_blocks"]["status"] == "computed"
+    assert ev["recovery"]["abstention_transitions"]["status"] == "computed"
+
+
+def test_order_violation_still_wins_over_comparability() -> None:
+    # Decreasing counts: order_not_witnessed keeps precedence over the
+    # comparability reasons — chronology and comparability are separate
+    # contracts and the typed reason must name the first failed gate.
+    receipts = _series(
+        [
+            _make_receipt(observation_count=20, model="first_order"),
+            _make_receipt(observation_count=10, model="empirical_prior"),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    for key in ("surprise_blocks", "confidence_blocks", "abstention_transitions"):
+        assert ev["recovery"][key]["reason"] == "order_not_witnessed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1,0 +1,974 @@
+"""NP5: deterministic artifact evaluator — contract + adversarial tests.
+
+Every exact-value fixture below is calculated independently in this file
+from the documented formulas — the module is never asked to verify
+itself.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import random
+
+import pytest
+
+from scripts.nextness_evaluator import (
+    ASSUMPTION_PREFIX_EXTENSION,
+    ASSUMPTION_SAME_SOURCE,
+    CONSISTENCY_CHECKS,
+    EVALUATION_SCHEMA,
+    MAX_DETAIL_ITEMS,
+    MAX_EVALUATION_BYTES,
+    MAX_INPUT_BYTES,
+    MAX_SERIES_RECEIPTS,
+    NOT_COMPUTABLE_REASONS,
+    EvaluatorInputError,
+    build_evaluation,
+    check_receipt_consistency,
+    chronology_witness,
+    evaluate,
+    load_json_artifact,
+    main,
+    serialize_evaluation,
+    validate_receipt,
+    validate_receipt_series,
+    validate_report,
+)
+from scripts.nextness_monitor import (
+    MonitorConfig,
+    build_receipt,
+    observations_from_log,
+    serialize_receipt,
+)
+from scripts.nextness_predictor import (
+    REJECT_REASONS,
+    build_report,
+    serialize_report,
+)
+
+A = "void_static"
+B = "compute_static"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders (hand-constructed, internally consistent artifacts)
+# ---------------------------------------------------------------------------
+
+
+def _make_report() -> dict:
+    rejections = {r: 0 for r in REJECT_REASONS}
+    rejections["malformed_json"] = 2
+    return {
+        "schema": "nextness-predictor-v1",
+        "config": {
+            "smoothing": 1.0,
+            "holdout_fraction": 0.25,
+            "max_rows": 100_000,
+            "max_line_bytes": 65_536,
+            "ece_bins": 10,
+            "vocabulary_size": 16,
+        },
+        "input": {
+            "rows_read": 12,
+            "rows_accepted": 8,
+            "rows_rejected": 2,
+            "rejections": rejections,
+        },
+        "evaluation": {
+            "train_rows": 6,
+            "holdout_rows": 2,
+            "split_index": 6,
+            "first_order_unseen_source_count": 1,
+            "models": {
+                "empirical_prior": {"nll_bits": 3.5, "brier": 0.9, "top1_accuracy": 0.25, "ece": 0.10},
+                "persistence": {"nll_bits": 3.9, "brier": 1.1, "top1_accuracy": 0.20, "ece": 0.30},
+                "first_order": {"nll_bits": 2.0, "brier": 0.5, "top1_accuracy": 0.60, "ece": 0.05},
+            },
+        },
+        "non_claims": ["baselines only"],
+    }
+
+
+def _make_receipt(
+    *,
+    observation_count: int = 40,
+    mean_confidence: float = 0.5,
+    mean_surprise_bits: float = 2.0,
+    ece: float = 0.1,
+    drift: float = 0.05,
+    reason: str = "none",
+    abstain: bool | None = None,
+    sufficiency: str | None = None,
+    model: str = "first_order",
+    min_history: int = 30,
+    window: int = 50,
+    cal_threshold: float = 0.2,
+    drift_threshold: float = 0.15,
+) -> dict:
+    return {
+        "schema": "nextness-monitor-v1",
+        "model": model,
+        "observation_count": observation_count,
+        "mean_confidence": mean_confidence,
+        "mean_surprise_bits": mean_surprise_bits,
+        "rolling_calibration_error": ece,
+        "distribution_drift_bits": drift,
+        "sufficiency": sufficiency
+        if sufficiency is not None
+        else ("sufficient" if observation_count >= min_history else "insufficient"),
+        "abstain": abstain if abstain is not None else (reason != "none"),
+        "abstain_reason": reason,
+        "input_reduced": False,
+        "discarded_field_count": 0,
+        "config": {
+            "min_history": min_history,
+            "window": window,
+            "low_confidence_threshold": 0.3,
+            "calibration_error_threshold": cal_threshold,
+            "drift_threshold_bits": drift_threshold,
+        },
+        "non_claim": "functional-metacognition-only",
+    }
+
+
+def _series(receipts: list[dict]) -> list[dict]:
+    return validate_receipt_series(receipts)
+
+
+def _write_log(tmp_path: pathlib.Path, tokens: list[str]) -> pathlib.Path:
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text(
+        "\n".join(
+            json.dumps({"generation": i, "token_counts": {t: 3}}) for i, t in enumerate(tokens)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Prediction section: independent hand calculations
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_section_hand_calculated_values() -> None:
+    ev = evaluate(report=validate_report(_make_report()))
+    pred = ev["prediction"]
+    # log2(16) = 4 exactly.
+    assert pred["uniform_nll_bits"] == {"status": "computed", "value": 4.0}
+    # Gaps: uniform minus recorded nll_bits, by hand.
+    assert pred["models"]["empirical_prior"]["nll_gap_to_uniform_bits"]["value"] == 4.0 - 3.5
+    assert pred["models"]["persistence"]["nll_gap_to_uniform_bits"]["value"] == pytest.approx(0.1)
+    assert pred["models"]["first_order"]["nll_gap_to_uniform_bits"]["value"] == 2.0
+    rankings = pred["rankings"]["value"]
+    assert rankings["by_nll_bits"] == ["first_order", "empirical_prior", "persistence"]
+    assert rankings["by_brier"] == ["first_order", "empirical_prior", "persistence"]
+    assert rankings["by_top1_accuracy"] == ["first_order", "empirical_prior", "persistence"]
+    assert pred["proper_score_rankings_agree"]["value"] is True
+    ingestion = pred["ingestion"]["value"]
+    assert ingestion["rejection_rate"] == 2 / 12
+    assert ingestion["first_order_unseen_source_rate"] == 1 / 2
+    # Significance is uncomputable from holdout means — typed result.
+    sig = pred["metric_difference_significance"]
+    assert sig["status"] == "not_computable"
+    assert sig["reason"] == "field_not_recorded"
+
+
+def test_ranking_tie_breaks_by_canonical_model_order() -> None:
+    report = _make_report()
+    for m in report["evaluation"]["models"].values():
+        m["nll_bits"] = 3.0  # three-way tie
+    ev = evaluate(report=validate_report(report))
+    assert ev["prediction"]["rankings"]["value"]["by_nll_bits"] == [
+        "empirical_prior",
+        "persistence",
+        "first_order",
+    ]
+
+
+def test_report_absent_prediction_is_typed_not_computable() -> None:
+    ev = evaluate(receipts=_series([_make_receipt()]))
+    for key in ("uniform_nll_bits", "models", "rankings", "ingestion"):
+        entry = ev["prediction"][key]
+        assert entry["status"] == "not_computable"
+        assert entry["reason"] == "artifact_absent"
+
+
+# ---------------------------------------------------------------------------
+# Consistency verdicts: hand-derived tri-state fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_reason_none_is_consistent_but_trigger_unverifiable() -> None:
+    verdicts = check_receipt_consistency(
+        validate_receipt(_make_receipt(reason="none"), "r")
+    )
+    assert verdicts["abstain_flag_matches_reason"] == "consistent"
+    assert verdicts["sufficiency_matches_history"] == "consistent"
+    assert verdicts["higher_precedence_excluded"] == "consistent"
+    # The "none" claim also asserts confidence and prev_seen non-triggers,
+    # neither of which the receipt records.
+    assert verdicts["stated_reason_trigger"] == "unverifiable"
+
+
+def test_calibration_drift_trigger_verifiable_both_ways() -> None:
+    fired = validate_receipt(
+        _make_receipt(reason="calibration_drift", ece=0.25, cal_threshold=0.2), "r"
+    )
+    assert check_receipt_consistency(fired)["stated_reason_trigger"] == "consistent"
+    contradicted = validate_receipt(
+        _make_receipt(reason="calibration_drift", ece=0.15, cal_threshold=0.2), "r"
+    )
+    assert check_receipt_consistency(contradicted)["stated_reason_trigger"] == "contradicted"
+
+
+def test_contradiction_tolerance_boundary_hand_derived() -> None:
+    # Both values are 6-dp-rounded; combined worst-case rounding error is
+    # 1e-6, and the tolerance is 2e-6. A recorded gap of 1e-6 must NOT be
+    # called a contradiction; a recorded gap of 3e-6 must be.
+    within = validate_receipt(
+        _make_receipt(reason="calibration_drift", ece=0.2 - 1e-6, cal_threshold=0.2), "r"
+    )
+    assert check_receipt_consistency(within)["stated_reason_trigger"] == "consistent"
+    beyond = validate_receipt(
+        _make_receipt(reason="calibration_drift", ece=0.2 - 3e-6, cal_threshold=0.2), "r"
+    )
+    assert check_receipt_consistency(beyond)["stated_reason_trigger"] == "contradicted"
+
+
+def test_unseen_state_trigger_is_unverifiable_but_precedence_checked() -> None:
+    ok = validate_receipt(
+        _make_receipt(reason="unseen_state", observation_count=40, min_history=30), "r"
+    )
+    v = check_receipt_consistency(ok)
+    assert v["stated_reason_trigger"] == "unverifiable"
+    assert v["higher_precedence_excluded"] == "consistent"
+    # insufficient_history has higher precedence: a receipt claiming
+    # unseen_state with too little history contradicts the procedure.
+    bad = validate_receipt(
+        _make_receipt(
+            reason="unseen_state", observation_count=10, min_history=30,
+            sufficiency="insufficient",
+        ),
+        "r",
+    )
+    assert check_receipt_consistency(bad)["higher_precedence_excluded"] == "contradicted"
+
+
+def test_distribution_shift_requires_calibration_not_fired() -> None:
+    # ece above threshold means calibration_drift should have fired first.
+    v = check_receipt_consistency(
+        validate_receipt(
+            _make_receipt(reason="distribution_shift", ece=0.3, cal_threshold=0.2,
+                          drift=0.2, drift_threshold=0.15),
+            "r",
+        )
+    )
+    assert v["higher_precedence_excluded"] == "contradicted"
+    assert v["stated_reason_trigger"] == "consistent"  # drift 0.2 > 0.15
+
+
+def test_reason_none_with_recorded_drift_above_threshold_contradicts() -> None:
+    v = check_receipt_consistency(
+        validate_receipt(
+            _make_receipt(reason="none", drift=0.2, drift_threshold=0.15), "r"
+        )
+    )
+    assert v["higher_precedence_excluded"] == "contradicted"
+
+
+def test_abstain_flag_and_sufficiency_contradictions() -> None:
+    flag = validate_receipt(_make_receipt(reason="low_confidence", abstain=False), "r")
+    assert check_receipt_consistency(flag)["abstain_flag_matches_reason"] == "contradicted"
+    suff = validate_receipt(
+        _make_receipt(observation_count=10, min_history=30, sufficiency="sufficient",
+                      reason="insufficient_history"),
+        "r",
+    )
+    assert check_receipt_consistency(suff)["sufficiency_matches_history"] == "contradicted"
+
+
+def test_insufficient_history_trigger_verifiable() -> None:
+    ok = validate_receipt(
+        _make_receipt(reason="insufficient_history", observation_count=10,
+                      min_history=30, sufficiency="insufficient"),
+        "r",
+    )
+    assert check_receipt_consistency(ok)["stated_reason_trigger"] == "consistent"
+    lying = validate_receipt(
+        _make_receipt(reason="insufficient_history", observation_count=99,
+                      min_history=30, sufficiency="sufficient"),
+        "r",
+    )
+    assert check_receipt_consistency(lying)["stated_reason_trigger"] == "contradicted"
+
+
+# ---------------------------------------------------------------------------
+# Chronology witness + recovery section
+# ---------------------------------------------------------------------------
+
+
+def test_chronology_witness() -> None:
+    inc = _series([_make_receipt(observation_count=n) for n in (10, 20, 30)])
+    assert chronology_witness(inc) == {"witnessed": True, "first_violation_index": None}
+    dup = _series([_make_receipt(observation_count=n) for n in (10, 20, 20)])
+    assert chronology_witness(dup) == {"witnessed": False, "first_violation_index": 2}
+    single = _series([_make_receipt()])
+    assert chronology_witness(single)["witnessed"] is True
+
+
+def test_recovery_transitions_hand_traced() -> None:
+    # abstain pattern T T F T F F T over strictly increasing counts:
+    # completed runs [2, 1]; onsets 2; reorientations 2; trailing run 1.
+    pattern = [True, True, False, True, False, False, True]
+    receipts = _series(
+        [
+            _make_receipt(
+                observation_count=10 * (i + 1),
+                reason="low_confidence" if abstain else "none",
+                abstain=abstain,
+            )
+            for i, abstain in enumerate(pattern)
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    trans = ev["recovery"]["abstention_transitions"]["value"]
+    assert trans["abstention_onsets"] == 2
+    assert trans["reorientations"] == 2
+    assert trans["completed_abstention_run_lengths_receipts"] == [2, 1]
+    assert trans["unresolved_trailing_abstention_receipts"] == 1
+
+
+def test_block_means_hand_calculated_with_error_bound() -> None:
+    # (n2*m2 - n1*m1) / (n2 - n1) = (40*2.5 - 30*2.0) / 10 = 4.0 exactly;
+    # error bound (n1 + n2) * 5e-7 / (n2 - n1) = 70 * 5e-7 / 10 = 3.5e-6.
+    receipts = _series(
+        [
+            _make_receipt(observation_count=30, mean_surprise_bits=2.0),
+            _make_receipt(observation_count=40, mean_surprise_bits=2.5),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    blocks = ev["recovery"]["surprise_blocks"]["value"]
+    assert blocks["block_count"] == 1
+    block = blocks["blocks"][0]
+    assert block["block_mean"] == 4.0
+    assert block["error_bound"] == pytest.approx(3.5e-6)
+    assert block["within_bounds"] is True
+    assert blocks["all_within_bounds"] is True
+    # The prefix-extension assumption was used and must be declared.
+    assert ASSUMPTION_PREFIX_EXTENSION in ev["assumptions"]
+
+
+def test_block_means_falsify_prefix_extension_assumption() -> None:
+    # Cumulative means 10.0 over 30 then 1.0 over 31 would require the
+    # single new observation to have surprise (31*1 - 30*10)/1 = -269
+    # bits — impossible for a value bounded in [0, 1000], so the series
+    # cannot be prefix-extensions of one stream.
+    receipts = _series(
+        [
+            _make_receipt(observation_count=30, mean_surprise_bits=10.0),
+            _make_receipt(observation_count=31, mean_surprise_bits=1.0),
+        ]
+    )
+    blocks = evaluate(receipts=receipts)["recovery"]["surprise_blocks"]["value"]
+    assert blocks["blocks"][0]["block_mean"] == pytest.approx(-269.0)
+    assert blocks["blocks"][0]["within_bounds"] is False
+    assert blocks["all_within_bounds"] is False
+
+
+def test_order_not_witnessed_blocks_order_dependent_metrics_only() -> None:
+    receipts = _series(
+        [
+            _make_receipt(observation_count=40, reason="low_confidence"),
+            _make_receipt(observation_count=30),  # decreasing: witness fails
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    assert ev["recovery"]["chronology"]["value"]["witnessed"] is False
+    for key in ("abstention_transitions", "surprise_blocks", "confidence_blocks"):
+        assert ev["recovery"][key]["status"] == "not_computable"
+        assert ev["recovery"][key]["reason"] == "order_not_witnessed"
+    # Order-free metrics still compute.
+    assert ev["abstention"]["abstention_rate"]["value"] == 0.5
+    assert ev["calibration"]["max_rolling_calibration_error"]["status"] == "computed"
+    assert ev["calibration"]["latest_rolling_calibration_error"]["status"] == "not_computable"
+    assert ev["assumptions"] == []  # no order → prefix assumption never used
+
+
+def test_single_receipt_series_too_short_for_transitions() -> None:
+    ev = evaluate(receipts=_series([_make_receipt()]))
+    assert ev["recovery"]["abstention_transitions"]["reason"] == "series_too_short"
+    assert ev["recovery"]["per_observation_recovery"]["reason"] == "field_not_recorded"
+
+
+# ---------------------------------------------------------------------------
+# Abstention section aggregates
+# ---------------------------------------------------------------------------
+
+
+def test_abstention_aggregates_and_reason_histogram() -> None:
+    receipts = _series(
+        [
+            _make_receipt(observation_count=10, min_history=30,
+                          reason="insufficient_history", sufficiency="insufficient"),
+            _make_receipt(observation_count=40, reason="none"),
+            _make_receipt(observation_count=50, reason="calibration_drift",
+                          ece=0.25, cal_threshold=0.2),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    ab = ev["abstention"]
+    assert ab["receipt_count"]["value"] == 3
+    assert ab["abstention_rate"]["value"] == pytest.approx(2 / 3)
+    counts = ab["reason_counts"]["value"]
+    assert counts["insufficient_history"] == 1
+    assert counts["none"] == 1
+    assert counts["calibration_drift"] == 1
+    assert counts["unseen_state"] == 0
+    assert ab["configurations_identical"]["value"] is True
+    assert ab["abstention_quality"]["status"] == "not_computable"
+    consistency = ab["consistency"]["value"]
+    assert set(consistency) == set(CONSISTENCY_CHECKS)
+    for check in CONSISTENCY_CHECKS:
+        tallies = consistency[check]["verdicts"]
+        assert sum(tallies.values()) == 3
+        assert consistency[check]["contradicted_indices_truncated"] is False
+
+
+def test_mixed_configurations_flagged() -> None:
+    receipts = _series(
+        [
+            _make_receipt(observation_count=30, min_history=30),
+            _make_receipt(observation_count=40, min_history=31),
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    assert ev["abstention"]["configurations_identical"]["value"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cross-artifact check (live emitters + synthetic contradiction)
+# ---------------------------------------------------------------------------
+
+
+def _live_artifacts(tmp_path: pathlib.Path) -> tuple[dict, dict]:
+    log = _write_log(tmp_path, [A, B] * 30)  # 60 rows: 45 train / 15 holdout
+    report = build_report(log)
+    observations, reference, recent = observations_from_log(log, "first_order")
+    receipt = build_receipt(
+        model="first_order",
+        observations=observations,
+        reference_counts=reference,
+        recent_counts=recent,
+        config=MonitorConfig(),
+    )
+    return report, receipt
+
+
+def test_live_emitter_artifacts_validate_and_cross_check_consistent(tmp_path) -> None:
+    # The evaluator must accept exactly what NP1/NP2 actually emit, and —
+    # since the receipt's window (50) covers the whole holdout (15) — the
+    # receipt's rolling ECE and mean surprise must match the report's
+    # holdout ECE and nll_bits within one 6-dp rounding.
+    report_raw, receipt_raw = _live_artifacts(tmp_path)
+    ev = evaluate(
+        report=validate_report(report_raw),
+        receipts=_series([receipt_raw]),
+    )
+    cross = ev["cross_check"]
+    assert cross["assumption"] == ASSUMPTION_SAME_SOURCE
+    assert cross["ece_match"]["status"] == "computed"
+    ece_value = cross["ece_match"]["value"]
+    assert ece_value["covering_receipt_count"] == 1
+    assert ece_value["results_truncated"] is False
+    assert all(entry["verdict"] == "consistent" for entry in ece_value["results"])
+    assert all(
+        entry["verdict"] == "consistent"
+        for entry in cross["surprise_nll_match"]["value"]["results"]
+    )
+    assert ASSUMPTION_SAME_SOURCE in ev["assumptions"]
+
+
+def test_cross_check_detects_synthetic_contradiction(tmp_path) -> None:
+    report_raw, receipt_raw = _live_artifacts(tmp_path)
+    receipt_raw = dict(receipt_raw)
+    receipt_raw["rolling_calibration_error"] = round(
+        min(1.0, receipt_raw["rolling_calibration_error"] + 0.01), 6
+    )
+    ev = evaluate(report=validate_report(report_raw), receipts=_series([receipt_raw]))
+    assert (
+        ev["cross_check"]["ece_match"]["value"]["results"][0]["verdict"] == "contradicted"
+    )
+
+
+def test_cross_check_divergent_cap_regime_is_unverifiable_not_contradicted(tmp_path) -> None:
+    # With pathological-but-legal smoothing (1e-306), a single holdout
+    # observation with P(actual) < 1e-300 is recorded differently by the
+    # two emitters (NP1 floors at ~996.58 bits, NP2 records up to 1000),
+    # so genuinely same-source means diverge by ~3.42/n bits — far past
+    # the tolerance. The total-bits witness must mark the comparison
+    # unverifiable rather than declare a false contradiction.
+    tokens = [A] * 60
+    tokens[50] = "unclassified"  # novel dominant token inside the holdout
+    log = _write_log(tmp_path, tokens)
+    report_raw = build_report(log, smoothing=1e-306)
+    observations, reference, recent = observations_from_log(
+        log, "first_order", smoothing=1e-306
+    )
+    receipt_raw = build_receipt(
+        model="first_order",
+        observations=observations,
+        reference_counts=reference,
+        recent_counts=recent,
+        config=MonitorConfig(),
+    )
+    ev = evaluate(report=validate_report(report_raw), receipts=_series([receipt_raw]))
+    results = ev["cross_check"]["surprise_nll_match"]["value"]["results"]
+    assert results and all(entry["verdict"] == "unverifiable" for entry in results)
+
+
+def test_genuine_fp_overshoot_report_still_validates(tmp_path) -> None:
+    # NP1's nll_bits is a naive float sum / n; on an all-floored holdout
+    # (persistence over a strict alternation with smoothing=1e-306) the
+    # mean overshoots -log2(1e-300) by accumulated rounding. That
+    # byte-genuine report must validate, not be rejected as hostile.
+    log = _write_log(tmp_path, [A, B] * 30)
+    report_raw = build_report(log, smoothing=1e-306)
+    validated = validate_report(report_raw)  # must not raise
+    assert validated["models"]["persistence"]["nll_bits"] >= 996.0
+    # A fabricated value beyond the documented slack is still rejected.
+    forged = build_report(log, smoothing=1e-306)
+    forged["evaluation"]["models"]["persistence"]["nll_bits"] = 997.0
+    with pytest.raises(EvaluatorInputError, match="outside"):
+        validate_report(forged)
+
+
+def test_cross_check_requires_covering_receipt(tmp_path) -> None:
+    report_raw, receipt_raw = _live_artifacts(tmp_path)
+    receipt_raw = dict(receipt_raw)
+    receipt_raw["observation_count"] = 14  # not the full holdout
+    ev = evaluate(report=validate_report(report_raw), receipts=_series([receipt_raw]))
+    assert ev["cross_check"]["ece_match"]["reason"] == "no_covering_receipt"
+    assert ASSUMPTION_SAME_SOURCE not in ev["assumptions"]
+
+
+# ---------------------------------------------------------------------------
+# Validation: fail-closed adversarial corpus
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_schema_variants_rejected() -> None:
+    report = _make_report()
+    report["schema"] = "nextness-predictor-v2"
+    with pytest.raises(EvaluatorInputError, match="unknown variant"):
+        validate_report(report)
+    receipt = _make_receipt()
+    receipt["schema"] = "nextness-monitor-v0"
+    with pytest.raises(EvaluatorInputError, match="unknown variant"):
+        validate_receipt(receipt, "r")
+
+
+def test_unknown_and_missing_keys_rejected() -> None:
+    extra = _make_report()
+    extra["surprise_field"] = 1
+    with pytest.raises(EvaluatorInputError, match="key set mismatch"):
+        validate_report(extra)
+    missing = _make_report()
+    del missing["config"]
+    with pytest.raises(EvaluatorInputError, match="key set mismatch"):
+        validate_report(missing)
+    receipt = _make_receipt()
+    del receipt["config"]
+    with pytest.raises(EvaluatorInputError, match="key set mismatch"):
+        validate_receipt(receipt, "r")
+
+
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda r: r["input"].__setitem__("rows_read", 5), "rows_read <"),
+        (lambda r: r["input"]["rejections"].__setitem__("malformed_json", 1), "do not sum"),
+        (lambda r: r["evaluation"].__setitem__("split_index", 5), "split_index"),
+        (lambda r: r["evaluation"].__setitem__("holdout_rows", 3), "!= rows_accepted"),
+        (lambda r: r["evaluation"].__setitem__("first_order_unseen_source_count", 3), "outside"),
+    ],
+)
+def test_internal_accounting_violations_rejected(mutate, match) -> None:
+    report = _make_report()
+    mutate(report)
+    with pytest.raises(EvaluatorInputError, match=match):
+        validate_report(report)
+
+
+def test_bool_is_not_a_count_or_flag_substitute() -> None:
+    receipt = _make_receipt()
+    receipt["observation_count"] = True
+    with pytest.raises(EvaluatorInputError, match="builtin int"):
+        validate_receipt(receipt, "r")
+    receipt = _make_receipt()
+    receipt["abstain"] = 1
+    with pytest.raises(EvaluatorInputError, match="builtin bool"):
+        validate_receipt(receipt, "r")
+
+
+def test_hostile_container_and_string_subclasses_rejected() -> None:
+    class EvilDict(dict):
+        def keys(self):  # pragma: no cover - must never be consulted
+            raise AssertionError("hostile keys() was consulted")
+
+    with pytest.raises(EvaluatorInputError, match="builtin dict"):
+        validate_report(EvilDict(_make_report()))
+
+    class EvilStr(str):
+        def __eq__(self, other):  # pragma: no cover - must never be consulted
+            raise AssertionError("hostile __eq__ was consulted")
+
+        __hash__ = str.__hash__
+
+    receipt = _make_receipt()
+    receipt["model"] = EvilStr("first_order")
+    with pytest.raises(EvaluatorInputError, match="builtin str"):
+        validate_receipt(receipt, "r")
+
+
+def test_astronomical_and_nonfinite_numbers_rejected(tmp_path) -> None:
+    receipt = _make_receipt()
+    receipt["observation_count"] = 10**7  # beyond MAX_ROWS_CEILING
+    with pytest.raises(EvaluatorInputError, match="outside"):
+        validate_receipt(receipt, "r")
+    receipt = _make_receipt()
+    receipt["mean_confidence"] = 10**400  # OverflowError path
+    with pytest.raises(EvaluatorInputError, match="finite float"):
+        validate_receipt(receipt, "r")
+    # NaN smuggled through a real JSON file (Python's json accepts NaN).
+    nan_file = tmp_path / "nan.json"
+    nan_file.write_text(
+        json.dumps(_make_receipt()).replace("0.5", "NaN", 1), encoding="utf-8"
+    )
+    parsed, _, _ = load_json_artifact(nan_file)
+    with pytest.raises(EvaluatorInputError, match="not finite"):
+        validate_receipt(parsed, "r")
+
+
+def test_oversized_artifact_fails_closed_before_parse(tmp_path) -> None:
+    big = tmp_path / "big.json"
+    big.write_bytes(b"x" * (MAX_INPUT_BYTES + 10))
+    with pytest.raises(EvaluatorInputError, match="exceeds"):
+        load_json_artifact(big)
+
+
+def test_pathologically_nested_artifact_fails_closed(tmp_path) -> None:
+    deep = tmp_path / "deep.json"
+    deep.write_bytes(b"[" * 200_000)  # within the size bound, hostile depth
+    with pytest.raises(EvaluatorInputError, match="depth limit"):
+        load_json_artifact(deep)
+
+
+def test_series_bounds_fail_closed() -> None:
+    with pytest.raises(EvaluatorInputError, match="empty"):
+        validate_receipt_series([])
+    with pytest.raises(EvaluatorInputError, match="exceeding"):
+        validate_receipt_series([{}] * (MAX_SERIES_RECEIPTS + 1))
+    with pytest.raises(EvaluatorInputError, match="builtin dict"):
+        validate_receipt_series([_make_receipt(), "not a receipt"])
+    with pytest.raises(EvaluatorInputError, match="receipt object or an array"):
+        validate_receipt_series("just a string")
+
+
+def test_no_artifacts_is_an_input_error() -> None:
+    with pytest.raises(EvaluatorInputError, match="nothing to evaluate"):
+        evaluate()
+
+
+def test_not_computable_reasons_are_from_fixed_vocabulary() -> None:
+    ev = evaluate(receipts=_series([_make_receipt()]))
+
+    def _walk(node) -> None:
+        if isinstance(node, dict):
+            if node.get("status") == "not_computable":
+                assert node["reason"] in NOT_COMPUTABLE_REASONS
+                assert isinstance(node["requires"], str) and node["requires"]
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(ev)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_byte_identical_across_runs(tmp_path) -> None:
+    report_raw, receipt_raw = _live_artifacts(tmp_path)
+    report_file = tmp_path / "report.json"
+    report_file.write_text(serialize_report(report_raw), encoding="utf-8")
+    receipts_file = tmp_path / "receipts.json"
+    receipts_file.write_text(
+        json.dumps([json.loads(serialize_receipt(receipt_raw))]), encoding="utf-8"
+    )
+    outputs = {
+        serialize_evaluation(
+            build_evaluation(report_path=report_file, receipts_path=receipts_file)
+        )
+        for _ in range(3)
+    }
+    assert len(outputs) == 1
+    evaluation = json.loads(next(iter(outputs)))
+    assert evaluation["schema"] == EVALUATION_SCHEMA
+    assert evaluation["artifacts"]["report"]["provided"] is True
+    assert evaluation["artifacts"]["receipts"]["receipt_count"] == 1
+    # Provenance: no paths, no timestamps — just content hashes.
+    assert len(evaluation["artifacts"]["report"]["sha256"]) == 64
+    assert "time" not in next(iter(outputs)).lower()
+
+
+def test_input_key_order_does_not_change_the_evaluation(tmp_path) -> None:
+    report = _make_report()
+
+    def _reorder(obj):
+        if isinstance(obj, dict):
+            return {k: _reorder(obj[k]) for k in reversed(list(obj))}
+        return obj
+
+    a = tmp_path / "a.json"
+    a.write_text(json.dumps(report), encoding="utf-8")
+    b = tmp_path / "b.json"
+    b.write_text(json.dumps(_reorder(report)), encoding="utf-8")
+    ev_a = build_evaluation(report_path=a)
+    ev_b = build_evaluation(report_path=b)
+    # The bytes differ, so provenance differs — but every computed value
+    # must be identical.
+    ev_a["artifacts"] = ev_b["artifacts"] = None
+    assert serialize_evaluation(ev_a) == serialize_evaluation(ev_b)
+
+
+# ---------------------------------------------------------------------------
+# Property-style seeded traces (stdlib random only — no new dependency)
+# ---------------------------------------------------------------------------
+
+
+def _seeded_series(rng: random.Random, length: int) -> list[dict]:
+    series = []
+    count = 0
+    for _ in range(length):
+        count += rng.randint(1, 50)
+        reason = rng.choice(
+            ["none", "insufficient_history", "unseen_state", "low_confidence",
+             "calibration_drift", "distribution_shift"]
+        )
+        series.append(
+            _make_receipt(
+                observation_count=count,
+                mean_confidence=round(rng.random(), 6),
+                mean_surprise_bits=round(rng.random() * 10, 6),
+                ece=round(rng.random(), 6),
+                drift=round(rng.random(), 6),
+                reason=reason,
+                sufficiency=rng.choice(["sufficient", "insufficient"]),
+            )
+        )
+    return series
+
+
+@pytest.mark.parametrize("seed", [7, 77, 777])
+def test_seeded_series_bounded_deterministic_and_shuffle_invariant(seed: int) -> None:
+    rng = random.Random(seed)
+    raw = _seeded_series(rng, 20)
+    ev1 = evaluate(receipts=_series(raw))
+    ev2 = evaluate(receipts=_series(raw))
+    assert serialize_evaluation(ev1) == serialize_evaluation(ev2)
+    assert len(serialize_evaluation(ev1).encode("utf-8")) <= MAX_EVALUATION_BYTES
+
+    # Order-free metrics must survive any reordering: seeded shuffles
+    # plus a reversal (which guarantees the chronology witness fails, so
+    # order-dependent metrics must degrade to typed not_computable —
+    # never to wrong numbers).
+    permutations = [list(reversed(raw))]
+    for _ in range(3):
+        shuffled = list(raw)
+        rng.shuffle(shuffled)
+        permutations.append(shuffled)
+    for permuted in permutations:
+        ev_p = evaluate(receipts=_series(permuted))
+        assert ev_p["abstention"]["reason_counts"] == ev1["abstention"]["reason_counts"]
+        assert ev_p["abstention"]["abstention_rate"] == ev1["abstention"]["abstention_rate"]
+        assert (
+            ev_p["calibration"]["max_rolling_calibration_error"]
+            == ev1["calibration"]["max_rolling_calibration_error"]
+        )
+        for check in CONSISTENCY_CHECKS:
+            assert (
+                ev_p["abstention"]["consistency"]["value"][check]["verdicts"]
+                == ev1["abstention"]["consistency"]["value"][check]["verdicts"]
+            )
+        if permuted != raw:  # a permutation that breaks strict order
+            assert ev_p["recovery"]["abstention_transitions"]["status"] == "not_computable"
+
+
+def test_full_length_series_stays_inside_output_ceiling() -> None:
+    # Worst-ish case: the maximum series length, every receipt
+    # contradictory (so contradiction indices saturate), all block lists
+    # at their caps — the evaluation must still fit the 64 KiB ceiling,
+    # with truncation flagged explicitly rather than silently.
+    receipts = _series(
+        [
+            _make_receipt(
+                observation_count=10 + i,
+                reason="calibration_drift",
+                ece=0.1,             # below threshold: trigger contradicted
+                abstain=False,       # contradicts the stated reason
+                sufficiency="insufficient",  # contradicts history
+            )
+            for i in range(MAX_SERIES_RECEIPTS)
+        ]
+    )
+    ev = evaluate(receipts=receipts)
+    serialized = serialize_evaluation(ev)
+    assert len(serialized.encode("utf-8")) <= MAX_EVALUATION_BYTES
+    consistency = ev["abstention"]["consistency"]["value"]
+    assert consistency["abstain_flag_matches_reason"]["contradicted_indices_truncated"] is True
+    assert (
+        len(consistency["abstain_flag_matches_reason"]["contradicted_indices"])
+        == MAX_DETAIL_ITEMS
+    )
+    blocks = ev["recovery"]["surprise_blocks"]["value"]
+    assert blocks["blocks_truncated"] is True
+    assert blocks["block_count"] == MAX_SERIES_RECEIPTS - 1
+
+
+def test_report_plus_full_covering_series_stays_inside_output_ceiling() -> None:
+    # The other saturation direction: a valid report plus the maximum
+    # series where EVERY receipt covers the report's holdout (equal
+    # counts — a legitimate recorded corpus whose chronology witness
+    # fails). Cross-check result lists must truncate explicitly and the
+    # whole evaluation must stay inside the 64 KiB ceiling.
+    report = validate_report(_make_report())  # holdout_rows == 2
+    receipts = _series(
+        [_make_receipt(observation_count=2, min_history=5) for _ in range(MAX_SERIES_RECEIPTS)]
+    )
+    ev = evaluate(report=report, receipts=receipts)
+    assert len(serialize_evaluation(ev).encode("utf-8")) <= MAX_EVALUATION_BYTES
+    for key in ("ece_match", "surprise_nll_match"):
+        value = ev["cross_check"][key]["value"]
+        assert value["covering_receipt_count"] == MAX_SERIES_RECEIPTS
+        assert value["results_truncated"] is True
+        assert len(value["results"]) == MAX_DETAIL_ITEMS
+
+
+# ---------------------------------------------------------------------------
+# CLI: exit codes, write boundary, concise errors
+# ---------------------------------------------------------------------------
+
+
+def _write_artifacts(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    report_file = tmp_path / "report.json"
+    report_file.write_text(json.dumps(_make_report()), encoding="utf-8")
+    receipts_file = tmp_path / "receipts.json"
+    receipts_file.write_text(
+        json.dumps([_make_receipt(observation_count=n) for n in (10, 20)]),
+        encoding="utf-8",
+    )
+    return report_file, receipts_file
+
+
+def test_cli_success_stdout_and_output_file(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file)]) == 0
+    stdout = capsys.readouterr().out
+    assert json.loads(stdout)["schema"] == EVALUATION_SCHEMA
+
+    out = tmp_path / "evaluation.json"
+    assert main(["--report", str(report_file), "--output", str(out)]) == 0
+    first = out.read_bytes()
+    assert main(["--report", str(report_file), "--output", str(out)]) == 0
+    assert out.read_bytes() == first  # byte-identical rewrite
+    # LF-only on every platform: the written artifact's bytes are exactly
+    # the canonical serialization, never newline-translated.
+    assert b"\r" not in first
+    assert first == serialize_evaluation(build_evaluation(report_path=report_file)).encode("utf-8")
+
+
+def test_cli_requires_at_least_one_artifact(capsys) -> None:
+    assert main([]) == 2
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+def test_cli_missing_and_malformed_artifacts_exit_2(tmp_path, capsys) -> None:
+    assert main(["--report", str(tmp_path / "absent.json")]) == 2
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert main(["--report", str(bad)]) == 2
+    unknown = tmp_path / "unknown.json"
+    unknown.write_text(json.dumps({"schema": "mystery-v9"}), encoding="utf-8")
+    assert main(["--receipts", str(unknown)]) == 2
+    for line in capsys.readouterr().err.splitlines():
+        assert line.startswith("error:")
+
+
+def test_cli_write_boundary_outside_input_dir_exit_4(tmp_path, capsys) -> None:
+    report_file, _ = _write_artifacts(tmp_path / "inputs")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    assert (
+        main(["--report", str(report_file), "--output", str(elsewhere / "e.json")]) == 4
+    )
+    assert "outside the primary input" in capsys.readouterr().err
+
+
+def test_cli_write_boundary_never_inside_data_tree(tmp_path, capsys, monkeypatch) -> None:
+    import scripts.nextness_evaluator as evaluator_module
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(evaluator_module, "_repo_data_dir", lambda: data_dir.resolve())
+    report_file = data_dir / "report.json"
+    report_file.write_text(json.dumps(_make_report()), encoding="utf-8")
+    # Output inside the input's own directory would normally be allowed —
+    # but that directory IS the data/ tree, so it must be refused.
+    assert (
+        main(["--report", str(report_file), "--output", str(data_dir / "e.json")]) == 4
+    )
+    assert "data/ tree" in capsys.readouterr().err
+
+
+def test_cli_oversized_evaluation_exit_5(tmp_path, capsys, monkeypatch) -> None:
+    import scripts.nextness_evaluator as evaluator_module
+
+    monkeypatch.setattr(evaluator_module, "MAX_EVALUATION_BYTES", 64)
+    report_file, _ = _write_artifacts(tmp_path)
+    assert main(["--report", str(report_file)]) == 5
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+# ---------------------------------------------------------------------------
+# Live end-to-end: emitter files → CLI → evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_live_pipeline_via_cli(tmp_path, capsys) -> None:
+    report_raw, receipt_raw = _live_artifacts(tmp_path)
+    report_file = tmp_path / "report.json"
+    report_file.write_text(serialize_report(report_raw), encoding="utf-8")
+    receipts_file = tmp_path / "receipt.json"
+    receipts_file.write_text(serialize_receipt(receipt_raw), encoding="utf-8")
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file)]) == 0
+    evaluation = json.loads(capsys.readouterr().out)
+    assert evaluation["schema"] == EVALUATION_SCHEMA
+    # A single live receipt loads as a series of one.
+    assert evaluation["artifacts"]["receipts"]["receipt_count"] == 1
+    assert (
+        evaluation["cross_check"]["ece_match"]["value"]["results"][0]["verdict"]
+        == "consistent"
+    )


### PR DESCRIPTION
## What this is

**PACKAGE NP5** — first PR of the Kev-authorized offline Nextness instrumentation runway, stacked on **#355's audited head `54440cf2`** (NP2). Three new files, nothing else touched:

| File | Lines | Role |
|---|---|---|
| `scripts/nextness_evaluator.py` | ~950 | deterministic evaluator over recorded artifacts (`nextness-evaluation-v1`) |
| `tests/test_nextness_evaluator.py` | 53 tests | hand-calculated fixtures, adversarial corpus, seeded metamorphic properties, live-emitter integration |
| `docs/NEXTNESS_EVALUATOR_CONTRACT.md` | — | full contract incl. computable/uncomputable tables |

It reads NP1 reports and NP2 receipt series **that already exist on disk** and answers: *what do these artifacts honestly establish about prediction, uncertainty, abstention and recovery after surprise — and what remains uncomputable?* It never tunes, actuates, selects rules, invokes a model, contacts a service, or writes into the engine/observer.

## Existing evidence (separate from proposal)

- NP1 (`nextness-predictor-v1`) records per-model holdout means (nll_bits/brier/top1/ece) + row accounting; no per-observation data, no variance.
- NP2 (`nextness-monitor-v1`) records aggregates + the abstention decision, but **not** the latest observation's `confidence`/`prev_seen` — the inputs two of six abstention reasons depend on — and no timestamps (by design).

## Design (driven by those facts)

- **Result envelope**: every metric is `computed` or typed `not_computable` (fixed reason vocabulary: `artifact_absent` / `field_not_recorded` / `series_too_short` / `order_not_witnessed` / `no_covering_receipt`). Absent evidence is never guessed around.
- **Tri-state consistency verdicts** per receipt (`consistent`/`contradicted`/`unverifiable`) for exactly the decision clauses the recorded fields witness, with derived tolerances (`2e-6` recorded-vs-recorded, `1e-6` recorded-vs-unrounded — 2× worst-case 6-dp rounding) so a declared contradiction can never be a rounding artifact.
- **Chronology witness**: strictly increasing `observation_count`; failure degrades order-dependent metrics to typed results, order-free metrics still compute.
- **Recovery**: abstention onsets/reorientations/run lengths at receipt granularity; inter-receipt block means recovered algebraically `(n2·m2−n1·m1)/(n2−n1)` **with propagated error bounds**, under a *stated* prefix-extension assumption that out-of-range blocks explicitly falsify.
- **Cross-checks** (report↔receipt) conditional on a *stated* same-source assumption, with a **total-bits witness** for the NP1-floor(996.58)/NP2-cap(1000) divergent regime → `unverifiable`, not false `contradicted`.
- **Hostile-input boundary**: 1 MiB pre-parse read bound, 256-receipt series bound, exact-type validation everywhere (no conversion hooks, no hostile `repr`, RecursionError fail-closed), exact key sets (unknown variants rejected), NP1 accounting identities re-checked. 64 KiB output ceiling fail-closed, proven at max series length in **both** saturation directions. sha256-of-bytes provenance; no timestamps/randomness/paths; LF-only `--output` bytes on every platform.
- CLI exits 0/2/4/5 (no exit-3: "not enough evidence" is a typed result, not a failure), one concise `error:` line, never a traceback.

## Metrics rejected as uncomputable (typed in output)

Full abstention-decision verification (fields unrecorded) · abstention quality (aggregates only) · miscalibration direction (unsigned ECE) · metric-difference significance (no variance) · per-observation recovery (cumulative means only) · series order without the witness.

## Verification

- Targeted: **53/53** · full maintained suite: **977 passed / 27 skipped** · `py_compile` OK.
- Live CLI demo: byte-identical evaluations across runs; write-boundary refusals (exit 4) receipted.
- Adversarial multi-lens self-review (4 lenses + independent refutation agents): **9 confirmed findings, all folded** — incl. a live-reproduced false-contradiction in the divergent-cap regime (fixed with the total-bits witness + regression test driving real emitters at `smoothing=1e-306`), fp-overshoot rejection of genuine all-floored reports (validation slack + live regression), uncapped cross-check lists breaching the 64 KiB ceiling on valid input (capped with explicit truncation + ceiling test), CRLF `--output` translation (LF-only + byte-equality test), and claim-narrowing in comments/test names.

## Non-claims

No awareness/consciousness/phenomenology/biological-equivalence claim. No "improvement"/"winner" language — gaps and fixed-tie-break rankings only. A `not_computable` result describes the artifacts' evidence, not the underlying system.

## Boundary note (out of scope, flagged for a future package)

NP1's own `--output` writes with platform newline translation (report sha256 differs Windows↔Linux). Not touched here — #354 is frozen for Jack; this evaluator hashes whatever bytes it receives and is unaffected.

**Stack**: #354 ← #355 ← **this PR**. Left open and unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment — Jack HOLD delta (2026-07-15, head `bddf4c67`)

All three live review threads addressed in one correction commit on top of the audited head `a2cd84cb` (delta reviewable in isolation):

**A. Series comparability, separate from chronology** (codex thread @ evaluator:571). The chronology witness stays strictly-increasing `observation_count` only; a new `series_comparability` fact ({model_stable, config_stable}, both recorded per receipt — checked, never assumed) now gates recovery. Blocks require one stable model (`model_not_stable` otherwise); abstention transitions additionally require one stable monitor config (`config_not_stable`); gate precedence `order_not_witnessed > series_too_short > model_not_stable > config_not_stable`; the prefix-extension assumption is emitted only when block recovery actually ran. **Failing-first receipt**: mixed-model (first_order n=10 → empirical_prior n=20), changed-config, stable-series and decreasing-counts regressions — 3 of 4 failed against the pre-fix code (`test_mixed_model_series...`, `test_changed_config...`, `test_stable_series...`), now green.

**B. Honest precedence truth table** (codex thread @ evaluator:750). A recorded earlier trigger ⇒ `contradicted`; an unrecorded earlier trigger that could have fired (`unseen_state`/`low_confidence` are not in the v1 receipt) ⇒ `unverifiable` — never `consistent`. `consistent` survives only for `insufficient_history` (nothing precedes it) and `unseen_state` (its only earlier clause is recorded). Exact table now in the contract doc; 15-cell table-driven suite. **Failing-first receipt**: 4 cells (`low_confidence`/`calibration_drift`/`distribution_shift`/`none`, history-ok, no recorded contradiction) failed pre-fix as `consistent`-vs-`unverifiable`, now green.

**C. Byte output** (gemini thread @ evaluator:1272). `--output` now uses `write_bytes(serialized.encode("utf-8"))` — LF-only byte identity with no dependence on `Path.write_text(newline=)` availability.

Reason vocabulary extended (`model_not_stable`, `config_not_stable`) — frozen by the NP7 guard in its own amendment. Receipts: targeted **72/72**, full suite **996 passed / 27 skipped**, `py_compile` OK. Threads intentionally left unresolved for Jack.
