### PR TITLE
fix(nextness): NP5 evaluator input-identity guard — refuse --output aliasing any supplied artifact

### DIFF
--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -217,6 +217,13 @@ primary input artifact's directory (the `--report` file when provided,
 else the `--receipts` file) and **never** inside the repository `data/`
 tree — the same convention as `nextness_predictor`.
 
+**Explicit primary selection**: the primary input is chosen by fixed
+role order — `report` when provided, otherwise `receipts` — never by
+mapping construction or insertion order, and identity checks iterate
+the recognized roles in that same fixed order. Validating with no
+input at all is a descriptive validation error (never a bare
+`StopIteration`).
+
 **Input-identity guard** (NP6/NP8 convention): `--output` may never
 name or alias **any** supplied input artifact — report or receipts,
 primary or not. Aliases are refused by **resolved path** (covering the

--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -217,13 +217,35 @@ primary input artifact's directory (the `--report` file when provided,
 else the `--receipts` file) and **never** inside the repository `data/`
 tree — the same convention as `nextness_predictor`.
 
+**Input-identity guard** (NP6/NP8 convention): `--output` may never
+name or alias **any** supplied input artifact — report or receipts,
+primary or not. Aliases are refused by **resolved path** (covering the
+direct path, lexical variants like `sub/../report.json`, and symlink
+aliases — resolution targets are compared, not link or segment names)
+and by **file identity** (`os.path.samefile` on the resolved paths:
+device + inode / file ID, catching existing hard links whose paths
+differ). Any failure to verify an existing output's identity is itself
+a refusal — **fail closed**, never a fall-through. Refusal exits 4 with
+one concise `error:` line, no traceback; every supplied input is left
+byte-identical and no evaluation is written. The guard runs **before
+any artifact is parsed or any evaluation computed** — a refused
+invocation never reads the artifacts at all. Ordinary sibling outputs —
+nonexistent, or existing non-alias files — remain allowed.
+
+**Residual race, stated precisely**: identity is verified at validation
+time; the later write does not re-verify. A concurrent actor replacing
+the output path between validation and write can still redirect the
+write. The guard defends against aliases that exist when it validates —
+it does not claim to eliminate the validation-to-write (TOCTOU)
+interval.
+
 ## CLI exit codes
 
 | Code | Meaning |
 |---|---|
 | 0 | success |
 | 2 | validation failure: missing/oversized/malformed artifact, unknown variant, or no artifact provided (argparse usage errors also exit 2) |
-| 4 | output-path failure: write-boundary violation or unwritable target |
+| 4 | output-path failure: write-boundary violation, input-artifact alias (direct path / lexical / symlink / hard link / unverifiable identity), or unwritable target |
 | 5 | serialized evaluation exceeds the 64 KiB ceiling (fail closed) |
 
 There is deliberately no exit-3: "not enough evidence" is never a CLI
@@ -254,4 +276,8 @@ requires touching NP1): `nextness_predictor`'s own `--output` writes
 with platform newline translation, so an NP1 report file's sha256
 differs between Windows and Linux even when its content is identical;
 this evaluator hashes whatever bytes it is given and is unaffected, but
