### PR TITLE
test(nextness): pin directory and symlink output boundaries

### DIFF
--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1415,6 +1415,9 @@ def test_cli_symlink_to_directory_output_target_pinned(tmp_path, capsys) -> None
     assert real_dir.is_dir()
     assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
     assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+    # The output link itself was not replaced by a regular file.
+    assert link.is_symlink()
+    assert link.resolve() == real_dir.resolve()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1366,6 +1366,58 @@ def test_cli_sibling_outputs_remain_allowed(tmp_path, capsys) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Output-boundary pins: directory and symlink-to-directory targets.
+#
+# Coverage pinning of ESTABLISHED behavior (not a defect): a directory
+# target passes path validation (it is inside the primary input's
+# directory and aliases nothing) and is refused at write time by the
+# documented OSError lane — exit 4, one concise ``error:`` line, no
+# traceback, every input byte-identical, the directory and its contents
+# untouched, and no output artifact (whole or partial) created.
+# ---------------------------------------------------------------------------
+
+
+def _sentinel_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    return target_dir
+
+
+def test_cli_existing_directory_output_target_pinned(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    target_dir = _sentinel_dir(tmp_path)
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(target_dir)],
+        [report_file, receipts_file],
+    )
+    assert target_dir.is_dir()
+    assert (target_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in target_dir.iterdir()) == ["keep.txt"]
+
+
+def test_cli_symlink_to_directory_output_target_pinned(tmp_path, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    real_dir = _sentinel_dir(tmp_path)
+    link = tmp_path / "evaluation.json"
+    try:
+        link.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+    _expect_alias_refusal(
+        capsys, tmp_path,
+        ["--report", str(report_file), "--receipts", str(receipts_file),
+         "--output", str(link)],
+        [report_file, receipts_file],
+    )
+    assert real_dir.is_dir()
+    assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+
+
+# ---------------------------------------------------------------------------
 # Live end-to-end: emitter files → CLI → evaluation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -375,6 +375,9 @@ def test_cli_symlink_to_directory_output_target_pinned(chain, tmp_path, capsys) 
     assert real_dir.is_dir()
     assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
     assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+    # The output link itself was not replaced by a regular file.
+    assert link.is_symlink()
+    assert link.resolve() == real_dir.resolve()
 
 
 @pytest.mark.parametrize("role", list(ROLES))

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -321,6 +321,80 @@ def test_cli_write_boundary_and_alias_identity(chain, tmp_path, capsys) -> None:
     assert "identity" in err or "overwrite" in err
 
 
+# ---------------------------------------------------------------------------
+# Output-boundary pins: directory targets, symlink-to-directory targets,
+# and symlink output aliases against EVERY supplied input role.
+#
+# Coverage pinning of ESTABLISHED behavior (not a defect):
+# - a directory target passes path validation (inside the primary
+#   input's directory, aliases nothing) and is refused at write time by
+#   the documented OSError lane;
+# - a symlink whose resolution target IS a supplied input is refused by
+#   the identity guard before any packet is built.
+# Both refusals: exit 4, one concise ``error:`` line, no traceback,
+# every supplied input byte-identical, directory/sentinel contents
+# unchanged, no output artifact (whole or partial) created.
+# ---------------------------------------------------------------------------
+
+
+def _pin_packet_refusal(capsys, chain, tmp_path, out_target) -> None:
+    before = {role: path.read_bytes() for role, path in chain.items()}
+    entries_before = sorted(p.name for p in tmp_path.iterdir())
+
+    assert main(_chain_args(chain) + ["--output", str(out_target)]) == 4
+
+    captured = capsys.readouterr()
+    err_lines = [line for line in captured.err.strip().splitlines() if line]
+    assert len(err_lines) == 1 and err_lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+    for role, path in chain.items():
+        assert path.read_bytes() == before[role], f"input mutated: {role}"
+    assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+def test_cli_existing_directory_output_target_pinned(chain, tmp_path, capsys) -> None:
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    _pin_packet_refusal(capsys, chain, tmp_path, target_dir)
+    assert target_dir.is_dir()
+    assert (target_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in target_dir.iterdir()) == ["keep.txt"]
+
+
+def test_cli_symlink_to_directory_output_target_pinned(chain, tmp_path, capsys) -> None:
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    link = tmp_path / "packet.json"
+    try:
+        link.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+    _pin_packet_refusal(capsys, chain, tmp_path, link)
+    assert real_dir.is_dir()
+    assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+
+
+@pytest.mark.parametrize("role", list(ROLES))
+def test_cli_symlink_output_alias_of_each_input_role_pinned(
+    chain, tmp_path, capsys, role
+) -> None:
+    """A symlink inside the primary input's directory whose resolution
+    target IS the supplied ``role`` artifact must be refused by the
+    identity guard — for every role the chain fixture exposes."""
+    link = tmp_path / f"alias_{role}.json"
+    try:
+        link.symlink_to(chain[role])
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported here (e.g. Windows w/o privilege)")
+    _pin_packet_refusal(capsys, chain, tmp_path, link)
+    # The link itself is untouched and still resolves to the intact input.
+    assert link.resolve() == chain[role].resolve()
+    assert link.read_bytes() == chain[role].read_bytes()
+
+
 def test_cli_data_tree_refused(chain, tmp_path, capsys, monkeypatch) -> None:
     import scripts.nextness_evidence_packet as packet_module
 

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -719,6 +719,63 @@ def test_symlink_output_alias_refused_and_inputs_intact(tmp_path, capsys) -> Non
 
 
 # ---------------------------------------------------------------------------
+# Output-boundary pins: directory and symlink-to-directory targets.
+#
+# Coverage pinning of ESTABLISHED behavior (not a defect): a directory
+# target passes path validation (inside the input-log directory, aliases
+# nothing) and is refused at write time by the documented OSError lane —
+# exit 4, one concise ``error:`` line, no traceback, both inputs
+# byte-identical, the directory and its contents untouched, no output
+# artifact (whole or partial) created.
+# ---------------------------------------------------------------------------
+
+
+def _pin_dir_target_refusal(capsys, tmp_path, out_target) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    log_before = log.read_bytes()
+    protocol_before = protocol.read_bytes()
+    entries_before = sorted(p.name for p in tmp_path.iterdir())
+
+    assert main([str(log), str(protocol), "--output", str(out_target)]) == 4
+
+    captured = capsys.readouterr()
+    err_lines = [line for line in captured.err.strip().splitlines() if line]
+    assert len(err_lines) == 1 and err_lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+    assert log.read_bytes() == log_before
+    assert protocol.read_bytes() == protocol_before
+    assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+def test_cli_existing_directory_output_target_pinned(tmp_path, capsys) -> None:
+    target_dir = tmp_path / "already_here"
+    target_dir.mkdir()
+    (target_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    _pin_dir_target_refusal(capsys, tmp_path, target_dir)
+    assert target_dir.is_dir()
+    assert (target_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in target_dir.iterdir()) == ["keep.txt"]
+
+
+def test_cli_symlink_to_directory_output_target_pinned(tmp_path, capsys) -> None:
+    import os
+
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
+    link = tmp_path / "lab.json"
+    try:
+        os.symlink(real_dir, link, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation not permitted on this platform/user")
+    _pin_dir_target_refusal(capsys, tmp_path, link)
+    assert real_dir.is_dir()
+    assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
+    assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+
+
+# ---------------------------------------------------------------------------
 # CLI: exit codes, write boundary, concise errors
 # ---------------------------------------------------------------------------
 

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -759,20 +759,21 @@ def test_cli_existing_directory_output_target_pinned(tmp_path, capsys) -> None:
 
 
 def test_cli_symlink_to_directory_output_target_pinned(tmp_path, capsys) -> None:
-    import os
-
     real_dir = tmp_path / "real_dir"
     real_dir.mkdir()
     (real_dir / "keep.txt").write_text("keep me\n", encoding="utf-8")
     link = tmp_path / "lab.json"
     try:
-        os.symlink(real_dir, link, target_is_directory=True)
-    except OSError:
+        link.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
         pytest.skip("symlink creation not permitted on this platform/user")
     _pin_dir_target_refusal(capsys, tmp_path, link)
     assert real_dir.is_dir()
     assert (real_dir / "keep.txt").read_text(encoding="utf-8") == "keep me\n"
     assert sorted(p.name for p in real_dir.iterdir()) == ["keep.txt"]
+    # The output link itself was not replaced by a regular file.
+    assert link.is_symlink()
+    assert link.resolve() == real_dir.resolve()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

**Coverage pinning only — test files, zero production-source or documentation change, no defect.** The 2026-07-16 Nextness output-boundary audit verified *live* that the evaluator, replay lab and evidence packet all refuse directory output targets through their documented write-time `OSError` lane (exit 4, one concise `error:` line, no traceback, inputs byte-identical) — but recorded that **no focused regression test pins that behavior**: directory-target tests stood at predictor 1 / metrics 3 / evaluator 0 / replay_lab 0 / evidence_packet 0, and the evidence packet had zero symlink coverage anywhere. A future refactor could silently regress the lane. This PR pins it.

## Coverage added

| Pin | evaluator | replay lab | evidence packet |
|---|---|---|---|
| existing-directory output target | ✓ | ✓ | ✓ |
| symlink-to-directory output target (skip-guarded) | ✓ | ✓ | ✓ |
| symlink output alias of a supplied input (skip-guarded) | — (file-alias lanes already pinned) | — (already pinned) | ✓ **parameterized across all six roles**: report · receipts · evaluation · lab · protocol · log |

Every pin asserts the established contract exactly:

- exit code **4**;
- **one** concise `error:` stderr line in the module's established format;
- **no traceback**;
- **every supplied input byte-identical** (hashed/compared before and after);
- **directory and sentinel contents unchanged** (directory still a directory, sentinel file byte-identical, entry listing identical);
- **no output replacement or partial output** (fixture-directory entry snapshot identical);
- symlink pins **skip-guarded** on hosts without symlink privilege — honestly skipped, never reported as passes — and exercised on Ubuntu CI.

The two mechanisms pinned are both *established* behavior: directory targets are refused by the **write-time `OSError` lane** (validation legitimately passes — a directory inside the primary input's directory aliases nothing), while packet symlink aliases of inputs are refused by the **identity guard before any packet is built** (resolution targets compared).

## Changed-file boundary (exactly three, tests only)

```
 tests/test_nextness_evaluator.py       | 52 ++++++++++++++
 tests/test_nextness_evidence_packet.py | 74 ++++++++++++++++++
 tests/test_nextness_replay_lab.py      | 57 ++++++++++++++
 3 files changed, 183 insertions(+)
```

## Verification (all against unchanged production code — that is the point)

- New pins in isolation: **3 passed, 9 skipped** (Windows local; skips = symlink lanes)
- Three targeted files: **201 passed, 12 skipped**
- Focused Nextness suite (10 files): **746 passed, 18 skipped**
- Full maintained Python suite: **1330 passed, 45 skipped**
- `py_compile` (three touched test files): passed

Skip-count deltas are exactly the 9 new symlink guards; pass-count deltas are exactly the new executable pins. No production behavior differed from the pinned expectations — had it, this runway would have stopped and reported instead of repairing.

## Collision fences

Branched from freshly fetched `main = a31296b3` (post-#369). Open-PR overlap inspected immediately before branching and publishing: #353, #356 — no overlap; Ian's **#370** touches only `experiments/swarm_hunter_lab/**` — benign disjoint movement, recorded, untouched. #369's calibration files untouched (this branch contains zero non-test changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
