### PR TITLE
fix(metrics): typed operational output-write failure lane (exit 4)

### DIFF
--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -352,11 +352,12 @@ missing-log lane. Repaired by a **narrowly typed** lane, and recorded
 here as metrics-specific truth (this is not harmonisation with any
 other module's map):
 
-- `OSError` is caught **only around the output file's binary
-  open/write/close region** inside `compute_run_metrics`, where it
-  becomes the typed `MetricsOutputWriteError` with a concise
-  path-specific message. Read-side or computation errors are **never**
-  reclassified as output failures and continue to propagate loudly.
+- `OSError` is caught **only around the output region — output-parent
+  creation plus the binary open/write/close** — inside
+  `compute_run_metrics`, where it becomes the typed
+  `MetricsOutputWriteError` with a concise path-specific message.
+  Read-side or computation errors are **never** reclassified as output
+  failures and continue to propagate loudly.
 - The CLI maps `MetricsOutputWriteError` to **exit 4** with one
   `error:` line — deliberately distinct from **exit 3 + `safety
   error:`** (pre-write containment/identity/directory safety refusal),
@@ -364,8 +365,14 @@ other module's map):
   documented). Complete map: 0 success · 1 missing log · 2
   data/validation · 3 pre-write safety refusal (`safety error:`) · 4
   operational output-write failure (`error:`).
-- On the repaired lane the input log and any pre-existing destination
-  bytes are left untouched; no whole or partial output replaces them.
+- **Destination-preservation contract, stated precisely**: a failure at
+  or before the binary open — a read-only destination, or a failed
+  output-parent mkdir — leaves any existing destination byte-identical
+  (nothing was truncated) and creates no output. Once the binary open
+  has succeeded, output is direct, streamed and **non-atomic**: a later
+  write or close failure may leave a truncated or partial destination,
+  and **no general destination-preservation guarantee is made or
+  implied**. The input log is unchanged in every case.
 - Streaming binary LF-only output, row order, field order, formulas,
   aggregate values, ordinary sibling-overwrite behavior, and the
   documented validation-to-write (TOCTOU) non-claim are all unchanged.

--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -372,7 +372,11 @@ other module's map):
   has succeeded, output is direct, streamed and **non-atomic**: a later
   write or close failure may leave a truncated or partial destination,
   and **no general destination-preservation guarantee is made or
-  implied**. The input log is unchanged in every case.
+  implied**. In the exercised failure lanes, and absent the documented
+  validation-to-write replacement race (§9.1), the input log remains
+  unchanged. This repair adds no stronger input-log guarantee: a
+  concurrent actor may still redirect the later direct write, as the
+  existing TOCTOU non-claim states.
 - Streaming binary LF-only output, row order, field order, formulas,
   aggregate values, ordinary sibling-overwrite behavior, and the
   documented validation-to-write (TOCTOU) non-claim are all unchanged.

--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -341,6 +341,36 @@ in NP5/NP6/NP8, later NP1):
 All metric formulas, row ordering, JSON field ordering, the stdout
 summary and every exit code are unchanged by this amendment.
 