-cross-platform golden-fixture work should account for it.
+cross-platform golden-fixture work should account for it. (A repair
+switching NP1 to explicit UTF-8 byte output was subsequently carried
+for review in
+[PR #364](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/364);
+its disposition is repository history.)

--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -50,8 +50,14 @@ Safety contract (Lane B, mirrors nextness_predictor/nextness_monitor):
   before any arithmetic; unknown schemas, unknown keys and missing keys
   are all rejected (unknown variants never pass silently).
 - Writes are permitted ONLY inside the directory of the primary input
-  artifact (``WriteOutsideLogDirError`` otherwise) and NEVER inside the
-  repository ``data/`` tree — the same convention as nextness_predictor.
+  artifact (``WriteOutsideLogDirError`` otherwise), NEVER inside the
+  repository ``data/`` tree, and NEVER onto a path that IS any supplied
+  input artifact — report or receipts alike: aliases are refused by
+  resolved path and by file identity (``os.path.samefile`` on resolved
+  paths; hard links included), failing closed when identity cannot be
+  verified. Identity is checked at validation time, before any artifact
+  is parsed or any evaluation computed; the later write does not
+  re-verify (documented residual race, same as NP6/NP8).
 - Deterministic output: sorted keys, fixed schema, no wall-clock
   timestamps, no random identifiers, no absolute paths (provenance is
   the SHA-256 of each artifact's raw bytes); the same input bytes always
@@ -65,6 +71,7 @@ import argparse
 import hashlib
 import json
 import math
+import os
 import pathlib
 import sys
 from collections.abc import Mapping, Sequence
@@ -1240,12 +1247,33 @@ def _repo_data_dir() -> pathlib.Path:
     return (pathlib.Path(__file__).resolve().parent.parent / "data").resolve()
 
 
-def validate_output_path(out_path: pathlib.Path, primary_input: pathlib.Path) -> None:
+def validate_output_path(
+    out_path: pathlib.Path, inputs: Mapping[str, pathlib.Path]
+) -> None:
     """--output may land ONLY inside the primary input artifact's
     directory (the --report file when provided, else the --receipts
-    file), and NEVER inside the repository ``data/`` tree — the same
-    rule nextness_predictor enforces for its own reports."""
-    input_dir_resolved = primary_input.resolve().parent
+    file), NEVER inside the repository ``data/`` tree — the same rule
+    nextness_predictor enforces for its own reports — and NEVER on a
+    path that IS any supplied input artifact (corrected-NP6/NP8
+    semantics): by resolved path (which also covers lexical and symlink
+    aliases, dangling ones included — resolution targets are compared,
+    not link or segment names) or by file identity
+    (``os.path.samefile`` on the RESOLVED paths: device + inode / file
+    ID, which covers existing hard links whose paths differ).
+
+    ``inputs`` maps role name (``"report"`` / ``"receipts"``) to the
+    supplied path, in primary-first order; identity is checked against
+    EVERY entry, not merely the primary.
+
+    Residual filesystem race, stated precisely (same as NP6/NP8):
+    identity is verified at validation time; the later write does not
+    re-verify. A concurrent actor replacing the output path between
+    validation and write can still redirect the write. This guard
+    defends against aliases that exist when it validates — it does not
+    claim protection against concurrent hostile filesystem manipulation.
+    """
+    primary = next(iter(inputs.values()))
+    input_dir_resolved = primary.resolve().parent
     out_resolved = out_path.resolve()
     try:
         out_resolved.relative_to(input_dir_resolved)
@@ -1254,6 +1282,29 @@ def validate_output_path(out_path: pathlib.Path, primary_input: pathlib.Path) ->
             f"refusing to write evaluation outside the primary input "
             f"artifact's directory: {out_resolved} is not inside {input_dir_resolved}"
         ) from e
+    for role, input_path in inputs.items():
+        input_resolved = input_path.resolve()
+        if out_resolved == input_resolved:
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input {role} artifact: {out_resolved}"
+            )
+        # Hard links share identity while having distinct paths. Only an
+        # EXISTING output can alias an input; stat runs on the resolved
+        # paths and any failure to verify is itself a refusal (fail
+        # closed), never a fall-through.
+        if out_resolved.exists():
+            try:
+                same = os.path.samefile(out_resolved, input_resolved)
+            except OSError as e:
+                raise WriteOutsideLogDirError(
+                    f"cannot verify output file identity against the input "
+                    f"{role} artifact: {out_resolved}"
+                ) from e
+            if same:
+                raise WriteOutsideLogDirError(
+                    f"refusing to overwrite the input {role} artifact "
+                    f"(shared file identity): {out_resolved}"
+                )
     data_dir = _repo_data_dir()
     if out_resolved == data_dir or data_dir in out_resolved.parents:
         raise WriteOutsideLogDirError(
@@ -1289,8 +1340,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output", type=pathlib.Path, default=None,
         help=(
             "optional evaluation path; must resolve inside the primary "
-            "input artifact's directory and outside the repository data/ "
-            "tree (default: stdout)"
+            "input artifact's directory, outside the repository data/ "
+            "tree, and must not name or alias any supplied input "
+            "artifact (default: stdout)"
         ),
     )
     return parser
@@ -1323,10 +1375,17 @@ def main(argv: list[str] | None = None) -> int:
         if path is not None and not path.is_file():
             print(f"error: {label} artifact not found: {path}", file=sys.stderr)
             return 2
-    primary = args.report if args.report is not None else args.receipts
+    # Primary-first, fixed role order; identity is checked against every
+    # supplied input, and validation runs BEFORE any artifact is parsed
+    # or any evaluation computed.
+    inputs: dict[str, pathlib.Path] = {}
+    if args.report is not None:
+        inputs["report"] = args.report
+    if args.receipts is not None:
+        inputs["receipts"] = args.receipts
     try:
         if args.output is not None:
-            validate_output_path(args.output, primary)
+            validate_output_path(args.output, inputs)
         evaluation = build_evaluation(
             report_path=args.report, receipts_path=args.receipts
         )

--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -1262,8 +1262,12 @@ def validate_output_path(
     ID, which covers existing hard links whose paths differ).
 
     ``inputs`` maps role name (``"report"`` / ``"receipts"``) to the
-    supplied path, in primary-first order; identity is checked against
-    EVERY entry, not merely the primary.
+    supplied path. The primary is selected EXPLICITLY by fixed role
+    order — ``report`` when present, else ``receipts`` — never by the
+    mapping's insertion order, and identity is checked against EVERY
+    recognized entry in that same fixed order, not merely the primary.
+    An empty mapping is a descriptive ``EvaluatorInputError``, never a
+    bare ``StopIteration``.
 
     Residual filesystem race, stated precisely (same as NP6/NP8):
     identity is verified at validation time; the later write does not
@@ -1272,7 +1276,15 @@ def validate_output_path(
     defends against aliases that exist when it validates — it does not
     claim protection against concurrent hostile filesystem manipulation.
     """
-    primary = next(iter(inputs.values()))
+    # Fixed, explicit role order (report first) — primary selection and
+    # identity iteration are independent of how the mapping was built.
+    ordered = [(role, inputs[role]) for role in ("report", "receipts") if role in inputs]
+    if not ordered:
+        raise EvaluatorInputError(
+            "no input artifact supplied for output validation: provide "
+            "report and/or receipts"
+        )
+    primary = ordered[0][1]
     input_dir_resolved = primary.resolve().parent
     out_resolved = out_path.resolve()
     try:
@@ -1282,7 +1294,7 @@ def validate_output_path(
             f"refusing to write evaluation outside the primary input "
             f"artifact's directory: {out_resolved} is not inside {input_dir_resolved}"
         ) from e
-    for role, input_path in inputs.items():
+    for role, input_path in ordered:
         input_resolved = input_path.resolve()
         if out_resolved == input_resolved:
             raise WriteOutsideLogDirError(

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -32,10 +32,12 @@ from scripts.nextness_evaluator import (
     load_json_artifact,
     main,
     serialize_evaluation,
+    validate_output_path,
     validate_receipt,
     validate_receipt_series,
     validate_report,
 )
+from scripts.nextness_observer import WriteOutsideLogDirError
 from scripts.nextness_monitor import (
     MonitorConfig,
     build_receipt,
@@ -1285,6 +1287,63 @@ def test_alias_refusal_precedes_evaluation_computation(tmp_path, capsys, monkeyp
 
 
 # --- ordinary sibling outputs remain allowed ---------------------------------
+
+
+def _artifacts_in_two_dirs(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    """A report and a receipts artifact in two DIFFERENT directories, so
+    primary selection visibly decides which directory confines --output."""
+    report_dir = tmp_path / "report_dir"
+    receipts_dir = tmp_path / "receipts_dir"
+    report_dir.mkdir()
+    receipts_dir.mkdir()
+    report_file = report_dir / "report.json"
+    report_file.write_text(json.dumps(_make_report()), encoding="utf-8")
+    receipts_file = receipts_dir / "receipts.json"
+    receipts_file.write_text(
+        json.dumps([_make_receipt(observation_count=n) for n in (10, 20)]),
+        encoding="utf-8",
+    )
+    return report_file, receipts_file
+
+
+def test_primary_is_report_regardless_of_mapping_insertion_order(tmp_path) -> None:
+    # Receipts inserted FIRST: the report must still be primary — an
+    # output beside the report is allowed under the normal lane rules.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    assert list(inputs) == ["receipts", "report"]  # hostile insertion order
+    validate_output_path(report_file.parent / "evaluation.json", inputs)  # no raise
+
+
+def test_output_beside_receipts_refused_when_report_present(tmp_path) -> None:
+    # Same hostile insertion order: an output beside the RECEIPTS but
+    # outside the report's directory violates primary confinement.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(receipts_file.parent / "evaluation.json", inputs)
+
+
+def test_receipts_only_mapping_uses_receipts_as_primary(tmp_path) -> None:
+    _, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    validate_output_path(
+        receipts_file.parent / "evaluation.json", {"receipts": receipts_file}
+    )  # no raise: receipts is the primary when it is the only input
+
+
+def test_empty_inputs_mapping_is_descriptive_error_never_stopiteration(tmp_path) -> None:
+    with pytest.raises(EvaluatorInputError, match="no input artifact"):
+        validate_output_path(tmp_path / "evaluation.json", {})
+
+
+def test_identity_checks_hold_under_hostile_insertion_order(tmp_path) -> None:
+    # Aliases of EITHER artifact stay refused regardless of mapping order.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(report_file, inputs)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(receipts_file, inputs)
 
 
 def test_cli_sibling_outputs_remain_allowed(tmp_path, capsys) -> None:

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -8,6 +8,7 @@ itself.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import random
 
@@ -1088,6 +1089,221 @@ def test_cli_oversized_evaluation_exit_5(tmp_path, capsys, monkeypatch) -> None:
     err = capsys.readouterr().err
     assert err.startswith("error:")
     assert "Traceback" not in err
+
+
+# ---------------------------------------------------------------------------
+# Output identity guard: --output must never name or alias ANY supplied
+# input artifact (report OR receipts, primary or not) — by resolved path
+# and by file identity (os.path.samefile on resolved inputs; fail closed
+# when identity cannot be verified). Refusal contract: exit 4, ONE
+# concise ``error:`` line, no traceback, every supplied input
+# byte-identical, no replacement artifact written, and the refusal
+# happens BEFORE any evaluation computation.
+# ---------------------------------------------------------------------------
+
+
+def _make_hardlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        os.link(target, link)
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("hard links unsupported on this filesystem")
+
+
+def _make_symlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+
+
+def _expect_alias_refusal(
+    capsys,
+    tmp_path: pathlib.Path,
+    argv: list[str],
+    inputs: list[pathlib.Path],
+) -> None:
+    """Full refusal contract for one CLI invocation."""
+    before = {p: p.read_bytes() for p in inputs}
+    entries_before = sorted(p.name for p in tmp_path.iterdir())
+    assert main(argv) == 4, argv
+    captured = capsys.readouterr()
+    assert captured.err.startswith("error:"), argv
+    assert captured.err.count("error:") == 1, argv
+    assert "Traceback" not in captured.err, argv
+    for p, b in before.items():
+        assert p.read_bytes() == b, f"input mutated: {p}"
+    assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+# --- report-only: all four alias identities --------------------------------
+
+
+def test_cli_report_only_direct_output_alias_is_refused(tmp_path, capsys) -> None:
+    report_file, _ = _write_artifacts(tmp_path)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--output", str(report_file)],
+        [report_file],
+    )
+
+
+def test_cli_report_only_lexical_output_alias_is_refused(tmp_path, capsys) -> None:
+    report_file, _ = _write_artifacts(tmp_path)
+    alias = tmp_path / "sub" / ".." / "report.json"
+    assert str(alias) != str(report_file)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--output", str(alias)],
+        [report_file],
+    )
+
+
+def test_cli_report_only_symlink_output_alias_is_refused(tmp_path, capsys) -> None:
+    report_file, _ = _write_artifacts(tmp_path)
+    link = tmp_path / "evaluation.json"
+    _make_symlink_or_skip(report_file, link)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--output", str(link)],
+        [report_file],
+    )
+
+
+def test_cli_report_only_hardlink_output_alias_is_refused(tmp_path, capsys) -> None:
+    report_file, _ = _write_artifacts(tmp_path)
+    link = tmp_path / "evaluation.json"
+    _make_hardlink_or_skip(report_file, link)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--output", str(link)],
+        [report_file, link],
+    )
+
+
+# --- receipts-only: the same four identities --------------------------------
+
+
+def test_cli_receipts_only_direct_output_alias_is_refused(tmp_path, capsys) -> None:
+    _, receipts_file = _write_artifacts(tmp_path)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--receipts", str(receipts_file), "--output", str(receipts_file)],
+        [receipts_file],
+    )
+
+
+def test_cli_receipts_only_lexical_output_alias_is_refused(tmp_path, capsys) -> None:
+    _, receipts_file = _write_artifacts(tmp_path)
+    alias = tmp_path / "sub" / ".." / "receipts.json"
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--receipts", str(receipts_file), "--output", str(alias)],
+        [receipts_file],
+    )
+
+
+def test_cli_receipts_only_symlink_output_alias_is_refused(tmp_path, capsys) -> None:
+    _, receipts_file = _write_artifacts(tmp_path)
+    link = tmp_path / "evaluation.json"
+    _make_symlink_or_skip(receipts_file, link)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--receipts", str(receipts_file), "--output", str(link)],
+        [receipts_file],
+    )
+
+
+def test_cli_receipts_only_hardlink_output_alias_is_refused(tmp_path, capsys) -> None:
+    _, receipts_file = _write_artifacts(tmp_path)
+    link = tmp_path / "evaluation.json"
+    _make_hardlink_or_skip(receipts_file, link)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--receipts", str(receipts_file), "--output", str(link)],
+        [receipts_file, link],
+    )
+
+
+# --- both supplied: output aliasing EITHER input is refused -----------------
+
+
+def test_cli_both_supplied_output_aliasing_report_is_refused(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(report_file)],
+        [report_file, receipts_file],
+    )
+
+
+def test_cli_both_supplied_output_aliasing_receipts_is_refused(tmp_path, capsys) -> None:
+    # The non-primary input: report is primary, receipts sits in the same
+    # directory — only an every-supplied-input identity check catches this.
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(receipts_file)],
+        [report_file, receipts_file],
+    )
+
+
+def test_cli_both_supplied_hardlink_of_receipts_is_refused(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    link = tmp_path / "evaluation.json"
+    _make_hardlink_or_skip(receipts_file, link)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(link)],
+        [report_file, receipts_file, link],
+    )
+
+
+# --- refusal precedes evaluation computation --------------------------------
+
+
+def test_alias_refusal_precedes_evaluation_computation(tmp_path, capsys, monkeypatch) -> None:
+    import scripts.nextness_evaluator as evaluator_module
+
+    report_file, receipts_file = _write_artifacts(tmp_path)
+
+    def spy(*args, **kwargs):
+        raise AssertionError("build_evaluation invoked despite alias refusal")
+
+    monkeypatch.setattr(evaluator_module, "build_evaluation", spy)
+    assert main(
+        ["--report", str(report_file), "--output", str(report_file)]
+    ) == 4
+    assert main(
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(receipts_file)]
+    ) == 4
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+
+
+# --- ordinary sibling outputs remain allowed ---------------------------------
+
+
+def test_cli_sibling_outputs_remain_allowed(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    report_before = report_file.read_bytes()
+    receipts_before = receipts_file.read_bytes()
+
+    fresh = tmp_path / "evaluation.json"          # nonexistent sibling
+    assert main(["--report", str(report_file), "--receipts",
+                 str(receipts_file), "--output", str(fresh)]) == 0
+    assert json.loads(fresh.read_bytes())["schema"] == EVALUATION_SCHEMA
+
+    stale = tmp_path / "stale.json"               # existing non-alias sibling
+    stale.write_text("previous content\n", encoding="utf-8")
+    assert main(["--report", str(report_file), "--output", str(stale)]) == 0
+    assert json.loads(stale.read_bytes())["schema"] == EVALUATION_SCHEMA
+
+    assert report_file.read_bytes() == report_before
+    assert receipts_file.read_bytes() == receipts_before
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

One bounded reliability repair to NP5's `--output` lane, closing the gap recorded for Jack in the 2026-07-15 Stage-3 cross-stack audit: `scripts/nextness_evaluator.py`'s `validate_output_path` checked directory confinement and the `data/` tree only, so `--output` could name or alias a **supplied input artifact** and replace that recorded artifact (an NP1 report or NP2 receipt series) with the evaluation. Reproduced live on unmodified `main`: direct alias and hard-link alias both exited 0 and destroyed the recorded artifact.

No schema, metric, serialization, exit-code or dependency change; no shared-helper refactor; the other two allowed files are the test file and the contract doc. Branched directly from `main = deb028cd`, independent (not stacked on #357 or #364).

## The repair

- `validate_output_path` now takes the supplied inputs as a primary-first role mapping (the NP8 shape) and checks identity against **every** supplied input — report and receipts, primary or not — by **resolved-path equality** and **`os.path.samefile` on the resolved paths** (device + inode / file ID; hard links included). Any failure to verify an existing output's identity is itself a refusal — **fail closed**.
- The primary-input **directory confinement rule is preserved unchanged**, as is the `data/`-tree refusal.
- Validation runs **before any artifact is parsed or any evaluation is computed** — proven by a test that monkeypatches `build_evaluation` with a spy that would raise if invoked.
- Refusal contract: exit **4**, one concise `error:` line, no traceback, every supplied input byte-identical, no replacement artifact written.
- The existing byte-output behavior (`write_bytes(serialized.encode("utf-8"))`, LF-only) is untouched and re-asserted by the pre-existing test.

## Failing-first receipts (against unmodified `main`, Windows 11, Python 3.13)

`git diff main -- scripts/nextness_evaluator.py` was empty when these ran.

| # | Regression | Result on unmodified main |
|---|---|---|
| 1–2 | report-only: direct / lexical alias | **FAILED** — exit 0, report destroyed |
| 3 | report-only: hard-link alias | **FAILED** — exit 0, destroyed through link |
| 4–5 | receipts-only: direct / lexical alias | **FAILED** — exit 0, receipts destroyed |
| 6 | receipts-only: hard-link alias | **FAILED** — exit 0 |
| 7 | both supplied: output aliases report | **FAILED** — exit 0 |
| 8 | both supplied: output aliases **receipts (non-primary)** | **FAILED** — exit 0; only an every-input check can catch this |
| 9 | refusal-precedes-evaluation spy | **FAILED** — builder was invoked |
| 10–11 | symlink lanes (report-only / receipts-only) | **SKIPPED** locally (Windows w/o symlink privilege) — exercised on Ubuntu CI |
| 12 | sibling outputs remain allowed | PASSED (regression fence, expected) |

Rollup: `9 failed, 1 passed, 2 skipped`. Post-repair: **83 passed, 2 skipped** (full evaluator file, including the both-supplied hard-link lane that the failing-first filter didn't select — it fails pre-repair for the same reason and passes post-repair).

## Identity truth table (all tested)

| `--output` target | report-only | receipts-only | both supplied | Mechanism |
|---|---|---|---|---|
| the report path / its lexical variant | refused, exit 4 | n/a | refused, exit 4 | resolved-path equality |
| the receipts path / its lexical variant | n/a | refused, exit 4 | **refused, exit 4** (non-primary) | resolved-path equality, every-input loop |
| symlink to either input (where supported) | refused, exit 4 | refused, exit 4 | refused, exit 4 | resolved-path equality (resolution target compared) |
| hard link to either input (where supported) | refused, exit 4 | refused, exit 4 | refused, exit 4 | `samefile` on resolved paths |
| existing path with unverifiable identity (`samefile` raises) | refused, exit 4 | refused, exit 4 | refused, exit 4 | fail closed |
| outside primary input's directory | refused, exit 4 (unchanged) | ← | ← | confinement rule preserved |
| inside repository `data/` tree | refused, exit 4 (unchanged) | ← | ← | preserved |
| nonexistent ordinary sibling | allowed, exit 0 | ← | ← | — |
| existing non-alias sibling | allowed, exit 0 | ← | ← | — |

Every refusal leaves every supplied input byte-identical and writes nothing (directory-entry snapshot asserted); a refused invocation never parses an artifact or computes an evaluation.

## Remaining TOCTOU boundary (documented, not eliminated)

Identity is verified at validation time; the later write does not re-verify. A concurrent actor replacing the output path between validation and write can still redirect the write. Same precisely-stated residual as NP6/NP8, now stated in the module docstring, the guard's docstring and the contract doc.

## Verification receipts

- Targeted: `tests/test_nextness_evaluator.py` — **83 passed, 2 skipped** (skips = symlink lanes, local Windows only).
- Full maintained Python suite: **1231 passed, 30 skipped**.
- `py_compile` both Python files: OK.
- Hash-seed repetitions `PYTHONHASHSEED=0/1/424242`: 83/2 each.
- Contract doc updated: identity guard, refusal contract, exit-4 row, TOCTOU statement; plus a time-anchored pointer on the doc's pre-existing NP1-newline note (that repair is carried in PR #364; disposition is repository history).
- CI: full rollup on this PR; left to conclude before handoff. PR stays **open and unmerged** for Jack.

## Exact file statistics

```
 docs/NEXTNESS_EVALUATOR_CONTRACT.md |  30 ++++-
 scripts/nextness_evaluator.py       |  79 +++++++++++--
 tests/test_nextness_evaluator.py    | 216 ++++++++++++++++++++++++++++++++++++
 3 files changed, 313 insertions(+), 12 deletions(-)
```

One commit, `b0075f387badb493cb4e51f0cc249776730eccb2`, from `main = deb028cd`. Allowed-file fence held exactly.

## Non-claims

- The TOCTOU interval is **not** eliminated.
- No claim about other modules' output lanes (the sibling `nextness_metrics` repair is its own independent PR in this runway).
- The evaluator's epistemics are unchanged: it still observes and scores recordings, never acts, and proves nothing about awareness or experience.


## Correction record — explicit primary-input contract (2026-07-15, Jack narrow-HOLD)

**Heads**: `b0075f387badb493cb4e51f0cc249776730eccb2` → `f7a5e1beeffce029ed23f1cf9f8190df6aa28580` (one commit, ordinary push; base unchanged `deb028cd`). 3 files, +82/−4.

**Defect (contract/robustness, not a reproduced CLI failure)**: `validate_output_path` picked its primary via `next(iter(inputs.values()))` — mapping insertion order. The CLI constructs report-first, so live behavior was correct; any differently-ordered caller would get receipts-directory confinement (and an empty mapping raised bare `StopIteration`).

**Fix**: primary selected explicitly by fixed role order — `report` when present, else `receipts`; identity checks iterate recognized roles in that same fixed order; empty mapping → descriptive `EvaluatorInputError` ("no input artifact supplied…"), consistent with the CLI's documented no-artifact exit-2 meaning. No accepted-role broadening; no CLI behavior change; every alias check, exit code, byte contract, schema and TOCTOU statement unchanged. This implements the substance of the open review suggestion (thread left untouched, per fence).

**Primary-order truth table** (report + receipts in *different* directories, mapping built receipts-first — hostile order):

| Case | Held head `b0075f38` | Corrected `f7a5e1be` |
|---|---|---|
| output beside **report** | ✗ wrongly refused (confined to receipts dir) | ✓ allowed (normal lane rules) |
| output beside **receipts** (non-alias) | ✗ wrongly allowed | ✓ refused (outside report's directory) |
| receipts-only mapping | receipts primary ✓ | receipts primary ✓ (unchanged) |
| empty mapping | **StopIteration** (bare) | descriptive `EvaluatorInputError` |
| alias of report / of receipts, hostile order | refused ✓ | refused ✓ (unchanged) |

**Failing-first receipts** (against the held head, module diff empty): 3 failed — beside-report wrongly refused, beside-receipts wrongly allowed, live `StopIteration`; 2 fences passed (receipts-only primary, hostile-order alias refusals).

**Verification**: evaluator file **88 passed / 2 skipped** (+5 new lanes); hash-seeds 0/1/424242 identical; full maintained suite **1236 passed / 30 skipped**; `py_compile` OK. Contract doc gains the explicit-primary paragraph. CI runs on the new head; PR stays **open and unmerged** for Jack.

<details>
<summary>Exact correction diff (f7a5e1be)</summary>

```diff
diff --git a/docs/NEXTNESS_EVALUATOR_CONTRACT.md b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
index f266944..f2e1f3d 100644
--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -217,6 +217,13 @@ primary input artifact's directory (the `--report` file when provided,
 else the `--receipts` file) and **never** inside the repository `data/`
 tree — the same convention as `nextness_predictor`.
 
+**Explicit primary selection**: the primary input is chosen by fixed
+role order — `report` when provided, otherwise `receipts` — never by
+mapping construction or insertion order, and identity checks iterate
+the recognized roles in that same fixed order. Validating with no
+input at all is a descriptive validation error (never a bare
+`StopIteration`).
+
 **Input-identity guard** (NP6/NP8 convention): `--output` may never
 name or alias **any** supplied input artifact — report or receipts,
 primary or not. Aliases are refused by **resolved path** (covering the
diff --git a/scripts/nextness_evaluator.py b/scripts/nextness_evaluator.py
index 62cb4d1..0d7b067 100644
--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -1262,8 +1262,12 @@ def validate_output_path(
     ID, which covers existing hard links whose paths differ).
 
     ``inputs`` maps role name (``"report"`` / ``"receipts"``) to the
-    supplied path, in primary-first order; identity is checked against
-    EVERY entry, not merely the primary.
+    supplied path. The primary is selected EXPLICITLY by fixed role
+    order — ``report`` when present, else ``receipts`` — never by the
+    mapping's insertion order, and identity is checked against EVERY
+    recognized entry in that same fixed order, not merely the primary.
+    An empty mapping is a descriptive ``EvaluatorInputError``, never a
+    bare ``StopIteration``.
 
     Residual filesystem race, stated precisely (same as NP6/NP8):
     identity is verified at validation time; the later write does not
@@ -1272,7 +1276,15 @@ def validate_output_path(
     defends against aliases that exist when it validates — it does not
     claim protection against concurrent hostile filesystem manipulation.
     """
-    primary = next(iter(inputs.values()))
+    # Fixed, explicit role order (report first) — primary selection and
+    # identity iteration are independent of how the mapping was built.
+    ordered = [(role, inputs[role]) for role in ("report", "receipts") if role in inputs]
+    if not ordered:
+        raise EvaluatorInputError(
+            "no input artifact supplied for output validation: provide "
+            "report and/or receipts"
+        )
+    primary = ordered[0][1]
     input_dir_resolved = primary.resolve().parent
     out_resolved = out_path.resolve()
     try:
@@ -1282,7 +1294,7 @@ def validate_output_path(
             f"refusing to write evaluation outside the primary input "
             f"artifact's directory: {out_resolved} is not inside {input_dir_resolved}"
         ) from e
-    for role, input_path in inputs.items():
+    for role, input_path in ordered:
         input_resolved = input_path.resolve()
         if out_resolved == input_resolved:
             raise WriteOutsideLogDirError(
diff --git a/tests/test_nextness_evaluator.py b/tests/test_nextness_evaluator.py
index 12ca78c..923b2fd 100644
--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -32,10 +32,12 @@ from scripts.nextness_evaluator import (
     load_json_artifact,
     main,
     serialize_evaluation,
+    validate_output_path,
     validate_receipt,
     validate_receipt_series,
     validate_report,
 )
+from scripts.nextness_observer import WriteOutsideLogDirError
 from scripts.nextness_monitor import (
     MonitorConfig,
     build_receipt,
@@ -1287,6 +1289,63 @@ def test_alias_refusal_precedes_evaluation_computation(tmp_path, capsys, monkeyp
 # --- ordinary sibling outputs remain allowed ---------------------------------
 
 
+def _artifacts_in_two_dirs(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    """A report and a receipts artifact in two DIFFERENT directories, so
+    primary selection visibly decides which directory confines --output."""
+    report_dir = tmp_path / "report_dir"
+    receipts_dir = tmp_path / "receipts_dir"
+    report_dir.mkdir()
+    receipts_dir.mkdir()
+    report_file = report_dir / "report.json"
+    report_file.write_text(json.dumps(_make_report()), encoding="utf-8")
+    receipts_file = receipts_dir / "receipts.json"
+    receipts_file.write_text(
+        json.dumps([_make_receipt(observation_count=n) for n in (10, 20)]),
+        encoding="utf-8",
+    )
+    return report_file, receipts_file
+
+
+def test_primary_is_report_regardless_of_mapping_insertion_order(tmp_path) -> None:
+    # Receipts inserted FIRST: the report must still be primary — an
+    # output beside the report is allowed under the normal lane rules.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    assert list(inputs) == ["receipts", "report"]  # hostile insertion order
+    validate_output_path(report_file.parent / "evaluation.json", inputs)  # no raise
+
+
+def test_output_beside_receipts_refused_when_report_present(tmp_path) -> None:
+    # Same hostile insertion order: an output beside the RECEIPTS but
+    # outside the report's directory violates primary confinement.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(receipts_file.parent / "evaluation.json", inputs)
+
+
+def test_receipts_only_mapping_uses_receipts_as_primary(tmp_path) -> None:
+    _, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    validate_output_path(
+        receipts_file.parent / "evaluation.json", {"receipts": receipts_file}
+    )  # no raise: receipts is the primary when it is the only input
+
+
+def test_empty_inputs_mapping_is_descriptive_error_never_stopiteration(tmp_path) -> None:
+    with pytest.raises(EvaluatorInputError, match="no input artifact"):
+        validate_output_path(tmp_path / "evaluation.json", {})
+
+
+def test_identity_checks_hold_under_hostile_insertion_order(tmp_path) -> None:
+    # Aliases of EITHER artifact stay refused regardless of mapping order.
+    report_file, receipts_file = _artifacts_in_two_dirs(tmp_path)
+    inputs = {"receipts": receipts_file, "report": report_file}
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(report_file, inputs)
+    with pytest.raises(WriteOutsideLogDirError):
+        validate_output_path(receipts_file, inputs)
+
+
 def test_cli_sibling_outputs_remain_allowed(tmp_path, capsys) -> None:
     report_file, receipts_file = _write_artifacts(tmp_path)
     report_before = report_file.read_bytes()
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

