### PR TITLE
CI: non-required swarm-hunter lab workflow (prerequisite for S1)

### DIFF
--- a/.github/workflows/swarm-hunter-lab.yml
+++ b/.github/workflows/swarm-hunter-lab.yml
@@ -1,0 +1,31 @@
+name: swarm-hunter-lab
+
+on:
+  pull_request:
+    paths:
+      - "experiments/swarm_hunter_lab/**"
+  push:
+    branches: [main]
+    paths:
+      - "experiments/swarm_hunter_lab/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: swarm-hunter-lab-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lab-tests:
+    name: swarm-hunter-lab (non-required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - name: Install lab dependencies
+        run: pip install numpy pytest
+      - name: Run lab-local suite
+        run: python -m pytest experiments/swarm_hunter_lab/tests -q


### PR DESCRIPTION
## What (Kev-authorized Prompt 1 — prerequisite for S1; one file, no merge authority)

Adds `.github/workflows/swarm-hunter-lab.yml`, **byte-exact to the audited Pass-9 frozen text** from the S1 contract freeze (verified by diff before commit). Nothing else changes.

## Properties, stated for the record

- **Non-required status**: this workflow is not added to any required-check list or ruleset; the existing required-check floor (`agent-safety`, `verify-python`, `frontend-quality`) is unchanged.
- **Path-filter scope**: triggers only on `experiments/swarm_hunter_lab/**` (pull_request, and push to main). The workflow file is **deliberately not in its own path filter**, so this workflow-only PR cannot self-trigger against a lab directory that does not exist yet — there is no "absent directory means success" escape hatch. After this merges, any S1 lab PR triggers it.
- **Permissions**: `contents: read` only. No secrets, artifacts, caches, write permissions, or external services; the future detector/tests make no network calls (dependency install is the standard CI pip fetch, identical to the existing floor).
- **Pinned actions**: the repository's exact pins — `actions/checkout@9c091bb2… # v7.0.0`, `actions/setup-python@ece7cb06… # v6.3.0`; Python 3.12 matching `ci.yml`; deps `numpy pytest` only.
- **Concurrency**: superseded PR runs are cancelled (`swarm-hunter-lab-${{ github.ref }}`).
- **Test command**: `python -m pytest experiments/swarm_hunter_lab/tests -q` — the exact lab test directory.
- **Rollback**: delete this file.

## Lane

Open and **unmerged** for Jack's audit. The merge of this PR is **not pre-authorized** — it awaits Kev's separate word naming the exact PR number, head commit, and checks. S1 implementation (Prompt 2) is authorized but gated until this PR is audited, green, and merged under that separate word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
