### PR TITLE
fix(nextness): NP1 output-boundary reliability — input-alias refusal + byte-exact file output

### DIFF
--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -101,11 +101,35 @@ is checked against a **64 KiB ceiling — fail closed** (`ReportTooLargeError`).
 
 ## Write boundary
 
-- Default output is **stdout**.
+- Default output is **stdout** (unchanged: `sys.stdout.write` of the
+  canonical serialization).
 - `--output` must resolve **inside the input-log directory** (mirrors
   `nextness_metrics`; `WriteOutsideLogDirError` otherwise) and must
   **never** resolve inside the repository `data/` tree — even when the
   input log itself lives there. Reports about `data/` logs go to stdout.
+- **Input-identity guard** (same convention as NP6/NP8): `--output` may
+  never name or alias the input log itself. Refused by **resolved path**
+  (covers the direct path, lexical variants like `sub/../log.jsonl`, and
+  symlink aliases — resolution targets are compared, not link or segment
+  names) and by **file identity** (`os.path.samefile`: device + inode /
+  file ID, which catches existing hard links whose paths differ). Any
+  failure to verify identity is itself a refusal — **fail closed**,
+  never a fall-through. Refusal exits 4 with one concise `error:` line,
+  no traceback; the input log is left byte-identical and no report is
+  written. Ordinary sibling outputs — nonexistent or existing non-alias
+  files — remain allowed.
+- **Residual race, stated precisely**: identity is verified at
+  validation time; the later write does not re-verify. A concurrent
+  actor replacing the output path between validation and write can still
+  redirect the write. The guard defends against aliases that exist when
+  it validates; it does not claim to eliminate the validation-to-write
+  (TOCTOU) interval.
+- **File-output byte contract**: the report file is written as explicit
+  UTF-8 **bytes** — exactly `serialize_report(report).encode("utf-8")`,
+  with a single trailing LF — on every platform. Windows newline
+  translation (`\n` → `\r\n`, the old `write_text` behavior) can never
+  alter the canonical bytes, so file reports are byte-identical across
+  platforms and match the documented byte-identity guarantee.
 - No network, HTTP, ZMQ, Ollama or model calls anywhere in the module
   (statically auditable: the only imports are stdlib + `TOKEN_NAMES` /
   `WriteOutsideLogDirError` from `scripts.nextness_observer`).
@@ -122,7 +146,7 @@ exits.
 | 0 | success |
 | 2 | validation failure: missing log file or out-of-bounds configuration (argparse usage errors also exit 2) |
 | 3 | insufficient history for a train/holdout split |
-| 4 | output-path failure: write-boundary violation or unwritable target |
+| 4 | output-path failure: write-boundary violation, input-log alias (direct path / lexical / symlink / hard link / unverifiable identity), or unwritable target |
 | 5 | serialized report exceeds the 64 KiB ceiling (fail closed) |
 
 ## Relationship to what comes next

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -24,8 +24,16 @@ Safety contract (Lane B, mirrors nextness_observer/nextness_metrics):
   I/O is reading one JSONL file and (optionally) writing one report next
   to it.
 - Writes are permitted ONLY inside the resolved input-log directory
