### PR TITLE
feat: deterministic evidence packet over recorded Nextness artifacts (PACKAGE NP8)

### DIFF
--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -16,7 +16,7 @@ links the v1 schemas themselves record**:
 | `evaluation_report_sha256` | NP5 evaluation (`artifacts.report.sha256`) | the report file's bytes |
 | `evaluation_receipts_sha256` | NP5 evaluation (`artifacts.receipts.sha256`) | the receipts file's bytes |
 | `lab_protocol_sha256` | NP6 lab report (`input.protocol_sha256`) | the protocol file's bytes |
-| `lab_sequence_sha256` | NP6 lab report (`input.sequence_sha256`) | the log's accepted dominant-token sequence, recomputed through NP1's own bounded reader |
+| `lab_sequence_sha256` | NP6 lab report (`input.sequence_sha256`) | the log's accepted dominant-token sequence, recomputed through NP1's own bounded reader **with the lab's recorded `max_rows`/`max_line_bytes`** |
 
 A checkable link is `verified` or `broken` (byte-level hash
 comparison, both hashes reported). A link whose counterpart was not
@@ -24,6 +24,23 @@ provided is typed `not_computable` / `counterpart_absent`; a link the
 recording artifact did not embed (e.g. an evaluation produced without
 receipts) is `not_computable` / `link_not_recorded` — **absence is
 never failure and never invention**.
+
+**Recorded reader bounds.** A lab produced under non-default
+`--max-rows`/`--max-line-bytes` accepted a *different* sequence than
+the defaults would, so the sequence link recomputes with the lab's own
+recorded `config.max_rows`/`config.max_line_bytes` — exact-type
+validated against the same acceptance ranges NP1/NP6 enforce (bool,
+float, string, negative, zero and out-of-range values are malformed
+input, fail closed) and echoed in the link as `reader_bounds`. The log
+manifest entry's own `sequence_sha256` uses NP1 defaults, with the
+bounds echoed as `sequence_bounds`. No lab ⇒ no bounds are invented.
+
+**`provided` flags are exact builtin bools.** In
+`evaluation.artifacts.<role>.provided`: `true` requires and verifies
+the recorded sha256; `false` is typed `link_not_recorded`; **every
+other value** (1, 0, "true", "false", null, [], {}) is malformed input
+and raises — a truthy non-bool can never silently suppress
+verification.
 
 ## Honest validation depth (recorded per artifact)
 
@@ -53,8 +70,22 @@ phenomenology or biological-equivalence claim.
 
 ≤ `MAX_PACKET_ARTIFACTS` (8) artifacts (the one-per-role rule caps
 practice at six); every JSON input read through a hard pre-parse bound
-(`MAX_INPUT_BYTES`, 1 MiB — the log through NP1's own row/line bounds
-as well); output checked against a **64 KiB fail-closed ceiling**.
+(`MAX_INPUT_BYTES`, 1 MiB), **parsed exactly once** (spy-tested);
+output checked against a **64 KiB fail-closed ceiling**.
+
+**Log size contract** (`MAX_LOG_BYTES`, 16 MiB): the raw log gets its
+own role-specific ceiling — size-checked via `stat` **before any
+read**, re-enforced during reading, and hashed in fixed-size 64 KiB
+chunks (the log is never materialized whole). Justification: NP1
+ingests at most `MAX_ROWS_DEFAULT` = 100,000 physical records per run
+and observer-emitted rows (single-line JSON, one generation plus at
+most 16 token-count keys) are well under 170 bytes, so 16 MiB covers
+every default-bounds observer-emitted log. **This is deliberately not
+a universal-compatibility claim**: a log recorded under raised
+`--max-rows`/`--max-line-bytes` settings may exceed the ceiling and is
+refused fail-closed — NP8 packages a documented subset of what NP1/NP6
+can, in the extreme, ingest. Tested at the exact limit, limit+1, and
+with a valid >1 MiB log whose sequence link verifies.
 Deterministic sorted-key serialization, fixed vocabularies, no
 timestamps, no random identifiers, no absolute paths; byte-identical
 across repeated runs; manifest order is the fixed role order regardless

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -76,16 +76,18 @@ output checked against a **64 KiB fail-closed ceiling**.
 **Log size contract** (`MAX_LOG_BYTES`, 16 MiB): the raw log gets its
 own role-specific ceiling — size-checked via `stat` **before any
 read**, re-enforced during reading, and hashed in fixed-size 64 KiB
-chunks (the log is never materialized whole). Justification: NP1
-ingests at most `MAX_ROWS_DEFAULT` = 100,000 physical records per run
-and observer-emitted rows (single-line JSON, one generation plus at
-most 16 token-count keys) are well under 170 bytes, so 16 MiB covers
-every default-bounds observer-emitted log. **This is deliberately not
-a universal-compatibility claim**: a log recorded under raised
-`--max-rows`/`--max-line-bytes` settings may exceed the ceiling and is
-refused fail-closed — NP8 packages a documented subset of what NP1/NP6
-can, in the extreme, ingest. Tested at the exact limit, limit+1, and
-with a valid >1 MiB log whose sequence link verifies.
+chunks (the log is never materialized whole). **16 MiB is NP8's own
+explicit packaging/work ceiling** — it keeps the hash and the bounded
+sequence read cheap and testable. It is **not derived as coverage of
+NP1's defaults**: observer rows carry more than a generation and token
+counts (timestamps, filenames, lattice shape, sampling information,
+metrics, diagnostics, a nested budget block), so **no claim is made
+about what fraction of real or default-configuration logs fit** until
+that is measured. NP8 intentionally accepts raw logs no larger than
+16 MiB; otherwise-valid larger logs are refused fail-closed — a
+documented subset of what NP1/NP6 can ingest. Tested at the exact
+limit, limit+1, and with a valid >1 MiB log whose sequence link
+verifies.
 Deterministic sorted-key serialization, fixed vocabularies, no
 timestamps, no random identifiers, no absolute paths; byte-identical
 across repeated runs; manifest order is the fixed role order regardless

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -1,0 +1,85 @@
+# Nextness Evidence Packet Contract (NP8)
+
+**Module**: `scripts/nextness_evidence_packet.py` · **Tests**: `tests/test_nextness_evidence_packet.py`
+**Schema**: `nextness-evidence-packet-v1` · **Status**: packaging and provenance verification only — no new metric
+
+## What this is
+
+A compact, offline **audit manifest** over up to eight recorded
+Nextness artifacts (one per role: `report`, `receipts`, `evaluation`,
+`lab`, `protocol`, `log`). For each artifact it records the schema
+identifier, byte length and SHA-256; and it **verifies the provenance
+links the v1 schemas themselves record**:
+
+| Link | Recorded by | Verified against |
+|---|---|---|
+| `evaluation_report_sha256` | NP5 evaluation (`artifacts.report.sha256`) | the report file's bytes |
+| `evaluation_receipts_sha256` | NP5 evaluation (`artifacts.receipts.sha256`) | the receipts file's bytes |
+| `lab_protocol_sha256` | NP6 lab report (`input.protocol_sha256`) | the protocol file's bytes |
+| `lab_sequence_sha256` | NP6 lab report (`input.sequence_sha256`) | the log's accepted dominant-token sequence, recomputed through NP1's own bounded reader |
+
+A checkable link is `verified` or `broken` (byte-level hash
+comparison, both hashes reported). A link whose counterpart was not
+provided is typed `not_computable` / `counterpart_absent`; a link the
+recording artifact did not embed (e.g. an evaluation produced without
+receipts) is `not_computable` / `link_not_recorded` — **absence is
+never failure and never invention**.
+
+## Honest validation depth (recorded per artifact)
+
+- `report`, `receipts`, `protocol` — validated through the **existing**
+  validators (`nextness_evaluator.validate_report` /
+  `validate_receipt_series`, `nextness_replay_lab.load_protocol`);
+  manifest records `validation: "full"`. Nothing is duplicated.
+- `evaluation`, `lab` — no public validator exists; only the schema
+  identifier and the exact link fields consumed are checked, and the
+  manifest says so: `validation: "schema_identifier_only"`.
+- `log` — not JSON; it enters the stack only through
+  `read_dominant_sequence`; the manifest records both the raw-byte hash
+  and the accepted-sequence hash (`validation: "sequence_reader"`).
+
+Unknown schema variants, malformed link fields, duplicate JSON keys and
+artifacts failing their validators are all rejected **fail-closed**.
+
+## Non-claims (load-bearing, embedded in every packet)
+
+No scoring, ranking, recommendation, tuning, action, model invocation
+or service contact (no such structure exists in the output — key-walk
+tested). A `not_computable` link says which artifacts were provided,
+not anything about integrity. No awareness, consciousness,
+phenomenology or biological-equivalence claim.
+
+## Bounds and determinism
+
+≤ `MAX_PACKET_ARTIFACTS` (8) artifacts (the one-per-role rule caps
+practice at six); every JSON input read through a hard pre-parse bound
+(`MAX_INPUT_BYTES`, 1 MiB — the log through NP1's own row/line bounds
+as well); output checked against a **64 KiB fail-closed ceiling**.
+Deterministic sorted-key serialization, fixed vocabularies, no
+timestamps, no random identifiers, no absolute paths; byte-identical
+across repeated runs; manifest order is the fixed role order regardless
+of invocation order.
+
+## Write boundary
+
+Default output is **stdout**. `--output` must resolve inside the
+primary input's directory (first provided role in the fixed order),
+never inside the repository `data/` tree, and never on a path aliasing
+**any** input — by resolved path and by file identity
+(`os.path.samefile`; existing hard links included), with the same
+validation-time semantics and documented residual race as the NP6 lab.
+Files are written as raw UTF-8 bytes (LF-only).
+
+## CLI exit codes
+
+`0` success · `2` validation failure (missing/oversized/malformed/
+unknown-variant artifact, or none provided) · `4` output-path failure ·
+`5` packet over the ceiling. One concise `error:` line per expected
+failure, never a traceback.
+
+## Safety
+
+Offline; no network; imports only the four Nextness instrument modules
+and stdlib (statically auditable). Reads only the files named on the
+command line; never modifies an input (the whole-chain tests assert
+byte-identity after every refusal path).

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -111,15 +111,16 @@ MAX_PACKET_ARTIFACTS: Final[int] = 8
 MAX_PACKET_BYTES: Final[int] = 64 * 1024
 
 #: Role-specific ceiling for the raw log (JSON artifacts keep the 1 MiB
