### PR TITLE
fix(calibration): refuse output paths that alias the input log

### DIFF
--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -64,6 +64,7 @@ import dataclasses
 import hashlib
 import json
 import math
+import os
 import pathlib
 import re
 import tempfile
@@ -123,17 +124,53 @@ def _validate_calibration_output_path(
     out_path: pathlib.Path,
     log_path: pathlib.Path,
 ) -> None:
-    """Refuse output paths that resolve outside the input log's directory.
+    """Refuse output paths outside the log directory, or that ARE the input log.
 
-    Mirrors ``nextness_metrics._validate_metrics_output_path`` so the same
-    Lane B safety contract applies to calibration outputs. Resolves both
-    paths to canonical absolute form before comparing — symlink-aware.
+    Every caller runs this guard before any experiment computation, and
+    ``_write_calibration_jsonl`` opens its target with ``"w"`` — so a
+    fall-through here destroys the observer's recorded log, the one
+    artifact the Nextness stack cannot recompute. The enforced contract,
+    in evaluation order:
+
+    1. **Containment** — the output must resolve inside ``log_path``'s
+       directory. Catches literal mismatches (``/tmp/other.jsonl``) and
+       traversal/symlink escapes (``../elsewhere/out.jsonl``).
+    2. **Directory targets** — an output resolving to an existing
+       directory (including through a symlink) is refused; it can never
+       be an output file.
+    3. **Direct and resolved-path aliases** — an output resolving to the
+       input log itself is refused. Resolution targets are compared, not
+       path segments, so lexical variants (``sub/../log.jsonl``) and
+       symlink aliases resolving to the input log are covered.
+    4. **File identity** — for an existing target, ``os.path.samefile``
+       (device + inode / file ID) catches hard links whose paths differ.
+       If identity **cannot** be established the guard **fails closed** —
+       an unverifiable target is refused, never a fall-through.
+
+    Ordinary sibling outputs — nonexistent, or existing non-alias files —
+    remain permitted; overwriting a stale calibration output is allowed.
+
+    This matches the **identity and directory protections** of
+    ``nextness_metrics._validate_metrics_output_path`` (same rules, same
+    order, same fail-closed posture). It deliberately does **not** claim
+    parity with that module's *writer*: ``_write_calibration_jsonl``
+    still writes in text mode, so calibration output is not byte-identical
+    across platforms the way the metrics writer's is. That difference is
+    out of this guard's scope.
+
+    Residual race, stated precisely: identity is verified here, at
+    validation time; the later write does not re-verify. A concurrent
+    actor replacing the output path between validation and write can
+    still redirect the write. This guard defends against aliases that
+    exist when it validates — it does not claim to eliminate the
+    validation-to-write (TOCTOU) interval.
 
     Raises :class:`WriteOutsideLogDirError` (reused from
     ``scripts.nextness_observer``) so the safety vocabulary stays unified
     across all three Lane B modules (observer + metrics + calibration).
     """
-    log_dir_resolved = log_path.resolve().parent
+    log_resolved = log_path.resolve()
+    log_dir_resolved = log_resolved.parent
     out_resolved = out_path.resolve()
     try:
         out_resolved.relative_to(log_dir_resolved)
@@ -142,6 +179,31 @@ def _validate_calibration_output_path(
             f"refusing to write calibration output outside log_path's "
             f"directory: {out_resolved} is not inside {log_dir_resolved}"
         ) from e
+    if out_resolved.is_dir():
+        raise WriteOutsideLogDirError(
+            f"refusing to write calibration output onto a directory: {out_resolved}"
+        )
+    if out_resolved == log_resolved:
+        raise WriteOutsideLogDirError(
+            f"refusing to overwrite the input log file: {out_resolved}"
+        )
+    # Hard links share identity while having distinct paths. Only an
+    # EXISTING output can alias the input; stat runs on the resolved
+    # paths and any failure to verify is itself a refusal (fail closed),
+    # never a fall-through.
+    if out_resolved.exists():
+        try:
+            same = os.path.samefile(out_resolved, log_resolved)
+        except OSError as e:
+            raise WriteOutsideLogDirError(
+                f"cannot verify output file identity against the input log "
+                f"file: {out_resolved}"
+            ) from e
+        if same:
+            raise WriteOutsideLogDirError(
+                f"refusing to overwrite the input log file (shared file "
+                f"identity): {out_resolved}"
+            )
 
 
 def _validate_config_log_directory(

--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -144,8 +144,15 @@ def _validate_calibration_output_path(
        symlink aliases resolving to the input log are covered.
     4. **File identity** — for an existing target, ``os.path.samefile``
        (device + inode / file ID) catches hard links whose paths differ.
-       If identity **cannot** be established the guard **fails closed** —
-       an unverifiable target is refused, never a fall-through.
+       ``samefile`` is called only when BOTH resolved targets are
+       confirmed to exist: a missing input log — valid before the
+       observer's first write — cannot share file identity with a
+       distinct existing sibling, so a genuine ``FileNotFoundError``
+       (confirmed absence, including one arising in the residual
+       interval between the existence checks and the stat) is treated
+       as "no shared identity". Every OTHER inspection failure
+       (permission, I/O) still **fails closed** — an unverifiable
+       target is refused, never a fall-through to permission-to-write.
 
     Ordinary sibling outputs — nonexistent, or existing non-alias files —
     remain permitted; overwriting a stale calibration output is allowed.
@@ -187,13 +194,19 @@ def _validate_calibration_output_path(
         raise WriteOutsideLogDirError(
             f"refusing to overwrite the input log file: {out_resolved}"
         )
-    # Hard links share identity while having distinct paths. Only an
-    # EXISTING output can alias the input; stat runs on the resolved
-    # paths and any failure to verify is itself a refusal (fail closed),
-    # never a fall-through.
-    if out_resolved.exists():
+    # Hard links share identity while having distinct paths. Identity
+    # comparison requires both endpoints to exist: a missing input log
+    # (valid before the observer's first write) cannot share identity
+    # with a distinct existing sibling, so samefile runs only when both
+    # resolved targets are confirmed to exist. A FileNotFoundError from
+    # the residual interval between those checks and the stat is the
+    # same confirmed absence. Every OTHER inspection failure is itself
+    # a refusal (fail closed), never a fall-through.
+    if out_resolved.exists() and log_resolved.exists():
         try:
             same = os.path.samefile(out_resolved, log_resolved)
+        except FileNotFoundError:
+            same = False  # confirmed absence: no shared identity possible
         except OSError as e:
             raise WriteOutsideLogDirError(
                 f"cannot verify output file identity against the input log "

--- a/scripts/nextness_calibration.py
+++ b/scripts/nextness_calibration.py
@@ -67,6 +67,7 @@ import math
 import os
 import pathlib
 import re
+import stat as stat_module
 import tempfile
 from typing import Any
 
@@ -135,24 +136,35 @@ def _validate_calibration_output_path(
     1. **Containment** — the output must resolve inside ``log_path``'s
        directory. Catches literal mismatches (``/tmp/other.jsonl``) and
        traversal/symlink escapes (``../elsewhere/out.jsonl``).
-    2. **Directory targets** — an output resolving to an existing
+    2. **Output status probe** — the output's true state is established
+       with an explicit ``stat()``, because a boolean ``Path.exists()``
+       cannot distinguish confirmed absence from an inaccessible or
+       otherwise uninspectable path (it reports False for both; the
+       stdlib documents ``stat()`` as the way to tell those apart).
+       Only a genuine ``FileNotFoundError`` counts as confirmed
+       absence; every other probe failure (permission, I/O) **fails
+       closed** with ``WriteOutsideLogDirError``.
+    3. **Directory targets** — an output resolving to an existing
        directory (including through a symlink) is refused; it can never
-       be an output file.
-    3. **Direct and resolved-path aliases** — an output resolving to the
+       be an output file. Detected from the captured stat result, never
+       from a boolean status method.
+    4. **Direct and resolved-path aliases** — an output resolving to the
        input log itself is refused. Resolution targets are compared, not
        path segments, so lexical variants (``sub/../log.jsonl``) and
-       symlink aliases resolving to the input log are covered.
-    4. **File identity** — for an existing target, ``os.path.samefile``
-       (device + inode / file ID) catches hard links whose paths differ.
-       ``samefile`` is called only when BOTH resolved targets are
-       confirmed to exist: a missing input log — valid before the
-       observer's first write — cannot share file identity with a
-       distinct existing sibling, so a genuine ``FileNotFoundError``
-       (confirmed absence, including one arising in the residual
-       interval between the existence checks and the stat) is treated
-       as "no shared identity". Every OTHER inspection failure
-       (permission, I/O) still **fails closed** — an unverifiable
-       target is refused, never a fall-through to permission-to-write.
+       symlink aliases resolving to the input log are covered. This
+       comparison is stat-free and applies whether or not either file
+       exists yet.
+    5. **File identity** — a *distinct* output confirmed absent is
+       allowed (nothing can share identity with it). Otherwise the input
+       log is probed the same way: a log confirmed absent — valid before
+       the observer's first write — cannot share file identity with a
+       distinct existing sibling, so the output is allowed; any other
+       log-probe failure **fails closed**. When both endpoints exist,
+       their captured stat results are compared with
+       ``os.path.samestat`` (device + inode / file ID), which catches
+       hard links whose paths differ — and, unlike a boolean-gated
+       ``samefile`` call, cannot be bypassed by a suppressed or false
+       existence report for either endpoint.
 
     Ordinary sibling outputs — nonexistent, or existing non-alias files —
     remain permitted; overwriting a stale calibration output is allowed.
@@ -186,37 +198,55 @@ def _validate_calibration_output_path(
             f"refusing to write calibration output outside log_path's "
             f"directory: {out_resolved} is not inside {log_dir_resolved}"
         ) from e
-    if out_resolved.is_dir():
+    # Establish each endpoint's TRUE state with explicit stat() probes.
+    # A boolean Path.exists() cannot distinguish confirmed absence from
+    # an inaccessible/uninspectable path (it reports False for both), so
+    # gating identity comparison on it would let a suppressed or false
+    # status report skip the hard-link check entirely. Only a genuine
+    # FileNotFoundError counts as confirmed absence; every other probe
+    # failure is itself a refusal (fail closed), never a fall-through.
+    try:
+        out_stat = out_resolved.stat()
+    except FileNotFoundError:
+        out_stat = None  # confirmed absent
+    except OSError as e:
+        raise WriteOutsideLogDirError(
+            f"cannot inspect output path status: {out_resolved}"
+        ) from e
+    if out_stat is not None and stat_module.S_ISDIR(out_stat.st_mode):
         raise WriteOutsideLogDirError(
             f"refusing to write calibration output onto a directory: {out_resolved}"
         )
+    # Direct/resolved equality is stat-free and applies even when the
+    # file does not exist yet.
     if out_resolved == log_resolved:
         raise WriteOutsideLogDirError(
             f"refusing to overwrite the input log file: {out_resolved}"
         )
-    # Hard links share identity while having distinct paths. Identity
-    # comparison requires both endpoints to exist: a missing input log
-    # (valid before the observer's first write) cannot share identity
-    # with a distinct existing sibling, so samefile runs only when both
-    # resolved targets are confirmed to exist. A FileNotFoundError from
-    # the residual interval between those checks and the stat is the
-    # same confirmed absence. Every OTHER inspection failure is itself
-    # a refusal (fail closed), never a fall-through.
-    if out_resolved.exists() and log_resolved.exists():
-        try:
-            same = os.path.samefile(out_resolved, log_resolved)
-        except FileNotFoundError:
-            same = False  # confirmed absence: no shared identity possible
-        except OSError as e:
-            raise WriteOutsideLogDirError(
-                f"cannot verify output file identity against the input log "
-                f"file: {out_resolved}"
-            ) from e
-        if same:
-            raise WriteOutsideLogDirError(
-                f"refusing to overwrite the input log file (shared file "
-                f"identity): {out_resolved}"
-            )
+    if out_stat is None:
+        # A distinct output confirmed absent cannot share identity with
+        # anything: allowed.
+        return
+    try:
+        log_stat = log_resolved.stat()
+    except FileNotFoundError:
+        # The input log is confirmed absent (valid before the observer's
+        # first write): a distinct existing sibling cannot share file
+        # identity with it. Allowed.
+        return
+    except OSError as e:
+        raise WriteOutsideLogDirError(
+            f"cannot verify output file identity against the input log "
+            f"file: {out_resolved}"
+        ) from e
+    # Hard links share identity while having distinct paths; samestat on
+    # the captured probe results (device + inode / file ID) catches them
+    # and cannot be bypassed by a false existence report.
+    if os.path.samestat(out_stat, log_stat):
+        raise WriteOutsideLogDirError(
+            f"refusing to overwrite the input log file (shared file "
+            f"identity): {out_resolved}"
+        )
 
 
 def _validate_config_log_directory(

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -434,6 +434,70 @@ def test_validate_output_ordinary_siblings_remain_allowed(tmp_path):
     _validate_calibration_output_path(stale, log_path)
 
 
+def test_validate_output_existing_sibling_allowed_when_log_missing(tmp_path):
+    """First-run compatibility: before the observer's first write the input
+    log does not exist yet. A missing log cannot share file identity with a
+    distinct existing sibling, so an ordinary stale sibling output must be
+    ALLOWED — the guard must not convert samefile's FileNotFoundError into
+    a refusal."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"          # absent: valid first run
+    stale = log_dir / "calibration_determinism.jsonl"
+    stale.write_text("stale previous output\n", encoding="utf-8")
+    assert not log_path.exists()
+    _validate_calibration_output_path(stale, log_path)  # must not raise
+
+
+def test_validate_output_direct_alias_refused_even_when_log_missing(tmp_path):
+    """Path equality with the input log stays refused even before the log
+    exists — resolved-path comparison needs no stat."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"          # absent
+    assert not log_path.exists()
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_calibration_output_path(log_path, log_path)
+    alias = log_dir / "sub" / ".." / "nextness_runs.jsonl"
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_calibration_output_path(alias, log_path)
+
+
+def test_validate_output_non_filenotfound_oserror_still_fails_closed(tmp_path, monkeypatch):
+    """Only CONFIRMED ABSENCE is exempt: any other identity-inspection
+    failure (permission, I/O) must still refuse — never fall through to
+    permission-to-write."""
+    log_path = _identity_setup(tmp_path)                # log EXISTS here
+    sibling = log_path.parent / "calibration_determinism.jsonl"
+    sibling.write_text("previous\n", encoding="utf-8")
+
+    def perm_boom(*args, **kwargs):
+        raise PermissionError("identity inspection denied")
+
+    monkeypatch.setattr(os.path, "samefile", perm_boom)
+    _expect_guard_refusal(sibling, log_path)
+
+
+def test_check_determinism_first_run_allows_existing_stale_sibling(tmp_path):
+    """End-to-end through the exported public entry point: with log_path
+    initially absent and an ordinary stale sibling out_path present, the
+    call must COMPLETE and write the permitted calibration output."""
+    snapshots_dir, log_path, config = _calibration_setup(tmp_path)
+    assert not log_path.exists()                        # first run: no log yet
+    out_path = log_path.parent / "calibration_determinism.jsonl"
+    out_path.write_text("stale previous output\n", encoding="utf-8")
+
+    aggregate = check_determinism(
+        [], out_path=out_path, log_path=log_path,
+        calibration_set="short", config=config, repeats=2,
+    )
+
+    assert isinstance(aggregate, dict)                  # completed normally
+    written = out_path.read_text(encoding="utf-8")
+    assert written != "stale previous output\n"         # permitted output written
+    assert '"experiment": "determinism"' in written
+
+
 def test_check_determinism_refuses_output_aliasing_log_before_computation(
     tmp_path, monkeypatch
 ):

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -407,18 +407,56 @@ def test_validate_output_symlink_to_directory_is_refused(tmp_path):
     assert real_dir.is_dir()
 
 
+def _patch_stat_for(monkeypatch, victim: pathlib.Path, exc: OSError) -> None:
+    """Make ``Path.stat()`` raise ``exc`` for exactly one resolved path.
+
+    Boolean ``Path.exists()`` swallows such errors and reports False, so
+    these tests exercise the guard's REAL probes: only ``stat()`` can
+    distinguish confirmed absence from an uninspectable path.
+    """
+    real_stat = pathlib.Path.stat
+
+    def probed(self, **kwargs):
+        if self == victim:
+            raise exc
+        return real_stat(self, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "stat", probed)
+
+
 def test_validate_output_unverifiable_identity_fails_closed(tmp_path, monkeypatch):
-    """If an existing target's identity cannot be established, the guard
-    must refuse — never fall through to the writer."""
+    """A non-FileNotFoundError from the LOG path's status probe must fail
+    closed — never fall through to the writer. (Tests the actual stat
+    probe; a boolean exists() would swallow this into False.)"""
     log_path = _identity_setup(tmp_path)
     sibling = log_path.parent / "calibration_determinism.jsonl"
     sibling.write_text("previous\n", encoding="utf-8")
-
-    def boom(*args, **kwargs):
-        raise OSError("identity cannot be established")
-
-    monkeypatch.setattr(os.path, "samefile", boom)
+    _patch_stat_for(monkeypatch, log_path.resolve(),
+                    OSError("identity cannot be established"))
     _expect_guard_refusal(sibling, log_path)
+
+
+def test_validate_output_hardlink_not_bypassed_by_suppressed_existence(
+    tmp_path, monkeypatch
+):
+    """Jack's reproduction: a REAL hard-link alias (both files genuinely
+    exist) must stay refused even when a boolean existence probe would
+    report false/suppressed status for the log — the guard must not gate
+    identity comparison on Path.exists()."""
+    log_path = _identity_setup(tmp_path)
+    link = log_path.parent / "calibration_determinism.jsonl"
+    _hardlink_or_skip(log_path, link)
+
+    log_resolved = log_path.resolve()
+    real_exists = pathlib.Path.exists
+
+    def suppressed(self, **kwargs):
+        if self == log_resolved:
+            return False
+        return real_exists(self, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "exists", suppressed)
+    _expect_guard_refusal(link, log_path)
 
 
 def test_validate_output_ordinary_siblings_remain_allowed(tmp_path):
@@ -464,17 +502,14 @@ def test_validate_output_direct_alias_refused_even_when_log_missing(tmp_path):
 
 
 def test_validate_output_non_filenotfound_oserror_still_fails_closed(tmp_path, monkeypatch):
-    """Only CONFIRMED ABSENCE is exempt: any other identity-inspection
-    failure (permission, I/O) must still refuse — never fall through to
-    permission-to-write."""
+    """Only CONFIRMED ABSENCE (FileNotFoundError) is exempt: a
+    PermissionError from the OUTPUT path's status probe must still refuse
+    — never fall through to permission-to-write."""
     log_path = _identity_setup(tmp_path)                # log EXISTS here
     sibling = log_path.parent / "calibration_determinism.jsonl"
     sibling.write_text("previous\n", encoding="utf-8")
-
-    def perm_boom(*args, **kwargs):
-        raise PermissionError("identity inspection denied")
-
-    monkeypatch.setattr(os.path, "samefile", perm_boom)
+    _patch_stat_for(monkeypatch, sibling.resolve(),
+                    PermissionError("status inspection denied"))
     _expect_guard_refusal(sibling, log_path)
 
 

--- a/tests/test_nextness_calibration.py
+++ b/tests/test_nextness_calibration.py
@@ -26,12 +26,16 @@ patch-radius coarse-graining).
 """
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import pathlib
 import time
 
 import numpy as np
 import pytest
