### PR TITLE
fix(metrics): legacy nextness_metrics output repair — input-alias refusal + byte-exact streamed output

### DIFF
--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -325,6 +325,12 @@ in NP5/NP6/NP8, later NP1):
   translation can no longer alter the derived file's bytes, so
   re-runs are byte-identical across platforms. Streaming is
   preserved: the output is never materialized in full.
+- **Directory-target refusal**: an `--out` that resolves to an existing
+  directory (including through a symlink) is refused in the same exit-3
+  boundary lane, before the log is read or any metric computed — the
+  binary open would otherwise escape as an uncaught
+  `IsADirectoryError`/`PermissionError` traceback after computation.
+  Ordinary non-alias *file* targets are unaffected.
 - **Residual race, stated precisely**: identity is verified at
   validation time; the write does not re-verify. A concurrent actor
   replacing the output path between validation and write can still

--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -301,6 +301,40 @@ Deliberately deferred to **Lane A** (engine track, separately scoped, currently 
 - ✅ `allow_pickle=False` preserved in any new snapshot reads (the metrics module reads JSONL, not `.npz`, so this is N/A for the new module, but is preserved in `process_snapshot()` extensions).
 - ✅ Bounded compute (the metrics module is $O(N \cdot K)$ where $N$ is number of snapshots and $K$ is vocabulary size; both are small).
 
+### 9.1 Output-boundary hardening (2026-07-15 reliability amendment)
+
+Two gaps in the original write lane were repaired after the Nextness
+NP-stack established the house convention for derived-output safety
+(`os.path.samefile` identity guards in NP6/NP8; explicit byte output
+in NP5/NP6/NP8, later NP1):
+
+- **Input-identity guard**: `--out` may never name or alias the input
+  log — refused by resolved-path equality (direct path, lexical
+  variants like `sub/../log.jsonl`, symlink aliases) and by file
+  identity (`os.path.samefile` on resolved paths, catching hard
+  links), failing closed when an existing output's identity cannot be
+  verified. The refusal keeps the existing boundary convention (exit
+  code 3, one `safety error:` line, `WriteOutsideLogDirError`) and
+  happens before the log is read, any metric computed, or any output
+  parent created. Ordinary sibling outputs — nonexistent or existing
+  non-alias — remain allowed.
+- **Byte-exact streamed output**: the derived JSONL is written in
+  binary mode, one row at a time — each line is its canonical
+  `json.dumps(..., sort_keys=True, default=str)` serialization encoded
+  as UTF-8 plus a single LF byte. Windows text-mode newline
+  translation can no longer alter the derived file's bytes, so
+  re-runs are byte-identical across platforms. Streaming is
+  preserved: the output is never materialized in full.
+- **Residual race, stated precisely**: identity is verified at
+  validation time; the write does not re-verify. A concurrent actor
+  replacing the output path between validation and write can still
+  redirect the write. The guard defends against aliases that exist at
+  validation time; it does not claim to eliminate the
+  validation-to-write (TOCTOU) interval.
+
+All metric formulas, row ordering, JSON field ordering, the stdout
+summary and every exit code are unchanged by this amendment.
+
 ## 10. Open questions for AURA + Jack
 
 1. **CCI composition**: I've defined it as a product of three factors in $[0, 1]$. An alternative is a weighted geometric mean, $\text{CCI} = (B^{w_1} \cdot R^{w_2} \cdot (1-H)^{w_3})^{1/(w_1+w_2+w_3)}$. The product is simpler and has the right "any factor zero → CCI zero" property. Weighted GM lets us emphasize boundary rate over balance if calibration suggests we should. Recommend starting with the simple product; revisit in PR #4 if calibration shows it's miscalibrated.

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -93,6 +93,12 @@ def _validate_metrics_output_path(
     ``scripts.nextness_observer``) so the safety vocabulary stays
     unified across both modules.
 
+    Directory-target guard: an ``out_path`` that resolves to an existing
+    directory (including through a symlink) is refused here in the same
+    boundary lane — the binary open would otherwise raise
+    ``IsADirectoryError``/``PermissionError`` as an uncaught traceback
+    only after the log had been read and every metric computed.
+
     Input-identity guard (Nextness NP6/NP8 convention): the output may
     also never BE the input log — refused by resolved path (which
     covers the direct path, lexical variants like ``sub/../log.jsonl``
@@ -120,6 +126,14 @@ def _validate_metrics_output_path(
             f"refusing to write metrics output outside log_path's directory: "
             f"{out_resolved} is not inside {log_dir_resolved}"
         ) from e
+    # An existing directory (or a symlink resolving to one) can never be
+    # a metrics output file. Refuse here, in the established boundary
+    # lane, rather than letting the later binary open escape as an
+    # IsADirectoryError/PermissionError traceback after computation.
+    if out_resolved.is_dir():
+        raise WriteOutsideLogDirError(
+            f"refusing to write metrics output onto a directory: {out_resolved}"
+        )
     if out_resolved == log_resolved:
         raise WriteOutsideLogDirError(
             f"refusing to overwrite the input log file: {out_resolved}"

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -15,6 +15,18 @@ Scope guarantees (carried forward from PR #138 / PR #140):
       JSONL log. Enforced via :class:`WriteOutsideLogDirError` reused
       from ``scripts.nextness_observer``; the safety vocabulary is
       unified across modules.
+    - **No writes onto the input log itself** — an ``--out`` that names or
+      aliases ``log_path`` (direct path, lexical variant, symlink, hard
+      link) is refused by resolved path and by file identity
+      (``os.path.samefile`` on resolved paths), failing closed when an
+      existing output's identity cannot be verified. Identity is checked
+      at validation time, before the log is read or any metric computed;
+      the later write does not re-verify (documented residual race, same
+      statement as the Nextness NP6/NP8 guards).
+    - **Byte-exact output** — the derived JSONL is written in binary mode:
+      each row is its canonical ``json.dumps(..., sort_keys=True,
+      default=str)`` serialization encoded as UTF-8 plus a single LF
+      byte, streamed row by row, immune to platform newline translation.
     - No HTTP, ZMQ, or network of any kind.
     - CPU-only.
     - allow_pickle=False (no .npz reads here; JSONL only).
@@ -40,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import pathlib
 import sys
 from collections.abc import Mapping, Sequence
@@ -79,8 +92,26 @@ def _validate_metrics_output_path(
     :class:`WriteOutsideLogDirError` (reused from
     ``scripts.nextness_observer``) so the safety vocabulary stays
     unified across both modules.
+
+    Input-identity guard (Nextness NP6/NP8 convention): the output may
+    also never BE the input log — refused by resolved path (which
+    covers the direct path, lexical variants like ``sub/../log.jsonl``
+    and symlink aliases: resolution targets are compared, not link or
+    segment names) and by file identity (``os.path.samefile`` on the
+    RESOLVED paths: device + inode / file ID, covering existing hard
+    links whose paths differ). Any failure to verify an existing
+    output's identity is itself a refusal — fail closed, never a
+    fall-through.
+
+    Residual filesystem race, stated precisely: identity is verified at
+    validation time; the later write does not re-verify. A concurrent
+    actor replacing the output path between validation and write can
+    still redirect the write. This guard defends against aliases that
+    exist when it validates — it does not claim to eliminate the
+    validation-to-write (TOCTOU) interval.
     """
-    log_dir_resolved = log_path.resolve().parent
+    log_resolved = log_path.resolve()
+    log_dir_resolved = log_resolved.parent
     out_resolved = out_path.resolve()
     try:
         out_resolved.relative_to(log_dir_resolved)
@@ -89,6 +120,27 @@ def _validate_metrics_output_path(
             f"refusing to write metrics output outside log_path's directory: "
             f"{out_resolved} is not inside {log_dir_resolved}"
         ) from e
+    if out_resolved == log_resolved:
+        raise WriteOutsideLogDirError(
+            f"refusing to overwrite the input log file: {out_resolved}"
+        )
+    # Hard links share identity while having distinct paths. Only an
+    # EXISTING output can alias the input; stat runs on the resolved
+    # paths and any failure to verify is itself a refusal (fail closed),
+    # never a fall-through.
+    if out_resolved.exists():
+        try:
+            same = os.path.samefile(out_resolved, log_resolved)
+        except OSError as e:
+            raise WriteOutsideLogDirError(
+                f"cannot verify output file identity against the input log "
+                f"file: {out_resolved}"
+            ) from e
+        if same:
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input log file (shared file "
+                f"identity): {out_resolved}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -434,11 +486,14 @@ def compute_run_metrics(
 
     # Write output deterministically. Note: NO ``generated_at`` field.
     # ``sort_keys=True`` makes the JSON field order deterministic too.
+    # Binary mode, streamed row by row: each line is the canonical
+    # serialization encoded as UTF-8 plus a single LF byte, so the
+    # derived file's bytes never depend on platform newline translation.
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open("w", encoding="utf-8") as f:
+    with out_path.open("wb") as f:
         for row in pair_rows:
-            f.write(json.dumps(row, sort_keys=True, default=str) + "\n")
-        f.write(json.dumps(aggregate, sort_keys=True, default=str) + "\n")
+            f.write(json.dumps(row, sort_keys=True, default=str).encode("utf-8") + b"\n")
+        f.write(json.dumps(aggregate, sort_keys=True, default=str).encode("utf-8") + b"\n")
 
     return aggregate
 

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import pathlib
 
 import pytest
@@ -612,3 +613,154 @@ def test_cli_main_returns_nonzero_for_outside_log_dir_output(tmp_path, capsys):
     assert "outside log_path" in captured.err.lower()
     # No side effects: the outside-of-boundary parent dir must not exist
     assert not (tmp_path / "elsewhere").exists()
+
+
+# ---------------------------------------------------------------------------
+# Input-identity guard: --out must never name or alias the input log —
+# by resolved path and by file identity (os.path.samefile on resolved
+# paths; fail closed when identity cannot be verified). Refusals keep
+# the existing metrics boundary-failure convention: exit code 3, one
+# "safety error:" line, WriteOutsideLogDirError vocabulary, no
+# traceback — and happen BEFORE any metrics computation, output-parent
+# creation or derived-output write.
+# ---------------------------------------------------------------------------
+
+
+def _two_entry_log(tmp_path: pathlib.Path) -> pathlib.Path:
+    log_path = tmp_path / "nextness_runs.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+    return log_path
+
+
+def _make_hardlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        os.link(target, link)
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("hard links unsupported on this filesystem")
+
+
+def _make_symlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+
+
+def _expect_alias_refusal(capsys, tmp_path, log_path, out_arg) -> None:
+    """Full refusal contract: exit 3 · one safety-error line · no
+    traceback · input byte-identical · no derived output or new entry."""
+    input_before = log_path.read_bytes()
+    entries_before = sorted(p.name for p in tmp_path.iterdir())
+    rc = main(["--log", str(log_path), "--out", str(out_arg)])
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+def test_cli_out_naming_input_log_is_refused(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    _expect_alias_refusal(capsys, tmp_path, log_path, log_path)
+
+
+def test_cli_out_lexical_alias_of_log_is_refused(tmp_path, capsys):
+    # Distinct lexically, identical once resolved; 'sub' does not exist
+    # and must not be created (refusal precedes any parent mkdir).
+    log_path = _two_entry_log(tmp_path)
+    alias = tmp_path / "sub" / ".." / "nextness_runs.jsonl"
+    assert str(alias) != str(log_path)
+    _expect_alias_refusal(capsys, tmp_path, log_path, alias)
+    assert not (tmp_path / "sub").exists()
+
+
+def test_cli_out_symlink_alias_of_log_is_refused(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    link = tmp_path / "out.jsonl"
+    _make_symlink_or_skip(log_path, link)
+    _expect_alias_refusal(capsys, tmp_path, log_path, link)
+
+
+def test_cli_out_hardlink_alias_of_log_is_refused(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    link = tmp_path / "out.jsonl"
+    _make_hardlink_or_skip(log_path, link)
+    input_before = log_path.read_bytes()
+    rc = main(["--log", str(log_path), "--out", str(link)])
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert link.read_bytes() == input_before  # shared identity: still the log
+
+
+def test_compute_run_metrics_refuses_alias_directly(tmp_path):
+    log_path = _two_entry_log(tmp_path)
+    with pytest.raises(WriteOutsideLogDirError):
+        compute_run_metrics(log_path, log_path)
+    with pytest.raises(WriteOutsideLogDirError):
+        compute_run_metrics(log_path, tmp_path / "sub" / ".." / "nextness_runs.jsonl")
+
+
+def test_alias_refusal_precedes_metrics_computation(tmp_path, capsys, monkeypatch):
+    import scripts.nextness_metrics as metrics_module
+
+    log_path = _two_entry_log(tmp_path)
+
+    def spy(*args, **kwargs):
+        raise AssertionError("metrics computation ran despite alias refusal")
+
+    # kl_divergence is on the per-pair computation path for this
+    # two-entry log; a refused invocation must never reach it.
+    monkeypatch.setattr(metrics_module, "kl_divergence", spy)
+    assert main(["--log", str(log_path), "--out", str(log_path)]) == 3
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+
+
+def test_cli_out_ordinary_siblings_remain_allowed(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    input_before = log_path.read_bytes()
+
+    fresh = tmp_path / "out.jsonl"                 # nonexistent sibling
+    assert main(["--log", str(log_path), "--out", str(fresh)]) == 0
+    assert fresh.is_file()
+
+    stale = tmp_path / "stale.jsonl"               # existing non-alias sibling
+    stale.write_text("previous content\n", encoding="utf-8")
+    assert main(["--log", str(log_path), "--out", str(stale)]) == 0
+    assert stale.read_bytes() == fresh.read_bytes()
+
+    assert log_path.read_bytes() == input_before
+    capsys.readouterr()  # drain summaries
+
+
+# ---------------------------------------------------------------------------
+# Output byte contract: canonical per-row JSON, UTF-8, LF bytes only —
+# no platform newline translation, byte-identical rewrite.
+# ---------------------------------------------------------------------------
+
+
+def test_output_bytes_are_canonical_utf8_lf_only(tmp_path):
+    log_path = _two_entry_log(tmp_path)
+    out_path = tmp_path / "out.jsonl"
+    assert main(["--log", str(log_path), "--out", str(out_path)]) == 0
+    raw = out_path.read_bytes()
+    assert b"\r" not in raw                        # no CRLF translation
+    assert raw.endswith(b"\n") and not raw.endswith(b"\n\n")
+    # Every line is exactly its canonical serialization re-encoded.
+    lines = raw.split(b"\n")[:-1]
+    rebuilt = b"".join(
+        json.dumps(json.loads(line), sort_keys=True, default=str).encode("utf-8")
+        + b"\n"
+        for line in lines
+    )
+    assert raw == rebuilt
+    # Byte-identical idempotent rewrite.
+    assert main(["--log", str(log_path), "--out", str(out_path)]) == 0
+    assert out_path.read_bytes() == raw

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -741,6 +741,73 @@ def test_cli_out_ordinary_siblings_remain_allowed(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
+# Directory-target failure lane: an existing directory inside the log
+# directory must be refused in the established exit-3 boundary lane —
+# never escape as an IsADirectoryError/PermissionError traceback from
+# the binary open.
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_tree(root: pathlib.Path) -> list[tuple[str, bytes | None]]:
+    out = []
+    for p in sorted(root.rglob("*")):
+        out.append((str(p.relative_to(root)), p.read_bytes() if p.is_file() else None))
+    return out
+
+
+def test_cli_out_naming_existing_directory_is_refused_exit_3(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    input_before = log_path.read_bytes()
+    tree_before = _snapshot_tree(tmp_path)
+
+    rc = main(["--log", str(log_path), "--out", str(target_dir)])
+
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert _snapshot_tree(tmp_path) == tree_before  # dir + contents unchanged
+
+
+def test_directory_refusal_precedes_metrics_computation(tmp_path, capsys, monkeypatch):
+    import scripts.nextness_metrics as metrics_module
+
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+
+    def spy(*args, **kwargs):
+        raise AssertionError("metrics computation ran despite directory refusal")
+
+    monkeypatch.setattr(metrics_module, "kl_divergence", spy)
+    assert main(["--log", str(log_path), "--out", str(target_dir)]) == 3
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_cli_out_symlink_to_directory_is_refused_exit_3(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "real_dir"
+    target_dir.mkdir()
+    link = tmp_path / "out.jsonl"
+    try:
+        link.symlink_to(target_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+    input_before = log_path.read_bytes()
+    rc = main(["--log", str(log_path), "--out", str(link)])
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert target_dir.is_dir()
+
+
+# ---------------------------------------------------------------------------
 # Output byte contract: canonical per-row JSON, UTF-8, LF bytes only —
 # no platform newline translation, byte-identical rewrite.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

One bounded reliability repair to the legacy (pre-NP-stack, PR #142-vintage) `scripts/nextness_metrics.py` CLI, closing both gaps recorded for Jack in the 2026-07-15 Stage-3 cross-stack audit. Reproduced live on unmodified `main`: `--log L --out L` exits 0, prints its success summary, and replaces the input log with the derived output; and the derived JSONL is written in text mode, so Windows injects CRLF (20 CR bytes observed on the audit fixture), breaking cross-platform byte-identity.

Branched directly from `main = deb028cd`, fully independent — not stacked on #357, #364 or #365. No schema, metric, numerical, dependency or workflow change; no unrelated legacy behavior touched.

## The repair

- **Input-identity guard**: `_validate_metrics_output_path` (the existing guard, extended in place) now refuses any `--out` that IS the input log — by **resolved-path equality** (direct path, lexical variants like `sub/../log.jsonl`, symlink aliases: resolution targets compared, not link/segment names) and by **`os.path.samefile` on resolved paths** (device + inode / file ID; hard links). Any failure to verify an existing output's identity is itself a refusal — **fail closed**.
- **Refusal convention preserved exactly**: `WriteOutsideLogDirError` → the existing CLI boundary lane → **exit 3**, one concise `safety error:` line, no traceback. Refusal precedes the log read, all metric computation, and any output-parent creation (proved by a `kl_divergence` spy and a no-`mkdir` assertion on the lexical-alias lane). Input left byte-identical; no derived output written.
- **Byte-exact streamed output**: the writer opens the output in **binary mode** and streams row by row — each line is its canonical `json.dumps(row, sort_keys=True, default=str)` serialization encoded as UTF-8 plus an explicit `b"\n"`. **Streaming is preserved** — the complete output is never materialized. LF bytes only, on every platform.
- Row ordering, JSON field ordering, all metric calculations, the stdout summary and every exit code: unchanged.

## Failing-first receipts (against unmodified `main`, Windows 11, Python 3.13)

`git diff main -- scripts/nextness_metrics.py` was empty when these ran.

| # | Regression | Result on unmodified main |
|---|---|---|
| 1 | direct `--log L --out L` | **FAILED** — exit 0, success summary printed, input log destroyed |
| 2 | lexical alias (`sub/../nextness_runs.jsonl`) | **FAILED** — exit 0, input destroyed |
| 3 | hard-link alias | **FAILED** — exit 0, destroyed through the link |
| 4 | unit-level: `compute_run_metrics(log, log)` and lexical variant raise | **FAILED** — no refusal |
| 5 | refusal-precedes-computation spy (`kl_divergence`) | **FAILED** — computation ran |
| 6 | canonical UTF-8/LF byte contract | **FAILED** — CR bytes present (Windows text-mode translation) |
| 7 | symlink alias | **SKIPPED** locally (Windows w/o symlink privilege) — exercised on Ubuntu CI |
| 8 | ordinary siblings remain allowed | PASSED (regression fence, expected) |

Post-repair: **45 passed, 1 skipped** (full metrics file).

## Identity / newline truth table (all tested)

| `--out` target | Verdict | Mechanism |
|---|---|---|
| the log path itself | **refused, exit 3**, `safety error:` | resolved-path equality |
| lexical alias of the log | **refused, exit 3**; no `sub/` directory created | resolved-path equality, pre-mkdir |
| symlink to the log (where supported) | **refused, exit 3** | resolved-path equality (resolution target compared) |
| hard link to the log (where supported) | **refused, exit 3** | `samefile` on resolved paths |
| existing path with unverifiable identity (`samefile` raises `OSError`) | **refused, exit 3** | fail closed |
| outside the log directory | refused, exit 3 (unchanged lane, message unchanged) | containment rule preserved |
| nonexistent ordinary sibling | allowed, exit 0 | — |
| existing non-alias sibling | allowed (overwritten), exit 0 | — |

Newline contract: output bytes contain **zero CR bytes**; every line is its canonical serialization re-encoded (`raw == rebuilt` assertion); single trailing LF; byte-identical idempotent rewrite asserted. On POSIX the output bytes are unchanged from the old writer; on Windows the only difference is CRLF→LF.

## Remaining TOCTOU boundary (documented, not eliminated)

Identity is verified at validation time; the later write does not re-verify. A concurrent actor replacing the output path between validation and write can still redirect the write. Same precisely-stated residual as the Nextness NP6/NP8 guards, now stated in the module docstring, the guard's docstring, and §9.1 of the design doc.

## Verification receipts

- Targeted: `tests/test_nextness_metrics.py` — **45 passed, 1 skipped** (skip = symlink lane, local Windows only).
- Full maintained Python suite: **1227 passed, 29 skipped**.
- `py_compile` both Python files: OK.
- Hash-seed repetitions `PYTHONHASHSEED=0/1/424242`: 45/1 each.
- Design doc `PHASE_19_PR3_METRICS_PIPELINE.md` gains §9.1 (output-boundary hardening, 2026-07-15) — the historical design text above it is untouched.
- CI: full rollup on this PR; left to conclude before handoff. PR stays **open and unmerged** for Jack.

## Exact file statistics

```
 PHASE_19_PR3_METRICS_PIPELINE.md |  34 +++++++++
 scripts/nextness_metrics.py      |  63 ++++++++++++++--
 tests/test_nextness_metrics.py   | 152 +++++++++++++++++++++++++++++++++++++++
 3 files changed, 245 insertions(+), 4 deletions(-)
```

One commit, `88175e16bc1b564b4a62aa1a6ec0bac8c56720a0`, from `main = deb028cd`. Allowed-file fence held exactly.

## Non-claims

- The TOCTOU interval is **not** eliminated.
- No other legacy behavior of this module was repaired or altered — anything else noticed stays recorded for Jack, not fixed here.
- The metrics remain interpretive telemetry over observer logs; nothing here claims anything beyond software behavior.


## Correction record — directory-target failure lane (2026-07-15, Jack narrow-HOLD)

**Heads**: `88175e16bc1b564b4a62aa1a6ec0bac8c56720a0` → `c58bf7d84a3ea7ff15015a39ad890f0dcb86b52f` (one commit, ordinary push; base unchanged `deb028cd`). 3 files, +87/−0.

**Defect**: an existing directory inside the log directory passed `_validate_metrics_output_path`; the binary open later escaped as an uncaught traceback — after the log had been read and every metric computed. Failing-first on the held head: live **`PermissionError: [Errno 13]`** escaped from the open (the Windows form; `IsADirectoryError` on POSIX), and a `kl_divergence` spy proved computation ran before the crash.

**Fix**: `_validate_metrics_output_path` now explicitly rejects `out_resolved.is_dir()` (which also covers symlinks resolving to directories) immediately after the containment check — in the established `WriteOutsideLogDirError` → **exit 3** / one `safety error:` line lane, before any log read, metric computation, or write. No broad `OSError` catch was added; unrelated legacy error behavior, streaming binary output, calculations, stdout summary, and all exit codes are unchanged.

**Directory-target truth table**:

| `--out` target | Held head `88175e16` | Corrected `c58bf7d8` |
|---|---|---|
| existing directory inside log dir | uncaught `PermissionError`/`IsADirectoryError` traceback after full computation | **refused, exit 3**, one `safety error:` line, no traceback, before any computation |
| symlink resolving to a directory (where supported) | same traceback lane | **refused, exit 3** (Ubuntu CI exercises it) |
| directory + its contents after refusal | n/a (crash) | byte-identical (full-tree snapshot asserted) |
| input log after refusal | intact (crash was at write) | byte-identical, and now never even read |
| ordinary non-alias **file** targets (nonexistent / existing) | allowed | allowed, unchanged |
| all prior alias lanes + LF byte contract | green | green (full file re-run) |

**Verification**: metrics file **47 passed / 2 skipped** (+3 new lanes; skips = symlink lanes, local Windows only); hash-seeds 0/1/424242 identical; full maintained suite **1229 passed / 30 skipped**; `py_compile` OK. Design doc §9.1 gains the directory-target bullet. CI runs on the new head; PR stays **open and unmerged** for Jack.

<details>
<summary>Exact correction diff (c58bf7d8)</summary>

```diff
diff --git a/PHASE_19_PR3_METRICS_PIPELINE.md b/PHASE_19_PR3_METRICS_PIPELINE.md
index d574442..ed2e79c 100644
--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -325,6 +325,12 @@ in NP5/NP6/NP8, later NP1):
   translation can no longer alter the derived file's bytes, so
   re-runs are byte-identical across platforms. Streaming is
   preserved: the output is never materialized in full.
+- **Directory-target refusal**: an `--out` that resolves to an existing
+  directory (including through a symlink) is refused in the same exit-3
+  boundary lane, before the log is read or any metric computed — the
+  binary open would otherwise escape as an uncaught
+  `IsADirectoryError`/`PermissionError` traceback after computation.
+  Ordinary non-alias *file* targets are unaffected.
 - **Residual race, stated precisely**: identity is verified at
   validation time; the write does not re-verify. A concurrent actor
   replacing the output path between validation and write can still
diff --git a/scripts/nextness_metrics.py b/scripts/nextness_metrics.py
index 7de6cc2..18e962a 100644
--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -93,6 +93,12 @@ def _validate_metrics_output_path(
     ``scripts.nextness_observer``) so the safety vocabulary stays
     unified across both modules.
 
+    Directory-target guard: an ``out_path`` that resolves to an existing
+    directory (including through a symlink) is refused here in the same
+    boundary lane — the binary open would otherwise raise
+    ``IsADirectoryError``/``PermissionError`` as an uncaught traceback
+    only after the log had been read and every metric computed.
+
     Input-identity guard (Nextness NP6/NP8 convention): the output may
     also never BE the input log — refused by resolved path (which
     covers the direct path, lexical variants like ``sub/../log.jsonl``
@@ -120,6 +126,14 @@ def _validate_metrics_output_path(
             f"refusing to write metrics output outside log_path's directory: "
             f"{out_resolved} is not inside {log_dir_resolved}"
         ) from e
+    # An existing directory (or a symlink resolving to one) can never be
+    # a metrics output file. Refuse here, in the established boundary
+    # lane, rather than letting the later binary open escape as an
+    # IsADirectoryError/PermissionError traceback after computation.
+    if out_resolved.is_dir():
+        raise WriteOutsideLogDirError(
+            f"refusing to write metrics output onto a directory: {out_resolved}"
+        )
     if out_resolved == log_resolved:
         raise WriteOutsideLogDirError(
             f"refusing to overwrite the input log file: {out_resolved}"
diff --git a/tests/test_nextness_metrics.py b/tests/test_nextness_metrics.py
index b2ee6b3..8825016 100644
--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -740,6 +740,73 @@ def test_cli_out_ordinary_siblings_remain_allowed(tmp_path, capsys):
     capsys.readouterr()  # drain summaries
 
 
+# ---------------------------------------------------------------------------
+# Directory-target failure lane: an existing directory inside the log
+# directory must be refused in the established exit-3 boundary lane —
+# never escape as an IsADirectoryError/PermissionError traceback from
+# the binary open.
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_tree(root: pathlib.Path) -> list[tuple[str, bytes | None]]:
+    out = []
+    for p in sorted(root.rglob("*")):
+        out.append((str(p.relative_to(root)), p.read_bytes() if p.is_file() else None))
+    return out
+
+
+def test_cli_out_naming_existing_directory_is_refused_exit_3(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    input_before = log_path.read_bytes()
+    tree_before = _snapshot_tree(tmp_path)
+
+    rc = main(["--log", str(log_path), "--out", str(target_dir)])
+
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert _snapshot_tree(tmp_path) == tree_before  # dir + contents unchanged
+
+
+def test_directory_refusal_precedes_metrics_computation(tmp_path, capsys, monkeypatch):
+    import scripts.nextness_metrics as metrics_module
+
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+
+    def spy(*args, **kwargs):
+        raise AssertionError("metrics computation ran despite directory refusal")
+
+    monkeypatch.setattr(metrics_module, "kl_divergence", spy)
+    assert main(["--log", str(log_path), "--out", str(target_dir)]) == 3
+    assert "Traceback" not in capsys.readouterr().err
+
+
+def test_cli_out_symlink_to_directory_is_refused_exit_3(tmp_path, capsys):
+    log_path = _two_entry_log(tmp_path)
+    target_dir = tmp_path / "real_dir"
+    target_dir.mkdir()
+    link = tmp_path / "out.jsonl"
+    try:
+        link.symlink_to(target_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+    input_before = log_path.read_bytes()
+    rc = main(["--log", str(log_path), "--out", str(link)])
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert captured.err.count("safety error:") == 1
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == input_before
+    assert target_dir.is_dir()
+
+
 # ---------------------------------------------------------------------------
 # Output byte contract: canonical per-row JSON, UTF-8, LF bytes only —
 # no platform newline translation, byte-identical rewrite.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

