### PR TITLE
feat: integrate NP9 full structural validation into the evidence packet (PACKAGE NP10)

### DIFF
--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -48,12 +48,22 @@ verification.
   validators (`nextness_evaluator.validate_report` /
   `validate_receipt_series`, `nextness_replay_lab.load_protocol`);
   manifest records `validation: "full"`. Nothing is duplicated.
-- `evaluation`, `lab` — no public validator exists; only the schema
-  identifier and the exact link fields consumed are checked, and the
-  manifest says so: `validation: "schema_identifier_only"`.
+- `evaluation`, `lab` — validated through NP9's **public structural
+  validators** (`nextness_artifact_validation`); the manifest now
+  records `validation: "full"` because the complete public structural
+  schema is actually covered. Each JSON artifact is still parsed
+  exactly once (the validators take the already-parsed object).
+  Malformed consumed fields therefore fail closed at validation and
+  can never suppress link verification.
 - `log` — not JSON; it enters the stack only through
   `read_dominant_sequence`; the manifest records both the raw-byte hash
   and the accepted-sequence hash (`validation: "sequence_reader"`).
+
+**Self-check**: the emitted packet is validated against NP9's
+`validate_evidence_packet` before serialization — a failure there is a
+programming error and propagates loudly. Provenance links remain
+independently recomputed by this module; structural validation never
+converts a broken link into success.
 
 Unknown schema variants, malformed link fields, duplicate JSON keys and
 artifacts failing their validators are all rejected **fail-closed**.

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -60,10 +60,14 @@ verification.
   and the accepted-sequence hash (`validation: "sequence_reader"`).
 
 **Self-check**: the emitted packet is validated against NP9's
-`validate_evidence_packet` before serialization — a failure there is a
-programming error and propagates loudly. Provenance links remain
-independently recomputed by this module; structural validation never
-converts a broken link into success.
+`validate_evidence_packet` before serialization. A failure there is an
+**internal programming/contract failure, not user input**: it is
+re-raised as a plain `RuntimeError` at the boundary (never the
+documented exit-2 input lane, which `ArtifactValidationError`'s
+`ValueError` ancestry would otherwise trigger) and propagates loudly.
+Malformed **external** artifacts keep the concise exit-2 contract.
+Provenance links remain independently recomputed by this module;
+structural validation never converts a broken link into success.
 
 Unknown schema variants, malformed link fields, duplicate JSON keys and
 artifacts failing their validators are all rejected **fail-closed**.

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -16,14 +16,16 @@ phenomenology or biological-equivalence claim is made or implied.
 
 Honesty contract:
 