-#: MAX_INPUT_BYTES). Justified from the stack's own defaults: NP1
-#: ingests at most MAX_ROWS_DEFAULT = 100,000 physical records per run,
-#: and observer-emitted rows (single-line JSON: a generation plus at
-#: most 16 token-count keys) are well under 170 bytes each, so 16 MiB
-#: covers every default-bounds observer-emitted log. This is
-#: deliberately NOT a universal-compatibility claim: a log recorded
-#: under raised --max-rows / --max-line-bytes settings may exceed it
-#: and is refused fail-closed. The size is checked via stat BEFORE any
-#: read, re-enforced during the chunked read, and the log is hashed in
+#: MAX_INPUT_BYTES). This is NP8's OWN explicit packaging/work ceiling,
+#: chosen so the chunked hash and the bounded sequence read stay cheap
+#: and testable. It is NOT derived as coverage of NP1's defaults:
+#: observer rows carry more than a generation and token counts
+#: (timestamps, filenames, lattice shape, sampling information,
+#: metrics, diagnostics, a nested budget block), so no claim is made
+#: about what fraction of real or default-configuration logs fit until
+#: that is measured. An otherwise-valid larger log is refused
+#: fail-closed. The size is checked via stat BEFORE any read,
+#: re-enforced during the chunked read, and the log is hashed in
 #: fixed-size chunks — never materialized whole.
 MAX_LOG_BYTES: Final[int] = 16 * 1024 * 1024
 _HASH_CHUNK_BYTES: Final[int] = 64 * 1024

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -1,0 +1,534 @@
+"""Deterministic evidence packet over recorded Nextness artifacts (NP8).
+
+Builds one compact, offline AUDIT MANIFEST over up to eight recorded
+artifacts from the Nextness stack — NP1 reports, NP2 receipt series,
+NP5 evaluations, NP6 lab reports/protocols and the underlying JSONL
+log — recording for each its schema, byte length and SHA-256, and
+verifying the provenance links the schemas themselves record (an NP5
+evaluation carries the sha256 of the report/receipts it evaluated; an
+NP6 lab report carries the sha256 of its protocol bytes and of the
+accepted dominant-token sequence).
+
+This is packaging and provenance verification — NOT a new prediction
+metric. Nothing here scores, ranks, recommends, tunes, acts, invokes a
+model or contacts a service, and no consciousness, awareness,
+phenomenology or biological-equivalence claim is made or implied.
+
+Honesty contract:
+
+- Artifacts are validated through the EXISTING validators where one
+  exists (NP5's ``validate_report`` / ``validate_receipt_series``,
+  NP6's ``load_protocol``); the evaluation and lab-report roles have no
+  public validator, so they are checked to their schema identifier and
+  the exact fields the packet consumes — and each manifest entry
+  records its ``validation`` depth (``full`` vs
+  ``schema_identifier_only``) rather than implying more than was
+  checked.
+- A provenance link whose counterpart artifact was not provided is a
+  typed ``not_computable`` result, never a failure and never invented.
+- A link that IS checkable is reported ``verified`` or ``broken`` by
+  byte-level hash comparison (the sequence link recomputes the
+  dominant-token sequence from the log through NP1's own bounded
+  reader).
+
+Safety contract (Lane B, mirrors NP5/NP6):
+
+- Offline only; reads only the artifact files named on the command
+  line, each through a hard pre-parse size bound; duplicate JSON keys
+  and hostile container subclasses are rejected fail-closed.
+- At most ``MAX_PACKET_ARTIFACTS`` artifacts; output checked against a
+  64 KiB fail-closed ceiling.
+- ``--output`` is confined to the primary input's directory, never the
+  repository ``data/`` tree, and never a path aliasing ANY input (by
+  resolved path and by file identity — hard links included; the same
+  validation-time semantics and documented residual race as NP6).
+- Deterministic: sorted keys, fixed schema, no timestamps, no random
+  identifiers, no absolute paths; byte-identical across repeated runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import sys
+from collections.abc import Mapping
+from typing import Any, Final
+
+from scripts.nextness_evaluator import (
+    EVALUATION_SCHEMA,
+    MAX_INPUT_BYTES,
+    EvaluatorInputError,
+    validate_receipt_series,
+    validate_report,
+)
+from scripts.nextness_monitor import RECEIPT_SCHEMA
+from scripts.nextness_observer import WriteOutsideLogDirError
+from scripts.nextness_predictor import REPORT_SCHEMA, read_dominant_sequence
+from scripts.nextness_replay_lab import (
+    LAB_SCHEMA,
+    PROTOCOL_SCHEMA,
+    LabInputError,
+    load_protocol,
+)
+
+# ---------------------------------------------------------------------------
+# Fixed contract constants
+# ---------------------------------------------------------------------------
+
+PACKET_SCHEMA: Final[str] = "nextness-evidence-packet-v1"
+
+#: One artifact per role, fixed role order (also the manifest order).
+ROLES: Final[tuple[str, ...]] = (
+    "report", "receipts", "evaluation", "lab", "protocol", "log",
+)
+
+#: Hard bound on artifacts per packet (the role set caps this at six
+#: today; the bound is the documented contract either way).
+MAX_PACKET_ARTIFACTS: Final[int] = 8
+
+#: Output ceiling — fail closed (same convention as the whole stack).
+MAX_PACKET_BYTES: Final[int] = 64 * 1024
+
+#: Provenance links the v1 schemas record (fixed vocabulary).
+LINK_KINDS: Final[tuple[str, ...]] = (
+    "evaluation_report_sha256",    # evaluation.artifacts.report.sha256   -> report bytes
+    "evaluation_receipts_sha256",  # evaluation.artifacts.receipts.sha256 -> receipts bytes
+    "lab_protocol_sha256",         # lab.input.protocol_sha256            -> protocol bytes
+    "lab_sequence_sha256",         # lab.input.sequence_sha256            -> log's accepted sequence
+)
+
+#: Typed not-computable vocabulary for links.
+LINK_NOT_COMPUTABLE_REASONS: Final[tuple[str, ...]] = (
+    "counterpart_absent",   # the artifact on one end was not provided
+    "link_not_recorded",    # the recording artifact did not embed the hash
+)
+
+NON_CLAIMS: Final[tuple[str, ...]] = (
+    "Packaging and provenance verification only: nothing here scores, "
+    "ranks, recommends, tunes, acts, invokes a model or contacts a "
+    "service.",
+    "A not_computable link is a statement about which artifacts were "
+    "provided, not about the artifacts' integrity.",
+    "No awareness, consciousness, phenomenology or biological-equivalence "
+    "claim is made or implied.",
+)
+
+_SCHEMA_BY_ROLE: Final[dict[str, str]] = {
+    "report": REPORT_SCHEMA,
+    "receipts": RECEIPT_SCHEMA,
+    "evaluation": EVALUATION_SCHEMA,
+    "lab": LAB_SCHEMA,
+    "protocol": PROTOCOL_SCHEMA,
+}
+
+_HEX64: Final[frozenset[str]] = frozenset("0123456789abcdef")
+
+
+class PacketInputError(ValueError):
+    """A malformed, hostile or unknown-variant packet input (fail closed)."""
+
+
+class PacketTooLargeError(RuntimeError):
+    """Serialized packet exceeded MAX_PACKET_BYTES (fail closed)."""
+
+
+# ---------------------------------------------------------------------------
+# Bounded loading (duplicate keys rejected; exact types on touched fields)
+# ---------------------------------------------------------------------------
+
+
+def _load_bounded_json(path: pathlib.Path) -> tuple[Any, str, int]:
+    """Bounded read + duplicate-key-rejecting parse.
+
+    Returns ``(parsed, sha256_hex, byte_count)``; at most
+    ``MAX_INPUT_BYTES + 1`` bytes are ever materialized.
+    """
+    with path.open("rb") as f:
+        raw = f.read(MAX_INPUT_BYTES + 1)
+    if len(raw) > MAX_INPUT_BYTES:
+        raise PacketInputError(f"artifact exceeds {MAX_INPUT_BYTES} bytes; refusing to parse")
+
+    def _no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in out:
+                raise PacketInputError(f"artifact: duplicate JSON key {key!r}")
+            out[key] = value
+        return out
+
+    try:
+        parsed = json.loads(raw.decode("utf-8", errors="strict"), object_pairs_hook=_no_duplicate_keys)
+    except PacketInputError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+        raise PacketInputError(f"artifact is not valid UTF-8 JSON: {e}") from e
+    except RecursionError as e:
+        raise PacketInputError("artifact nesting exceeds the parser's depth limit") from e
+    return parsed, hashlib.sha256(raw).hexdigest(), len(raw)
+
+
+def _exact_dict_field(container: Any, field: str, context: str) -> Any:
+    if type(container) is not dict:
+        raise PacketInputError(f"{context}: expected builtin dict, got {type(container).__name__}")
+    if field not in container:
+        raise PacketInputError(f"{context}: missing field {field!r}")
+    return container[field]
+
+
+def _exact_sha256(value: Any, context: str) -> str:
+    if type(value) is not str or len(value) != 64 or not set(value) <= _HEX64:
+        raise PacketInputError(f"{context}: expected a 64-char lowercase hex sha256")
+    return value
+
+
+def _schema_of(parsed: Any, role: str) -> str:
+    schema = _exact_dict_field(parsed, "schema", role)
+    if type(schema) is not str:
+        raise PacketInputError(f"{role}.schema: expected builtin str")
+    expected = _SCHEMA_BY_ROLE[role]
+    if schema != expected:
+        raise PacketInputError(
+            f"{role}.schema: unknown variant {schema!r} (expected {expected!r})"
+        )
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# Per-role validation (existing validators where they exist)
+# ---------------------------------------------------------------------------
+
+
+def _validate_role(role: str, path: pathlib.Path) -> dict[str, Any]:
+    """One manifest entry. ``validation`` records the honest depth."""
+    if role == "log":
+        # The log is not JSON; it enters the stack only through NP1's
+        # bounded reader. Hash the accepted dominant-token sequence the
+        # same way NP6 does (that is the identity the lab records), and
+        # the raw bytes for completeness.
+        with path.open("rb") as f:
+            raw = f.read(MAX_INPUT_BYTES + 1)
+        if len(raw) > MAX_INPUT_BYTES:
+            raise PacketInputError(f"log exceeds {MAX_INPUT_BYTES} bytes; refusing to parse")
+        sequence, _rejections, _rows = read_dominant_sequence(path)
+        return {
+            "role": "log",
+            "schema": "jsonl-nextness-runs",
+            "bytes": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "sequence_sha256": hashlib.sha256("\n".join(sequence).encode("utf-8")).hexdigest(),
+            "rows_accepted": len(sequence),
+            "validation": "sequence_reader",
+        }
+
+    parsed, digest, size = _load_bounded_json(path)
+    entry: dict[str, Any] = {
+        "role": role,
+        "bytes": size,
+        "sha256": digest,
+    }
+    try:
+        if role == "report":
+            entry["schema"] = _schema_of(parsed, role)
+            validate_report(parsed)
+            entry["validation"] = "full"
+        elif role == "receipts":
+            # A receipts artifact may be one receipt or a JSON array of
+            # receipts; an array has no top-level schema field, so the
+            # schema check is the series validator's own per-receipt
+            # check, not _schema_of.
+            series = validate_receipt_series(parsed)
+            entry["schema"] = RECEIPT_SCHEMA
+            entry["receipt_count"] = len(series)
+            entry["validation"] = "full"
+        elif role == "protocol":
+            entry["schema"] = _schema_of(parsed, role)
+            load_protocol(path)  # bounded re-read through NP6's own loader
+            entry["validation"] = "full"
+        else:
+            # evaluation / lab: no public validator exists; only the
+            # schema identifier and the link fields consumed below are
+            # checked. Saying "full" here would be a lie.
+            entry["schema"] = _schema_of(parsed, role)
+            entry["validation"] = "schema_identifier_only"
+    except (EvaluatorInputError, LabInputError) as e:
+        raise PacketInputError(f"{role}: {e}") from e
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Provenance links (verified / broken / typed not-computable)
+# ---------------------------------------------------------------------------
+
+
+def _link(status: str, **extra: Any) -> dict[str, Any]:
+    return {"status": status, **extra}
+
+
+def _not_computable_link(reason: str, requires: str) -> dict[str, Any]:
+    if reason not in LINK_NOT_COMPUTABLE_REASONS:  # internal invariant
+        raise ValueError(f"unknown link reason: {reason!r}")
+    return {"status": "not_computable", "reason": reason, "requires": requires}
+
+
+def _evaluation_link(
+    evaluation: Mapping[str, Any] | None,
+    counterpart_role: str,
+    counterpart_entry: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if evaluation is None:
+        return _not_computable_link("counterpart_absent", "an evaluation artifact")
+    artifacts = _exact_dict_field(evaluation, "artifacts", "evaluation")
+    slot = _exact_dict_field(artifacts, counterpart_role, "evaluation.artifacts")
+    provided = _exact_dict_field(slot, "provided", f"evaluation.artifacts.{counterpart_role}")
+    if provided is not True:
+        return _not_computable_link(
+            "link_not_recorded",
+            f"an evaluation produced WITH a {counterpart_role} artifact "
+            f"(this one records provided: false)",
+        )
+    recorded = _exact_sha256(
+        _exact_dict_field(slot, "sha256", f"evaluation.artifacts.{counterpart_role}"),
+        f"evaluation.artifacts.{counterpart_role}.sha256",
+    )
+    if counterpart_entry is None:
+        return _not_computable_link("counterpart_absent", f"the {counterpart_role} artifact itself")
+    actual = counterpart_entry["sha256"]
+    return _link(
+        "verified" if recorded == actual else "broken",
+        recorded_sha256=recorded,
+        actual_sha256=actual,
+    )
+
+
+def _lab_link(
+    lab: Mapping[str, Any] | None,
+    field: str,
+    counterpart_entry: Mapping[str, Any] | None,
+    counterpart_name: str,
+    counterpart_key: str,
+) -> dict[str, Any]:
+    if lab is None:
+        return _not_computable_link("counterpart_absent", "a lab-report artifact")
+    inp = _exact_dict_field(lab, "input", "lab")
+    recorded = _exact_sha256(_exact_dict_field(inp, field, "lab.input"), f"lab.input.{field}")
+    if counterpart_entry is None:
+        return _not_computable_link("counterpart_absent", counterpart_name)
+    actual = counterpart_entry[counterpart_key]
+    return _link(
+        "verified" if recorded == actual else "broken",
+        recorded_sha256=recorded,
+        actual_sha256=actual,
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end packet
+# ---------------------------------------------------------------------------
+
+
+def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
+    """One deterministic ``nextness-evidence-packet-v1`` manifest.
+
+    ``paths`` maps roles (subset of ROLES, at least one) to files.
+    Manifest order is the fixed ROLES order regardless of invocation
+    order — determinism over convenience.
+    """
+    unknown = sorted(set(paths) - set(ROLES))
+    if unknown:
+        raise PacketInputError(f"unknown artifact roles: {unknown}")
+    if not paths:
+        raise PacketInputError("no artifacts provided: nothing to package")
+    if len(paths) > MAX_PACKET_ARTIFACTS:
+        raise PacketInputError(
+            f"{len(paths)} artifacts exceed the {MAX_PACKET_ARTIFACTS} bound"
+        )
+
+    entries: dict[str, dict[str, Any]] = {}
+    parsed_evaluation: Mapping[str, Any] | None = None
+    parsed_lab: Mapping[str, Any] | None = None
+    for role in ROLES:
+        if role not in paths:
+            continue
+        entries[role] = _validate_role(role, paths[role])
+        if role == "evaluation":
+            parsed_evaluation, _, _ = _load_bounded_json(paths[role])
+        elif role == "lab":
+            parsed_lab, _, _ = _load_bounded_json(paths[role])
+
+    links = {
+        "evaluation_report_sha256": _evaluation_link(
+            parsed_evaluation, "report", entries.get("report")
+        ),
+        "evaluation_receipts_sha256": _evaluation_link(
+            parsed_evaluation, "receipts", entries.get("receipts")
+        ),
+        "lab_protocol_sha256": _lab_link(
+            parsed_lab, "protocol_sha256", entries.get("protocol"),
+            "the protocol artifact", "sha256",
+        ),
+        "lab_sequence_sha256": _lab_link(
+            parsed_lab, "sequence_sha256", entries.get("log"),
+            "the log artifact", "sequence_sha256",
+        ),
+    }
+
+    packet: dict[str, Any] = {
+        "schema": PACKET_SCHEMA,
+        "config": {
+            "max_packet_artifacts": MAX_PACKET_ARTIFACTS,
+            "max_input_bytes": MAX_INPUT_BYTES,
+            "max_packet_bytes": MAX_PACKET_BYTES,
+        },
+        "artifacts": [entries[role] for role in ROLES if role in entries],
+        "links": links,
+        "non_claims": list(NON_CLAIMS),
+    }
+    serialized = serialize_packet(packet)
+    if len(serialized.encode("utf-8")) > MAX_PACKET_BYTES:
+        raise PacketTooLargeError(
+            f"packet would exceed {MAX_PACKET_BYTES} bytes; refusing to emit"
+        )
+    return packet
+
+
+def serialize_packet(packet: Mapping[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, newline."""
+    return json.dumps(packet, sort_keys=True, separators=(",", ": "), indent=1) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Write boundary (corrected-NP6 semantics: identity-aware, race documented)
+# ---------------------------------------------------------------------------
+
+
+def _repo_data_dir() -> pathlib.Path:
+    return (pathlib.Path(__file__).resolve().parent.parent / "data").resolve()
+
+
+def validate_output_path(
+    out_path: pathlib.Path, inputs: Mapping[str, pathlib.Path]
+) -> None:
+    """--output must resolve inside the primary input's directory (first
+    provided role in ROLES order), never inside the repository data/
+    tree, and never on a path aliasing ANY input — by resolved path or
+    by file identity (hard links included). Identity is verified at
+    validation time only; the same residual filesystem race as the NP6
+    lab applies and no stronger claim is made."""
+    primary = next(inputs[role] for role in ROLES if role in inputs)
+    primary_dir = primary.resolve().parent
+    out_resolved = out_path.resolve()
+    try:
+        out_resolved.relative_to(primary_dir)
+    except ValueError as e:
+        raise WriteOutsideLogDirError(
+            f"refusing to write packet outside the primary input's directory: "
+            f"{out_resolved} is not inside {primary_dir}"
+        ) from e
+    for role in ROLES:
+        if role not in inputs:
+            continue
+        input_path = inputs[role]
+        if out_resolved == input_path.resolve():
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input {role} file: {out_resolved}"
+            )
+        if out_resolved.exists():
+            try:
+                same = os.path.samefile(out_resolved, input_path)
+            except OSError as e:
+                raise WriteOutsideLogDirError(
+                    f"cannot verify output file identity against the input "
+                    f"{role} file: {out_resolved}"
+                ) from e
+            if same:
+                raise WriteOutsideLogDirError(
+                    f"refusing to overwrite the input {role} file (shared "
+                    f"file identity): {out_resolved}"
+                )
+    data_dir = _repo_data_dir()
+    if out_resolved == data_dir or data_dir in out_resolved.parents:
+        raise WriteOutsideLogDirError(
+            f"refusing to write packet inside the repository data/ tree: {out_resolved}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deterministic evidence packet over recorded Nextness artifacts "
+            "(packaging and provenance verification only; see module "
+            "docstring for the full contract)."
+        )
+    )
+    for role in ROLES:
+        parser.add_argument(
+            f"--{role}", type=pathlib.Path, default=None,
+            help=f"path to a recorded {role} artifact",
+        )
+    parser.add_argument(
+        "--output", type=pathlib.Path, default=None,
+        help=(
+            "optional packet path; must resolve inside the primary input's "
+            "directory, outside the repository data/ tree, and must not "
+            "alias any input (default: stdout)"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit-code contract (mirrors NP5): ``0`` success · ``2`` validation
+    failure (missing/oversized/malformed/unknown-variant artifact, or
+    none provided) · ``4`` output-path failure · ``5`` packet over the
+    ceiling. One concise ``error:`` line per expected failure — never a
+    traceback; unexpected programming errors propagate loudly.
+    """
+    args = _build_parser().parse_args(argv)
+    paths = {
+        role: getattr(args, role) for role in ROLES if getattr(args, role) is not None
+    }
+    if not paths:
+        print("error: provide at least one artifact (--report/--receipts/"
+              "--evaluation/--lab/--protocol/--log)", file=sys.stderr)
+        return 2
+    for role, path in paths.items():
+        if not path.is_file():
+            print(f"error: {role} artifact not found: {path}", file=sys.stderr)
+            return 2
+    try:
+        if args.output is not None:
+            validate_output_path(args.output, paths)
+        packet = build_packet(paths)
+    except WriteOutsideLogDirError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 4
+    except PacketTooLargeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 5
+    except ValueError as e:  # includes PacketInputError and wrapped validators
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    serialized = serialize_packet(packet)
+    if args.output is not None:
+        try:
+            args.output.write_bytes(serialized.encode("utf-8"))
+        except OSError as e:
+            print(f"error: cannot write packet to {args.output}: {e}", file=sys.stderr)
+            return 4
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -27,9 +27,21 @@ Honesty contract:
 - A provenance link whose counterpart artifact was not provided is a
   typed ``not_computable`` result, never a failure and never invented.
 - A link that IS checkable is reported ``verified`` or ``broken`` by
-  byte-level hash comparison (the sequence link recomputes the
-  dominant-token sequence from the log through NP1's own bounded
-  reader).
+  byte-level hash comparison. The sequence link recomputes the
+  dominant-token sequence through NP1's own bounded reader using the
+  LAB'S OWN RECORDED ``max_rows`` / ``max_line_bytes`` (exact-type
+  validated against NP1/NP6's acceptance ranges and echoed in the link
+  as ``reader_bounds``) — never default bounds, which would report a
+  genuine non-default pair broken; when no lab is provided, no bounds
+  are invented.
+- ``evaluation.artifacts.<role>.provided`` is an EXACT builtin bool:
+  ``true`` requires and verifies the recorded sha256, ``false`` is
+  typed ``link_not_recorded``, and any other value is malformed input
+  (fail closed) — a truthy non-bool can never suppress verification.
+- Each JSON artifact is parsed exactly once (spy-tested); the log is
+  size-checked via stat BEFORE any read and hashed in fixed-size
+  chunks under its own ``MAX_LOG_BYTES`` ceiling — never materialized
+  whole.
 
 Safety contract (Lane B, mirrors NP5/NP6):
 
@@ -66,7 +78,13 @@ from scripts.nextness_evaluator import (
 )
 from scripts.nextness_monitor import RECEIPT_SCHEMA
 from scripts.nextness_observer import WriteOutsideLogDirError
-from scripts.nextness_predictor import REPORT_SCHEMA, read_dominant_sequence
+from scripts.nextness_predictor import (
+    MAX_LINE_BYTES_DEFAULT,
+    MAX_ROWS_CEILING,
+    MAX_ROWS_DEFAULT,
+    REPORT_SCHEMA,
+    read_dominant_sequence,
+)
 from scripts.nextness_replay_lab import (
     LAB_SCHEMA,
     PROTOCOL_SCHEMA,
@@ -91,6 +109,20 @@ MAX_PACKET_ARTIFACTS: Final[int] = 8
 
 #: Output ceiling — fail closed (same convention as the whole stack).
 MAX_PACKET_BYTES: Final[int] = 64 * 1024
+
+#: Role-specific ceiling for the raw log (JSON artifacts keep the 1 MiB
+#: MAX_INPUT_BYTES). Justified from the stack's own defaults: NP1
+#: ingests at most MAX_ROWS_DEFAULT = 100,000 physical records per run,
+#: and observer-emitted rows (single-line JSON: a generation plus at
+#: most 16 token-count keys) are well under 170 bytes each, so 16 MiB
+#: covers every default-bounds observer-emitted log. This is
+#: deliberately NOT a universal-compatibility claim: a log recorded
+#: under raised --max-rows / --max-line-bytes settings may exceed it
+#: and is refused fail-closed. The size is checked via stat BEFORE any
+#: read, re-enforced during the chunked read, and the log is hashed in
+#: fixed-size chunks — never materialized whole.
+MAX_LOG_BYTES: Final[int] = 16 * 1024 * 1024
+_HASH_CHUNK_BYTES: Final[int] = 64 * 1024
 
 #: Provenance links the v1 schemas record (fixed vocabulary).
 LINK_KINDS: Final[tuple[str, ...]] = (
@@ -201,27 +233,52 @@ def _schema_of(parsed: Any, role: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _validate_role(role: str, path: pathlib.Path) -> dict[str, Any]:
-    """One manifest entry. ``validation`` records the honest depth."""
+def _validate_role(role: str, path: pathlib.Path) -> tuple[dict[str, Any], Any]:
+    """One manifest entry plus the parsed object (``None`` for the log).
+
+    Each JSON artifact is parsed exactly ONCE — the parsed object is
+    returned so the link stage never re-reads the file. ``validation``
+    records the honest depth.
+    """
     if role == "log":
         # The log is not JSON; it enters the stack only through NP1's
-        # bounded reader. Hash the accepted dominant-token sequence the
-        # same way NP6 does (that is the identity the lab records), and
-        # the raw bytes for completeness.
+        # bounded reader. Size is checked BEFORE any read, re-enforced
+        # during the chunked hash (the file could grow in between), and
+        # the log is never materialized whole. The manifest records the
+        # raw-byte hash plus the accepted-sequence hash under NP1's
+        # DEFAULT reader bounds (echoed for reproducibility); the lab
+        # sequence LINK recomputes with the lab's own recorded bounds.
+        size = path.stat().st_size
+        if size > MAX_LOG_BYTES:
+            raise PacketInputError(f"log exceeds {MAX_LOG_BYTES} bytes; refusing to process")
+        digest = hashlib.sha256()
+        total = 0
         with path.open("rb") as f:
-            raw = f.read(MAX_INPUT_BYTES + 1)
-        if len(raw) > MAX_INPUT_BYTES:
-            raise PacketInputError(f"log exceeds {MAX_INPUT_BYTES} bytes; refusing to parse")
+            while True:
+                chunk = f.read(_HASH_CHUNK_BYTES)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > MAX_LOG_BYTES:
+                    raise PacketInputError(
+                        f"log exceeds {MAX_LOG_BYTES} bytes; refusing to process"
+                    )
+                digest.update(chunk)
         sequence, _rejections, _rows = read_dominant_sequence(path)
-        return {
+        entry = {
             "role": "log",
             "schema": "jsonl-nextness-runs",
-            "bytes": len(raw),
-            "sha256": hashlib.sha256(raw).hexdigest(),
+            "bytes": total,
+            "sha256": digest.hexdigest(),
             "sequence_sha256": hashlib.sha256("\n".join(sequence).encode("utf-8")).hexdigest(),
+            "sequence_bounds": {
+                "max_rows": MAX_ROWS_DEFAULT,
+                "max_line_bytes": MAX_LINE_BYTES_DEFAULT,
+            },
             "rows_accepted": len(sequence),
             "validation": "sequence_reader",
         }
+        return entry, None
 
     parsed, digest, size = _load_bounded_json(path)
     entry: dict[str, Any] = {
@@ -255,7 +312,7 @@ def _validate_role(role: str, path: pathlib.Path) -> dict[str, Any]:
             entry["validation"] = "schema_identifier_only"
     except (EvaluatorInputError, LabInputError) as e:
         raise PacketInputError(f"{role}: {e}") from e
-    return entry
+    return entry, parsed
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +340,15 @@ def _evaluation_link(
     artifacts = _exact_dict_field(evaluation, "artifacts", "evaluation")
     slot = _exact_dict_field(artifacts, counterpart_role, "evaluation.artifacts")
     provided = _exact_dict_field(slot, "provided", f"evaluation.artifacts.{counterpart_role}")
-    if provided is not True:
+    # EXACT builtin bool only. A truthy or falsy non-bool (1, "true",
+    # [], ...) must never silently suppress verification by sliding into
+    # the not-recorded branch — it is malformed input, fail closed.
+    if type(provided) is not bool:
+        raise PacketInputError(
+            f"evaluation.artifacts.{counterpart_role}.provided: expected "
+            f"builtin bool, got {type(provided).__name__}"
+        )
+    if provided is False:
         return _not_computable_link(
             "link_not_recorded",
             f"an evaluation produced WITH a {counterpart_role} artifact "
@@ -303,24 +368,80 @@ def _evaluation_link(
     )
 
 
-def _lab_link(
+def _recorded_reader_bounds(lab: Mapping[str, Any]) -> tuple[int, int]:
+    """The lab's recorded ingestion bounds, exact-type validated against
+    the same acceptance ranges NP1/NP6 enforce (fail closed on bool,
+    float, string, negative, zero or out-of-range values)."""
+    cfg = _exact_dict_field(lab, "config", "lab")
+    max_rows = _exact_dict_field(cfg, "max_rows", "lab.config")
+    if type(max_rows) is not int:
+        raise PacketInputError(
+            f"lab.config.max_rows: expected builtin int, got {type(max_rows).__name__}"
+        )
+    if not 0 < max_rows <= MAX_ROWS_CEILING:
+        raise PacketInputError(
+            f"lab.config.max_rows: {max_rows} outside (0, {MAX_ROWS_CEILING}]"
+        )
+    max_line_bytes = _exact_dict_field(cfg, "max_line_bytes", "lab.config")
+    if type(max_line_bytes) is not int:
+        raise PacketInputError(
+            f"lab.config.max_line_bytes: expected builtin int, got {type(max_line_bytes).__name__}"
+        )
+    if max_line_bytes <= 0:
+        raise PacketInputError(
+            f"lab.config.max_line_bytes: {max_line_bytes} must be positive"
+        )
+    return max_rows, max_line_bytes
+
+
+def _lab_protocol_link(
     lab: Mapping[str, Any] | None,
-    field: str,
-    counterpart_entry: Mapping[str, Any] | None,
-    counterpart_name: str,
-    counterpart_key: str,
+    protocol_entry: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     if lab is None:
         return _not_computable_link("counterpart_absent", "a lab-report artifact")
     inp = _exact_dict_field(lab, "input", "lab")
-    recorded = _exact_sha256(_exact_dict_field(inp, field, "lab.input"), f"lab.input.{field}")
-    if counterpart_entry is None:
-        return _not_computable_link("counterpart_absent", counterpart_name)
-    actual = counterpart_entry[counterpart_key]
+    recorded = _exact_sha256(
+        _exact_dict_field(inp, "protocol_sha256", "lab.input"), "lab.input.protocol_sha256"
+    )
+    if protocol_entry is None:
+        return _not_computable_link("counterpart_absent", "the protocol artifact")
+    actual = protocol_entry["sha256"]
     return _link(
         "verified" if recorded == actual else "broken",
         recorded_sha256=recorded,
         actual_sha256=actual,
+    )
+
+
+def _lab_sequence_link(
+    lab: Mapping[str, Any] | None,
+    log_path: pathlib.Path | None,
+) -> dict[str, Any]:
+    """The sequence link recomputes the accepted dominant-token sequence
+    with the LAB'S OWN RECORDED reader bounds — a lab produced under
+    non-default ``max_rows`` / ``max_line_bytes`` accepted a different
+    sequence than the defaults would, and comparing against a
+    default-bounds recomputation would report a genuine pair broken.
+    When no lab is provided, no bounds are invented."""
+    if lab is None:
+        return _not_computable_link("counterpart_absent", "a lab-report artifact")
+    max_rows, max_line_bytes = _recorded_reader_bounds(lab)
+    inp = _exact_dict_field(lab, "input", "lab")
+    recorded = _exact_sha256(
+        _exact_dict_field(inp, "sequence_sha256", "lab.input"), "lab.input.sequence_sha256"
+    )
+    if log_path is None:
+        return _not_computable_link("counterpart_absent", "the log artifact")
+    sequence, _rejections, _rows = read_dominant_sequence(
+        log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
+    )
+    actual = hashlib.sha256("\n".join(sequence).encode("utf-8")).hexdigest()
+    return _link(
+        "verified" if recorded == actual else "broken",
+        recorded_sha256=recorded,
+        actual_sha256=actual,
+        reader_bounds={"max_rows": max_rows, "max_line_bytes": max_line_bytes},
     )
 
 
@@ -347,16 +468,15 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
         )
 
     entries: dict[str, dict[str, Any]] = {}
-    parsed_evaluation: Mapping[str, Any] | None = None
-    parsed_lab: Mapping[str, Any] | None = None
+    parsed_by_role: dict[str, Any] = {}
     for role in ROLES:
         if role not in paths:
             continue
-        entries[role] = _validate_role(role, paths[role])
-        if role == "evaluation":
-            parsed_evaluation, _, _ = _load_bounded_json(paths[role])
-        elif role == "lab":
-            parsed_lab, _, _ = _load_bounded_json(paths[role])
+        # Exactly one parse per JSON artifact: the parsed object comes
+        # back with the manifest entry and is reused for the links.
+        entries[role], parsed_by_role[role] = _validate_role(role, paths[role])
+    parsed_evaluation = parsed_by_role.get("evaluation")
+    parsed_lab = parsed_by_role.get("lab")
 
     links = {
         "evaluation_report_sha256": _evaluation_link(
@@ -365,14 +485,8 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
         "evaluation_receipts_sha256": _evaluation_link(
             parsed_evaluation, "receipts", entries.get("receipts")
         ),
-        "lab_protocol_sha256": _lab_link(
-            parsed_lab, "protocol_sha256", entries.get("protocol"),
-            "the protocol artifact", "sha256",
-        ),
-        "lab_sequence_sha256": _lab_link(
-            parsed_lab, "sequence_sha256", entries.get("log"),
-            "the log artifact", "sequence_sha256",
-        ),
+        "lab_protocol_sha256": _lab_protocol_link(parsed_lab, entries.get("protocol")),
+        "lab_sequence_sha256": _lab_sequence_link(parsed_lab, paths.get("log")),
     }
 
     packet: dict[str, Any] = {

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1,0 +1,363 @@
+"""NP8: deterministic evidence packet — contract + adversarial tests.
+
+The packet is packaging and provenance verification only; every test
+below checks manifest/link truthfulness, never any new metric.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from scripts.nextness_evaluator import build_evaluation, serialize_evaluation
+from scripts.nextness_evidence_packet import (
+    LINK_KINDS,
+    MAX_INPUT_BYTES,
+    MAX_PACKET_BYTES,
+    PACKET_SCHEMA,
+    ROLES,
+    PacketInputError,
+    build_packet,
+    main,
+    serialize_packet,
+)
+from scripts.nextness_monitor import (
+    MonitorConfig,
+    build_receipt,
+    observations_from_log,
+    serialize_receipt,
+)
+from scripts.nextness_predictor import build_report, serialize_report
+from scripts.nextness_replay_lab import build_lab_report, serialize_lab_report
+
+A = "void_static"
+B = "compute_static"
+
+
+# ---------------------------------------------------------------------------
+# Fixture: one complete artifact chain, produced by the live emitters
+# ---------------------------------------------------------------------------
+
+
+def _write(path: pathlib.Path, content: str) -> pathlib.Path:
+    path.write_bytes(content.encode("utf-8"))
+    return path
+
+
+@pytest.fixture()
+def chain(tmp_path):
+    log = _write(
+        tmp_path / "nextness_runs.jsonl",
+        "\n".join(
+            json.dumps({"generation": i, "token_counts": {t: 3}})
+            for i, t in enumerate([A, B] * 30)
+        )
+        + "\n",
+    )
+    report_obj = build_report(log)
+    report = _write(tmp_path / "report.json", serialize_report(report_obj))
+    observations, reference, recent = observations_from_log(log, "first_order")
+    receipt_obj = build_receipt(
+        model="first_order",
+        observations=observations,
+        reference_counts=reference,
+        recent_counts=recent,
+        config=MonitorConfig(),
+    )
+    receipts = _write(tmp_path / "receipt.json", serialize_receipt(receipt_obj))
+    evaluation_obj = build_evaluation(report_path=report, receipts_path=receipts)
+    evaluation = _write(tmp_path / "evaluation.json", serialize_evaluation(evaluation_obj))
+    protocol = _write(
+        tmp_path / "protocol.json",
+        json.dumps(
+            {
+                "schema": "nextness-replay-protocol-v1",
+                "model": "first_order",
+                "smoothing": 1.0,
+                "holdout_fraction": 0.25,
+                "configurations": [
+                    {"label": "defaults", "min_history": 30, "window": 50,
+                     "low_confidence_threshold": 0.3,
+                     "calibration_error_threshold": 0.2,
+                     "drift_threshold_bits": 0.15}
+                ],
+            }
+        )
+        + "\n",
+    )
+    lab_obj = build_lab_report(log, protocol)
+    lab = _write(tmp_path / "lab.json", serialize_lab_report(lab_obj))
+    return {
+        "log": log, "report": report, "receipts": receipts,
+        "evaluation": evaluation, "protocol": protocol, "lab": lab,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The whole chain verifies
+# ---------------------------------------------------------------------------
+
+
+def test_full_chain_all_links_verified(chain) -> None:
+    packet = build_packet(chain)
+    assert packet["schema"] == PACKET_SCHEMA
+    assert [entry["role"] for entry in packet["artifacts"]] == list(ROLES)
+    for kind in LINK_KINDS:
+        assert packet["links"][kind]["status"] == "verified", kind
+    by_role = {entry["role"]: entry for entry in packet["artifacts"]}
+    assert by_role["report"]["validation"] == "full"
+    assert by_role["receipts"]["validation"] == "full"
+    assert by_role["receipts"]["receipt_count"] == 1
+    assert by_role["protocol"]["validation"] == "full"
+    # No public validator exists for these two — the depth says so.
+    assert by_role["evaluation"]["validation"] == "schema_identifier_only"
+    assert by_role["lab"]["validation"] == "schema_identifier_only"
+    assert by_role["log"]["validation"] == "sequence_reader"
+    assert len(by_role["log"]["sequence_sha256"]) == 64
+
+
+def test_receipts_array_form_counts(chain, tmp_path) -> None:
+    single = json.loads(chain["receipts"].read_text(encoding="utf-8"))
+    array_file = _write(tmp_path / "receipt_array.json", json.dumps([single, single]))
+    packet = build_packet({"receipts": array_file})
+    assert packet["artifacts"][0]["receipt_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Broken links are reported as broken — byte-level, no interpretation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tampered_role,link",
+    [
+        ("report", "evaluation_report_sha256"),
+        ("receipts", "evaluation_receipts_sha256"),
+        ("protocol", "lab_protocol_sha256"),
+    ],
+)
+def test_tampered_counterpart_breaks_exactly_that_link(chain, tampered_role, link) -> None:
+    # Append a trailing newline: content changes, artifact stays valid.
+    path = chain[tampered_role]
+    path.write_bytes(path.read_bytes() + b"\n")
+    packet = build_packet(chain)
+    assert packet["links"][link]["status"] == "broken"
+    assert packet["links"][link]["recorded_sha256"] != packet["links"][link]["actual_sha256"]
+    for other in LINK_KINDS:
+        if other != link:
+            assert packet["links"][other]["status"] == "verified", other
+
+
+def test_tampered_log_breaks_sequence_link(chain) -> None:
+    # One appended accepted row changes the dominant-token sequence.
+    chain["log"].write_bytes(
+        chain["log"].read_bytes()
+        + (json.dumps({"generation": 60, "token_counts": {A: 3}}) + "\n").encode()
+    )
+    packet = build_packet(chain)
+    assert packet["links"]["lab_sequence_sha256"]["status"] == "broken"
+
+
+# ---------------------------------------------------------------------------
+# Typed not-computable links — absence is never failure or invention
+# ---------------------------------------------------------------------------
+
+
+def test_missing_counterparts_are_typed_not_computable(chain) -> None:
+    packet = build_packet({"evaluation": chain["evaluation"]})
+    for kind in ("evaluation_report_sha256", "evaluation_receipts_sha256"):
+        entry = packet["links"][kind]
+        assert entry["status"] == "not_computable"
+        assert entry["reason"] == "counterpart_absent"
+    for kind in ("lab_protocol_sha256", "lab_sequence_sha256"):
+        assert packet["links"][kind]["reason"] == "counterpart_absent"
+
+
+def test_link_not_recorded_when_evaluation_lacked_the_artifact(chain, tmp_path) -> None:
+    # An evaluation produced WITHOUT receipts records provided: false —
+    # given a receipts file anyway, the link is honestly not_computable
+    # (link_not_recorded), never guessed.
+    report_only = build_evaluation(report_path=chain["report"])
+    eval_file = _write(tmp_path / "eval_report_only.json", serialize_evaluation(report_only))
+    packet = build_packet(
+        {"evaluation": eval_file, "report": chain["report"], "receipts": chain["receipts"]}
+    )
+    assert packet["links"]["evaluation_report_sha256"]["status"] == "verified"
+    entry = packet["links"]["evaluation_receipts_sha256"]
+    assert entry["status"] == "not_computable"
+    assert entry["reason"] == "link_not_recorded"
+
+
+def test_log_only_packet_is_valid_and_fully_typed(chain) -> None:
+    packet = build_packet({"log": chain["log"]})
+    assert len(packet["artifacts"]) == 1
+    for kind in LINK_KINDS:
+        assert packet["links"][kind]["status"] == "not_computable"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_packet_byte_identical_across_runs_and_role_order(chain) -> None:
+    outputs = {serialize_packet(build_packet(chain)) for _ in range(3)}
+    assert len(outputs) == 1
+    reordered = dict(reversed(list(chain.items())))
+    assert serialize_packet(build_packet(reordered)) == next(iter(outputs))
+    serialized = next(iter(outputs))
+    assert len(serialized.encode("utf-8")) <= MAX_PACKET_BYTES
+    assert "time" not in json.dumps(sorted(json.loads(serialized))).lower()
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed adversarial corpus
+# ---------------------------------------------------------------------------
+
+
+def test_role_and_count_bounds_fail_closed(chain) -> None:
+    with pytest.raises(PacketInputError, match="nothing to package"):
+        build_packet({})
+    with pytest.raises(PacketInputError, match="unknown artifact roles"):
+        build_packet({"telemetry": chain["log"]})
+
+
+def test_unknown_schema_variants_rejected(chain, tmp_path) -> None:
+    payload = json.loads(chain["evaluation"].read_text(encoding="utf-8"))
+    payload["schema"] = "nextness-evaluation-v2"
+    bad = _write(tmp_path / "bad_eval.json", json.dumps(payload))
+    with pytest.raises(PacketInputError, match="unknown variant"):
+        build_packet({"evaluation": bad})
+
+
+def test_invalid_report_rejected_through_existing_validator(chain, tmp_path) -> None:
+    payload = json.loads(chain["report"].read_text(encoding="utf-8"))
+    payload["evaluation"]["split_index"] += 1  # break an NP1 identity
+    bad = _write(tmp_path / "bad_report.json", json.dumps(payload))
+    with pytest.raises(PacketInputError, match="report:"):
+        build_packet({"report": bad})
+
+
+def test_duplicate_json_keys_rejected(tmp_path) -> None:
+    dup = _write(
+        tmp_path / "dup.json",
+        '{"schema": "nextness-evaluation-v1", "schema": "nextness-evaluation-v1"}',
+    )
+    with pytest.raises(PacketInputError, match="duplicate JSON key"):
+        build_packet({"evaluation": dup})
+
+
+def test_malformed_link_fields_rejected(chain, tmp_path) -> None:
+    payload = json.loads(chain["lab"].read_text(encoding="utf-8"))
+    payload["input"]["protocol_sha256"] = "NOT-A-HASH"
+    bad = _write(tmp_path / "bad_lab.json", json.dumps(payload))
+    with pytest.raises(PacketInputError, match="64-char lowercase hex"):
+        build_packet({"lab": bad, "protocol": chain["protocol"]})
+    payload = json.loads(chain["evaluation"].read_text(encoding="utf-8"))
+    payload["artifacts"] = []
+    bad2 = _write(tmp_path / "bad_eval_shape.json", json.dumps(payload))
+    with pytest.raises(PacketInputError, match="builtin dict"):
+        build_packet({"evaluation": bad2, "report": chain["report"]})
+
+
+def test_oversized_artifact_fails_closed(tmp_path) -> None:
+    big = tmp_path / "big.json"
+    big.write_bytes(b"x" * (MAX_INPUT_BYTES + 10))
+    with pytest.raises(PacketInputError, match="exceeds"):
+        build_packet({"evaluation": big})
+
+
+# ---------------------------------------------------------------------------
+# CLI: exit codes, write boundary incl. alias identity, concise errors
+# ---------------------------------------------------------------------------
+
+
+def _chain_args(chain) -> list[str]:
+    args = []
+    for role, path in chain.items():
+        args += [f"--{role}", str(path)]
+    return args
+
+
+def test_cli_success_and_lf_only_output(chain, tmp_path, capsys) -> None:
+    assert main(_chain_args(chain)) == 0
+    assert json.loads(capsys.readouterr().out)["schema"] == PACKET_SCHEMA
+    out = tmp_path / "packet.json"
+    assert main(_chain_args(chain) + ["--output", str(out)]) == 0
+    first = out.read_bytes()
+    assert main(_chain_args(chain) + ["--output", str(out)]) == 0
+    assert out.read_bytes() == first
+    assert b"\r" not in first
+
+
+def test_cli_expected_failures_concise(chain, tmp_path, capsys) -> None:
+    assert main([]) == 2
+    assert main(["--report", str(tmp_path / "absent.json")]) == 2
+    err = capsys.readouterr().err
+    for line in err.splitlines():
+        assert line.startswith("error:")
+    assert "Traceback" not in err
+
+
+def test_cli_write_boundary_and_alias_identity(chain, tmp_path, capsys) -> None:
+    import os
+
+    # tmp_path is the primary input's own directory; its PARENT is
+    # outside it (subdirectories are inside and legitimately allowed by
+    # the stack-wide containment convention).
+    outside = tmp_path.parent / "np8-outside-p.json"
+    assert main(_chain_args(chain) + ["--output", str(outside)]) == 4
+    # Naming ANY input directly is refused.
+    assert main(_chain_args(chain) + ["--output", str(chain["log"])]) == 4
+    # A hard link alias to any input is refused with the input intact.
+    alias = chain["log"].parent / "alias.json"
+    os.link(chain["protocol"], alias)
+    before = chain["protocol"].read_bytes()
+    assert main(_chain_args(chain) + ["--output", str(alias)]) == 4
+    assert chain["protocol"].read_bytes() == before
+    err = capsys.readouterr().err
+    assert "identity" in err or "overwrite" in err
+
+
+def test_cli_data_tree_refused(chain, tmp_path, capsys, monkeypatch) -> None:
+    import scripts.nextness_evidence_packet as packet_module
+
+    monkeypatch.setattr(
+        packet_module, "_repo_data_dir", lambda: chain["log"].parent.resolve()
+    )
+    assert main(_chain_args(chain) + ["--output", str(chain["log"].parent / "p.json")]) == 4
+    assert "data/ tree" in capsys.readouterr().err
+
+
+def test_cli_oversized_packet_exit_5(chain, capsys, monkeypatch) -> None:
+    import scripts.nextness_evidence_packet as packet_module
+
+    monkeypatch.setattr(packet_module, "MAX_PACKET_BYTES", 64)
+    assert main(_chain_args(chain)) == 5
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
+# ---------------------------------------------------------------------------
+# No ranking/scoring structure anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_no_ranking_or_score_fields(chain) -> None:
+    packet = build_packet(chain)
+    forbidden = {"winner", "rank", "ranking", "best", "recommendation", "score"}
+
+    def _walk(node) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                assert key.lower() not in forbidden
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(packet)
+    assert packet["non_claims"]

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -342,6 +342,231 @@ def test_cli_oversized_packet_exit_5(chain, capsys, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Correction A: the sequence link uses the LAB'S RECORDED reader bounds
+# ---------------------------------------------------------------------------
+
+
+def _make_protocol(tmp_path: pathlib.Path, name: str = "protocol.json", **overrides) -> pathlib.Path:
+    payload = {
+        "schema": "nextness-replay-protocol-v1",
+        "model": "first_order",
+        "smoothing": 1.0,
+        "holdout_fraction": 0.25,
+        "configurations": [
+            {"label": "defaults", "min_history": 30, "window": 50,
+             "low_confidence_threshold": 0.3,
+             "calibration_error_threshold": 0.2,
+             "drift_threshold_bits": 0.15}
+        ],
+    }
+    payload.update(overrides)
+    return _write(tmp_path / name, json.dumps(payload) + "\n")
+
+
+def _custom_bounds_pair(tmp_path: pathlib.Path, **reader_bounds):
+    # A 40-row log whose accepted sequence CHANGES under the custom
+    # bounds relative to NP1 defaults: row 20 is oversized for the
+    # custom max_line_bytes, and max_rows=10 cuts ingestion short.
+    rows = []
+    for i in range(40):
+        counts = {A: 3} if i % 2 == 0 else {B: 3}
+        if i == 20:
+            counts = {B: 3, "void_birth": 1, "unclassified": 2}  # longer line
+        rows.append(json.dumps({"generation": i, "token_counts": counts}))
+    log = _write(tmp_path / "custom_log.jsonl", "\n".join(rows) + "\n")
+    protocol = _make_protocol(tmp_path, name="custom_protocol.json")
+    lab_obj = build_lab_report(log, protocol, **reader_bounds)
+    lab = _write(tmp_path / "custom_lab.json", serialize_lab_report(lab_obj))
+    return log, lab
+
+
+@pytest.mark.parametrize(
+    "reader_bounds",
+    [
+        {"max_rows": 10},
+        {"max_line_bytes": 70},
+        {"max_rows": 30, "max_line_bytes": 70},
+    ],
+    ids=["max-rows-only", "max-line-bytes-only", "both"],
+)
+def test_lab_sequence_link_verifies_with_recorded_bounds(tmp_path, reader_bounds) -> None:
+    # A genuinely-paired log+lab produced with non-default reader bounds
+    # accepts a DIFFERENT sequence than the defaults would; the link
+    # must recompute with the lab's recorded bounds and verify.
+    log, lab = _custom_bounds_pair(tmp_path, **reader_bounds)
+    packet = build_packet({"lab": lab, "log": log})
+    link = packet["links"]["lab_sequence_sha256"]
+    assert link["status"] == "verified"
+    # The bounds actually used are reported for reproducibility.
+    for key, value in reader_bounds.items():
+        assert link["reader_bounds"][key] == value
+    # The custom bounds genuinely diverge from the defaults, or this
+    # test proves nothing: the manifest's default-bounds sequence hash
+    # must differ from the recorded one.
+    by_role = {e["role"]: e for e in packet["artifacts"]}
+    assert by_role["log"]["sequence_sha256"] != link["recorded_sha256"]
+
+
+def test_lab_sequence_link_tampered_digest_still_broken(tmp_path) -> None:
+    log, lab = _custom_bounds_pair(tmp_path, max_rows=10)
+    payload = json.loads(lab.read_text(encoding="utf-8"))
+    payload["input"]["sequence_sha256"] = "0" * 64
+    tampered = _write(tmp_path / "tampered_lab.json", json.dumps(payload))
+    packet = build_packet({"lab": tampered, "log": log})
+    assert packet["links"]["lab_sequence_sha256"]["status"] == "broken"
+
+
+def test_recorded_bounds_exact_boundaries_accepted(chain, tmp_path) -> None:
+    # Values at the exact NP1/NP6 acceptance boundaries must validate
+    # (the digest comparison then reports broken for this unpaired lab,
+    # which is fine — the bounds VALIDATION is what is under test).
+    from scripts.nextness_predictor import MAX_ROWS_CEILING
+
+    payload = json.loads(chain["lab"].read_text(encoding="utf-8"))
+    payload["config"]["max_rows"] = MAX_ROWS_CEILING
+    payload["config"]["max_line_bytes"] = 1
+    boundary = _write(tmp_path / "boundary_lab.json", json.dumps(payload))
+    packet = build_packet({"lab": boundary, "log": chain["log"]})
+    assert packet["links"]["lab_sequence_sha256"]["status"] in ("verified", "broken")
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_rows", 0),
+        ("max_rows", -1),
+        ("max_rows", 1_000_001),
+        ("max_rows", True),
+        ("max_rows", 10.0),
+        ("max_rows", "100"),
+        ("max_line_bytes", 0),
+        ("max_line_bytes", -5),
+        ("max_line_bytes", False),
+        ("max_line_bytes", 65536.0),
+        ("max_line_bytes", None),
+    ],
+)
+def test_malformed_recorded_bounds_rejected(chain, tmp_path, field, value) -> None:
+    payload = json.loads(chain["lab"].read_text(encoding="utf-8"))
+    payload["config"][field] = value
+    bad = _write(tmp_path / "bad_bounds_lab.json", json.dumps(payload))
+    with pytest.raises(PacketInputError, match=field):
+        build_packet({"lab": bad, "log": chain["log"]})
+
+
+# ---------------------------------------------------------------------------
+# Correction B: provided flags are EXACT builtin bools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "verified"),
+        (False, "link_not_recorded"),
+        (1, "error"),
+        (0, "error"),
+        ("true", "error"),
+        ("false", "error"),
+        (None, "error"),
+        ([], "error"),
+        ({}, "error"),
+    ],
+    ids=["True", "False", "int-1", "int-0", "str-true", "str-false",
+         "None", "list", "dict"],
+)
+def test_provided_flag_truth_table(chain, tmp_path, value, expected) -> None:
+    # A tampered evaluation must never SUPPRESS verification by smuggling
+    # a truthy/falsy non-bool through the provided flag: only builtin
+    # True verifies, only builtin False is typed link_not_recorded, and
+    # everything else is malformed input (fail closed).
+    payload = json.loads(chain["evaluation"].read_text(encoding="utf-8"))
+    payload["artifacts"]["report"]["provided"] = value
+    mutated = _write(tmp_path / "mutated_eval.json", json.dumps(payload))
+    inputs = {"evaluation": mutated, "report": chain["report"]}
+    if expected == "error":
+        with pytest.raises(PacketInputError, match="provided"):
+            build_packet(inputs)
+    else:
+        link = build_packet(inputs)["links"]["evaluation_report_sha256"]
+        if expected == "verified":
+            assert link["status"] == "verified"
+        else:
+            assert link["status"] == "not_computable"
+            assert link["reason"] == "link_not_recorded"
+
+
+# ---------------------------------------------------------------------------
+# Correction C: log size and memory contract (MAX_LOG_BYTES, chunked hash)
+# ---------------------------------------------------------------------------
+
+
+def test_log_larger_than_one_mib_is_accepted_and_verifies(tmp_path) -> None:
+    # ~2 MiB of genuine rows (>1 MiB, well under MAX_LOG_BYTES), with a
+    # small holdout fraction so the NP6 replay bound holds — the whole
+    # lab/log pair must package and the sequence link must verify.
+    from scripts.nextness_evidence_packet import MAX_LOG_BYTES
+
+    rows = [
+        json.dumps({"generation": i, "token_counts": {A if i % 2 == 0 else B: 3}})
+        for i in range(40_000)
+    ]
+    content = "\n".join(rows) + "\n"
+    assert 1_048_576 < len(content.encode()) <= MAX_LOG_BYTES
+    log = _write(tmp_path / "big_log.jsonl", content)
+    protocol = _make_protocol(tmp_path, holdout_fraction=0.05)
+    lab = _write(
+        tmp_path / "big_lab.json", serialize_lab_report(build_lab_report(log, protocol))
+    )
+    packet = build_packet({"lab": lab, "log": log})
+    assert packet["links"]["lab_sequence_sha256"]["status"] == "verified"
+    by_role = {e["role"]: e for e in packet["artifacts"]}
+    assert by_role["log"]["bytes"] == len(content.encode())
+    # Chunked hashing must equal a whole-file hash.
+    import hashlib
+
+    assert by_role["log"]["sha256"] == hashlib.sha256(content.encode()).hexdigest()
+
+
+def test_log_size_ceiling_exact_limit_and_limit_plus_one(tmp_path) -> None:
+    from scripts.nextness_evidence_packet import MAX_LOG_BYTES
+
+    row = json.dumps({"generation": 0, "token_counts": {A: 3}}) + "\n"
+    pad = MAX_LOG_BYTES - len(row.encode())
+    exact = _write(tmp_path / "exact.jsonl", row + " " * (pad - 1) + "\n")
+    assert exact.stat().st_size == MAX_LOG_BYTES
+    packet = build_packet({"log": exact})
+    assert packet["artifacts"][0]["bytes"] == MAX_LOG_BYTES
+
+    over = tmp_path / "over.jsonl"
+    over.write_bytes((row + " " * (pad - 1) + "\n").encode() + b"x")
+    assert over.stat().st_size == MAX_LOG_BYTES + 1
+    with pytest.raises(PacketInputError, match="log exceeds"):
+        build_packet({"log": over})
+
+
+# ---------------------------------------------------------------------------
+# Correction D: one parse per JSON artifact
+# ---------------------------------------------------------------------------
+
+
+def test_each_json_artifact_parsed_exactly_once(chain, monkeypatch) -> None:
+    import scripts.nextness_evidence_packet as packet_module
+
+    calls: dict[str, int] = {}
+    real = packet_module._load_bounded_json
+
+    def _spy(path):
+        calls[str(path)] = calls.get(str(path), 0) + 1
+        return real(path)
+
+    monkeypatch.setattr(packet_module, "_load_bounded_json", _spy)
+    build_packet(chain)
+    assert calls, "loader never invoked"
+    assert all(count == 1 for count in calls.values()), calls
+
+
+# ---------------------------------------------------------------------------
 # No ranking/scoring structure anywhere
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this is

