### PR TITLE
feat: offline replay laboratory for per-step abstention trajectories (PACKAGE NP6)

### DIFF
--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -99,8 +99,12 @@ steps; run count equals reorientations).
 - ≤ `MAX_LAB_CONFIGS` (8) configurations; ≤ `MAX_REPLAY_STEPS` (2000)
   holdout steps — a longer holdout is **refused**, because dropping
   early steps would misstate `first_non_abstain_step` and every run
-  length. Per-step rolling statistics cost O(steps × window), so the
-  bound also caps total work.
+  length. The bound is enforced from the already-bounded sequence
+  length **before any observation list is allocated**
+  (`replay_observations` is provably never invoked for an oversized
+  holdout — spy-tested), and a split-arithmetic invariant re-checks the
+  early computation against the bridge's own holdout. Per-step rolling
+  statistics cost O(steps × window), so the bound also caps total work.
 - Log reading inherits NP1's `max_rows` / `max_line_bytes` bounds via
   `read_dominant_sequence`; protocol files are size-checked before
   parsing; output is checked against a **64 KiB ceiling — fail closed**.
@@ -114,9 +118,22 @@ Provenance: the SHA-256 of the protocol file's raw bytes, and the
 SHA-256 of the **accepted dominant-token sequence** — the log enters
 the computation only through that sequence, so together with the row
 accounting and the configuration echo this reproduces every
-calculation. The lab is read-only with respect to both inputs (tested
-byte-for-byte, including through the CLI), and an `--output` that names
-either input file is refused rather than overwriting it.
+calculation. `--output` files are written as raw UTF-8 bytes (LF-only,
+no dependence on newer `Path.write_text` parameters).
+
+**Input protection**: the lab is read-only with respect to both inputs
+(tested byte-for-byte, including through the CLI). An `--output` that
+aliases either input is refused: by resolved path (which covers
+symlink aliases, including dangling ones — resolution targets are
+compared, not link names) and by file identity via `os.path.samefile`
+(device + inode, which covers existing hard links whose paths differ);
+an identity check that cannot complete is itself a refusal.
+**Residual race, stated precisely**: identity is verified at validation
+time and the later write does not re-verify, so a concurrent actor
+replacing the output path between validation and write can still
+redirect the write. The lab defends against aliases that exist when it
+validates; it does not claim protection against concurrent hostile
+filesystem manipulation.
 
 ## Write boundary and CLI
 

--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -1,0 +1,136 @@
+# Nextness Replay Laboratory Contract (NP6)
+
+**Module**: `scripts/nextness_replay_lab.py` · **Tests**: `tests/test_nextness_replay_lab.py`
+**Schemas**: `nextness-replay-lab-v1` (output) · `nextness-replay-protocol-v1` (input) · **Status**: laboratory observations only — replays recordings, never acts
+
+## What this is
+
+An offline replay laboratory: it takes **one recorded**
+`nextness_runs.jsonl` log and **one operator-written protocol file**
+(up to 8 monitor configurations), replays the log through NP2's own
+abstention decision procedure at **every holdout step**, and reports
+each configuration's abstention trajectory side by side.
+
+This reaches the granularity the NP5 evaluator cannot: NP5 reads
+receipts, and receipts record aggregates — so recovery after surprise
+is only resolvable at receipt granularity there. The lab replays the
+recording itself, so it can state *at which step the monitor first
+stopped abstaining, whether and how many times it re-abstained, and how
+many steps each completed reorientation took* — per configuration, over
+the same immutable input. (Onset step positions themselves are not
+emitted — the summary carries counts and run lengths, not a per-step
+timeline.)
+
+## Laboratory observations only (load-bearing)
+
+- Comparisons are **descriptive**. There is no ranking, no winner, no
+  recommendation and no score field anywhere in the output (tested by
+  key-walk); configurations appear in exactly the operator's input
+  order.
+- **Abstention is preserved**, not treated as a defect: a configuration
+  that never leaves abstention is reported exactly as such
+  (`first_non_abstain_step: null`, unresolved trailing run) — the test
+  suite pins this on NP2's known under-confidence regime.
+- **No search**: the operator hand-writes every configuration; the lab
+  never generates, perturbs, sweeps or optimizes them, and never reads
+  or writes any engine parameter.
+- No awareness, consciousness, phenomenology or biological-equivalence
+  claim.
+
+## No new semantics (the equivalence lock)
+
+The replay reuses NP1's public sequence reader, split arithmetic and
+distribution builders, and NP2's public `decide_abstention`,
+`rolling_ece`, `canonical_top` and `nextness_metrics.js_divergence`.
+The bridge loop is re-derived because `observations_from_log` returns
+the full observation list but **not** the train/holdout token lists the
+per-step drift windows need (its recent counts cover only the final
+window), and it accepts only a log path — reusing it would re-read the
+log and decouple the observations from the already-read sequence the
+lab hashes for provenance.
+
+The re-derivation is pinned to the live NP2 path by a parametrized
+lock across all three models, three configurations (including one where
+`distribution_shift` is the reason that actually decides) and two
+fixtures (one with a **fractional split**, so the floor arithmetic is
+discriminated; both with the regime change inside the holdout, so
+observations vary step to step): replayed observations must equal
+`observations_from_log`'s **float-for-float**, re-derived
+reference/recent counts must equal the bridge's, and the final-step
+decision must equal what `build_receipt` emits. Two per-step
+differential tests additionally rebuild every step's decision from
+independently written slices (one exercising `distribution_shift`
+mid-trajectory, one where per-step confidence alternates across the
+`low_confidence` threshold). These locks were mutation-tested: drift
+hardwired to zero, prefix-diluted recent windows, holdout-derived
+references, first-window slices, stale latest observations and
+floor→round split changes each fail the suite.
+
+At step *t* the monitor has seen exactly the first *t* bridge
+observations; rolling ECE runs over the last `window` of them, and
+drift compares the training reference against the last `window` holdout
+tokens — precisely NP2's receipt semantics evaluated at every prefix.
+
+## Protocol contract (input, fail-closed)
+
+`nextness-replay-protocol-v1`, exact key sets, exact types (no
+conversion hooks, bools never numbers, NaN/overflow rejected), bounded
+before parse (64 KiB): shared `model` / `smoothing` /
+`holdout_fraction` (NP1's own bounds), plus 1–8 configurations, each a
+unique label (≤ 64 chars) and the five `MonitorConfig` fields.
+Threshold validation is **delegated to NP2's own
+`MonitorConfig.validate`** — the lab cannot accept a configuration the
+monitor itself would reject. Unknown schema strings, unknown keys,
+duplicate labels and out-of-bounds values all fail closed.
+
+## Trajectory summary (per configuration)
+
+`step_count` · `abstention_step_rate` · `reason_step_counts` (fixed
+NP2 vocabulary) · `first_non_abstain_step` (1-based, or null) ·
+`abstention_onsets` · `reorientations` · completed run lengths (capped
+at 128 with an explicit `truncated` flag) · unresolved trailing run ·
+`final_abstain` / `final_reason` (directly comparable to a real NP2
+receipt). Seeded property tests hold the accounting identities (reason
+counts sum to steps; completed runs plus trailing equal abstained
+steps; run count equals reorientations).
+
+## Bounds (fail closed, never silent)
+
+- ≤ `MAX_LAB_CONFIGS` (8) configurations; ≤ `MAX_REPLAY_STEPS` (2000)
+  holdout steps — a longer holdout is **refused**, because dropping
+  early steps would misstate `first_non_abstain_step` and every run
+  length. Per-step rolling statistics cost O(steps × window), so the
+  bound also caps total work.
+- Log reading inherits NP1's `max_rows` / `max_line_bytes` bounds via
+  `read_dominant_sequence`; protocol files are size-checked before
+  parsing; output is checked against a **64 KiB ceiling — fail closed**.
+
+## Determinism and provenance
+
+Sorted-key JSON, fixed separators, newline-terminated; no wall-clock
+timestamps, no random identifiers, no absolute paths; byte-identical
+across repeated runs; `--output` files are LF-only on every platform.
+Provenance: the SHA-256 of the protocol file's raw bytes, and the
+SHA-256 of the **accepted dominant-token sequence** — the log enters
+the computation only through that sequence, so together with the row
+accounting and the configuration echo this reproduces every
+calculation. The lab is read-only with respect to both inputs (tested
+byte-for-byte, including through the CLI), and an `--output` that names
+either input file is refused rather than overwriting it.
+
+## Write boundary and CLI
+
+Default output is **stdout**; `--output` must resolve inside the input
+log's directory and never inside the repository `data/` tree (NP1's
+convention). Exit codes mirror NP1: `0` success · `2` validation
+failure (including a holdout beyond the replay bound) · `3`
+insufficient history · `4` write-boundary/unwritable · `5` report over
+the ceiling. Expected failures print one concise `error:` line, never a
+traceback.
+
+## Safety
+
+Offline; no network; imports only `nextness_predictor`,
+`nextness_monitor`, `nextness_metrics`, `nextness_observer` and stdlib
+(statically auditable). Never invokes a model, never touches the
+engine, observer, orchestrator or tuning surfaces.

--- a/scripts/nextness_replay_lab.py
+++ b/scripts/nextness_replay_lab.py
@@ -36,8 +36,11 @@ Safety contract (Lane B, mirrors NP1/NP2/NP5):
 
 - Offline only; reads exactly two files (log + protocol), both through
   hard bounds; READ-ONLY with respect to both (tested byte-for-byte,
-  including through the CLI — an ``--output`` naming either input file
-  is refused rather than overwritten).
+  including through the CLI). An ``--output`` aliasing either input is
+  refused by resolved path AND by file identity (samefile: covers
+  existing hard links and symlink targets). Residual race documented in
+  validate_output_path: identity is checked at validation time, not
+  re-checked at write time.
 - Bounded work: at most ``MAX_LAB_CONFIGS`` configurations and
   ``MAX_REPLAY_STEPS`` holdout steps (fail closed above — never a
   silent truncation of the trajectory); protocol files are bounded
@@ -59,6 +62,7 @@ import argparse
 import hashlib
 import json
 import math
+import os
 import pathlib
 import sys
 from collections.abc import Mapping, Sequence