-  (``WriteOutsideLogDirError`` otherwise) and NEVER inside the
-  repository ``data/`` tree — reports about ``data/`` logs go to stdout.
+  (``WriteOutsideLogDirError`` otherwise), NEVER inside the repository
+  ``data/`` tree — reports about ``data/`` logs go to stdout — and NEVER
+  onto a path that IS the input log itself: aliases are refused by
+  resolved path and by file identity (``os.path.samefile``; hard links
+  included), failing closed when identity cannot be verified. Identity
+  is checked at validation time; the later write does not re-verify
+  (documented residual race, same as NP6/NP8).
+- File output is written as explicit UTF-8 BYTES (single trailing LF,
+  never platform newline translation): the file always contains exactly
+  ``serialize_report(report).encode("utf-8")``.
 - Chronological evaluation only: rows must arrive in strictly increasing
   ``generation`` order; out-of-order and duplicate generations are
   rejected and counted, never silently reordered (sorting could hide
@@ -51,6 +59,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import pathlib
 import sys
 from collections.abc import Mapping, Sequence
@@ -522,11 +531,24 @@ def validate_output_path(out_path: pathlib.Path, log_path: pathlib.Path) -> None
     """Enforce the NP1 write contract for --output.
 
     The report may land ONLY inside the resolved input-log directory
-    (mirroring nextness_metrics), and NEVER inside the repository
-    ``data/`` tree — even when the input log itself lives there. Reports
-    about ``data/`` logs go to stdout instead.
+    (mirroring nextness_metrics), NEVER inside the repository ``data/``
+    tree — even when the input log itself lives there; reports about
+    ``data/`` logs go to stdout instead — and NEVER on a path that IS
+    the input log: by resolved path (which also covers lexical and
+    symlink aliases, dangling ones included — resolution targets are
+    compared, not link or segment names) or by file identity
+    (``os.path.samefile``: device + inode / file ID, which covers
+    existing hard links whose paths differ).
+
+    Residual filesystem race, stated precisely (same as NP6/NP8):
+    identity is verified at validation time; the later write does not
+    re-verify. A concurrent actor replacing the output path between
+    validation and write can still redirect the write. This guard
+    defends against aliases that exist when it validates — it does not
+    claim protection against concurrent hostile filesystem manipulation.
     """
-    log_dir_resolved = log_path.resolve().parent
+    log_resolved = log_path.resolve()
+    log_dir_resolved = log_resolved.parent
     out_resolved = out_path.resolve()
     try:
         out_resolved.relative_to(log_dir_resolved)
@@ -535,6 +557,27 @@ def validate_output_path(out_path: pathlib.Path, log_path: pathlib.Path) -> None
             f"refusing to write predictor report outside the input-log "
             f"directory: {out_resolved} is not inside {log_dir_resolved}"
         ) from e
+    if out_resolved == log_resolved:
+        raise WriteOutsideLogDirError(
+            f"refusing to overwrite the input log file: {out_resolved}"
+        )
+    # Hard links share identity while having distinct paths. Only an
+    # EXISTING output can alias the input; stat runs on the resolved
+    # path and any failure to verify is itself a refusal (fail closed),
+    # never a fall-through.
+    if out_resolved.exists():
+        try:
+            same = os.path.samefile(out_resolved, log_path)
+        except OSError as e:
+            raise WriteOutsideLogDirError(
+                f"cannot verify output file identity against the input log "
+                f"file: {out_resolved}"
+            ) from e
+        if same:
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input log file (shared file "
+                f"identity): {out_resolved}"
+            )
     data_dir = _repo_data_dir()
     if out_resolved == data_dir or data_dir in out_resolved.parents:
         raise WriteOutsideLogDirError(
@@ -563,7 +606,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "optional report path; must resolve inside the input log's "
-            "directory and outside the repository data/ tree (default: stdout)"
+            "directory, outside the repository data/ tree, and must not "
+            "name or alias the input log itself (default: stdout)"
         ),
     )
     parser.add_argument("--smoothing", type=float, default=SMOOTHING_DEFAULT)
@@ -622,7 +666,10 @@ def main(argv: list[str] | None = None) -> int:
     serialized = serialize_report(report)
     if args.output is not None:
         try:
-            args.output.write_text(serialized, encoding="utf-8")
+            # Explicit UTF-8 bytes (NP5/NP6/NP8 convention): the file is
+            # exactly serialize_report(report).encode("utf-8"), one
+            # trailing LF, immune to platform newline translation.
+            args.output.write_bytes(serialized.encode("utf-8"))
         except OSError as e:
             print(f"error: cannot write report to {args.output}: {e}", file=sys.stderr)
             return 4

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import pathlib
 
 import pytest
@@ -486,6 +487,162 @@ def test_output_inside_repo_data_tree_is_refused() -> None:
     with pytest.raises(WriteOutsideLogDirError):
         validate_output_path(data_log.parent / "report.json", data_log)
     # Pure path logic: nothing was created or written.