**PACKAGE NP8** — the optional Stage-5 PR of Kev's correction-and-evidence runway, created only after the corrected #358/#359/#360 stack reached conclusive green. Stacked on **corrected NP7 (#360, head `f59d362a`)**. Three new files, nothing else touched:

| File | Role |
|---|---|
| `scripts/nextness_evidence_packet.py` | audit manifest (`nextness-evidence-packet-v1`) |
| `tests/test_nextness_evidence_packet.py` | 22 tests: whole-chain verification, tamper detection, typed absences, adversarial corpus, CLI/boundary |
| `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md` | full contract |

**Packaging and provenance verification only — no new prediction metric.** Up to eight artifacts (one per role: report/receipts/evaluation/lab/protocol/log); per artifact: schema identifier, byte length, sha256; plus verification of the provenance links the v1 schemas themselves record (evaluation→report, evaluation→receipts, lab→protocol, lab→sequence — the last recomputed through NP1's own bounded reader).

## Honesty structure

- **Links**: `verified` / `broken` by byte-level hash comparison (both hashes reported) · typed `not_computable`/`counterpart_absent` when the other end wasn't provided · `not_computable`/`link_not_recorded` when the recording artifact never embedded the hash (e.g. an evaluation produced without receipts). Absence is never failure and never invention.
- **Validation depth recorded per artifact, never overstated**: `full` (existing validators reused — `validate_report`, `validate_receipt_series`, `load_protocol`; nothing duplicated), `schema_identifier_only` (evaluation/lab — no public validator exists, and the manifest says so), `sequence_reader` (log).
- Tamper tests: appending one byte to any counterpart breaks **exactly** that link while the others stay verified; appending one accepted row to the log breaks the sequence link.

## Boundaries & determinism

Fail-closed everywhere (1 MiB pre-parse bounds; duplicate-JSON-key rejection; exact-type checks on every consumed field; unknown schema variants rejected; malformed link fields rejected; 64 KiB output ceiling). Write boundary uses the **corrected NP6 semantics**: containment + resolved-path + `samefile` identity refusal against **all** inputs (hard links included), validation-time race documented, raw-byte LF-only output. Deterministic: fixed role order regardless of invocation order, byte-identical across runs, no timestamps/random IDs/paths, no ranking/score structure (key-walk tested). No dependencies, no workflow changes, no existing-file modifications.

## Verification

Targeted **22/22** · full maintained suite **1101 passed / 28 skipped** · `py_compile` OK · absolutes sweep clean. (Self-review performed manually on-seat — the multi-agent review fleet remains unavailable on this account's limits, as disclosed on #360.)

**Stack**: #354 ← #355 ← #358 (NP5′) ← #359 (NP6′) ← #360 (NP7′) ← **this PR**. Left open and unmerged for Jack's audit. This completes the correction runway's allocation (3 amendments + 1 optional PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment — Jack HOLD delta (2026-07-15, head `3822b620`)

One correction commit on the audited head `16393474` (ordinary push), all five live review threads addressed:

**A. Recorded reader bounds** (codex @ packet:215). The sequence link now recomputes with the lab's own recorded `config.max_rows`/`config.max_line_bytes` — exact-type validated against NP1/NP6's acceptance ranges (bool/float/string/negative/zero/out-of-range fail closed), echoed as `reader_bounds`. **Failing-first**: genuinely-paired log+lab built with `max_rows=10` / `max_line_bytes=70` / both reported **broken** pre-fix, **verified** post-fix (with a divergence guard proving the custom bounds actually change the sequence). Boundary values at the exact acceptance edges validate; tampered digest still broken; no lab ⇒ no bounds invented; log manifest entry keeps default-bounds `sequence_sha256` with an explicit `sequence_bounds` echo.

**B. Exact-bool `provided` flags** (codex @ packet:286 + gemini @ packet:291). Only builtin `true` verifies; builtin `false` is typed `link_not_recorded`; **everything else raises** (`PacketInputError`). 9-case truth table (`True/False/1/0/"true"/"false"/null/[]/{}`). **Failing-first**: `1`, `"true"`, `[]` previously slid into the not-recorded branch — silently suppressing verification.

**C. Log size & memory contract** (gemini @ packet:220). **Option 2**: role-specific `MAX_LOG_BYTES` = 16 MiB — ~~justified from the stack's own defaults~~ *(coverage justification withdrawn in the `9bd42d5a` record correction below)*, size-checked via `stat` **before any read**, re-enforced during the chunked 64 KiB hash; the log is **never materialized whole**. Explicitly documented as **not universal**: raised-bounds logs may exceed it and are refused fail-closed. Tested at the exact limit, limit+1, and a valid **>1 MiB** log whose sequence link verifies (chunked hash == whole-file hash).

**D. Single parse per artifact** (gemini @ packet:359). `_validate_role` returns the parsed object with the manifest entry; links reuse it. Validation depth and duplicate-key rejection unchanged. Loader-spy regression proves exactly one parse per JSON artifact (**failing-first**: evaluation/lab were parsed twice).

**E. Receipts**: targeted **50/50** (28 new failing-first regressions — 24 failed pre-fix), full suite **1129 passed / 28 skipped**, PYTHONHASHSEED 101/202/303 green, `py_compile` OK, claims sweep clean. Threads intentionally left unresolved for Jack.



---

## Record correction (2026-07-15, head `9bd42d5a`)

Jack's final HOLD item on this PR: the 16 MiB justification overclaimed. Observer rows carry more than a generation and token counts — timestamps, filenames, lattice shape, sampling information, metrics, diagnostics and a nested budget block — so "well under 170 bytes" and "16 MiB covers every default-bounds observer-emitted log" were **not established** and are **withdrawn** from the module comment, the contract doc and this body.

**Exact contract now stated everywhere**: NP8 intentionally accepts raw logs no larger than 16 MiB; the ceiling is **NP8's own explicit packaging/work bound**, not derived as universal coverage of NP1 defaults; otherwise-valid larger logs are refused fail-closed; **no claim is made about what fraction of real or default-configuration logs fit until that is measured**. The >1 MiB, exact-limit and limit+1 receipts are unchanged and remain valid. No code change (docs/comment only); targeted 50/50, full suite 1129/28, `py_compile` OK.