-- Artifacts are validated through the EXISTING validators where one
-  exists (NP5's ``validate_report`` / ``validate_receipt_series``,
-  NP6's ``load_protocol``); the evaluation and lab-report roles have no
-  public validator, so they are checked to their schema identifier and
-  the exact fields the packet consumes — and each manifest entry
-  records its ``validation`` depth (``full`` vs
-  ``schema_identifier_only``) rather than implying more than was
-  checked.
+- Artifacts are validated through the EXISTING validators: NP5's
+  ``validate_report`` / ``validate_receipt_series``, NP6's
+  ``load_protocol``, and — for the evaluation and lab-report roles —
+  NP9's public structural validators
+  (``scripts.nextness_artifact_validation``), so every JSON role is
+  now fully structurally validated and its manifest entry records
+  ``validation: "full"`` honestly. The emitted packet is itself
+  checked against NP9's packet validator before serialization.
+  Structural validation is still not provenance verification: the
+  hash links below remain independently recomputed by this module.
 - A provenance link whose counterpart artifact was not provided is a
   typed ``not_computable`` result, never a failure and never invented.
 - A link that IS checkable is reported ``verified`` or ``broken`` by
@@ -306,14 +308,32 @@ def _validate_role(role: str, path: pathlib.Path) -> tuple[dict[str, Any], Any]:
             load_protocol(path)  # bounded re-read through NP6's own loader
             entry["validation"] = "full"
         else:
-            # evaluation / lab: no public validator exists; only the
-            # schema identifier and the link fields consumed below are
-            # checked. Saying "full" here would be a lie.
+            # evaluation / lab: full structural validation through the
+            # NP9 public validators (resolved lazily at call time — the
+            # NP9 module imports this module's constants, so a
+            # top-level import here would be a cycle).
+            validation = _np9()
             entry["schema"] = _schema_of(parsed, role)
-            entry["validation"] = "schema_identifier_only"
+            try:
+                if role == "evaluation":
+                    validation.validate_evaluation_artifact(parsed)
+                else:
+                    validation.validate_lab_artifact(parsed)
+            except validation.ArtifactValidationError as e:
+                raise PacketInputError(f"{role}: {e}") from e
+            entry["validation"] = "full"
     except (EvaluatorInputError, LabInputError) as e:
         raise PacketInputError(f"{role}: {e}") from e
     return entry, parsed
+
+
+def _np9():
+    """The NP9 validation module, imported lazily to avoid the import
+    cycle (NP9 imports this module's constants). Resolution happens at
+    call time so tests can monkeypatch the NP9 module's attributes."""
+    import scripts.nextness_artifact_validation as validation
+
+    return validation
 
 
 # ---------------------------------------------------------------------------
@@ -501,6 +521,10 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
         "links": links,
         "non_claims": list(NON_CLAIMS),
     }
+    # Self-check: the emitted packet must satisfy its own public
+    # structural validator before serialization. A failure here is a
+    # programming error, not an input error — it propagates loudly.
+    _np9().validate_evidence_packet(packet)
     serialized = serialize_packet(packet)
     if len(serialized.encode("utf-8")) > MAX_PACKET_BYTES:
         raise PacketTooLargeError(

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -522,9 +522,19 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
         "non_claims": list(NON_CLAIMS),
     }
     # Self-check: the emitted packet must satisfy its own public