+
+import scripts.nextness_calibration as calibration_module
 
 from scripts.nextness_observer import (
     MEMORY_CHANNEL_LAYOUT,
@@ -307,6 +311,165 @@ def test_validate_output_traversal_escape_rejected(tmp_path):
     out_path = log_dir / ".." / ".." / "escape.jsonl"
     with pytest.raises(WriteOutsideLogDirError):
         _validate_calibration_output_path(out_path, log_path)
+
+
+# ---------------------------------------------------------------------------
+# Output-identity guard: the calibration output may never BE the input log.
+#
+# Containment alone is not enough: an ``out_path`` inside the log directory
+# can still name, alias or shadow the log itself, and the writer opens its
+# target with ``"w"`` — so a guard fall-through destroys the observer's
+# recorded log, the one artifact in the Nextness stack that is not
+# recomputable from anything else.
+#
+# Refusal must happen BEFORE any experiment computation, must raise the
+# existing WriteOutsideLogDirError, and must leave the source bytes intact.
+# ---------------------------------------------------------------------------
+
+
+def _identity_setup(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A log directory containing a real, non-empty input log."""
+    log_dir = tmp_path / "data" / "nextness_log"
+    log_dir.mkdir(parents=True)
+    log_path = log_dir / "nextness_runs.jsonl"
+    log_path.write_text('{"generation": 1}\n', encoding="utf-8")
+    return log_path
+
+
+def _expect_guard_refusal(out_path: pathlib.Path, log_path: pathlib.Path) -> None:
+    """The guard refuses AND the source log survives byte-identically."""
+    before = hashlib.sha256(log_path.read_bytes()).hexdigest()
+    with pytest.raises(WriteOutsideLogDirError):
+        _validate_calibration_output_path(out_path, log_path)
+    assert hashlib.sha256(log_path.read_bytes()).hexdigest() == before
+
+
+def _symlink_or_skip(target: pathlib.Path, link: pathlib.Path, is_dir: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=is_dir)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows without privilege)")
+
+
+def _hardlink_or_skip(target: pathlib.Path, link: pathlib.Path) -> None:
+    try:
+        os.link(target, link)
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("hard links unsupported on this filesystem")
+
+
+def test_validate_output_direct_alias_of_log_is_refused(tmp_path):
+    log_path = _identity_setup(tmp_path)
+    _expect_guard_refusal(log_path, log_path)
+
+
+def test_validate_output_lexical_alias_of_log_is_refused(tmp_path):
+    # Distinct lexically, identical once resolved; 'sub' need not exist —
+    # resolution targets are compared, not path segments.
+    log_path = _identity_setup(tmp_path)
+    alias = log_path.parent / "sub" / ".." / "nextness_runs.jsonl"
+    assert str(alias) != str(log_path)
+    _expect_guard_refusal(alias, log_path)
+
+
+def test_validate_output_symlink_alias_of_log_is_refused(tmp_path):
+    log_path = _identity_setup(tmp_path)
+    link = log_path.parent / "calibration_determinism.jsonl"
+    _symlink_or_skip(log_path, link)
+    _expect_guard_refusal(link, log_path)
+
+
+def test_validate_output_hardlink_alias_of_log_is_refused(tmp_path):
+    # A hard link resolves to its own distinct path but shares file
+    # identity — only os.path.samefile can catch it.
+    log_path = _identity_setup(tmp_path)
+    link = log_path.parent / "calibration_determinism.jsonl"
+    _hardlink_or_skip(log_path, link)
+    _expect_guard_refusal(link, log_path)
+
+
+def test_validate_output_existing_directory_is_refused(tmp_path):
+    log_path = _identity_setup(tmp_path)
+    target_dir = log_path.parent / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep\n", encoding="utf-8")
+    _expect_guard_refusal(target_dir, log_path)
+    assert (target_dir / "keep.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+def test_validate_output_symlink_to_directory_is_refused(tmp_path):
+    log_path = _identity_setup(tmp_path)
+    real_dir = log_path.parent / "real_dir"
+    real_dir.mkdir()
+    link = log_path.parent / "calibration_determinism.jsonl"
+    _symlink_or_skip(real_dir, link, is_dir=True)
+    _expect_guard_refusal(link, log_path)
+    assert real_dir.is_dir()
+
+
+def test_validate_output_unverifiable_identity_fails_closed(tmp_path, monkeypatch):
+    """If an existing target's identity cannot be established, the guard
+    must refuse — never fall through to the writer."""
+    log_path = _identity_setup(tmp_path)
+    sibling = log_path.parent / "calibration_determinism.jsonl"
+    sibling.write_text("previous\n", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise OSError("identity cannot be established")
+
+    monkeypatch.setattr(os.path, "samefile", boom)
+    _expect_guard_refusal(sibling, log_path)
+
+
+def test_validate_output_ordinary_siblings_remain_allowed(tmp_path):
+    """The repair must not narrow the permitted lane."""
+    log_path = _identity_setup(tmp_path)
+    # Nonexistent ordinary sibling.
+    _validate_calibration_output_path(
+        log_path.parent / "calibration_determinism.jsonl", log_path
+    )
+    # Existing non-alias sibling (overwriting a stale output is allowed).
+    stale = log_path.parent / "calibration_stale.jsonl"
+    stale.write_text("previous content\n", encoding="utf-8")
+    _validate_calibration_output_path(stale, log_path)
+
+
+def test_check_determinism_refuses_output_aliasing_log_before_computation(
+    tmp_path, monkeypatch
+):
+    """End-to-end through an exported public entry point.
+
+    Jack's reproduction: a valid public call with ``out_path == log_path``
+    returned normally reporting ``hypothesis_supported`` while replacing the
+    input log. The guard must refuse first: no computation, no write, no
+    success aggregate, source bytes intact.
+    """
+    snapshots_dir, log_path, config = _calibration_setup(tmp_path)
+    log_path.write_text('{"generation": 1}\n', encoding="utf-8")
+    before = hashlib.sha256(log_path.read_bytes()).hexdigest()
+
+    def computation_spy(*args, **kwargs):
+        raise AssertionError("computation ran despite an aliased output path")
+
+    def write_spy(*args, **kwargs):
+        raise AssertionError("writer ran despite an aliased output path")
+
+    # The first computation step after the guard, and the writer itself.
+    monkeypatch.setattr(calibration_module, "_sort_snapshots_by_generation", computation_spy)
+    monkeypatch.setattr(calibration_module, "_write_calibration_jsonl", write_spy)
+
+    with pytest.raises(WriteOutsideLogDirError):
+        check_determinism(
+            [],
+            out_path=log_path,
+            log_path=log_path,
+            calibration_set="short",
+            config=config,
+            repeats=2,
+        )
+
+    assert hashlib.sha256(log_path.read_bytes()).hexdigest() == before
+    assert log_path.read_text(encoding="utf-8") == '{"generation": 1}\n'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`scripts/nextness_calibration.py`'s `_validate_calibration_output_path` enforced **directory containment only**. All eight exported calibration experiments (`check_determinism`, `shuffle_test`, `verify_memory_channels`, `sweep_stride`, `sweep_threshold`, `ablate_cascade`, `sweep_temporal`, `sweep_patch_radius`) accept both `out_path` and `log_path`, so a valid public call with `out_path` **naming or aliasing the input log** passed the guard. `_write_calibration_jsonl` then opened that path with `"w"` — truncating and replacing the observer's recorded `nextness_runs.jsonl`, **the one artifact in the Nextness stack that cannot be recomputed** from anything downstream. The call returned normally reporting `hypothesis_supported` while destroying its own input.

## Fix

The guard now enforces, in evaluation order, **before any experiment computation** (all eight entry points inherit it — no signature or body change):

1. **Containment** — output must resolve inside the log's directory (message unchanged).
2. **Directory targets** — an output resolving to an existing directory (including via symlink) is refused.
3. **Direct / resolved-path aliases** — an output resolving to the input log itself is refused; resolution targets are compared, so lexical variants (`sub/../log.jsonl`) and symlink aliases resolving to the input log are covered.
4. **File identity** — for an existing target, `os.path.samefile` catches hard links whose paths differ; if identity **cannot** be established the guard **fails closed** (unverifiable target refused, never a fall-through).

It raises the existing `WriteOutsideLogDirError`. **Ordinary sibling outputs remain allowed** — nonexistent and existing non-alias files, including overwriting a stale calibration output.

## Scope

**Exactly two repository files changed**: the calibration guard and its regression tests.

- `scripts/nextness_calibration.py` — guard + docstring (and `import os`)
- `tests/test_nextness_calibration.py` — identity/boundary regression tests

## Explicit exclusions (out of scope for this repair)

- **No writer-parity change.** `_write_calibration_jsonl` is untouched; it still writes text-mode, so calibration output is **not** claimed byte-identical across platforms the way the metrics writer's is.
- **No claim of eliminating the validation-to-write (TOCTOU) race.** Identity is verified at validation time; a concurrent actor replacing the path between validation and write can still redirect it. The guard defends against aliases that exist when it validates — documented, not eliminated.
- **No dangling-symlink file-target claim.** That behaviour remains outside this repair's tested scope.

## Validation (fresh, post-rebase onto current `main`)

Head `82c1becd`, parent = `main` `3b8a60f`:

- new identity/boundary tests: **7 passed, 2 skipped** (symlink lanes skip-guarded on Windows without privilege; exercised on Ubuntu CI — never reported as pass)
- `tests/test_nextness_calibration.py`: **201 passed, 2 skipped**
- focused Nextness suite (10 files): **738 passed, 9 skipped**
- full maintained Python suite: **1322 passed, 36 skipped**
- `py_compile` (both touched files): passed

Independent reproduction of the reported defect **refuses** post-fix, returns no success aggregate, and leaves the input log's SHA-256 unchanged; the previously recorded destroyed-state hash `77ed927f…` is no longer reproducible. The same aggregate bytes now land on a permitted sibling instead — behaviour and output bytes unchanged, only the destination corrected.


## Follow-up: missing-log first-run compatibility (`b5ce42ea`, addresses the inline review)

The review's finding was correct and independently reproduced: with `log_path` **not yet existing** — a valid state before the observer's first write — and an ordinary stale sibling `out_path` present, `os.path.samefile` raised `FileNotFoundError`, and the guard's broad fail-closed `except OSError` converted that into a wrongful `WriteOutsideLogDirError`, blocking a legitimate first run end-to-end through `check_determinism`.

**Corrected behavior** (one follow-up commit, no amend, ordinary fast-forward):

- ~~`samefile` gated on both endpoints existing~~ **(corrected in `baabc854` — the `b5ce42ea` gate used boolean `Path.exists()`, which cannot prove fail-closed behavior; see the follow-up section below).** The retained principle: a missing input log cannot share file identity with a distinct existing sibling.
- **Not** a broad `exists()` fall-through: every other inspection failure (permission, I/O) **still fails closed** — pinned by a `PermissionError` regression test.
- Direct / resolved-path equality with the log remains refused **even when the file does not yet exist** (stat-free comparison; test-pinned).
- Hard-link aliases remain refused when both files exist; directory, containment, computation-order and ordinary-sibling protections unchanged; dangling-symlink file-target behavior remains outside the claim.

**Failing-first receipts** (against `82c1becd`): guard-level *sibling-allowed-when-log-missing* and end-to-end *`check_determinism` first-run* both **FAILED**; the stat-free equality fence and the fail-closed `PermissionError` fence **passed** before and after.

**Fresh totals** (head `b5ce42ea`):

- identity/boundary subset: **14 passed, 2 skipped**
- `tests/test_nextness_calibration.py`: **205 passed, 2 skipped**
- focused Nextness suite (10 files): **742 passed, 9 skipped**
- full maintained Python suite: **1326 passed, 36 skipped**
- `py_compile` (both touched files): passed
- Post-fix reproduction: first run **completes** and writes the permitted 242-byte output to the sibling; the absent log is not created and nothing else is touched; all previously-verified refusal lanes re-verified live.


## Follow-up 2: stat-probe fail-closed guarantee (`baabc854`, addresses the second review finding)

The review was right again: `b5ce42ea` gated identity comparison on `if out_resolved.exists() and log_resolved.exists()`. A boolean `Path.exists()` **cannot distinguish confirmed absence from an inaccessible path** — it reports `False` for both (the stdlib directs callers to `stat()` when those states must be distinguished). Reproduced consequence: with a **real hard-link alias** (both files genuinely existing) and a suppressed/false status result for the log path, the boolean gate skipped identity comparison, the guard returned successfully, and the follow-on write destroyed the input bytes.

**Corrected mechanism** (one follow-up commit, no amend, ordinary fast-forward):

- Each endpoint's true state is established with an explicit **`stat()` probe**: only a genuine `FileNotFoundError` counts as **confirmed absence**; every other probe failure (permission, I/O) **fails closed** with `WriteOutsideLogDirError` — for the output probe and the log probe independently (both test-pinned).
- A *distinct* output confirmed absent is allowed; a *distinct existing* output is allowed **only when the log is confirmed absent** (first-run case preserved).
- Directory targets are detected **from the captured stat result**, not a boolean method; direct/resolved equality remains **stat-free** and applies even when absent.
- When both endpoints exist, the captured stat results are compared with **`os.path.samestat`** (device + inode / file ID) — hard links stay refused and the comparison **cannot be bypassed by a false existence report**.
- The two former `samefile`-patching tests were rewritten to probe the actual implementation (`Path.stat`), since `samefile` is no longer used.
- Unchanged: containment, computation order, ordinary-sibling behavior; the validation-to-write TOCTOU interval remains documented, not eliminated; dangling-symlink file targets remain outside the claim.

**Failing-first receipts** (against `b5ce42ea`): hard-link-alias-with-suppressed-existence **BYPASSED the guard** (and the follow-on write destroyed the input in a live reproduction); PermissionError from the output probe and generic OSError from the log probe were both swallowed into *allowed*. The missing-log first-run fence passed before and after.

**Fresh totals** (head `baabc854`):

- identity/boundary subset: **15 passed, 2 skipped**
- `tests/test_nextness_calibration.py`: **206 passed, 2 skipped**
- focused Nextness suite (10 files): **743 passed, 9 skipped**
- full maintained Python suite: **1327 passed, 36 skipped**
- `py_compile` (both touched files): passed
- Post-fix reproduction: Jack's bypass scenario now **refused** with input bytes intact; plain hard link refused via `samestat`; first-run sibling still permitted end-to-end through `check_determinism`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