@@ -468,18 +472,30 @@ def build_lab_report(
     sequence, rejections, rows_read = read_dominant_sequence(
         log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
     )
+    # Replay bound BEFORE any observation allocation: the holdout
+    # length is fully determined by the already-bounded sequence length
+    # and the protocol's holdout_fraction (the same floor arithmetic
+    # replay_observations uses — re-checked against its output below),
+    # so an oversized holdout is refused without ever constructing the
+    # observation list.
+    holdout_len = len(sequence) - math.floor(
+        len(sequence) * (1.0 - protocol["holdout_fraction"])
+    )
+    if holdout_len > MAX_REPLAY_STEPS:
+        raise LabInputError(
+            f"holdout has {holdout_len} steps, exceeding the {MAX_REPLAY_STEPS} "
+            f"replay bound (fail closed; re-record or adjust holdout_fraction "
+            f"rather than silently truncating a trajectory)"
+        )
     observations, train, holdout = replay_observations(
         sequence,
         protocol["model"],
         smoothing=protocol["smoothing"],
         holdout_fraction=protocol["holdout_fraction"],
     )
-    if len(holdout) > MAX_REPLAY_STEPS:
-        raise LabInputError(
-            f"holdout has {len(holdout)} steps, exceeding the {MAX_REPLAY_STEPS} "
-            f"replay bound (fail closed; re-record or adjust holdout_fraction "
-            f"rather than silently truncating a trajectory)"
-        )
+    # Split-arithmetic invariant: the early bound and the bridge must
+    # never disagree about the holdout length.
+    assert len(holdout) == holdout_len
 
     configurations: list[dict[str, Any]] = []
     for label, cfg in protocol["configs"]:
@@ -556,10 +572,19 @@ def validate_output_path(
     protocol_path: pathlib.Path,
 ) -> None:
     """--output may land ONLY inside the input log's directory, NEVER
-    inside the repository ``data/`` tree, and NEVER on top of either
-    input file (the recording and protocol are immutable inputs — an
-    in-directory output name that collides with them would silently
-    destroy the very artifact being replayed)."""
+    inside the repository ``data/`` tree, and NEVER on a path that IS
+    either input file — by resolved path (which also covers symlink
+    aliases, including dangling ones: resolution targets are compared,
+    not link names) or by file identity (``os.path.samefile``: device +
+    inode, which covers existing hard links whose paths differ).
+
+    Residual filesystem race, stated precisely: identity is verified at
+    validation time; the later write does not re-verify. A concurrent
+    actor replacing the output path between validation and write can
+    still redirect the write. The lab defends against aliases that
+    exist when it validates — it does not claim protection against
+    concurrent hostile filesystem manipulation.
+    """
     log_dir_resolved = log_path.resolve().parent
     out_resolved = out_path.resolve()
     try:
@@ -574,6 +599,23 @@ def validate_output_path(
             raise WriteOutsideLogDirError(
                 f"refusing to overwrite the input {label} file: {out_resolved}"
             )
+        # Hard links share identity while having distinct paths. Only an
+        # EXISTING output can alias an input; stat runs on the resolved
+        # path and any failure to verify is itself a refusal (fail
+        # closed), never a fall-through.
+        if out_resolved.exists():
+            try:
+                same = os.path.samefile(out_resolved, input_path)
+            except OSError as e:
+                raise WriteOutsideLogDirError(
+                    f"cannot verify output file identity against the input "
+                    f"{label} file: {out_resolved}"
+                ) from e
+            if same:
+                raise WriteOutsideLogDirError(
+                    f"refusing to overwrite the input {label} file (shared "
+                    f"file identity): {out_resolved}"
+                )
     data_dir = _repo_data_dir()
     if out_resolved == data_dir or data_dir in out_resolved.parents:
         raise WriteOutsideLogDirError(
@@ -658,9 +700,10 @@ def main(argv: list[str] | None = None) -> int:
     serialized = serialize_lab_report(report)
     if args.output is not None:
         try:
-            # newline="" keeps the recorded artifact LF-only on every
-            # platform (same rationale as the NP5 evaluator).
-            args.output.write_text(serialized, encoding="utf-8", newline="")
+            # Raw byte write: LF-only on every platform, with no
+            # dependence on Path.write_text's newline= parameter (same
+            # rationale as the NP5 evaluator).
+            args.output.write_bytes(serialized.encode("utf-8"))
         except OSError as e:
             print(f"error: cannot write lab report to {args.output}: {e}", file=sys.stderr)
             return 4

--- a/scripts/nextness_replay_lab.py
+++ b/scripts/nextness_replay_lab.py
@@ -1,0 +1,673 @@
+"""Offline replay laboratory over recorded Nextness logs (NP6).
+
+Replays one recorded ``nextness_runs.jsonl`` log through NP2's own
+abstention decision procedure, step by step across the chronological
+holdout, for a small operator-specified set of monitor configurations —
+and reports each configuration's abstention TRAJECTORY side by side.
+
+This answers the recovery-after-surprise question at a granularity the
+NP5 evaluator cannot reach from receipts alone: *at which holdout step
+does the monitor first stop abstaining, does it re-abstain after a
+regime change, and how long does reorientation take* — per
+configuration, over the same immutable recording.
+
+LABORATORY OBSERVATIONS ONLY (load-bearing):
+
+- Comparisons are descriptive. No configuration is ranked, selected,
+  recommended, "improved" or applied to anything; configurations are
+  reported in exactly the operator's input order and abstention is
+  preserved as a first-class outcome, never treated as a defect.
+- No engine parameter is read, searched or written. The only inputs are
+  one recorded log and one explicit protocol file; the operator writes
+  every configuration by hand — the lab never generates, perturbs or
+  optimizes them.
+- Nothing here is, or is evidence of, awareness, consciousness,
+  phenomenology or biological equivalence.
+
+No new prediction or decision semantics: the replay reuses NP1's public
+sequence reader, split arithmetic and distribution builders and NP2's
+public ``decide_abstention`` / ``rolling_ece`` / ``canonical_top`` and
+``nextness_metrics.js_divergence``. A regression test locks the
+replay's final step to what ``observations_from_log`` +
+``build_receipt`` produce for the same configuration, so bridge drift
+cannot pass silently.
+
+Safety contract (Lane B, mirrors NP1/NP2/NP5):
+
+- Offline only; reads exactly two files (log + protocol), both through
+  hard bounds; READ-ONLY with respect to both (tested byte-for-byte,
+  including through the CLI — an ``--output`` naming either input file
+  is refused rather than overwritten).
+- Bounded work: at most ``MAX_LAB_CONFIGS`` configurations and
+  ``MAX_REPLAY_STEPS`` holdout steps (fail closed above — never a
+  silent truncation of the trajectory); protocol files are bounded
+  before parsing.
+- Writes permitted ONLY inside the resolved input-log directory
+  (``WriteOutsideLogDirError`` otherwise) and NEVER inside the
+  repository ``data/`` tree; default output is stdout.
+- Deterministic output: sorted keys, fixed schema, no wall-clock
+  timestamps, no random identifiers, no absolute paths; provenance is
+  the SHA-256 of the protocol file's raw bytes and of the accepted
+  dominant-token sequence (the log enters the computation only through
+  that sequence). Byte-identical across repeated runs; 64 KiB
+  fail-closed ceiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import pathlib
+import sys
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from scripts.nextness_metrics import js_divergence
+from scripts.nextness_monitor import (
+    ABSTAIN_REASONS,
+    MODEL_ALLOWLIST,
+    MonitorConfig,
+    canonical_top,
+    decide_abstention,
+    rolling_ece,
+)
+from scripts.nextness_observer import WriteOutsideLogDirError
+from scripts.nextness_predictor import (
+    HOLDOUT_FRACTION_DEFAULT,
+    HOLDOUT_FRACTION_MAX,
+    HOLDOUT_FRACTION_MIN,
+    MAX_LINE_BYTES_DEFAULT,
+    MAX_ROWS_CEILING,
+    MAX_ROWS_DEFAULT,
+    SMOOTHING_DEFAULT,
+    SMOOTHING_MAX,
+    InsufficientHistoryError,
+    empirical_prior_distribution,
+    first_order_distribution,
+    persistence_distribution,
+    read_dominant_sequence,
+    transition_counts,
+)
+
+# ---------------------------------------------------------------------------
+# Fixed contract constants
+# ---------------------------------------------------------------------------
+
+LAB_SCHEMA: Final[str] = "nextness-replay-lab-v1"
+PROTOCOL_SCHEMA: Final[str] = "nextness-replay-protocol-v1"
+
+#: Hard bound on configurations per protocol (an ablation is a handful
+#: of hand-written regimes, not a parameter search).
+MAX_LAB_CONFIGS: Final[int] = 8
+
+#: Hard bound on replayed holdout steps. Per-step rolling statistics
+#: cost O(steps x window); this bound keeps the whole replay cheap and
+#: is FAIL CLOSED — a longer holdout is refused, never silently
+#: truncated (dropping early steps would misstate the trajectory).
+MAX_REPLAY_STEPS: Final[int] = 2_000
+
+#: Pre-parse ceiling for the protocol file.
+MAX_PROTOCOL_BYTES: Final[int] = 64 * 1024
+
+#: Output ceiling — fail closed (same convention as NP1/NP2/NP5).
+MAX_LAB_REPORT_BYTES: Final[int] = 64 * 1024
+
+#: Completed-run detail lists are capped WITH an explicit flag.
+MAX_DETAIL_ITEMS: Final[int] = 128
+
+#: Configuration labels are operator-chosen display names.
+MAX_LABEL_CHARS: Final[int] = 64
+
+NON_CLAIMS: Final[tuple[str, ...]] = (
+    "Laboratory observations over one immutable recording: comparisons "
+    "are descriptive, no configuration is ranked, selected, recommended "
+    "or applied.",
+    "Abstention is preserved as a first-class outcome, not treated as a "
+    "defect to eliminate.",
+    "No engine parameter is read, searched or written; no awareness, "
+    "consciousness, phenomenology or biological-equivalence claim is "
+    "made or implied.",
+)
+
+_PROTOCOL_KEYS: Final[frozenset[str]] = frozenset(
+    {"schema", "model", "smoothing", "holdout_fraction", "configurations"}
+)
+_CONFIGURATION_KEYS: Final[frozenset[str]] = frozenset(
+    {"label", "min_history", "window", "low_confidence_threshold",
+     "calibration_error_threshold", "drift_threshold_bits"}
+)
+
+
+class LabInputError(ValueError):
+    """A malformed, hostile or out-of-bounds protocol/log input (fail closed)."""
+
+
+class LabReportTooLargeError(RuntimeError):
+    """Serialized lab report exceeded MAX_LAB_REPORT_BYTES (fail closed)."""
+
+
+# ---------------------------------------------------------------------------
+# Protocol loading and validation (exact-type, fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def _exact_str(value: Any, field: str) -> str:
+    if type(value) is not str:
+        raise LabInputError(f"{field}: expected builtin str, got {type(value).__name__}")
+    return value
+
+
+def _exact_int(value: Any, field: str) -> int:
+    if type(value) is not int:
+        raise LabInputError(f"{field}: expected builtin int, got {type(value).__name__}")
+    return value
+
+
+def _exact_real(value: Any, field: str) -> float:
+    if type(value) is not int and type(value) is not float:
+        raise LabInputError(
+            f"{field}: expected a builtin real number, got {type(value).__name__}"
+        )
+    try:
+        as_float = float(value)
+    except (OverflowError, ValueError) as e:
+        raise LabInputError(f"{field}: not representable as a finite float") from e
+    if not math.isfinite(as_float):
+        raise LabInputError(f"{field}: not finite")
+    return as_float
+
+
+def _exact_dict(value: Any, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise LabInputError(f"{field}: expected builtin dict, got {type(value).__name__}")
+    present = set(value)
+    if present != keys:
+        unknown = sorted(k if type(k) is str else f"<{type(k).__name__}>" for k in present - keys)
+        missing = sorted(keys - present)
+        raise LabInputError(
+            f"{field}: key set mismatch (unknown={unknown}, missing={missing})"
+        )
+    return value
+
+
+def load_protocol(path: pathlib.Path) -> dict[str, Any]:
+    """Bounded read + exact-type validation of one protocol file.
+
+    Returns ``{"model", "smoothing", "holdout_fraction", "configs",
+    "sha256"}`` where ``configs`` is a list of ``(label,
+    MonitorConfig)`` pairs in input order. Threshold validation is
+    delegated to NP2's own ``MonitorConfig.validate`` so the lab can
+    never accept a configuration the monitor itself would reject.
+    """
+    with path.open("rb") as f:
+        raw = f.read(MAX_PROTOCOL_BYTES + 1)
+    if len(raw) > MAX_PROTOCOL_BYTES:
+        raise LabInputError(f"protocol exceeds {MAX_PROTOCOL_BYTES} bytes; refusing to parse")
+
+    def _no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        # A protocol is operator-authored: a duplicate key means two
+        # conflicting values were written and last-wins would silently
+        # pick one. Ambiguous variants fail closed instead.
+        out: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in out:
+                raise LabInputError(f"protocol: duplicate JSON key {key!r}")
+            out[key] = value
+        return out
+
+    try:
+        parsed = json.loads(raw.decode("utf-8", errors="strict"), object_pairs_hook=_no_duplicate_keys)
+    except LabInputError:
+        raise  # keep the precise duplicate-key message
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+        raise LabInputError(f"protocol is not valid UTF-8 JSON: {e}") from e
+    except RecursionError as e:
+        raise LabInputError("protocol nesting exceeds the parser's depth limit") from e
+
+    outer = _exact_dict(parsed, "protocol", _PROTOCOL_KEYS)
+    schema = _exact_str(outer["schema"], "protocol.schema")
+    if schema != PROTOCOL_SCHEMA:
+        raise LabInputError(
+            f"protocol.schema: unknown variant {schema!r} (expected {PROTOCOL_SCHEMA!r})"
+        )
+    model = _exact_str(outer["model"], "protocol.model")
+    if model not in MODEL_ALLOWLIST:
+        raise LabInputError(f"protocol.model: {model!r} not in fixed allowlist")
+    smoothing = _exact_real(outer["smoothing"], "protocol.smoothing")
+    if not 0.0 < smoothing <= SMOOTHING_MAX:
+        raise LabInputError(
+            f"protocol.smoothing: must be in (0, {SMOOTHING_MAX}], got {smoothing}"
+        )
+    holdout_fraction = _exact_real(outer["holdout_fraction"], "protocol.holdout_fraction")
+    if not HOLDOUT_FRACTION_MIN <= holdout_fraction <= HOLDOUT_FRACTION_MAX:
+        raise LabInputError(
+            f"protocol.holdout_fraction: must be in [{HOLDOUT_FRACTION_MIN}, "
+            f"{HOLDOUT_FRACTION_MAX}], got {holdout_fraction}"
+        )
+
+    raw_configs = outer["configurations"]
+    if type(raw_configs) is not list or not raw_configs:
+        raise LabInputError("protocol.configurations: expected a non-empty array")
+    if len(raw_configs) > MAX_LAB_CONFIGS:
+        raise LabInputError(
+            f"protocol.configurations: {len(raw_configs)} configurations exceed "
+            f"the {MAX_LAB_CONFIGS} bound"
+        )
+    configs: list[tuple[str, MonitorConfig]] = []
+    seen_labels: set[str] = set()
+    for i, item in enumerate(raw_configs):
+        entry = _exact_dict(item, f"protocol.configurations[{i}]", _CONFIGURATION_KEYS)
+        label = _exact_str(entry["label"], f"protocol.configurations[{i}].label")
+        if not label or len(label) > MAX_LABEL_CHARS:
+            raise LabInputError(
+                f"protocol.configurations[{i}].label: length must be in [1, {MAX_LABEL_CHARS}]"
+            )
+        if label in seen_labels:
+            raise LabInputError(f"protocol.configurations[{i}].label: duplicate {label!r}")
+        seen_labels.add(label)
+        cfg = MonitorConfig(
+            min_history=_exact_int(entry["min_history"], f"protocol.configurations[{i}].min_history"),
+            window=_exact_int(entry["window"], f"protocol.configurations[{i}].window"),
+            low_confidence_threshold=_exact_real(
+                entry["low_confidence_threshold"],
+                f"protocol.configurations[{i}].low_confidence_threshold",
+            ),
+            calibration_error_threshold=_exact_real(
+                entry["calibration_error_threshold"],
+                f"protocol.configurations[{i}].calibration_error_threshold",
+            ),
+            drift_threshold_bits=_exact_real(
+                entry["drift_threshold_bits"],
+                f"protocol.configurations[{i}].drift_threshold_bits",
+            ),
+        )
+        try:
+            cfg.validate()  # NP2's own bounds — the lab adds none of its own
+        except ValueError as e:
+            raise LabInputError(f"protocol.configurations[{i}]: {e}") from e
+        configs.append((label, cfg))
+
+    return {
+        "model": model,
+        "smoothing": smoothing,
+        "holdout_fraction": holdout_fraction,
+        "configs": configs,
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The replay: NP2's bridge semantics, one decision per holdout step
+# ---------------------------------------------------------------------------
+
+
+def replay_observations(
+    sequence: Sequence[str],
+    model: str,
+    *,
+    smoothing: float,
+    holdout_fraction: float,
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    """Rebuild NP2's bridge observations for one model over one sequence.
+
+    Returns ``(observations, train, holdout)``. This mirrors
+    ``nextness_monitor.observations_from_log`` exactly (same split
+    arithmetic, same distribution builders, same prev_seen semantics);
+    the equivalence-lock test in the suite compares the two end-to-end
+    so any silent divergence fails loudly.
+    """
+    if model not in MODEL_ALLOWLIST:
+        # Fail closed like the bridge it mirrors — an unknown model must
+        # never silently fall through to first_order semantics.
+        raise LabInputError(f"model {model!r} not in fixed allowlist {MODEL_ALLOWLIST}")
+    n = len(sequence)
+    split = math.floor(n * (1.0 - holdout_fraction))
+    train, holdout = list(sequence[:split]), list(sequence[split:])
+    if len(train) < 2 or len(holdout) < 1:
+        raise InsufficientHistoryError(
+            f"need >=2 train and >=1 holdout rows; got train={len(train)}, "
+            f"holdout={len(holdout)}"
+        )
+    prior = empirical_prior_distribution(train, smoothing)
+    table = transition_counts(train)
+    train_tokens = set(train)
+    previous_tokens = [train[-1]] + holdout[:-1]
+
+    observations: list[dict[str, Any]] = []
+    for prev, actual in zip(previous_tokens, holdout):
+        if model == "empirical_prior":
+            dist = prior
+            prev_seen = prev in train_tokens
+        elif model == "persistence":
+            dist = persistence_distribution(prev, smoothing)
+            prev_seen = prev in train_tokens
+        else:
+            dist = first_order_distribution(prev, table, prior, smoothing)
+            prev_seen = prev in table
+        top = canonical_top(dist)
+        observations.append(
+            {
+                "confidence": dist[top],
+                "hit": top == actual,
+                "p_actual": dist[actual],
+                "prev_seen": prev_seen,
+            }
+        )
+    return observations, train, holdout
+
+
+def _token_counts(tokens: Sequence[str]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for t in tokens:
+        out[t] = out.get(t, 0) + 1
+    return out
+
+
+def replay_trajectory(
+    observations: Sequence[Mapping[str, Any]],
+    train: Sequence[str],
+    holdout: Sequence[str],
+    config: MonitorConfig,
+) -> list[tuple[bool, str]]:
+    """One (abstain, reason) decision per holdout step.
+
+    At step t (1-based) the monitor has seen exactly the first t bridge
+    observations; rolling ECE runs over the last ``window`` of them and
+    drift compares the training reference against the last ``window``
+    holdout tokens — precisely NP2's receipt semantics evaluated at
+    every prefix instead of only the full holdout.
+    """
+    reference = _token_counts(train)
+    decisions: list[tuple[bool, str]] = []
+    for t in range(1, len(observations) + 1):
+        prefix = observations[:t]
+        window_slice = prefix[-config.window:]
+        ece = rolling_ece(window_slice)
+        recent = _token_counts(holdout[max(0, t - config.window):t])
+        drift = js_divergence(reference, recent)
+        decisions.append(
+            decide_abstention(
+                observation_count=t,
+                latest_confidence=prefix[-1]["confidence"],
+                latest_prev_seen=prefix[-1]["prev_seen"],
+                rolling_calibration_error=ece,
+                drift_bits=drift,
+                config=config,
+            )
+        )
+    return decisions
+
+
+def summarize_trajectory(decisions: Sequence[tuple[bool, str]]) -> dict[str, Any]:
+    """Deterministic bounded summary of one configuration's trajectory."""
+    steps = len(decisions)
+    abstained = sum(1 for abstain, _ in decisions if abstain)
+    reason_counts = {reason: 0 for reason in ABSTAIN_REASONS}
+    for _, reason in decisions:
+        reason_counts[reason] += 1
+
+    first_non_abstain: int | None = None
+    for i, (abstain, _) in enumerate(decisions):
+        if not abstain:
+            first_non_abstain = i + 1  # 1-based step index
+            break
+
+    onsets = 0
+    reorientations = 0
+    run_lengths: list[int] = []
+    current_run = 1 if decisions[0][0] else 0
+    for (prev_a, _), (curr_a, _) in zip(decisions, decisions[1:]):
+        if not prev_a and curr_a:
+            onsets += 1
+            current_run = 1
+        elif prev_a and curr_a:
+            current_run += 1
+        elif prev_a and not curr_a:
+            reorientations += 1
+            run_lengths.append(current_run)
+            current_run = 0
+    trailing = current_run if decisions[-1][0] else None
+
+    final_abstain, final_reason = decisions[-1]
+    return {
+        "step_count": steps,
+        "abstention_step_rate": abstained / steps,
+        "reason_step_counts": reason_counts,
+        "first_non_abstain_step": first_non_abstain,
+        "abstention_onsets": onsets,
+        "reorientations": reorientations,
+        "completed_abstention_run_lengths_steps": run_lengths[:MAX_DETAIL_ITEMS],
+        "run_lengths_truncated": len(run_lengths) > MAX_DETAIL_ITEMS,
+        "unresolved_trailing_abstention_steps": trailing,
+        "final_abstain": final_abstain,
+        "final_reason": final_reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end lab report
+# ---------------------------------------------------------------------------
+
+
+def build_lab_report(
+    log_path: pathlib.Path,
+    protocol_path: pathlib.Path,
+    *,
+    max_rows: int = MAX_ROWS_DEFAULT,
+    max_line_bytes: int = MAX_LINE_BYTES_DEFAULT,
+) -> dict[str, Any]:
+    """One deterministic ``nextness-replay-lab-v1`` report.
+
+    Configurations are replayed and reported in EXACTLY the protocol's
+    input order — there is no ranking, no winner and no recommendation
+    field, by contract.
+    """
+    protocol = load_protocol(protocol_path)
+    sequence, rejections, rows_read = read_dominant_sequence(
+        log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
+    )
+    observations, train, holdout = replay_observations(
+        sequence,
+        protocol["model"],
+        smoothing=protocol["smoothing"],
+        holdout_fraction=protocol["holdout_fraction"],
+    )
+    if len(holdout) > MAX_REPLAY_STEPS:
+        raise LabInputError(
+            f"holdout has {len(holdout)} steps, exceeding the {MAX_REPLAY_STEPS} "
+            f"replay bound (fail closed; re-record or adjust holdout_fraction "
+            f"rather than silently truncating a trajectory)"
+        )
+
+    configurations: list[dict[str, Any]] = []
+    for label, cfg in protocol["configs"]:
+        decisions = replay_trajectory(observations, train, holdout, cfg)
+        configurations.append(
+            {
+                "label": label,
+                "config": {
+                    "min_history": cfg.min_history,
+                    "window": cfg.window,
+                    "low_confidence_threshold": cfg.low_confidence_threshold,
+                    "calibration_error_threshold": cfg.calibration_error_threshold,
+                    "drift_threshold_bits": cfg.drift_threshold_bits,
+                },
+                "trajectory": summarize_trajectory(decisions),
+            }
+        )
+
+    # The log enters the computation only through the accepted
+    # dominant-token sequence, so that sequence's hash (plus the row
+    # accounting) is the reproduction-sufficient provenance for it.
+    sequence_digest = hashlib.sha256("\n".join(sequence).encode("utf-8")).hexdigest()
+
+    report: dict[str, Any] = {
+        "schema": LAB_SCHEMA,
+        "laboratory_observation": True,
+        "config": {
+            "max_lab_configs": MAX_LAB_CONFIGS,
+            "max_replay_steps": MAX_REPLAY_STEPS,
+            "max_rows": max_rows,
+            "max_line_bytes": max_line_bytes,
+            "model": protocol["model"],
+            "smoothing": protocol["smoothing"],
+            "holdout_fraction": protocol["holdout_fraction"],
+        },
+        "input": {
+            "rows_read": rows_read,
+            "rows_accepted": len(sequence),
+            "rows_rejected": sum(rejections.values()),
+            "rejections": rejections,
+            "train_rows": len(train),
+            "holdout_steps": len(holdout),
+            "sequence_sha256": sequence_digest,
+            "protocol_sha256": protocol["sha256"],
+        },
+        "configurations": configurations,
+        "non_claims": list(NON_CLAIMS),
+    }
+    serialized = serialize_lab_report(report)
+    if len(serialized.encode("utf-8")) > MAX_LAB_REPORT_BYTES:
+        raise LabReportTooLargeError(
+            f"lab report would exceed {MAX_LAB_REPORT_BYTES} bytes; refusing to emit"
+        )
+    return report
+
+
+def serialize_lab_report(report: Mapping[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, newline."""
+    return json.dumps(report, sort_keys=True, separators=(",", ": "), indent=1) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Write-boundary guard (same convention as NP1/NP5)
+# ---------------------------------------------------------------------------
+
+
+def _repo_data_dir() -> pathlib.Path:
+    return (pathlib.Path(__file__).resolve().parent.parent / "data").resolve()
+
+
+def validate_output_path(
+    out_path: pathlib.Path,
+    log_path: pathlib.Path,
+    protocol_path: pathlib.Path,
+) -> None:
+    """--output may land ONLY inside the input log's directory, NEVER
+    inside the repository ``data/`` tree, and NEVER on top of either
+    input file (the recording and protocol are immutable inputs — an
+    in-directory output name that collides with them would silently
+    destroy the very artifact being replayed)."""
+    log_dir_resolved = log_path.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(log_dir_resolved)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write lab report outside the input-log directory: "
+            f"{out_resolved} is not inside {log_dir_resolved}"
+        ) from e
+    for label, input_path in (("log", log_path), ("protocol", protocol_path)):
+        if out_resolved == input_path.resolve():
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input {label} file: {out_resolved}"
+            )
+    data_dir = _repo_data_dir()
+    if out_resolved == data_dir or data_dir in out_resolved.parents:
+        raise WriteOutsideLogDirError(
+            f"refusing to write lab report inside the repository data/ tree: {out_resolved}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline replay laboratory: per-step abstention trajectories for "
+            "operator-specified monitor configurations over one recorded "
+            "Nextness log (laboratory observations only; see module "
+            "docstring for the full contract)."
+        )
+    )
+    parser.add_argument("log_path", type=pathlib.Path, help="path to nextness_runs.jsonl")
+    parser.add_argument(
+        "protocol_path", type=pathlib.Path,
+        help="path to a nextness-replay-protocol-v1 JSON file",
+    )
+    parser.add_argument(
+        "--output", type=pathlib.Path, default=None,
+        help=(
+            "optional report path; must resolve inside the input log's "
+            "directory and outside the repository data/ tree (default: stdout)"
+        ),
+    )
+    parser.add_argument("--max-rows", type=int, default=MAX_ROWS_DEFAULT)
+    parser.add_argument("--max-line-bytes", type=int, default=MAX_LINE_BYTES_DEFAULT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit-code contract (mirrors NP1's expected-failure contract):
+
+    - ``0`` success
+    - ``2`` validation failure — missing input file, malformed or
+      out-of-bounds protocol, or a holdout longer than the replay bound
+      (argparse usage errors also exit 2)
+    - ``3`` insufficient history for a train/holdout split
+    - ``4`` output-path failure — write-boundary violation or an
+      unwritable target
+    - ``5`` lab report exceeds MAX_LAB_REPORT_BYTES (fail closed)
+
+    Every expected failure prints one concise ``error:`` line to stderr —
+    never a traceback; unexpected programming errors propagate loudly.
+    """
+    args = _build_parser().parse_args(argv)
+    for label, path in (("log", args.log_path), ("protocol", args.protocol_path)):
+        if not path.is_file():
+            print(f"error: {label} file not found: {path}", file=sys.stderr)
+            return 2
+    try:
+        if args.output is not None:
+            validate_output_path(args.output, args.log_path, args.protocol_path)
+        report = build_lab_report(
+            args.log_path,
+            args.protocol_path,
+            max_rows=args.max_rows,
+            max_line_bytes=args.max_line_bytes,
+        )
+    except WriteOutsideLogDirError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 4
+    except InsufficientHistoryError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+    except LabReportTooLargeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 5
+    except ValueError as e:  # includes LabInputError (its subclass)
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    serialized = serialize_lab_report(report)
+    if args.output is not None:
+        try:
+            # newline="" keeps the recorded artifact LF-only on every
+            # platform (same rationale as the NP5 evaluator).
+            args.output.write_text(serialized, encoding="utf-8", newline="")
+        except OSError as e:
+            print(f"error: cannot write lab report to {args.output}: {e}", file=sys.stderr)
+            return 4
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -1,0 +1,791 @@
+"""NP6: offline replay laboratory — contract + adversarial tests.
+
+Every exact-value fixture is hand-derived in this file from the
+documented decision procedure — the module is never asked to verify
+itself. The equivalence-lock section pins the replay's semantics to
+NP2's own bridge + receipt so silent divergence fails loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import random
+
+import pytest
+
+from scripts.nextness_monitor import (
+    MODEL_ALLOWLIST,
+    MonitorConfig,
+    build_receipt,
+    observations_from_log,
+)
+from scripts.nextness_predictor import read_dominant_sequence
+from scripts.nextness_replay_lab import (
+    LAB_SCHEMA,
+    MAX_LAB_CONFIGS,
+    MAX_LAB_REPORT_BYTES,
+    MAX_PROTOCOL_BYTES,
+    MAX_REPLAY_STEPS,
+    LabInputError,
+    build_lab_report,
+    load_protocol,
+    main,
+    replay_observations,
+    replay_trajectory,
+    serialize_lab_report,
+    summarize_trajectory,
+)
+
+A = "void_static"
+B = "compute_static"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_log(tmp_path: pathlib.Path, tokens: list[str]) -> pathlib.Path:
+    log = tmp_path / "nextness_runs.jsonl"
+    log.write_text(
+        "\n".join(
+            json.dumps({"generation": i, "token_counts": {t: 3}}) for i, t in enumerate(tokens)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return log
+
+
+def _config_entry(label: str, **overrides) -> dict:
+    entry = {
+        "label": label,
+        "min_history": 30,
+        "window": 50,
+        "low_confidence_threshold": 0.3,
+        "calibration_error_threshold": 0.2,
+        "drift_threshold_bits": 0.15,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _write_protocol(
+    tmp_path: pathlib.Path,
+    configurations: list[dict],
+    *,
+    model: str = "first_order",
+    smoothing: float = 1.0,
+    holdout_fraction: float = 0.25,
+    name: str = "protocol.json",
+) -> pathlib.Path:
+    protocol = tmp_path / name
+    protocol.write_text(
+        json.dumps(
+            {
+                "schema": "nextness-replay-protocol-v1",
+                "model": model,
+                "smoothing": smoothing,
+                "holdout_fraction": holdout_fraction,
+                "configurations": configurations,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return protocol
+
+
+#: Loose thresholds that never fire on the alternating fixture, so the
+#: only abstention driver left is min_history — making trajectories
+#: hand-derivable.
+_LOOSE = {
+    "low_confidence_threshold": 0.01,
+    "calibration_error_threshold": 0.9,
+    "drift_threshold_bits": 0.9,
+}
+
+
+# ---------------------------------------------------------------------------
+# Hand-derived trajectories
+# ---------------------------------------------------------------------------
+
+
+def test_trajectory_hand_derived_min_history_ablation(tmp_path) -> None:
+    # [A,B]*30: 60 accepted rows, split floor(60*0.75)=45 train, 15
+    # holdout steps. With loose thresholds the decision at step t is
+    # abstain(insufficient_history) iff t < min_history, else none.
+    # min_history=5  -> steps 1..4 abstain, first non-abstain step 5.
+    # min_history=10 -> steps 1..9 abstain, first non-abstain step 10.
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(
+        tmp_path,
+        [
+            _config_entry("strict-ish", min_history=10, **_LOOSE),
+            _config_entry("loose", min_history=5, **_LOOSE),
+        ],
+    )
+    report = build_lab_report(log, protocol)
+    assert report["schema"] == LAB_SCHEMA
+    assert report["laboratory_observation"] is True
+    assert report["input"]["holdout_steps"] == 15
+    assert report["input"]["train_rows"] == 45
+
+    by_label = {c["label"]: c["trajectory"] for c in report["configurations"]}
+    # Input order is preserved exactly — no ranking, no reordering.
+    assert [c["label"] for c in report["configurations"]] == ["strict-ish", "loose"]
+
+    strict = by_label["strict-ish"]
+    assert strict["step_count"] == 15
+    assert strict["first_non_abstain_step"] == 10
+    assert strict["abstention_step_rate"] == 9 / 15
+    assert strict["reason_step_counts"]["insufficient_history"] == 9
+    assert strict["reason_step_counts"]["none"] == 6
+    assert strict["abstention_onsets"] == 0
+    assert strict["reorientations"] == 1
+    assert strict["completed_abstention_run_lengths_steps"] == [9]
+    assert strict["unresolved_trailing_abstention_steps"] is None
+    assert strict["final_abstain"] is False
+    assert strict["final_reason"] == "none"
+
+    loose = by_label["loose"]
+    assert loose["first_non_abstain_step"] == 5
+    assert loose["abstention_step_rate"] == 4 / 15
+    assert loose["completed_abstention_run_lengths_steps"] == [4]
+
+
+def test_trajectory_preserves_honest_abstention_calibration_drift(tmp_path) -> None:
+    # NP2's permanent finding: alternating sequence + default smoothing
+    # (1.0) leaves first_order systematically under-confident (~0.605
+    # confidence, hit rate 1.0 -> rolling ECE ~0.395 > 0.2). Once
+    # min_history is satisfied the trajectory moves straight into
+    # calibration_drift and NEVER leaves abstention — the lab must
+    # report that outcome as-is, not force a "working" configuration.
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("default-ish", min_history=10)])
+    trajectory = build_lab_report(log, protocol)["configurations"][0]["trajectory"]
+    assert trajectory["first_non_abstain_step"] is None
+    assert trajectory["abstention_step_rate"] == 1.0
+    assert trajectory["reason_step_counts"]["insufficient_history"] == 9
+    assert trajectory["reason_step_counts"]["calibration_drift"] == 6
+    assert trajectory["final_abstain"] is True
+    assert trajectory["final_reason"] == "calibration_drift"
+    assert trajectory["unresolved_trailing_abstention_steps"] == 15
+    assert trajectory["reorientations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Equivalence lock: replay == NP2's own bridge + receipt
+# ---------------------------------------------------------------------------
+
+
+def _counts(tokens: list[str]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for t in tokens:
+        out[t] = out.get(t, 0) + 1
+    return out
+
+
+#: The drift-sensitive configuration lifts the calibration threshold out
+#: of the way so distribution_shift is the reason that actually DECIDES
+#: — without it the higher-precedence reasons mask the drift half of the
+#: replay and mutations there would be test-invisible.
+_DRIFT_SENSITIVE = {
+    "min_history": 5,
+    "window": 7,
+    "low_confidence_threshold": 0.01,
+    "calibration_error_threshold": 0.85,
+    "drift_threshold_bits": 0.05,
+}
+
+
+@pytest.mark.parametrize("model", MODEL_ALLOWLIST)
+@pytest.mark.parametrize(
+    "cfg_kwargs",
+    [
+        {"min_history": 10, "window": 50},
+        {"min_history": 5, "window": 7},
+        _DRIFT_SENSITIVE,
+    ],
+)
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        # 60 rows, integral split (45): the A-regime starts at index 52,
+        # so the change lands at holdout step 8 — mid-holdout, non-uniform.
+        [A, B] * 26 + [A] * 8,
+        # 61 rows, FRACTIONAL split (61*0.75 = 45.75 -> floor 45): pins
+        # the floor in the re-derived split arithmetic — round/ceil
+        # mutants produce different holdouts and fail the lock.
+        [A, B] * 24 + [A] * 13,
+    ],
+    ids=["integral-split", "fractional-split"],
+)
+def test_replay_final_step_matches_live_receipt(tmp_path, model, cfg_kwargs, tokens) -> None:
+    # The lab re-derives the bridge (it needs the train/holdout token
+    # lists for per-step drift windows, which observations_from_log does
+    # not return). This lock pins every re-derived piece to the live NP2
+    # path: observations float-for-float, reference/recent counts, and
+    # the final-step decision against build_receipt.
+    log = _write_log(tmp_path, tokens)
+    smoothing = 0.5
+    cfg = MonitorConfig(**cfg_kwargs)
+
+    sequence, _, _ = read_dominant_sequence(log)
+    observations, train, holdout = replay_observations(
+        sequence, model, smoothing=smoothing, holdout_fraction=0.25
+    )
+    live_obs, live_reference, live_recent = observations_from_log(
+        log, model, smoothing=smoothing, holdout_fraction=0.25, window=cfg.window
+    )
+    assert observations == live_obs  # exact float-for-float equality
+    assert _counts(train) == live_reference
+    assert _counts(holdout[-cfg.window:]) == live_recent
+
+    receipt = build_receipt(
+        model=model,
+        observations=live_obs,
+        reference_counts=live_reference,
+        recent_counts=live_recent,
+        config=cfg,
+    )
+    decisions = replay_trajectory(observations, train, holdout, cfg)
+    final_abstain, final_reason = decisions[-1]
+    assert final_abstain == receipt["abstain"]
+    assert final_reason == receipt["abstain_reason"]
+
+
+def test_equivalence_lock_exercises_distribution_shift(tmp_path) -> None:
+    # Meta-lock: at least one locked case must be DECIDED by drift, or
+    # the js_divergence half of the replay is dead code to the suite.
+    log = _write_log(tmp_path, [A, B] * 20 + [A] * 20)
+    cfg = MonitorConfig(**_DRIFT_SENSITIVE)
+    sequence, _, _ = read_dominant_sequence(log)
+    observations, train, holdout = replay_observations(
+        sequence, "first_order", smoothing=0.5, holdout_fraction=0.25
+    )
+    live_obs, live_reference, live_recent = observations_from_log(
+        log, "first_order", smoothing=0.5, holdout_fraction=0.25, window=cfg.window
+    )
+    receipt = build_receipt(
+        model="first_order",
+        observations=live_obs,
+        reference_counts=live_reference,
+        recent_counts=live_recent,
+        config=cfg,
+    )
+    assert receipt["abstain_reason"] == "distribution_shift"
+    decisions = replay_trajectory(observations, train, holdout, cfg)
+    assert decisions[-1] == (True, "distribution_shift")
+
+
+def test_replay_trajectory_matches_independent_per_step_reference(tmp_path) -> None:
+    # Differential check at EVERY step (the receipt lock pins only the
+    # final one): the expected decision is rebuilt here with
+    # independently written prefix/window slices feeding NP2's own
+    # decide_abstention, so an off-by-one in the lab's slicing shows up
+    # at some mid-trajectory step even when the final step agrees. The
+    # regime change lands at holdout step 8 (index 52 of a 45-row train
+    # prefix + 15-step holdout), the window (7) is shorter than the
+    # trajectory, and the drift-sensitive config lets distribution_shift
+    # actually decide steps — so windowed-recent-vs-whole-prefix
+    # mutants, first-window-vs-last-window mutants and stale-latest
+    # mutants all diverge from the reference at some step.
+    from scripts.nextness_metrics import js_divergence
+    from scripts.nextness_monitor import decide_abstention, rolling_ece
+
+    tokens = [A, B] * 26 + [A] * 8
+    log = _write_log(tmp_path, tokens)
+    sequence, _, _ = read_dominant_sequence(log)
+    cfg = MonitorConfig(**_DRIFT_SENSITIVE)
+    observations, train, holdout = replay_observations(
+        sequence, "first_order", smoothing=0.5, holdout_fraction=0.25
+    )
+    assert len(set(map(str, observations))) > 1  # non-degenerate holdout
+    decisions = replay_trajectory(observations, train, holdout, cfg)
+
+    reference_counts = _counts(train)
+    seen_reasons = set()
+    for step in range(1, len(holdout) + 1):
+        window_obs = observations[:step][-cfg.window:]
+        recent_counts = _counts(holdout[step - cfg.window if step > cfg.window else 0:step])
+        expected = decide_abstention(
+            observation_count=step,
+            latest_confidence=observations[step - 1]["confidence"],
+            latest_prev_seen=observations[step - 1]["prev_seen"],
+            rolling_calibration_error=rolling_ece(window_obs),
+            drift_bits=js_divergence(reference_counts, recent_counts),
+            config=cfg,
+        )
+        assert decisions[step - 1] == expected
+        seen_reasons.add(decisions[step - 1][1])
+    # The fixture must exercise the drift half mid-trajectory, or this
+    # differential proves less than it appears to.
+    assert "distribution_shift" in seen_reasons
+    assert len(seen_reasons) >= 2
+
+
+def test_per_step_latest_observation_decides_low_confidence(tmp_path) -> None:
+    # A fixture whose per-step confidence VARIES across the threshold:
+    # in [A,B,A,C]* the transition source A splits its mass between B
+    # and C (confidence ~0.38) while B and C both continue to A
+    # (~0.60). With low_confidence_threshold=0.5 the decision at each
+    # step depends on THAT step's latest observation — a replay that
+    # reused a stale observation (e.g. the first one) would emit a
+    # constant reason and diverge from the per-step reference.
+    from scripts.nextness_metrics import js_divergence
+    from scripts.nextness_monitor import decide_abstention, rolling_ece
+
+    C = "void_birth"
+    tokens = [A, B, A, C] * 15  # 60 rows: 45 train / 15 holdout
+    log = _write_log(tmp_path, tokens)
+    sequence, _, _ = read_dominant_sequence(log)
+    cfg = MonitorConfig(
+        min_history=5,
+        window=7,
+        low_confidence_threshold=0.5,
+        calibration_error_threshold=0.85,
+        drift_threshold_bits=0.9,
+    )
+    observations, train, holdout = replay_observations(
+        sequence, "first_order", smoothing=0.5, holdout_fraction=0.25
+    )
+    confidences = {ob["confidence"] for ob in observations}
+    assert len(confidences) > 1  # the threshold has something to separate
+    decisions = replay_trajectory(observations, train, holdout, cfg)
+
+    reference_counts = _counts(train)
+    for step in range(1, len(holdout) + 1):
+        window_obs = observations[:step][-cfg.window:]
+        recent_counts = _counts(holdout[step - cfg.window if step > cfg.window else 0:step])
+        expected = decide_abstention(
+            observation_count=step,
+            latest_confidence=observations[step - 1]["confidence"],
+            latest_prev_seen=observations[step - 1]["prev_seen"],
+            rolling_calibration_error=rolling_ece(window_obs),
+            drift_bits=js_divergence(reference_counts, recent_counts),
+            config=cfg,
+        )
+        assert decisions[step - 1] == expected
+    post_history = [reason for _, reason in decisions[cfg.min_history - 1:]]
+    assert "low_confidence" in post_history
+    assert "none" in post_history  # the reason genuinely alternates
+
+
+# ---------------------------------------------------------------------------
+# No-winner contract
+# ---------------------------------------------------------------------------
+
+
+def test_no_ranking_or_winner_fields_anywhere(tmp_path) -> None:
+    # The contract forbids ranking STRUCTURE, so the check walks keys —
+    # the non-claims prose legitimately names the forbidden concepts.
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(
+        tmp_path,
+        [
+            _config_entry("x", min_history=5, **_LOOSE),
+            _config_entry("y", min_history=10, **_LOOSE),
+        ],
+    )
+    report = build_lab_report(log, protocol)
+    forbidden = {"winner", "rank", "ranking", "best", "recommendation", "score"}
+
+    def _walk_keys(node) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                assert key.lower() not in forbidden
+                _walk_keys(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk_keys(item)
+
+    _walk_keys(report)
+    assert report["laboratory_observation"] is True
+
+
+def test_configuration_results_independent_of_protocol_order(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    entries = [
+        _config_entry("x", min_history=5, **_LOOSE),
+        _config_entry("y", min_history=10, **_LOOSE),
+    ]
+    fwd = _write_protocol(tmp_path, entries, name="fwd.json")
+    rev = _write_protocol(tmp_path, list(reversed(entries)), name="rev.json")
+    report_fwd = build_lab_report(log, fwd)
+    report_rev = build_lab_report(log, rev)
+    assert [c["label"] for c in report_fwd["configurations"]] == ["x", "y"]
+    assert [c["label"] for c in report_rev["configurations"]] == ["y", "x"]
+    fwd_by_label = {c["label"]: c for c in report_fwd["configurations"]}
+    rev_by_label = {c["label"]: c for c in report_rev["configurations"]}
+    assert fwd_by_label == rev_by_label  # per-config results order-free
+
+
+# ---------------------------------------------------------------------------
+# Determinism and read-only posture
+# ---------------------------------------------------------------------------
+
+
+def test_lab_report_byte_identical_and_inputs_untouched(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("only", min_history=5)])
+    log_bytes = log.read_bytes()
+    protocol_bytes = protocol.read_bytes()
+    outputs = {serialize_lab_report(build_lab_report(log, protocol)) for _ in range(3)}
+    assert len(outputs) == 1
+    serialized = next(iter(outputs))
+    assert len(serialized.encode("utf-8")) <= MAX_LAB_REPORT_BYTES
+    report = json.loads(serialized)
+    assert len(report["input"]["sequence_sha256"]) == 64
+    assert len(report["input"]["protocol_sha256"]) == 64
+    # Read-only with respect to both inputs, byte for byte.
+    assert log.read_bytes() == log_bytes
+    assert protocol.read_bytes() == protocol_bytes
+
+
+def test_protocol_key_order_does_not_change_results(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    base = {
+        "schema": "nextness-replay-protocol-v1",
+        "model": "first_order",
+        "smoothing": 1.0,
+        "holdout_fraction": 0.25,
+        "configurations": [_config_entry("only", min_history=5)],
+    }
+    fwd = tmp_path / "fwd.json"
+    fwd.write_text(json.dumps(base), encoding="utf-8")
+    rev = tmp_path / "rev.json"
+    rev.write_text(
+        json.dumps({k: base[k] for k in reversed(list(base))}), encoding="utf-8"
+    )
+    report_fwd = build_lab_report(log, fwd)
+    report_rev = build_lab_report(log, rev)
+    # The bytes differ (hash provenance differs); the science must not.
+    report_fwd["input"]["protocol_sha256"] = report_rev["input"]["protocol_sha256"] = None
+    assert serialize_lab_report(report_fwd) == serialize_lab_report(report_rev)
+
+
+# ---------------------------------------------------------------------------
+# Property-style seeded traces (stdlib random only — no new dependency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", [7, 77, 777])
+def test_seeded_trajectory_invariants(seed: int, tmp_path) -> None:
+    rng = random.Random(seed)
+    tokens = [rng.choice([A, B, "void_birth", "unclassified"]) for _ in range(120)]
+    log = _write_log(tmp_path, tokens)
+    protocol = _write_protocol(
+        tmp_path,
+        [
+            _config_entry(
+                f"cfg{i}",
+                min_history=rng.choice([5, 10, 30]),
+                window=rng.choice([5, 20, 50]),
+                low_confidence_threshold=rng.choice([0.1, 0.3, 0.7]),
+                calibration_error_threshold=rng.choice([0.1, 0.3]),
+                drift_threshold_bits=rng.choice([0.05, 0.3]),
+            )
+            for i in range(3)
+        ],
+        model=rng.choice(list(MODEL_ALLOWLIST)),
+    )
+    report = build_lab_report(log, protocol)
+    again = build_lab_report(log, protocol)
+    assert serialize_lab_report(report) == serialize_lab_report(again)
+
+    for entry in report["configurations"]:
+        t = entry["trajectory"]
+        steps = t["step_count"]
+        assert steps == report["input"]["holdout_steps"]
+        assert sum(t["reason_step_counts"].values()) == steps
+        abstained = steps - t["reason_step_counts"]["none"]
+        assert t["abstention_step_rate"] == abstained / steps
+        assert 0.0 <= t["abstention_step_rate"] <= 1.0
+        assert t["reorientations"] <= t["abstention_onsets"] + 1
+        assert t["run_lengths_truncated"] is False
+        assert len(t["completed_abstention_run_lengths_steps"]) == t["reorientations"]
+        # Every abstained step lives in exactly one maximal run:
+        # completed runs plus the unresolved trailing run must add up.
+        trailing = t["unresolved_trailing_abstention_steps"] or 0
+        assert sum(t["completed_abstention_run_lengths_steps"]) + trailing == abstained
+        if t["first_non_abstain_step"] is None:
+            assert t["abstention_step_rate"] == 1.0
+        else:
+            assert 1 <= t["first_non_abstain_step"] <= steps
+        assert (t["final_reason"] == "none") == (t["final_abstain"] is False)
+
+
+# ---------------------------------------------------------------------------
+# Protocol validation: fail-closed adversarial corpus
+# ---------------------------------------------------------------------------
+
+
+def test_protocol_bounds_fail_closed(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    too_many = _write_protocol(
+        tmp_path,
+        [_config_entry(f"c{i}") for i in range(MAX_LAB_CONFIGS + 1)],
+        name="many.json",
+    )
+    with pytest.raises(LabInputError, match="exceed"):
+        build_lab_report(log, too_many)
+    empty = _write_protocol(tmp_path, [], name="empty.json")
+    with pytest.raises(LabInputError, match="non-empty"):
+        build_lab_report(log, empty)
+    dupes = _write_protocol(
+        tmp_path, [_config_entry("same"), _config_entry("same")], name="dupes.json"
+    )
+    with pytest.raises(LabInputError, match="duplicate"):
+        build_lab_report(log, dupes)
+    long_label = _write_protocol(
+        tmp_path, [_config_entry("x" * 65)], name="long.json"
+    )
+    with pytest.raises(LabInputError, match="length"):
+        build_lab_report(log, long_label)
+
+
+def test_protocol_unknown_variants_and_types_fail_closed(tmp_path) -> None:
+    with pytest.raises(LabInputError, match="unknown variant"):
+        load_protocol(_write_schema_variant(tmp_path))
+    extra = tmp_path / "extra.json"
+    payload = {
+        "schema": "nextness-replay-protocol-v1",
+        "model": "first_order",
+        "smoothing": 1.0,
+        "holdout_fraction": 0.25,
+        "configurations": [_config_entry("a")],
+        "surprise": 1,
+    }
+    extra.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(LabInputError, match="key set mismatch"):
+        load_protocol(extra)
+
+    bool_history = _write_protocol(
+        tmp_path, [_config_entry("a", min_history=True)], name="bool.json"
+    )
+    with pytest.raises(LabInputError, match="builtin int"):
+        load_protocol(bool_history)
+
+    nan_file = tmp_path / "nan.json"
+    nan_file.write_text(
+        json.dumps(
+            {
+                "schema": "nextness-replay-protocol-v1",
+                "model": "first_order",
+                "smoothing": 1.0,
+                "holdout_fraction": 0.25,
+                "configurations": [_config_entry("a")],
+            }
+        ).replace("0.3", "NaN", 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(LabInputError, match="not finite"):
+        load_protocol(nan_file)
+
+    out_of_monitor_bounds = _write_protocol(
+        tmp_path,
+        [_config_entry("a", calibration_error_threshold=1.5)],
+        name="oob.json",
+    )
+    with pytest.raises(LabInputError, match="must be a float in"):
+        load_protocol(out_of_monitor_bounds)
+
+    unknown_model = _write_protocol(
+        tmp_path, [_config_entry("a")], model="second_order", name="model.json"
+    )
+    with pytest.raises(LabInputError, match="allowlist"):
+        load_protocol(unknown_model)
+
+
+def _write_schema_variant(tmp_path: pathlib.Path) -> pathlib.Path:
+    p = tmp_path / "variant.json"
+    p.write_text(
+        json.dumps(
+            {
+                "schema": "nextness-replay-protocol-v2",
+                "model": "first_order",
+                "smoothing": 1.0,
+                "holdout_fraction": 0.25,
+                "configurations": [_config_entry("a")],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_oversized_protocol_fails_closed_before_parse(tmp_path) -> None:
+    big = tmp_path / "big.json"
+    big.write_bytes(b"x" * (MAX_PROTOCOL_BYTES + 10))
+    with pytest.raises(LabInputError, match="exceeds"):
+        load_protocol(big)
+
+
+def test_replay_step_bound_fails_closed_not_truncated(tmp_path) -> None:
+    # holdout_fraction 0.5 over 2*(MAX_REPLAY_STEPS+1) rows yields
+    # MAX_REPLAY_STEPS+1 holdout steps — one past the bound.
+    tokens = [A, B] * (MAX_REPLAY_STEPS + 1)
+    log = _write_log(tmp_path, tokens)
+    protocol = _write_protocol(
+        tmp_path, [_config_entry("a")], holdout_fraction=0.5
+    )
+    with pytest.raises(LabInputError, match="replay bound"):
+        build_lab_report(log, protocol)
+
+
+# ---------------------------------------------------------------------------
+# CLI: exit codes, write boundary, concise errors
+# ---------------------------------------------------------------------------
+
+
+def test_cli_success_stdout_and_lf_only_output(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("only", min_history=5)])
+    assert main([str(log), str(protocol)]) == 0
+    stdout = capsys.readouterr().out
+    assert json.loads(stdout)["schema"] == LAB_SCHEMA
+
+    out = tmp_path / "lab.json"
+    assert main([str(log), str(protocol), "--output", str(out)]) == 0
+    first = out.read_bytes()
+    assert main([str(log), str(protocol), "--output", str(out)]) == 0
+    assert out.read_bytes() == first
+    assert b"\r" not in first
+    assert first == serialize_lab_report(build_lab_report(log, protocol)).encode("utf-8")
+
+
+def test_cli_expected_failures_concise(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a")])
+    assert main([str(tmp_path / "absent.jsonl"), str(protocol)]) == 2
+    assert main([str(log), str(tmp_path / "absent.json")]) == 2
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert main([str(log), str(bad)]) == 2
+    short_dir = tmp_path / "short"
+    short_dir.mkdir()
+    short_log = _write_log(short_dir, [A, B])
+    short_protocol = _write_protocol(short_dir, [_config_entry("a")])
+    assert main([str(short_log), str(short_protocol)]) == 3
+    err = capsys.readouterr().err
+    for line in err.splitlines():
+        assert line.startswith("error:")
+    assert "Traceback" not in err
+
+
+def test_cli_refuses_to_overwrite_either_input(tmp_path, capsys) -> None:
+    # An in-directory --output that names the log or the protocol would
+    # destroy the immutable recording — refused, inputs byte-intact.
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    log_bytes = log.read_bytes()
+    protocol_bytes = protocol.read_bytes()
+    assert main([str(log), str(protocol), "--output", str(log)]) == 4
+    assert main([str(log), str(protocol), "--output", str(protocol)]) == 4
+    err = capsys.readouterr().err
+    assert "refusing to overwrite the input" in err
+    assert log.read_bytes() == log_bytes
+    assert protocol.read_bytes() == protocol_bytes
+    # A legitimate in-directory output leaves both inputs untouched too.
+    out = tmp_path / "lab-output.json"
+    assert main([str(log), str(protocol), "--output", str(out)]) == 0
+    assert log.read_bytes() == log_bytes
+    assert protocol.read_bytes() == protocol_bytes
+
+
+def test_duplicate_protocol_keys_fail_closed(tmp_path) -> None:
+    dup = tmp_path / "dup.json"
+    dup.write_text(
+        '{"schema": "nextness-replay-protocol-v1", "model": "first_order", '
+        '"model": "persistence", "smoothing": 1.0, "holdout_fraction": 0.25, '
+        '"configurations": [{"label": "a", "min_history": 30, "window": 50, '
+        '"low_confidence_threshold": 0.3, "calibration_error_threshold": 0.2, '
+        '"drift_threshold_bits": 0.15}]}',
+        encoding="utf-8",
+    )
+    with pytest.raises(LabInputError, match="duplicate JSON key"):
+        load_protocol(dup)
+
+
+def test_replay_observations_rejects_unknown_model() -> None:
+    with pytest.raises(LabInputError, match="allowlist"):
+        replay_observations(
+            [A, B] * 10, "persistance", smoothing=0.5, holdout_fraction=0.25
+        )
+
+
+def test_cli_write_boundary_exit_4(tmp_path, capsys, monkeypatch) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log = _write_log(log_dir, [A, B] * 30)
+    protocol = _write_protocol(log_dir, [_config_entry("a", min_history=5)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    assert main([str(log), str(protocol), "--output", str(elsewhere / "lab.json")]) == 4
+    assert "outside the input-log directory" in capsys.readouterr().err
+
+    import scripts.nextness_replay_lab as lab_module
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(lab_module, "_repo_data_dir", lambda: data_dir.resolve())
+    data_log = _write_log(data_dir, [A, B] * 30)
+    data_protocol = _write_protocol(data_dir, [_config_entry("a", min_history=5)])
+    assert (
+        main([str(data_log), str(data_protocol), "--output", str(data_dir / "lab.json")]) == 4
+    )
+    assert "data/ tree" in capsys.readouterr().err
+
+
+def test_cli_oversized_report_exit_5(tmp_path, capsys, monkeypatch) -> None:
+    import scripts.nextness_replay_lab as lab_module
+
+    monkeypatch.setattr(lab_module, "MAX_LAB_REPORT_BYTES", 64)
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    assert main([str(log), str(protocol)]) == 5
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+# ---------------------------------------------------------------------------
+# Output ceiling at maximum breadth
+# ---------------------------------------------------------------------------
+
+
+def test_max_configs_report_stays_inside_ceiling(tmp_path) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(
+        tmp_path,
+        [
+            _config_entry(f"configuration-{i:02d}-{'x' * 40}", min_history=5 + i)
+            for i in range(MAX_LAB_CONFIGS)
+        ],
+    )
+    report = build_lab_report(log, protocol)
+    assert len(report["configurations"]) == MAX_LAB_CONFIGS
+    assert len(serialize_lab_report(report).encode("utf-8")) <= MAX_LAB_REPORT_BYTES
+
+
+def test_summarize_trajectory_alternating_pattern_hand_traced() -> None:
+    # Decisions T T F T F F T (reasons arbitrary but coherent):
+    # completed runs [2, 1]; onsets 2; reorientations 2; trailing 1.
+    decisions = [
+        (True, "insufficient_history"),
+        (True, "insufficient_history"),
+        (False, "none"),
+        (True, "low_confidence"),
+        (False, "none"),
+        (False, "none"),
+        (True, "distribution_shift"),
+    ]
+    t = summarize_trajectory(decisions)
+    assert t["abstention_onsets"] == 2
+    assert t["reorientations"] == 2
+    assert t["completed_abstention_run_lengths_steps"] == [2, 1]
+    assert t["unresolved_trailing_abstention_steps"] == 1
+    assert t["first_non_abstain_step"] == 3
+    assert t["abstention_step_rate"] == 4 / 7
+    assert t["final_reason"] == "distribution_shift"

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -634,6 +634,90 @@ def test_replay_step_bound_fails_closed_not_truncated(tmp_path) -> None:
         build_lab_report(log, protocol)
 
 
+def test_replay_bound_rejects_before_observations_allocation(tmp_path, monkeypatch) -> None:
+    # The bound must be enforced from the ALREADY-BOUNDED sequence
+    # length, before replay_observations is ever invoked — the oversized
+    # observation list must never be constructed.
+    import scripts.nextness_replay_lab as lab_module
+
+    tokens = [A, B] * (MAX_REPLAY_STEPS + 1)
+    log = _write_log(tmp_path, tokens)
+    protocol = _write_protocol(tmp_path, [_config_entry("a")], holdout_fraction=0.5)
+    invocations: list[int] = []
+    real = lab_module.replay_observations
+
+    def _spy(*args, **kwargs):
+        invocations.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(lab_module, "replay_observations", _spy)
+    with pytest.raises(LabInputError, match="replay bound"):
+        build_lab_report(log, protocol)
+    assert invocations == []  # never called; no observation list built
+
+
+@pytest.mark.parametrize(
+    "fraction,rows,expect_ok",
+    [
+        (0.5, 2 * MAX_REPLAY_STEPS, True),        # holdout exactly at the limit
+        (0.5, 2 * MAX_REPLAY_STEPS + 2, False),   # limit + 1
+        (0.25, 4 * MAX_REPLAY_STEPS + 4, False),  # limit + 1 at another fraction
+        (0.05, 20 * MAX_REPLAY_STEPS, True),      # max accepted sequence, holdout == limit
+        (0.05, 20 * MAX_REPLAY_STEPS + 20, False),
+    ],
+    ids=["limit@0.5", "limit+1@0.5", "limit+1@0.25", "limit@0.05", "limit+1@0.05"],
+)
+def test_replay_bound_boundary_across_fractions(tmp_path, fraction, rows, expect_ok) -> None:
+    tokens = [A if i % 2 == 0 else B for i in range(rows)]
+    log = _write_log(tmp_path, tokens)
+    protocol = _write_protocol(
+        tmp_path,
+        [_config_entry("a", min_history=5, window=5, **_LOOSE)],
+        holdout_fraction=fraction,
+    )
+    if expect_ok:
+        report = build_lab_report(log, protocol)
+        assert report["input"]["holdout_steps"] == MAX_REPLAY_STEPS
+    else:
+        with pytest.raises(LabInputError, match="replay bound"):
+            build_lab_report(log, protocol)
+
+
+def test_hard_link_output_alias_refused_and_inputs_intact(tmp_path, capsys) -> None:
+    # An --output that is an existing HARD LINK to an input shares its
+    # file identity while having a different path: writing through it
+    # would destroy the recording. It must be refused with the inputs
+    # byte-intact.
+    import os
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    for label, target in (("log", log), ("protocol", protocol)):
+        alias = tmp_path / f"alias_{label}.json"
+        os.link(target, alias)
+        before = target.read_bytes()
+        assert main([str(log), str(protocol), "--output", str(alias)]) == 4
+        assert target.read_bytes() == before
+        err = capsys.readouterr().err
+        assert "identity" in err or "overwrite" in err
+        alias.unlink()
+
+
+def test_symlink_output_alias_refused_and_inputs_intact(tmp_path, capsys) -> None:
+    import os
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    alias = tmp_path / "alias_symlink.json"
+    try:
+        os.symlink(log, alias)
+    except OSError:
+        pytest.skip("symlink creation not permitted on this platform/user")
+    before = log.read_bytes()
+    assert main([str(log), str(protocol), "--output", str(alias)]) == 4
+    assert log.read_bytes() == before
+
+
 # ---------------------------------------------------------------------------
 # CLI: exit codes, write boundary, concise errors
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

**PACKAGE NP6** — second PR of the Kev-authorized offline Nextness instrumentation runway, stacked on **NP5 (#358, head `a2cd84cb`)**. Three new files, nothing else touched:

| File | Role |
|---|---|
| `scripts/nextness_replay_lab.py` | replay lab (`nextness-replay-lab-v1` output, `nextness-replay-protocol-v1` input) |
| `tests/test_nextness_replay_lab.py` | 43 tests: hand-derived trajectories, mutation-pinned equivalence locks, per-step differentials, adversarial protocol corpus, seeded properties |
| `docs/NEXTNESS_REPLAY_LAB_CONTRACT.md` | full contract |

It replays **one recorded log** through NP2's own abstention decision procedure at **every holdout step**, for up to 8 **operator-written** monitor configurations, and reports each configuration's trajectory side by side. This reaches the granularity NP5 cannot: receipts record aggregates, so NP5's recovery metrics stop at receipt granularity — the lab states at which step the monitor first stopped abstaining, whether/how many times it re-abstained, and how long each completed reorientation took, over the same immutable recording.

## Laboratory observations only

- **No ranking, no winner, no recommendation, no score** — enforced structurally (key-walk test); configurations appear in exactly the operator's input order.
- **Abstention preserved**: a configuration that never leaves abstention is reported as-is (pinned on NP2's known under-confidence regime: `first_non_abstain_step: null`, trailing run 15/15).
- **No search**: the lab never generates, perturbs or optimizes configurations, and never touches engine parameters. Threshold validation is delegated to NP2's own `MonitorConfig.validate`.

## No new semantics — mutation-pinned equivalence locks

The bridge loop is re-derived (justification in the doc: `observations_from_log` doesn't return the train/holdout token lists per-step drift windows need), and pinned to the live NP2 path:

- Parametrized lock: 3 models × 3 configs (**one where `distribution_shift` actually decides**) × 2 fixtures (**one fractional split**, both with the regime change **inside the holdout**): observations float-for-float, reference/recent counts, final decision vs `build_receipt`.
- Two per-step differentials against independently-written slices (one exercising `distribution_shift` mid-trajectory; one where per-step confidence alternates across the `low_confidence` threshold).
- **Mutation receipts**: all six demonstrated mutants now fail the suite — drift hardwired to 0, prefix-diluted recent window, holdout-derived reference, first-window slice, stale latest observation, floor→round split. (The review fleet proved the *original* suite was blind to all six; the rebuilt locks kill each.)

## Bounds & hostile-input posture

≤8 configs · ≤2000 replay steps (**fail closed, never silently truncated** — dropping early steps would misstate every trajectory) · 64 KiB protocol pre-parse bound + **duplicate-JSON-key rejection** + RecursionError fail-closed + exact key sets/types · unknown model/schema rejected (incl. a fail-closed gate in `replay_observations` itself) · 64 KiB output ceiling · run-length lists capped at 128 with explicit flags.

**Read-only inputs, tested byte-for-byte including through the CLI**: `--output` naming either input file is refused (exit 4) — the review fleet demonstrated the original guard allowed overwriting the recording itself.

## Determinism & provenance

Sorted-key JSON, LF-only `--output`, no timestamps/randomness/paths; provenance = sha256(protocol bytes) + sha256(accepted dominant-token sequence) + full row accounting (the log enters the computation only through that sequence). Byte-identical across runs; protocol key-order invariance tested.

## Verification

Targeted **43/43** · full suite **1020 passed / 27 skipped** · `py_compile` OK · mutation harness receipts above (final run: 6/6 killed, baseline restored 43/43).

Adversarial multi-lens self-review (4 lenses + refutation agents): **11 confirmed findings, all folded; 2 refuted**. Standouts: mutation-proven drift-half test blindness, degenerate lock fixture (regime change landed in train, holdout uniform), unpinned floor arithmetic, input-overwrite gap, silent unknown-model fallthrough, duplicate-key last-wins, and three doc overclaims narrowed.

## Non-claims

Laboratory observations over recordings; comparisons descriptive, never "improvements". No engine parameter read/searched/written. No awareness/consciousness/phenomenology/biological-equivalence claim.

## Boundary note (out of scope, flagged)

NP1's `validate_output_path` shares the overwrite-identity gap in principle (its `--output` may name the input log). #354 is frozen for Jack — flagged for a future package, not touched here.

**Stack**: #354 ← #355 ← #358 (NP5) ← **this PR**. Left open and unmerged for Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment — Jack HOLD delta (2026-07-15, head `17ae4eb2`)

**Rebase receipt**: NP6's original commit was rebased from base `a2cd84cb` onto corrected NP5 `bddf4c67` — patch **byte-identical** (`cmp` of pre/post diff-of-diffs passes; `range-diff` reports `=` for `9f4ceca` → `73f3d5f`). The correction is one commit on top, reviewable in isolation.

All three live review threads addressed:

**A. Pre-allocation replay bound** (codex thread @ lab:475). The holdout length is now computed from the already-bounded sequence length + protocol `holdout_fraction` **before** `replay_observations` runs; an oversized holdout never constructs the observation list. **Failing-first receipt**: a spy on `replay_observations` proved pre-fix invocation; now provably never invoked (message and fail-closed semantics unchanged), with a split-arithmetic invariant re-checking the early computation against the bridge's own holdout. Boundary tests: exact limit / limit+1 / max accepted sequence across fractions 0.5, 0.25, 0.05.

**B. File-identity alias guard** (codex thread @ lab:573). `validate_output_path` now refuses by resolved path (covers symlink aliases, including dangling — resolution targets compared, not link names) **and** by `os.path.samefile` identity (device+inode — covers existing hard links); an identity check that cannot complete is itself a refusal. **Failing-first receipt**: pre-fix, `--output` naming a hard link to the log returned 0 and **destroyed the recording**; now exit 4 with both inputs byte-intact (tested for log and protocol; symlink case skips locally without privilege and runs on CI Linux). **Residual race stated precisely** (docstring + contract): identity is verified at validation time, not re-verified at write — no stronger immutability is claimed than enforced.

**C. Byte output** (gemini thread @ lab:663). `--output` uses `write_bytes` — LF-only identity, no `Path.write_text(newline=)` dependence, matching corrected NP5.

Receipts: targeted **50 passed / 1 skipped**, full suite **1046 passed / 28 skipped**, `py_compile` OK. Threads intentionally left unresolved for Jack.