-    # structural validator before serialization. A failure here is a
-    # programming error, not an input error — it propagates loudly.
-    _np9().validate_evidence_packet(packet)
+    # structural validator before serialization. A failure here is an
+    # internal programming/contract failure, NOT malformed user input —
+    # and ArtifactValidationError inherits ValueError, which the CLI
+    # catches as the documented exit-2 input lane. Re-raise as a plain
+    # RuntimeError at this boundary so the internal failure propagates
+    # loudly instead of masquerading as a concise input error.
+    validation = _np9()
+    try:
+        validation.validate_evidence_packet(packet)
+    except validation.ArtifactValidationError as e:
+        raise RuntimeError(
+            f"internal: emitted packet failed self-validation: {e}"
+        ) from e
     serialized = serialize_packet(packet)
     if len(serialized.encode("utf-8")) > MAX_PACKET_BYTES:
         raise PacketTooLargeError(

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -111,9 +111,9 @@ def test_full_chain_all_links_verified(chain) -> None:
     assert by_role["receipts"]["validation"] == "full"
     assert by_role["receipts"]["receipt_count"] == 1
     assert by_role["protocol"]["validation"] == "full"
-    # No public validator exists for these two — the depth says so.
-    assert by_role["evaluation"]["validation"] == "schema_identifier_only"
-    assert by_role["lab"]["validation"] == "schema_identifier_only"
+    # Full structural validation through the NP9 public validators.
+    assert by_role["evaluation"]["validation"] == "full"
+    assert by_role["lab"]["validation"] == "full"
     assert by_role["log"]["validation"] == "sequence_reader"
     assert len(by_role["log"]["sequence_sha256"]) == 64
 
@@ -332,9 +332,14 @@ def test_cli_data_tree_refused(chain, tmp_path, capsys, monkeypatch) -> None:
 
 
 def test_cli_oversized_packet_exit_5(chain, capsys, monkeypatch) -> None:
+    import scripts.nextness_artifact_validation as validation_module
     import scripts.nextness_evidence_packet as packet_module
 
     monkeypatch.setattr(packet_module, "MAX_PACKET_BYTES", 64)
+    # The self-validator pins the config echo to the v1 constant, so its
+    # expectation must move with the monkeypatched ceiling for the
+    # ceiling breach itself to be reachable.
+    monkeypatch.setitem(validation_module._PACKET_CONFIG, "max_packet_bytes", 64)
     assert main(_chain_args(chain)) == 5
     err = capsys.readouterr().err
     assert err.startswith("error:")
@@ -480,9 +485,18 @@ def test_provided_flag_truth_table(chain, tmp_path, value, expected) -> None:
     # a truthy/falsy non-bool through the provided flag: only builtin
     # True verifies, only builtin False is typed link_not_recorded, and
     # everything else is malformed input (fail closed).
-    payload = json.loads(chain["evaluation"].read_text(encoding="utf-8"))
-    payload["artifacts"]["report"]["provided"] = value
-    mutated = _write(tmp_path / "mutated_eval.json", json.dumps(payload))
+    if expected == "link_not_recorded":
+        # A GENUINE provided:false evaluation comes from the emitter
+        # itself (receipts-only) — full validation rejects a synthetic
+        # slot that keeps stale sha/bytes keys beside provided:false.
+        genuine = build_evaluation(receipts_path=chain["receipts"])
+        mutated = _write(
+            tmp_path / "receipts_only_eval.json", serialize_evaluation(genuine)
+        )
+    else:
+        payload = json.loads(chain["evaluation"].read_text(encoding="utf-8"))
+        payload["artifacts"]["report"]["provided"] = value
+        mutated = _write(tmp_path / "mutated_eval.json", json.dumps(payload))
     inputs = {"evaluation": mutated, "report": chain["report"]}
     if expected == "error":
         with pytest.raises(PacketInputError, match="provided"):
@@ -564,6 +578,93 @@ def test_each_json_artifact_parsed_exactly_once(chain, monkeypatch) -> None:
     build_packet(chain)
     assert calls, "loader never invoked"
     assert all(count == 1 for count in calls.values()), calls
+
+
+# ---------------------------------------------------------------------------
+# NP10 integration: full structural validation of evaluation/lab inputs
+# (failing-first corpus — pre-integration NP8 accepted every one of these)
+# ---------------------------------------------------------------------------
+
+
+def _mutated_artifact_file(tmp_path, source: pathlib.Path, name: str, mutate) -> pathlib.Path:
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    mutate(payload)
+    return _write(tmp_path / name, json.dumps(payload))
+
+
+EVALUATION_INPUT_MUTATIONS = [
+    ("unknown-extra-field", lambda a: a.__setitem__("surprise", 1)),
+    ("malformed-envelope", lambda a: a["prediction"]["uniform_nll_bits"].__setitem__("status", "maybe")),
+    ("invalid-chronology", lambda a: a["recovery"]["chronology"]["value"].__setitem__("first_violation_index", 1)),
+]
+
+
+@pytest.mark.parametrize("name,mutate", EVALUATION_INPUT_MUTATIONS,
+                         ids=[m[0] for m in EVALUATION_INPUT_MUTATIONS])
+def test_malformed_evaluation_inputs_rejected(chain, tmp_path, name, mutate) -> None:
+    bad = _mutated_artifact_file(tmp_path, chain["evaluation"], f"bad_eval_{name}.json", mutate)
+    with pytest.raises(PacketInputError, match="evaluation:"):
+        build_packet({"evaluation": bad, "report": chain["report"]})
+
+
+def _lab_counts_desync(a: dict) -> None:
+    a["configurations"][0]["trajectory"]["reason_step_counts"]["unseen_state"] += 1
+
+
+def _lab_duplicate_labels(a: dict) -> None:
+    a["configurations"].append(json.loads(json.dumps(a["configurations"][0])))
+
+
+def _lab_final_incoherent(a: dict) -> None:
+    trajectory = a["configurations"][0]["trajectory"]
+    trajectory["final_abstain"] = not trajectory["final_abstain"]
+
+
+def _lab_truncation_lie(a: dict) -> None:
+    a["configurations"][0]["trajectory"]["run_lengths_truncated"] = True
+
+
+LAB_INPUT_MUTATIONS = [
+    ("reason-counts-desync", _lab_counts_desync),
+    ("duplicate-labels", _lab_duplicate_labels),
+    ("final-incoherent", _lab_final_incoherent),
+    ("truncation-lie", _lab_truncation_lie),
+]
+
+
+@pytest.mark.parametrize("name,mutate", LAB_INPUT_MUTATIONS,
+                         ids=[m[0] for m in LAB_INPUT_MUTATIONS])
+def test_malformed_lab_inputs_rejected(chain, tmp_path, name, mutate) -> None:
+    bad = _mutated_artifact_file(tmp_path, chain["lab"], f"bad_lab_{name}.json", mutate)
+    with pytest.raises(PacketInputError, match="lab:"):
+        build_packet({"lab": bad, "protocol": chain["protocol"]})
+
+
+def test_manifest_depth_is_full_for_evaluation_and_lab(chain) -> None:
+    # With NP9 integrated, the honest depth label rises to "full" — the
+    # only deliberate output change of the integration.
+    packet = build_packet(chain)
+    by_role = {entry["role"]: entry for entry in packet["artifacts"]}
+    assert by_role["evaluation"]["validation"] == "full"
+    assert by_role["lab"]["validation"] == "full"
+    # Provenance results are unchanged by the integration.
+    for kind, link in packet["links"].items():
+        assert link["status"] == "verified", kind
+
+
+def test_emitted_packet_is_self_validated(chain, monkeypatch) -> None:
+    import scripts.nextness_artifact_validation as validation_module
+
+    calls: list[int] = []
+    real = validation_module.validate_evidence_packet
+
+    def _spy(obj):
+        calls.append(1)
+        return real(obj)
+
+    monkeypatch.setattr(validation_module, "validate_evidence_packet", _spy)
+    build_packet({"log": chain["log"]})
+    assert calls == [1]  # exactly one self-validation before serialization
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -667,6 +667,32 @@ def test_emitted_packet_is_self_validated(chain, monkeypatch) -> None:
     assert calls == [1]  # exactly one self-validation before serialization
 
 
+def test_self_validation_failure_is_internal_not_input_error(chain, monkeypatch, capsys) -> None:
+    # A failure while validating the packet NP8 JUST EMITTED is an
+    # internal programming/contract failure — it must propagate loudly,
+    # never masquerade as the documented exit-2 "malformed user input"
+    # lane (ArtifactValidationError inherits ValueError, which main
+    # catches for external artifacts).
+    import scripts.nextness_artifact_validation as validation_module
+    from scripts.nextness_artifact_validation import ArtifactValidationError
+
+    def _boom(obj):
+        raise ArtifactValidationError("injected internal contract failure")
+
+    monkeypatch.setattr(validation_module, "validate_evidence_packet", _boom)
+    with pytest.raises(RuntimeError, match="internal"):
+        main(["--log", str(chain["log"])])
+    # And a genuinely malformed EXTERNAL artifact still takes the
+    # documented concise exit-2 lane (validator untouched for inputs).
+    monkeypatch.undo()
+    bad = chain["log"].parent / "bad_eval.json"
+    bad.write_bytes(b'{"schema": "nextness-evaluation-v2"}')
+    assert main(["--evaluation", str(bad)]) == 2
+    err = capsys.readouterr().err
+    assert err.startswith("error:")
+    assert "Traceback" not in err
+
+
 # ---------------------------------------------------------------------------
 # No ranking/scoring structure anywhere
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

**PACKAGE NP10** — second and final PR of Kev's validation runway, stacked on **NP9 (#362, head `ffdac6ae`)**. Touches exactly the three allowed NP8 files (no new integration doc needed — the contract doc section covers it):

| File | Delta |
|---|---|
| `scripts/nextness_evidence_packet.py` | +48/−? — NP9 validators wired in, packet self-validation |
| `tests/test_nextness_evidence_packet.py` | +113 — failing-first integration corpus |
| `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md` | honest-depth section updated |

## Integration contract (all Jack items)

- **Evaluation and lab inputs get full structural validation** via NP9's `validate_evaluation_artifact` / `validate_lab_artifact`, run on the **already-parsed object** — single parse per artifact preserved (loader-spy regression still passes). NP9 is resolved lazily at call time (it imports this module's constants; a top-level import would be a cycle), through the module so monkeypatching stays visible.
- **Manifest depth** for evaluation/lab rises `schema_identifier_only` → `full` — a label the validator now actually earns, and the **only deliberate output change**.
- **The emitted packet is self-validated** against `validate_evidence_packet` before serialization (spy-tested: exactly one call); a failure there is a programming error and propagates loudly.
- **Provenance links remain independently recomputed by NP8** — structural validation never converts a broken link into success; malformed consumed fields now fail closed at validation and cannot suppress link verification.