+
+
+# ---------------------------------------------------------------------------
+# Output identity guard: --output must never name or alias the input log
+# (same convention as NP6/NP8: resolved path + os.path.samefile, fail
+# closed when identity cannot be verified). Refusal contract at the CLI:
+# exit 4, ONE concise ``error:`` line, no traceback, input byte-identical,
+# no report written anywhere.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_output_direct_same_path_is_refused(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(log, log)
+
+
+def test_validate_output_lexical_alias_is_refused(tmp_path) -> None:
+    # A path that names the log through a redundant component: distinct
+    # lexically, identical once resolved. 'sub' need not exist — the
+    # comparison is between resolution targets, not link/segment names.
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    alias = tmp_path / "sub" / ".." / "nextness_runs.jsonl"
+    assert str(alias) != str(log)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(alias, log)
+
+
+def _make_hardlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        os.link(target, link)
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("hard links unsupported on this filesystem")
+
+
+def _make_symlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+
+
+def test_validate_output_hardlink_alias_is_refused(tmp_path) -> None:
+    # A hard link has a distinct path (resolution does NOT unify it) but
+    # shares file identity — only os.path.samefile can catch it.
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    link = tmp_path / "report.json"
+    _make_hardlink_or_skip(log, link)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(link, log)
+
+
+def test_validate_output_symlink_alias_is_refused(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    link = tmp_path / "report.json"
+    _make_symlink_or_skip(log, link)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(link, log)
+
+
+def test_validate_output_ordinary_siblings_still_allowed(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    validate_output_path(tmp_path / "report.json", log)  # nonexistent: allowed
+    existing = tmp_path / "existing.json"
+    existing.write_text("old content\n", encoding="utf-8")
+    validate_output_path(existing, log)  # existing non-alias: allowed
+
+
+def _cli_alias_refusal_receipt(
+    capsys, tmp_path: pathlib.Path, log: pathlib.Path, out_arg: pathlib.Path
+) -> None:
+    """Full refusal contract: exit 4 · one error: line · no traceback ·
+    input byte-identical · no report written (no new filesystem entry)."""
+    input_before = log.read_bytes()
+    entries_before = sorted(p.name for p in tmp_path.iterdir())
+    err = _expect_cli_failure(capsys, [str(log), "--output", str(out_arg)], 4)
+    assert err.count("error:") == 1
+    assert log.read_bytes() == input_before
+    assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+def test_cli_output_naming_input_log_is_refused(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    _cli_alias_refusal_receipt(capsys, tmp_path, log, log)
+
+
+def test_cli_output_lexical_alias_is_refused(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    alias = tmp_path / "sub" / ".." / "nextness_runs.jsonl"
+    _cli_alias_refusal_receipt(capsys, tmp_path, log, alias)
+
+
+def test_cli_output_hardlink_alias_is_refused(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    link = tmp_path / "report.json"
+    _make_hardlink_or_skip(log, link)
+    input_before = log.read_bytes()
+    err = _expect_cli_failure(capsys, [str(log), "--output", str(link)], 4)
+    assert err.count("error:") == 1
+    assert log.read_bytes() == input_before
+    assert link.read_bytes() == input_before  # shared identity: still the log
+
+
+def test_cli_output_symlink_alias_is_refused(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    link = tmp_path / "report.json"
+    _make_symlink_or_skip(log, link)
+    input_before = log.read_bytes()
+    err = _expect_cli_failure(capsys, [str(log), "--output", str(link)], 4)
+    assert err.count("error:") == 1
+    assert log.read_bytes() == input_before
+
+
+def test_cli_nonexistent_sibling_output_remains_allowed(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    input_before = log.read_bytes()
+    out = tmp_path / "report.json"
+    assert main([str(log), "--output", str(out)]) == 0
+    assert out.is_file()
+    assert log.read_bytes() == input_before
+    assert json.loads(out.read_text(encoding="utf-8"))["schema"] == REPORT_SCHEMA
+
+
+def test_cli_existing_non_alias_sibling_output_remains_allowed(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "report.json"
+    out.write_text("stale previous content\n", encoding="utf-8")
+    assert main([str(log), "--output", str(out)]) == 0
+    assert json.loads(out.read_text(encoding="utf-8"))["schema"] == REPORT_SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# File-output byte contract: exactly serialize_report(...).encode("utf-8"),
+# LF only, independent of platform newline translation.
+# ---------------------------------------------------------------------------
+
+
+def test_file_output_bytes_are_exact_canonical_utf8(tmp_path) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "report.json"
+    assert main([str(log), "--output", str(out)]) == 0
+    expected = serialize_report(build_report(log)).encode("utf-8")
+    data = out.read_bytes()
+    assert data == expected
+    assert b"\r" not in data                    # no platform CRLF translation
+    assert data.endswith(b"\n")                 # exactly one trailing LF byte
+    assert not data.endswith(b"\n\n")
+
+
+def test_stdout_report_matches_canonical_serialization(tmp_path, capsys) -> None:
+    # Established stdout contract, asserted character-exactly: stdout is
+    # sys.stdout.write(serialize_report(report)) — unchanged by the file
+    # byte-output repair.
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    assert main([str(log)]) == 0
+    assert capsys.readouterr().out == serialize_report(build_report(log))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

One bounded reliability repair to NP1's `--output` lane, now that NP1 (`scripts/nextness_predictor.py`, merged via #354) lives on `main` (`deb028cd`). It closes the two known output gaps and changes nothing else — no schema, calculation, default, row/line limit, dependency, workflow or mathematical change; no other Nextness module touched; no shared abstraction introduced.

**Gap 1 — input destruction.** `--output` could name or alias the input log (direct path, lexical variant like `sub/../log.jsonl`, symlink, hard link). Validation passed, the report was built from the intact log, and the write then destroyed the input. Proven live on unmodified `main` (CLI exits 0, log replaced by the report).

**Gap 2 — Windows newline translation.** `Path.write_text()` translated the canonical LF, so file bytes were not `serialize_report(report).encode("utf-8")` on Windows (measured: 60 CR bytes injected, 1463 vs 1403 canonical bytes on the ordinary fixture).

## The repair

- `validate_output_path` now refuses any output that **is** the input log, mirroring the established NP6/NP8 identity guard: **resolved-path comparison** (catches direct, lexical, symlink and case aliases — resolution targets are compared, not link/segment names) **and `os.path.samefile`** for existing targets (catches hard links: device + inode / file ID). Any failure to verify identity is itself a refusal — **fail closed**, never a fall-through.
- Refusal contract: exit **4**, one concise `error:` line, no traceback, input byte-identical, **no report written** — validation runs before `build_report`, so a refused invocation never even computes a report.
- File output switched from `write_text` to explicit **UTF-8 bytes**: `args.output.write_bytes(serialized.encode("utf-8"))` (the NP5/NP6/NP8 convention). File bytes now equal `serialize_report(report).encode("utf-8")` exactly, single trailing LF, on every platform.
- Stdout lane untouched: still `sys.stdout.write(serialized)`.

## Failing-first receipts (run against unmodified `main` module, Windows 11, Python 3.13)

`git diff main -- scripts/nextness_predictor.py` was empty when these ran; only the tests existed.

| # | Regression | Result on unmodified main |
|---|---|---|
| 1 | `test_validate_output_direct_same_path_is_refused` | **FAILED** — no refusal raised |
| 2 | `test_validate_output_lexical_alias_is_refused` | **FAILED** — no refusal raised |
| 3 | `test_validate_output_hardlink_alias_is_refused` | **FAILED** — no refusal raised |
| 4 | `test_cli_output_naming_input_log_is_refused` | **FAILED** — exit 0, input destroyed |
| 5 | `test_cli_output_lexical_alias_is_refused` | **FAILED** — exit 0, input destroyed |
| 6 | `test_cli_output_hardlink_alias_is_refused` | **FAILED** — exit 0, input destroyed |
| 7 | `test_file_output_bytes_are_exact_canonical_utf8` | **FAILED** — CRLF bytes ≠ canonical UTF-8 |
| 8–9 | `test_validate_output_symlink_alias_is_refused` / `test_cli_output_symlink_alias_is_refused` | **SKIPPED** locally (Windows w/o symlink privilege) — exercised live on Ubuntu CI |
| 10–13 | allowed-lane + stdout protections (ordinary siblings, nonexistent/existing non-alias output, stdout contract) | PASSED (regression fences, expected) |

Rollup: `7 failed, 5 passed, 2 skipped` (the 5 passes include one pre-existing escape-lane test matched by the filter). Post-repair: **50 passed, 2 skipped** (full predictor file), symlink lanes green on Ubuntu CI (see checks).

## Truth table — output aliases and ordinary outputs (all tested)

| `--output` target | Verdict | Mechanism |
|---|---|---|
| the log path itself | **refused, exit 4** | resolved-path equality |
| lexical alias (`sub/../nextness_runs.jsonl`) | **refused, exit 4** | resolved-path equality |
| symlink to the log (where supported) | **refused, exit 4** | resolved-path equality (resolution target compared) |
| hard link to the log (where supported) | **refused, exit 4** | `os.path.samefile` (device+inode / file ID) |
| existing path whose identity cannot be verified (`samefile` raises `OSError`) | **refused, exit 4** | fail closed |
| outside the log directory | refused, exit 4 | unchanged escape guard |
| inside repository `data/` tree | refused, exit 4 | unchanged data-tree guard |
| nonexistent ordinary sibling | **allowed**, exit 0 | — |
| existing non-alias sibling | **allowed** (overwritten), exit 0 | — |
| unwritable target (e.g. a directory) | refused, exit 4 | unchanged `OSError`-on-write lane |

Every refusal: one `error:` line, no traceback, input byte-identical, no report written (directory-entry snapshot asserted).

## Exact intentional output differences (pre vs post, ordinary valid fixture)

- **stdout**: byte-identical pre vs post (subprocess capture compared exact; plus character-exact `capsys` assertion against `serialize_report`). Unchanged contract.
- **file**: post-repair bytes = pre-repair bytes with `CRLF → LF` only (verified `post == pre.replace(b"\r\n", b"\n")`; 1463 → 1403 bytes, 60 → 0 CR bytes on the fixture); parsed JSON identical pre vs post; exactly one trailing LF. **This is the entire intentional difference.** On POSIX, file bytes are unchanged.

## Windows newline contract

File reports are now explicit UTF-8 bytes: `serialize_report(report).encode("utf-8")`, byte-identical across platforms, single LF line terminators, immune to platform text-mode translation. Asserted by `test_file_output_bytes_are_exact_canonical_utf8` (`data == expected`, `b"\r" not in data`, single trailing LF).

## Remaining TOCTOU boundary (documented, not eliminated)

Identity is verified at **validation time**; the later write does not re-verify. A concurrent actor replacing the output path between validation and write can still redirect the write. The guard defends against aliases that exist when it validates — it does not claim protection against concurrent hostile filesystem manipulation. This is the same precisely-stated residual as NP6/NP8, now stated in the NP1 module docstring, `validate_output_path` docstring, and the baseline doc.

## Adversarial review of new assertion/exception lanes

- `resolve()` failures are not converted to refusals — they propagate loudly (unexpected programming errors stay loud; only `WriteOutsideLogDirError` and the write-lane `OSError` are caught).
- The resolved-path check runs before `samefile`, so direct/lexical/symlink/case aliases are refused even on filesystems where `samefile` support is degraded; `samefile` is only needed for hard links, and its `OSError` is itself a refusal.
- Case-variant alias on Windows is covered twice over (resolve() canonicalizes on-disk case; samefile agrees).
- Refusal precedes `build_report` → refused runs never compute a report; test snapshots directory entries to prove nothing is created.
- An output naming the log's *directory* still exits 4 via the unchanged unwritable-target lane (`samefile(dir, log)` is False; the write raises `OSError`) — pre-existing test still green.
- Skip guards (`os.link`/`symlink_to` raising `OSError`/`NotImplementedError`) skip only on genuine platform unsupport; both lanes run on Ubuntu CI.

## Test and verification receipts

- Targeted: `tests/test_nextness_predictor.py` — **50 passed, 2 skipped** (skips = symlink lanes, local Windows only).
- Full maintained Python suite: **1231 passed, 30 skipped** in 33s.
- `py_compile` both changed Python files: OK.
- Hash-seed repetitions: `PYTHONHASHSEED=0/1/424242` × predictor file — 50/2 each.
- Exact pre/post report-byte comparison on the ordinary fixture: receipts above.
- CI: full rollup on this PR (see checks tab) — left to conclude before handoff; PR stays **open and unmerged** for Jack.

## Exact file statistics

```
 docs/NEXTNESS_PREDICTION_BASELINE.md |  28 ++++++-
 scripts/nextness_predictor.py        |  63 ++++++++++++--
 tests/test_nextness_predictor.py     | 157 +++++++++++++++++++++++++++++++++++
 3 files changed, 238 insertions(+), 10 deletions(-)
```

One commit, `ab585f72360493381e5f41429608216e4159628a`, branched directly from `main = deb028cd` (independent — not stacked on #357). Allowed-file fence held exactly: these three files only.

## Non-claims

- The TOCTOU interval is **not** eliminated (documented above).
- No claim about any other Nextness module's output lane (a separate read-only cross-stack audit is reported in the runway handoff, not here).
- Baselines remain baselines: no intelligence, awareness or performance claim anywhere in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