+### 9.2 Operational output-write failure lane (2026-07-17 reliability amendment)
+
+The 2026-07-17 CLI failure-contract audit reproduced (twice, public CLI)
+an escaped `PermissionError` traceback when `--out` named an existing
+**read-only file** inside the log directory: every pre-write safety
+check legitimately passed, and the binary `open("wb")` then failed with
+no handler — crashing at process exit 1, numerically colliding with the
+missing-log lane. Repaired by a **narrowly typed** lane, and recorded
+here as metrics-specific truth (this is not harmonisation with any
+other module's map):
+
+- `OSError` is caught **only around the output file's binary
+  open/write/close region** inside `compute_run_metrics`, where it
+  becomes the typed `MetricsOutputWriteError` with a concise
+  path-specific message. Read-side or computation errors are **never**
+  reclassified as output failures and continue to propagate loudly.
+- The CLI maps `MetricsOutputWriteError` to **exit 4** with one
+  `error:` line — deliberately distinct from **exit 3 + `safety
+  error:`** (pre-write containment/identity/directory safety refusal),
+  **exit 2** (data/validation), and **exit 1** (missing log, now also
+  documented). Complete map: 0 success · 1 missing log · 2
+  data/validation · 3 pre-write safety refusal (`safety error:`) · 4
+  operational output-write failure (`error:`).
+- On the repaired lane the input log and any pre-existing destination
+  bytes are left untouched; no whole or partial output replaces them.
+- Streaming binary LF-only output, row order, field order, formulas,
+  aggregate values, ordinary sibling-overwrite behavior, and the
+  documented validation-to-write (TOCTOU) non-claim are all unchanged.
+  No atomic-write behavior was introduced.
+
 ## 10. Open questions for AURA + Jack
 
 1. **CCI composition**: I've defined it as a product of three factors in $[0, 1]$. An alternative is a weighted geometric mean, $\text{CCI} = (B^{w_1} \cdot R^{w_2} \cdot (1-H)^{w_3})^{1/(w_1+w_2+w_3)}$. The product is simpler and has the right "any factor zero → CCI zero" property. Weighted GM lets us emphasize boundary rate over balance if calibration suggests we should. Recommend starting with the simple product; revisit in PR #4 if calibration shows it's miscalibrated.

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -46,6 +46,13 @@ Determinism contract (per Jack's audit on PR #141):
 CLI:
     python -m scripts.nextness_metrics --log <jsonl-in> --out <jsonl-out>
         [--smoothing FLOAT] [--boundary-delta FLOAT]
+
+    Exit codes: 0 success · 1 missing log (``error:``) · 2 data/validation
+    failure (``error:``; argparse usage errors also exit 2) · 3 pre-write
+    containment/identity/directory safety refusal (``safety error:``) ·
+    4 operational output-write failure (``error:``). Expected failures
+    print one concise line, never a traceback; unexpected errors
+    (including read-side OSErrors) propagate loudly.
 """
 from __future__ import annotations
 
@@ -66,6 +73,19 @@ from scripts.nextness_observer import (
     shannon_entropy_bits as _shannon_entropy_bits,
     void_compute_balance as _void_compute_balance,
 )
+
+
+class MetricsOutputWriteError(RuntimeError):
+    """Operational failure while writing the derived metrics output file.
+
+    Raised only from the output file's binary open/write region in
+    :func:`compute_run_metrics` — never for read-side or computation
+    errors, which stay loud. The CLI maps this to its own exit code (4)
+    so callers can distinguish "the write itself failed operationally"
+    (e.g. a read-only destination) from a pre-write safety refusal
+    (exit 3, ``WriteOutsideLogDirError``), a data error (exit 2), and a
+    missing input log (exit 1).
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -503,11 +523,22 @@ def compute_run_metrics(
     # Binary mode, streamed row by row: each line is the canonical
     # serialization encoded as UTF-8 plus a single LF byte, so the
     # derived file's bytes never depend on platform newline translation.
+    #
+    # The OSError catch is deliberately confined to the output file's
+    # binary open/write/close region: an operational write failure (e.g.
+    # a read-only destination) becomes the typed MetricsOutputWriteError,
+    # while read-side or computation errors above are NEVER reclassified
+    # as output failures and stay loud.
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open("wb") as f:
-        for row in pair_rows:
-            f.write(json.dumps(row, sort_keys=True, default=str).encode("utf-8") + b"\n")
-        f.write(json.dumps(aggregate, sort_keys=True, default=str).encode("utf-8") + b"\n")
+    try:
+        with out_path.open("wb") as f:
+            for row in pair_rows:
+                f.write(json.dumps(row, sort_keys=True, default=str).encode("utf-8") + b"\n")
+            f.write(json.dumps(aggregate, sort_keys=True, default=str).encode("utf-8") + b"\n")
+    except OSError as e:
+        raise MetricsOutputWriteError(
+            f"cannot write metrics output to {out_path}: {e}"
+        ) from e
 
     return aggregate
 
@@ -553,7 +584,26 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point. Returns 0 on success, non-zero on error."""
+    """CLI entry point.
+
+    Exit-code contract (complete map; each expected failure prints one
+    concise prefixed line to stderr, never a traceback):
+
+    - ``0`` success (multi-line summary on stdout; derived JSONL written)
+    - ``1`` missing input log (``error:``)
+    - ``2`` data/validation failure — malformed JSONL or out-of-bounds
+      configuration (``error:``; argparse's own usage errors also exit 2)
+    - ``3`` pre-write containment/identity/directory safety refusal
+      (``safety error:``, ``WriteOutsideLogDirError``) — the guard runs
+      before the log is read or any metric computed
+    - ``4`` operational output-write failure (``error:``,
+      ``MetricsOutputWriteError``) — the write itself failed, e.g. a
+      read-only destination; inputs and any pre-existing destination
+      bytes are left untouched
+
+    Unexpected programming errors (including read-side OSErrors)
+    propagate loudly rather than being reclassified.
+    """
     args = _build_parser().parse_args(argv)
     log_path = pathlib.Path(args.log)
     out_path = pathlib.Path(args.out)
@@ -566,6 +616,11 @@ def main(argv: list[str] | None = None) -> int:
             smoothing=args.smoothing,
             boundary_delta=args.boundary_delta,
         )
+    except MetricsOutputWriteError as e:
+        # Operational write failure: the output could not be written
+        # even though every pre-write safety check passed.
+        print(f"error: {e}", file=sys.stderr)
+        return 4
     except WriteOutsideLogDirError as e:
         # Lane B safety violation: --out points outside the log file's
         # directory. Return distinct non-zero code so callers can
@@ -589,6 +644,7 @@ def main(argv: list[str] | None = None) -> int:
 
 
 __all__ = [
+    "MetricsOutputWriteError",
     "smoothed_distribution",
     "kl_divergence",
     "js_divergence",

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -91,9 +91,12 @@ class MetricsOutputWriteError(RuntimeError):
     parent mkdir) leaves any existing destination byte-identical —
     nothing was truncated. Once the binary open has succeeded, output is
     direct, streamed and non-atomic, so a later write or close failure
-    may leave a truncated or partial destination. The input log is
-    unchanged in every case. No atomic-write behavior is provided or
-    claimed.
+    may leave a truncated or partial destination. In the exercised
+    failure lanes, and absent the documented validation-to-write
+    replacement race, the input log remains unchanged. This repair adds
+    no stronger input-log guarantee: a concurrent actor may still
+    redirect the later direct write, as the existing TOCTOU non-claim
+    states. No atomic-write behavior is provided or claimed.
     """
 
 
@@ -611,8 +614,12 @@ def main(argv: list[str] | None = None) -> int:
       before the log is read or any metric computed
     - ``4`` operational output-write failure (``error:``,
       ``MetricsOutputWriteError``) — an OSError in the output region:
-      parent creation, binary open, streamed writes, or close. The
-      input log is always unchanged. Destination preservation is
+      parent creation, binary open, streamed writes, or close. In the
+      exercised failure lanes, and absent the documented
+      validation-to-write replacement race, the input log remains
+      unchanged; this repair adds no stronger input-log guarantee — a
+      concurrent actor may still redirect the later direct write, as
+      the existing TOCTOU non-claim states. Destination preservation is
       guaranteed only for failures at or before the binary open (a
       read-only destination is never truncated); once open succeeds,
       direct streamed non-atomic output may be truncated or partial if

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -76,15 +76,24 @@ from scripts.nextness_observer import (
 
 
 class MetricsOutputWriteError(RuntimeError):
-    """Operational failure while writing the derived metrics output file.
+    """Operational failure in the derived output's write region.
 
-    Raised only from the output file's binary open/write region in
-    :func:`compute_run_metrics` — never for read-side or computation
-    errors, which stay loud. The CLI maps this to its own exit code (4)
-    so callers can distinguish "the write itself failed operationally"
-    (e.g. a read-only destination) from a pre-write safety refusal
+    Raised only from the OUTPUT region of :func:`compute_run_metrics` —
+    output-parent creation plus the binary open/write/close — never for
+    read-side or computation errors, which stay loud. The CLI maps this
+    to its own exit code (4) so callers can distinguish "the output
+    could not be produced operationally" from a pre-write safety refusal
     (exit 3, ``WriteOutsideLogDirError``), a data error (exit 2), and a
     missing input log (exit 1).
+
+    Destination-preservation contract, stated precisely: a failure at or
+    before the binary open (e.g. a read-only destination, or a failed
+    parent mkdir) leaves any existing destination byte-identical —
+    nothing was truncated. Once the binary open has succeeded, output is
+    direct, streamed and non-atomic, so a later write or close failure
+    may leave a truncated or partial destination. The input log is
+    unchanged in every case. No atomic-write behavior is provided or
+    claimed.
     """
 
 
@@ -524,13 +533,17 @@ def compute_run_metrics(
     # serialization encoded as UTF-8 plus a single LF byte, so the
     # derived file's bytes never depend on platform newline translation.
     #
-    # The OSError catch is deliberately confined to the output file's
-    # binary open/write/close region: an operational write failure (e.g.
-    # a read-only destination) becomes the typed MetricsOutputWriteError,
-    # while read-side or computation errors above are NEVER reclassified
-    # as output failures and stay loud.
-    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # The OSError catch is deliberately confined to the OUTPUT region —
+    # parent-directory creation plus the binary open/write/close: an
+    # operational failure anywhere in it (unwritable parent, read-only
+    # destination, mid-stream device error) becomes the typed
+    # MetricsOutputWriteError, while read-side or computation errors
+    # above are NEVER reclassified as output failures and stay loud.
+    # Failures at or before open leave an existing destination
+    # byte-identical; after a successful open, streamed non-atomic
+    # output may be truncated/partial if a later write or close fails.
     try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("wb") as f:
             for row in pair_rows:
                 f.write(json.dumps(row, sort_keys=True, default=str).encode("utf-8") + b"\n")
@@ -597,9 +610,13 @@ def main(argv: list[str] | None = None) -> int:
       (``safety error:``, ``WriteOutsideLogDirError``) — the guard runs
       before the log is read or any metric computed
     - ``4`` operational output-write failure (``error:``,
-      ``MetricsOutputWriteError``) — the write itself failed, e.g. a
-      read-only destination; inputs and any pre-existing destination
-      bytes are left untouched
+      ``MetricsOutputWriteError``) — an OSError in the output region:
+      parent creation, binary open, streamed writes, or close. The
+      input log is always unchanged. Destination preservation is
+      guaranteed only for failures at or before the binary open (a
+      read-only destination is never truncated); once open succeeds,
+      direct streamed non-atomic output may be truncated or partial if
+      a later write/close fails — no atomic-write claim is made.
 
     Unexpected programming errors (including read-side OSErrors)
     propagate loudly rather than being reclassified.

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -514,12 +514,31 @@ def test_cli_main_runs_on_real_input(tmp_path, capsys):
 
 
 def test_cli_main_missing_log_returns_nonzero(tmp_path, capsys):
-    """CLI surfaces missing-file error as non-zero exit code."""
+    """CLI surfaces a missing log as EXACTLY exit 1 (its documented lane).
+
+    Upgraded from a nonzero-only assertion: exit 1 is metrics' distinct
+    missing-input code, and pinning it exactly keeps it distinguishable
+    from the exit-4 operational write-failure lane."""
     rc = main(["--log", str(tmp_path / "missing.jsonl"),
                "--out", str(tmp_path / "out.jsonl")])
-    assert rc != 0
+    assert rc == 1
     captured = capsys.readouterr()
     assert "not found" in captured.err.lower()
+    assert captured.err.count("error:") == 1
+    assert "Traceback" not in captured.err
+
+
+def test_cli_malformed_data_exits_2_exactly(tmp_path, capsys):
+    """Malformed JSONL rows are a data error: EXACTLY exit 2, one concise
+    error: line, no traceback."""
+    bad = tmp_path / "nextness_runs.jsonl"
+    bad.write_text("{not json at all\n", encoding="utf-8")
+    rc = main(["--log", str(bad), "--out", str(tmp_path / "out.jsonl")])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert captured.err.count("error:") == 1
+    assert captured.err.startswith("error:")
+    assert "Traceback" not in captured.err
 
 
 # ---------------------------------------------------------------------------
@@ -607,12 +626,88 @@ def test_cli_main_returns_nonzero_for_outside_log_dir_output(tmp_path, capsys):
     ])
 
     rc = main(["--log", str(log_path), "--out", str(out_path)])
-    assert rc != 0
+    assert rc == 3  # upgraded from nonzero-only: the exact safety-refusal code
     captured = capsys.readouterr()
     assert "safety error" in captured.err.lower()
     assert "outside log_path" in captured.err.lower()
     # No side effects: the outside-of-boundary parent dir must not exist
     assert not (tmp_path / "elsewhere").exists()
+
+
+# ---------------------------------------------------------------------------
+# Operational output-write failure lane (exit 4): a write-side OSError is
+# an EXPECTED operational failure — one concise error: line, exit 4, no
+# traceback, inputs and any pre-existing destination byte-identical. It is
+# deliberately distinct from exit 3 (pre-write safety refusal) and from
+# exit 1 (missing log), and must never be produced by READ-side errors.
+# ---------------------------------------------------------------------------
+
+
+def _patch_binary_write_open(monkeypatch, victim_resolved: pathlib.Path, exc: OSError):
+    """Make Path.open raise ``exc`` only for the victim path's BINARY WRITE.
+
+    Reads and every other path stay untouched, so the failure is pinned to
+    the output file's open/write region and nothing else."""
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and pathlib.Path(self).resolve() == victim_resolved:
+            raise exc
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+
+
+def test_cli_write_side_permission_error_is_concise_exit_4(tmp_path, capsys, monkeypatch):
+    """Deterministic cross-platform pin of the repaired lane: a
+    PermissionError raised by the output file's binary open reaches
+    main() as the typed output-write failure — exit 4, one error: line,
+    no traceback, input log and pre-existing destination untouched."""
+    log_path = tmp_path / "nextness_runs.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+    out_path = tmp_path / "out.jsonl"
+    out_path.write_text("stale pre-existing content\n", encoding="utf-8")
+    log_before = log_path.read_bytes()
+    dest_before = out_path.read_bytes()
+
+    _patch_binary_write_open(monkeypatch, out_path.resolve(),
+                             PermissionError(13, "write denied"))
+
+    rc = main(["--log", str(log_path), "--out", str(out_path)])
+
+    assert rc == 4
+    captured = capsys.readouterr()
+    err_lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(err_lines) == 1
+    assert err_lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+    assert log_path.read_bytes() == log_before
+    assert out_path.read_bytes() == dest_before
+
+
+def test_read_side_unexpected_oserror_is_not_reclassified(tmp_path, monkeypatch):
+    """Scope precision: an unexpected OSError on the LOG READ must not be
+    converted into exit 4 by an over-broad handler — it stays loud."""
+    log_path = tmp_path / "nextness_runs.jsonl"
+    _write_log(log_path, [
+        _make_entry(generation=1, snapshot_file="a.npz"),
+        _make_entry(generation=2, snapshot_file="b.npz"),
+    ])
+    out_path = tmp_path / "out.jsonl"
+    victim = log_path.resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "b" not in mode and pathlib.Path(self).resolve() == victim:
+            raise PermissionError(13, "read denied")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError, match="read denied"):
+        main(["--log", str(log_path), "--out", str(out_path)])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -635,11 +635,16 @@ def test_cli_main_returns_nonzero_for_outside_log_dir_output(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
-# Operational output-write failure lane (exit 4): a write-side OSError is
-# an EXPECTED operational failure — one concise error: line, exit 4, no
-# traceback, inputs and any pre-existing destination byte-identical. It is
-# deliberately distinct from exit 3 (pre-write safety refusal) and from
-# exit 1 (missing log), and must never be produced by READ-side errors.
+# Operational output-write failure lane (exit 4): an OSError anywhere in
+# the OUTPUT region — parent-directory creation, binary open, streamed
+# writes, close — is an EXPECTED operational failure: one concise error:
+# line, exit 4, no traceback, input log byte-identical. Destination
+# preservation is guaranteed ONLY for failures at or before binary open
+# (a read-only destination is never truncated); once open succeeds,
+# direct streamed non-atomic output may be truncated or partial if a
+# later write/close fails. The lane must never be produced by READ-side
+# errors, and is distinct from exit 3 (pre-write safety refusal) and
+# exit 1 (missing log).
 # ---------------------------------------------------------------------------
 
 
@@ -647,27 +652,43 @@ def _patch_binary_write_open(monkeypatch, victim_resolved: pathlib.Path, exc: OS
     """Make Path.open raise ``exc`` only for the victim path's BINARY WRITE.
 
     Reads and every other path stay untouched, so the failure is pinned to
-    the output file's open/write region and nothing else."""
+    the output file's open and nothing else."""
     real_open = pathlib.Path.open
 
     def patched(self, mode="r", *args, **kwargs):
-        if "w" in mode and "b" in mode and pathlib.Path(self).resolve() == victim_resolved:
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
             raise exc
         return real_open(self, mode, *args, **kwargs)
 
     monkeypatch.setattr(pathlib.Path, "open", patched)
 
 
-def test_cli_write_side_permission_error_is_concise_exit_4(tmp_path, capsys, monkeypatch):
-    """Deterministic cross-platform pin of the repaired lane: a
-    PermissionError raised by the output file's binary open reaches
-    main() as the typed output-write failure — exit 4, one error: line,
-    no traceback, input log and pre-existing destination untouched."""
+def _write_two_row_log(tmp_path: pathlib.Path) -> pathlib.Path:
     log_path = tmp_path / "nextness_runs.jsonl"
     _write_log(log_path, [
         _make_entry(generation=1, snapshot_file="a.npz"),
         _make_entry(generation=2, snapshot_file="b.npz"),
     ])
+    return log_path
+
+
+def _expect_exit4_receipt(capsys) -> None:
+    captured = capsys.readouterr()
+    err_lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(err_lines) == 1
+    assert err_lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_output_open_permission_error_is_concise_exit_4(tmp_path, capsys, monkeypatch):
+    """OUTPUT-OPEN failure (deterministic, cross-platform): a
+    PermissionError raised by the output file's binary open — i.e.
+    BEFORE any truncation — reaches main() as the typed output-write
+    failure. Exit 4, one error: line, no traceback, input log untouched,
+    and the pre-existing destination byte-identical: destination
+    preservation IS guaranteed at open time, because open never
+    succeeded."""
+    log_path = _write_two_row_log(tmp_path)
     out_path = tmp_path / "out.jsonl"
     out_path.write_text("stale pre-existing content\n", encoding="utf-8")
     log_before = log_path.read_bytes()
@@ -676,32 +697,95 @@ def test_cli_write_side_permission_error_is_concise_exit_4(tmp_path, capsys, mon
     _patch_binary_write_open(monkeypatch, out_path.resolve(),
                              PermissionError(13, "write denied"))
 
-    rc = main(["--log", str(log_path), "--out", str(out_path)])
-
-    assert rc == 4
-    captured = capsys.readouterr()
-    err_lines = [l for l in captured.err.strip().splitlines() if l.strip()]
-    assert len(err_lines) == 1
-    assert err_lines[0].startswith("error:")
-    assert "Traceback" not in captured.err
+    assert main(["--log", str(log_path), "--out", str(out_path)]) == 4
+    _expect_exit4_receipt(capsys)
     assert log_path.read_bytes() == log_before
     assert out_path.read_bytes() == dest_before
+
+
+def test_cli_output_parent_mkdir_permission_error_is_concise_exit_4(
+    tmp_path, capsys, monkeypatch
+):
+    """OUTPUT-PARENT-CREATION failure: parent mkdir is part of the output
+    region, so a PermissionError there must land in the same typed exit-4
+    lane — not escape as a traceback. Log untouched; no output created."""
+    log_path = _write_two_row_log(tmp_path)
+    out_path = tmp_path / "newsub" / "out.jsonl"  # inside containment; parent absent
+    victim = (tmp_path / "newsub").resolve()
+    log_before = log_path.read_bytes()
+    real_mkdir = pathlib.Path.mkdir
+
+    def patched(self, *args, **kwargs):
+        if self.resolve() == victim:
+            raise PermissionError(13, "mkdir denied")
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", patched)
+
+    assert main(["--log", str(log_path), "--out", str(out_path)]) == 4
+    _expect_exit4_receipt(capsys)
+    assert log_path.read_bytes() == log_before
+    assert not (tmp_path / "newsub").exists()  # no output, no partial scaffolding
+
+
+def test_cli_mid_write_oserror_is_concise_exit_4(tmp_path, capsys, monkeypatch):
+    """MID-WRITE failure: after binary open succeeds and one row has been
+    written, a later write raising OSError must still land in the typed
+    exit-4 lane — one error: line, no traceback, input log untouched.
+
+    Deliberately NO destination-integrity assertion: output is direct,
+    streamed and non-atomic, so a mid-write failure may leave a truncated
+    or partial destination. That is the documented contract."""
+    log_path = _write_two_row_log(tmp_path)  # 2 rows -> 1 pair row + aggregate
+    out_path = tmp_path / "out.jsonl"
+    log_before = log_path.read_bytes()
+    out_resolved = out_path.resolve()
+    real_open = pathlib.Path.open
+    writes = {"n": 0}
+
+    class _FailAfterFirstWrite:
+        def __init__(self, raw):
+            self._raw = raw
+
+        def write(self, data):
+            writes["n"] += 1
+            if writes["n"] > 1:
+                raise OSError(28, "device full mid-stream")
+            return self._raw.write(data)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._raw.__exit__(*exc)
+
+        def __getattr__(self, name):
+            return getattr(self._raw, name)
+
+    def patched(self, mode="r", *args, **kwargs):
+        raw = real_open(self, mode, *args, **kwargs)
+        if "w" in mode and "b" in mode and self.resolve() == out_resolved:
+            return _FailAfterFirstWrite(raw)
+        return raw
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+
+    assert main(["--log", str(log_path), "--out", str(out_path)]) == 4
+    _expect_exit4_receipt(capsys)
+    assert writes["n"] > 1  # the failure genuinely occurred mid-stream
+    assert log_path.read_bytes() == log_before
 
 
 def test_read_side_unexpected_oserror_is_not_reclassified(tmp_path, monkeypatch):
     """Scope precision: an unexpected OSError on the LOG READ must not be
     converted into exit 4 by an over-broad handler — it stays loud."""
-    log_path = tmp_path / "nextness_runs.jsonl"
-    _write_log(log_path, [
-        _make_entry(generation=1, snapshot_file="a.npz"),
-        _make_entry(generation=2, snapshot_file="b.npz"),
-    ])
+    log_path = _write_two_row_log(tmp_path)
     out_path = tmp_path / "out.jsonl"
     victim = log_path.resolve()
     real_open = pathlib.Path.open
 
     def patched(self, mode="r", *args, **kwargs):
-        if "r" in mode and "b" not in mode and pathlib.Path(self).resolve() == victim:
+        if "r" in mode and "b" not in mode and self.resolve() == victim:
             raise PermissionError(13, "read denied")
         return real_open(self, mode, *args, **kwargs)
 


### PR DESCRIPTION
## Root cause (audit finding CBD-1, reproduced twice through the public CLI)

`nextness_metrics` crashed with an **uncaught `PermissionError` traceback** when `--out` named an existing **read-only file** inside the log directory. Every pre-write safety check legitimately passed (containment ✓, not a directory ✓, not an alias ✓), then `compute_run_metrics`' binary `open("wb")` failed with no handler: full traceback, **process exit 1 — numerically colliding with the (previously undocumented) missing-log exit 1**, so callers could not distinguish "log absent" from "metrics crashed". Every sibling file-producing Nextness CLI handles the identical scenario at exit 4 with one concise `error:` line. Same escape class as the #366 directory-target finding — that repair added the `is_dir()` pre-check but no write-lane `OSError` handling.

## Fix — deliberately narrow typed lane

- `OSError` is caught **only around the output region — output-parent creation plus the binary open/write/close** — inside `compute_run_metrics`, where it becomes the new typed **`MetricsOutputWriteError`** with a concise path-specific message *(parent creation folded into the typed region in `33fc4a9f`, addressing the inline review)*.
- **No broad `except OSError` around the computation**: read-side or unexpected errors are never reclassified as output failures — pinned by a scope-precision regression that proves a read-side `PermissionError` still propagates loudly.
- `main()` catches the typed exception **before** the existing handlers → exactly one `error:` line → **exit 4**.
- No atomic-write behavior introduced; no partial-write redesign; the documented validation-to-write (TOCTOU) non-claim stands.

## Complete metrics exit map (now documented in `main()` docstring + design-doc §9.2 — metrics-specific truth, not harmonisation)

| Code | Lane | Prefix |
|---|---|---|
| 0 | success | — |
| 1 | missing input log | `error:` |
| 2 | data/validation failure (argparse usage also 2) | `error:` |
| 3 | pre-write containment / identity / directory safety refusal | `safety error:` |
| **4** | **operational output-write failure (new typed lane: parent creation, open, write, close)** | `error:` |

## Failing-first receipts (unmodified `main = 3059df5f`)

- **Deterministic cross-platform**: the new write-side regression (targeted patch raising `PermissionError` only for the output path's binary write) **failed with the live escaped `PermissionError`** — proof the error reached public `main()` uncaught.
- **Windows public CLI**: read-only-file reproduction exited **1 with a full traceback**, twice (audit receipts P23/P24; Leg-0 digests: log `1e461af6a245a783…` and destination `117c5d6a0f57e8e2…` byte-identical before/after both crashes).
- Fences green pre-repair: missing log ==1 · malformed ==2 · outside-boundary ==3 · read-side propagation.

## Post-repair verification

- **Independent public-CLI read-only reproduction (twice)**: **exit 4 · exactly 1 stderr line · `error:` prefix · no traceback**; destination and log byte-identical both runs.
- **Output preservation**: ordinary success output **byte-identical to the pre-repair baseline** — 17,534 B, sha256 `f4fc89a32b865b5631c4a6988a9518df0fff3bb5d37e01c5a3f567251183ed91`; CR bytes 0; trailing LF; streaming, row order, field order, formulas, aggregates, sibling-overwrite all unchanged.
- **Live exit matrix post-repair**: success 0 · missing 1 (`error:`) · malformed 2 (`error:`) · outside-boundary 3 (`safety error:`) · direct alias 3 (`safety error:`) — all traceback-free.

## Regression tests added/upgraded (in `tests/test_nextness_metrics.py`)

1. Write-side `PermissionError` via targeted patching (output path's binary write only): **==4**, exactly one `error:` line, no traceback, input **and pre-existing destination** byte-identical.
2. Exact codes: missing log **==1** and outside-boundary **==3** (both upgraded from nonzero-only), malformed data **==2** (new), directory/identity ==3 and ordinary ==0 already pinned by #366/#369-era tests.
3. Scope precision: read-side unexpected `OSError` **propagates** (not converted to 4).
4. Byte/LF/streaming contracts: existing pins unchanged and green.

## Test totals

- `tests/test_nextness_metrics.py`: **50 passed, 2 skipped**
- Focused Nextness (10 files): **749 passed, 18 skipped**
- Full maintained suite: **1333 passed, 45 skipped**
- `py_compile` (both touched Python files): OK

## Scope

Exactly three files: `scripts/nextness_metrics.py` (+66/−2 area), `tests/test_nextness_metrics.py` (+101/−6 area), `PHASE_19_PR3_METRICS_PIPELINE.md` (+30) — **3 files, +189/−8**. No other repository file changed.


## Follow-up (`33fc4a9f`) — parent creation in the typed region + precise destination contract

The inline review was right: on `18d760dd`, `out_path.parent.mkdir(...)` sat **outside** the typed region, so a `PermissionError` during output-parent creation still escaped as a traceback (reproduced failing-first: live escape on `18d760dd`). `mkdir` is output-side work — it now lives inside the same `try` as the binary open/write/close and lands in the exit-4 lane. Read-side/computation errors remain uncaught and loud (propagation pin retained).

**Destination-preservation contract, corrected precisely everywhere it is stated:**
- A failure **at or before the binary open** — read-only destination (public reproduction: exit 4, one `error:` line, no traceback, twice; destination byte-identical) or failed parent creation — leaves any existing destination **unchanged** and creates no output.
- **Once the binary open has succeeded**, output is direct, streamed and **non-atomic**: a later write or close failure may leave a **truncated or partial destination**, and **no general destination-preservation guarantee is made or implied** (pinned by a deterministic mid-write `OSError` test that deliberately asserts no destination integrity).
- ~~The input log is unchanged in every case~~ **(corrected in `44f0b584`)**: in the exercised failure lanes, and absent the documented validation-to-write replacement race, the input log remains unchanged. **This repair adds no stronger input-log guarantee** — a concurrent actor may still redirect the later direct write, as the existing TOCTOU non-claim states. **No atomic-write redesign** under this repair.

**Tests** (net on `33fc4a9f`): failing-first parent-mkdir `PermissionError` pin (escaped live on `18d760dd`; now ==4, one line, no traceback, log unchanged, no scaffolding created) · open-time test renamed `test_cli_output_open_permission_error_is_concise_exit_4`, byte-preservation assertion retained and scoped to open time · new deterministic mid-write `OSError` pin (one successful write, then failure → ==4, one line, no traceback, log unchanged; deliberately no destination-integrity assertion) · read-side propagation pin preserved · `pathlib.Path(self).resolve()` → `self.resolve()` ×2.

**Fresh totals** (head `33fc4a9f`): metrics **52 passed / 2 skipped** · focused Nextness **751 / 18** · full suite **1335 / 45** · `py_compile` ×2 OK · live matrix 0/1/2/3/3/4 exact, all one-line, traceback-free · success output still **byte-identical** to the pre-repair baseline (`f4fc89a3…`, 17,534 B) · public reproductions ×2 each for read-only destination **and** parent-creation failure (file-as-parent), all exit 4 concise.


## Final wording correction (`44f0b584`, documentation only)

The follow-up's absolute claim that the input log is "unchanged in every case" was inconsistent with the module's own preserved **validation-to-write TOCTOU non-claim** (a concurrent actor replacing the output path between validation and write can redirect the direct write — including at the log). Corrected in the module docstrings and design-doc §9.2 to the qualified form above. **No behavior or test change**; targeted metrics tests re-run green (52 passed / 2 skipped), `py_compile` clean, `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