## Failing-first receipts

All **9 integration tests failed against pre-integration NP8** (the malformed artifacts were accepted), all pass now: evaluation with an unknown extra field · malformed computed/not_computable envelope · invalid chronology structure · lab with desynced reason counts · duplicate configuration labels · final reason/abstain incoherence · truncation-flag lie · depth-label check · self-validation spy.

Valid #358/#359/#361-generated artifacts remain accepted (whole-chain test: all four links still `verified`, byte deltas confined to the two depth labels). Two pre-existing tests were corrected to match honest semantics: the provided-flag `False` case now uses a **genuine emitter-produced receipts-only evaluation** (the old synthetic fixture kept stale sha/bytes keys beside `provided: false` — full validation rightly rejects that), and the exit-5 ceiling test moves the self-validator's config pin together with the monkeypatched ceiling.

## Verification

Targeted **59/59 (NP8) + 74/74 (NP9)** · full suite **1212 passed / 28 skipped** · PYTHONHASHSEED 101/202/303 green · `py_compile` OK · no new dependency, no workflow change. Self-review manual on-seat (fleets remain unavailable — standing disclosure).

**Stack**: #354 ← #355 ← #358 ← #359 ← #360 ← #361 ← #362 (NP9) ← **this PR**. Left open and unmerged for Jack's audit. This completes the validation runway's two-PR allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Amendment — Jack delta (2026-07-15, head `788af0ea`)

**Rebase receipt**: NP10's original commit was rebased from base `ffdac6ae` onto corrected NP9 `42f2d772` — patch **byte-identical** (`cmp` of pre/post diff-of-diffs passes; `range-diff` reports `=` for `b837f76` → `043fef2`). The correction is one commit on top.

**Exception contract (both threads @ packet:527).** `ArtifactValidationError` inherits `ValueError`, and `main` catches `ValueError` as the documented exit-2 malformed-input lane — so a failure while validating the packet NP8 *just emitted* (an internal programming/contract failure) previously masqueraded as ordinary user input. The self-validation boundary now re-raises as a plain `RuntimeError` (`internal: emitted packet failed self-validation: …`), which propagates loudly; `PacketTooLargeError` remains the only caught `RuntimeError` subclass, so no other lane changes.

**Failing-first receipt**: an injected validator failure after otherwise-valid inputs returned **exit 2 pre-fix**; it now raises `RuntimeError`. The same test proves malformed **external** artifacts keep the concise exit-2 contract (one `error:` line, no traceback). Contract doc updated.

**Receipts**: targeted **60/60**, full suite **1220 passed / 28 skipped** on the cascaded head, PYTHONHASHSEED 101/202/303 green, `py_compile` OK. Threads intentionally left unresolved for Jack.
