### PR TITLE
test(nextness): pin output-write stage contracts; document destination boundaries

### DIFF
--- a/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
+++ b/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
@@ -71,15 +71,29 @@ argparse's own `SystemExit(2)` — bypassing `main()`'s return path — with
 carve-out ("argparse's own usage errors also exit 2"); the argparse pins in the
 focused suites assert code 2, the `usage:` prefix, and no traceback.
 
-## Unexpected-error propagation
+## Unexpected-error propagation (bounded by each catch set)
 
-All six CLIs deliberately catch only their expected failure types; unexpected
-programming errors **propagate loudly** rather than masquerading as clean
-exits. This is docstring-stated in predictor, monitor, evaluator, replay lab
-and evidence packet, and stated for metrics in its module CLI section.
-Test-backed by propagation pins in all six focused suites (predictor's
-long-standing pin; metrics' read-side pin from PR #372; monitor/evaluator/
-replay-lab/evidence-packet pins added alongside this note).
+Each CLI's `main()` catches its **documented catch classes**; exceptions
+outside those classes propagate. The catch sets differ, and in five of the
+six they are broader than the typed subclasses alone:
+
+- **Plain `ValueError` is broadly mapped to exit 2** in predictor, metrics,
+  monitor, replay lab and evidence packet: their typed input errors subclass
+  `ValueError` and the catch clause names the base class, so a plain
+  `ValueError` escaping a call inside the `try` region takes the documented
+  data-failure lane rather than propagating.
+- The **evaluator catches its typed `EvaluatorInputError`** (alongside its
+  typed write-safety and ceiling classes), **not arbitrary plain
+  `ValueError`**; a plain `ValueError` raised inside its `try` region
+  propagates.
+- The focused propagation pins prove **their exact lanes only**: a sentinel
+  `RuntimeError` propagating in predictor, monitor, evaluator, replay lab
+  and evidence packet, and a read-side `OSError` propagating in metrics
+  (PR #372's pin). They establish those lanes, not a general theorem.
+
+**No claim is made that every possible programming error propagates**;
+propagation is exactly the complement of each CLI's documented catch set,
+per the maps above.
 
 ## Identity-inspection fail-closed rows
 

--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -246,6 +246,19 @@ write. The guard defends against aliases that exist when it validates —
 it does not claim to eliminate the validation-to-write (TOCTOU)
 interval.
 
+**Destination boundary on operational write failure** (audited 2026-07-17;
+stage-pinned in the focused tests): a failure **at or before the binary
+open** — an unwritable or read-only destination, an absent or invalid
+parent — preserves any existing destination byte-identically and creates
+no output. **After a successful direct non-atomic open**, a later failure
+may truncate the destination or leave partial output (the whole-buffer
+write truncates on open, so a failed write leaves an empty file). A
+**close-time failure** may leave the complete canonical evaluation bytes
+in place even though the run reports the operational-failure exit —
+a present file does not imply a successful run. Supplied-input
+preservation on these lanes is bounded by the existing validation-to-write
+(TOCTOU) non-claim. No atomic-write behavior is provided or implied.
+
 ## CLI exit codes
 
 | Code | Meaning |

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -117,6 +117,19 @@ never inside the repository `data/` tree, and never on a path aliasing
 validation-time semantics and documented residual race as the NP6 lab.
 Files are written as raw UTF-8 bytes (LF-only).
 
+**Destination boundary on operational write failure** (audited 2026-07-17;
+stage-pinned in the focused tests): a failure **at or before the binary
+open** — an unwritable or read-only destination, an absent or invalid
+parent — preserves any existing destination byte-identically and creates
+no output. **After a successful direct non-atomic open**, a later failure
+may truncate the destination or leave partial output (the whole-buffer
+write truncates on open, so a failed write leaves an empty file). A
+**close-time failure** may leave the complete canonical packet bytes
+in place even though the run reports the operational-failure exit —
+a present file does not imply a successful run. Supplied-input
+preservation on these lanes is bounded by the existing validation-to-write
+(TOCTOU) non-claim. No atomic-write behavior is provided or implied.
+
 ## CLI exit codes
 
 `0` success · `2` validation failure (missing/oversized/malformed/

--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -130,6 +130,19 @@ is checked against a **64 KiB ceiling — fail closed** (`ReportTooLargeError`).
   translation (`\n` → `\r\n`, the old `write_text` behavior) can never
   alter the canonical bytes, so file reports are byte-identical across
   platforms and match the documented byte-identity guarantee.
+**Destination boundary on operational write failure** (audited 2026-07-17;
+stage-pinned in the focused tests): a failure **at or before the binary
+open** — an unwritable or read-only destination, an absent or invalid
+parent — preserves any existing destination byte-identically and creates
+no output. **After a successful direct non-atomic open**, a later failure
+may truncate the destination or leave partial output (the whole-buffer
+write truncates on open, so a failed write leaves an empty file). A
+**close-time failure** may leave the complete canonical report bytes
+in place even though the run reports the operational-failure exit —
+a present file does not imply a successful run. Supplied-input
+preservation on these lanes is bounded by the existing validation-to-write
+(TOCTOU) non-claim. No atomic-write behavior is provided or implied.
+
 - No network, HTTP, ZMQ, Ollama or model calls anywhere in the module
   (statically auditable: the only imports are stdlib + `TOKEN_NAMES` /
   `WriteOutsideLogDirError` from `scripts.nextness_observer`).

--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -130,19 +130,18 @@ is checked against a **64 KiB ceiling — fail closed** (`ReportTooLargeError`).
   translation (`\n` → `\r\n`, the old `write_text` behavior) can never
   alter the canonical bytes, so file reports are byte-identical across
   platforms and match the documented byte-identity guarantee.
-**Destination boundary on operational write failure** (audited 2026-07-17;
-stage-pinned in the focused tests): a failure **at or before the binary
-open** — an unwritable or read-only destination, an absent or invalid
-parent — preserves any existing destination byte-identically and creates
-no output. **After a successful direct non-atomic open**, a later failure
-may truncate the destination or leave partial output (the whole-buffer
-write truncates on open, so a failed write leaves an empty file). A
-**close-time failure** may leave the complete canonical report bytes
-in place even though the run reports the operational-failure exit —
-a present file does not imply a successful run. Supplied-input
-preservation on these lanes is bounded by the existing validation-to-write
-(TOCTOU) non-claim. No atomic-write behavior is provided or implied.
-
+- **Destination boundary on operational write failure** (audited 2026-07-17;
+  stage-pinned in the focused tests): a failure **at or before the binary
+  open** — an unwritable or read-only destination, an absent or invalid
+  parent — preserves any existing destination byte-identically and creates
+  no output. **After a successful direct non-atomic open**, a later failure
+  may truncate the destination or leave partial output (the whole-buffer
+  write truncates on open, so a failed write leaves an empty file). A
+  **close-time failure** may leave the complete canonical report bytes
+  in place even though the run reports the operational-failure exit —
+  a present file does not imply a successful run. Supplied-input
+  preservation on these lanes is bounded by the existing validation-to-write
+  (TOCTOU) non-claim. No atomic-write behavior is provided or implied.
 - No network, HTTP, ZMQ, Ollama or model calls anywhere in the module
   (statically auditable: the only imports are stdlib + `TOKEN_NAMES` /
   `WriteOutsideLogDirError` from `scripts.nextness_observer`).

--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -139,6 +139,8 @@ filesystem manipulation.
 
 Default output is **stdout**; `--output` must resolve inside the input
 log's directory and never inside the repository `data/` tree (NP1's
+convention).
+
 **Destination boundary on operational write failure** (audited 2026-07-17;
 stage-pinned in the focused tests): a failure **at or before the binary
 open** — an unwritable or read-only destination, an absent or invalid
@@ -152,7 +154,7 @@ a present file does not imply a successful run. Supplied-input
 preservation on these lanes is bounded by the existing validation-to-write
 (TOCTOU) non-claim. No atomic-write behavior is provided or implied.
 
-convention). Exit codes mirror NP1: `0` success · `2` validation
+Exit codes mirror NP1: `0` success · `2` validation
 failure (including a holdout beyond the replay bound) · `3`
 insufficient history · `4` write-boundary/unwritable · `5` report over
 the ceiling. Expected failures print one concise `error:` line, never a

--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -139,6 +139,19 @@ filesystem manipulation.
 
 Default output is **stdout**; `--output` must resolve inside the input
 log's directory and never inside the repository `data/` tree (NP1's
+**Destination boundary on operational write failure** (audited 2026-07-17;
+stage-pinned in the focused tests): a failure **at or before the binary
+open** — an unwritable or read-only destination, an absent or invalid
+parent — preserves any existing destination byte-identically and creates
+no output. **After a successful direct non-atomic open**, a later failure
+may truncate the destination or leave partial output (the whole-buffer
+write truncates on open, so a failed write leaves an empty file). A
+**close-time failure** may leave the complete canonical lab-report bytes
+in place even though the run reports the operational-failure exit —
+a present file does not imply a successful run. Supplied-input
+preservation on these lanes is bounded by the existing validation-to-write
+(TOCTOU) non-claim. No atomic-write behavior is provided or implied.
+
 convention). Exit codes mirror NP1: `0` success · `2` validation
 failure (including a holdout beyond the replay bound) · `3`
 insufficient history · `4` write-boundary/unwritable · `5` report over

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1500,3 +1500,125 @@ def test_cli_unexpected_errors_are_not_hidden(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(evaluator_module, "build_evaluation", boom)
     with pytest.raises(RuntimeError, match="sentinel propagation probe"):
         main(["--report", str(report_file)])
+
+
+# ---------------------------------------------------------------------------
+# Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
+# 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
+# the expected exit-4 operational-write lane — distinct from PUBLIC
+# filesystem behavior and never a public-reachability claim. Stage counters
+# assert the intended operation (open/write/close) actually fired, so no pin
+# can pass by triggering the wrong stage.
+# ---------------------------------------------------------------------------
+
+
+class _StageProxy:
+    def __init__(self, raw, fail_write_at=None, fail_close=False):
+        self._raw = raw
+        self._fail_at = fail_write_at
+        self._fail_close = fail_close
+        self.writes_ok = 0
+        self.close_attempted = False
+
+    def write(self, data):
+        if self._fail_at is not None and self.writes_ok + 1 >= self._fail_at:
+            raise OSError(28, "injected write failure")
+        n = self._raw.write(data)
+        self.writes_ok += 1
+        return n
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close_attempted = True
+        self._raw.__exit__(*exc)
+        if self._fail_close and exc[0] is None:
+            raise OSError(5, "injected close failure")
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def _patch_output_stage(monkeypatch, victim_resolved, *, deny_open=False,
+                        fail_write_at=None, fail_close=False):
+    """Patch ONLY the victim path's binary-write open; returns stage state."""
+    state = {"opens": 0, "proxy": None}
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
+            state["opens"] += 1
+            if deny_open:
+                raise PermissionError(13, "injected open denial")
+            raw = real_open(self, mode, *args, **kwargs)
+            state["proxy"] = _StageProxy(raw, fail_write_at, fail_close)
+            return state["proxy"]
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    return state
+
+
+def _stage_exit4_receipt(capsys):
+    captured = capsys.readouterr()
+    lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_output_open_denial_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Open denial: no truncation ever happened — existing destination,
+    inputs and directory inventory all byte-identical; exit 4, one line."""
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    out = tmp_path / "stage_pin.out"
+    out.write_text("pre-existing destination\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [report_file, receipts_file] + [out]}
+    inv = sorted(p.name for p in tmp_path.iterdir())
+    state = _patch_output_stage(monkeypatch, out.resolve(), deny_open=True)
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is None  # failed AT open
+    for p, b in before.items():
+        assert p.read_bytes() == b
+    assert sorted(p.name for p in tmp_path.iterdir()) == inv
+
+
+def test_cli_post_open_write_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Post-open failure of the FIRST whole-buffer write: open succeeded,
+    zero writes completed, destination truncated to empty; inputs
+    unchanged; exit 4 with one concise line."""
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    out = tmp_path / "stage_pin.out"
+    out.write_text("stale bytes to observe truncation\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [report_file, receipts_file]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_write_at=1)
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None  # open SUCCEEDED
+    assert state["proxy"].writes_ok == 0                       # first write failed
+    assert out.exists() and out.stat().st_size == 0            # truncated-empty
+    for p, b in before.items():
+        assert p.read_bytes() == b
+
+
+def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Close-time failure: every write succeeded, the context exit raised —
+    the destination holds the COMPLETE canonical serialized bytes although
+    the run reports exit 4."""
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    canon = tmp_path / "canonical.out"
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(canon)]) == 0          # capture canonical success bytes
+    capsys.readouterr()
+    canonical = canon.read_bytes()
+    out = tmp_path / "stage_pin.out"
+    before = {p: p.read_bytes() for p in [report_file, receipts_file]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_close=True)
+    assert main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None
+    assert state["proxy"].writes_ok == 1                       # whole buffer written
+    assert state["proxy"].close_attempted                      # failure was AT close
+    assert out.read_bytes() == canonical                       # complete bytes present
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -851,3 +851,125 @@ def test_cli_unexpected_errors_are_not_hidden(chain, monkeypatch) -> None:
     monkeypatch.setattr(packet_module, "build_packet", boom)
     with pytest.raises(RuntimeError, match="sentinel propagation probe"):
         main(_chain_args(chain))
+
+
+# ---------------------------------------------------------------------------
+# Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
+# 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
+# the expected exit-4 operational-write lane — distinct from PUBLIC
+# filesystem behavior and never a public-reachability claim. Stage counters
+# assert the intended operation (open/write/close) actually fired, so no pin
+# can pass by triggering the wrong stage.
+# ---------------------------------------------------------------------------
+
+
+class _StageProxy:
+    def __init__(self, raw, fail_write_at=None, fail_close=False):
+        self._raw = raw
+        self._fail_at = fail_write_at
+        self._fail_close = fail_close
+        self.writes_ok = 0
+        self.close_attempted = False
+
+    def write(self, data):
+        if self._fail_at is not None and self.writes_ok + 1 >= self._fail_at:
+            raise OSError(28, "injected write failure")
+        n = self._raw.write(data)
+        self.writes_ok += 1
+        return n
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close_attempted = True
+        self._raw.__exit__(*exc)
+        if self._fail_close and exc[0] is None:
+            raise OSError(5, "injected close failure")
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def _patch_output_stage(monkeypatch, victim_resolved, *, deny_open=False,
+                        fail_write_at=None, fail_close=False):
+    """Patch ONLY the victim path's binary-write open; returns stage state."""
+    state = {"opens": 0, "proxy": None}
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
+            state["opens"] += 1
+            if deny_open:
+                raise PermissionError(13, "injected open denial")
+            raw = real_open(self, mode, *args, **kwargs)
+            state["proxy"] = _StageProxy(raw, fail_write_at, fail_close)
+            return state["proxy"]
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    return state
+
+
+def _stage_exit4_receipt(capsys):
+    captured = capsys.readouterr()
+    lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_output_open_denial_pinned(chain, tmp_path, capsys, monkeypatch) -> None:
+    """Open denial: no truncation ever happened — existing destination,
+    inputs and directory inventory all byte-identical; exit 4, one line."""
+    _ = tmp_path  # chain fixture provides inputs in tmp_path
+    out = tmp_path / "stage_pin.out"
+    out.write_text("pre-existing destination\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in list(chain.values()) + [out]}
+    inv = sorted(p.name for p in tmp_path.iterdir())
+    state = _patch_output_stage(monkeypatch, out.resolve(), deny_open=True)
+    assert main(_chain_args(chain) + ["--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is None  # failed AT open
+    for p, b in before.items():
+        assert p.read_bytes() == b
+    assert sorted(p.name for p in tmp_path.iterdir()) == inv
+
+
+def test_cli_post_open_write_failure_pinned(chain, tmp_path, capsys, monkeypatch) -> None:
+    """Post-open failure of the FIRST whole-buffer write: open succeeded,
+    zero writes completed, destination truncated to empty; inputs
+    unchanged; exit 4 with one concise line."""
+    _ = tmp_path  # chain fixture provides inputs in tmp_path
+    out = tmp_path / "stage_pin.out"
+    out.write_text("stale bytes to observe truncation\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in list(chain.values())}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_write_at=1)
+    assert main(_chain_args(chain) + ["--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None  # open SUCCEEDED
+    assert state["proxy"].writes_ok == 0                       # first write failed
+    assert out.exists() and out.stat().st_size == 0            # truncated-empty
+    for p, b in before.items():
+        assert p.read_bytes() == b
+
+
+def test_cli_close_time_failure_pinned(chain, tmp_path, capsys, monkeypatch) -> None:
+    """Close-time failure: every write succeeded, the context exit raised —
+    the destination holds the COMPLETE canonical serialized bytes although
+    the run reports exit 4."""
+    _ = tmp_path  # chain fixture provides inputs in tmp_path
+    canon = tmp_path / "canonical.out"
+    assert main(_chain_args(chain) + ["--output", str(canon)]) == 0          # capture canonical success bytes
+    capsys.readouterr()
+    canonical = canon.read_bytes()
+    out = tmp_path / "stage_pin.out"
+    before = {p: p.read_bytes() for p in list(chain.values())}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_close=True)
+    assert main(_chain_args(chain) + ["--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None
+    assert state["proxy"].writes_ok == 1                       # whole buffer written
+    assert state["proxy"].close_attempted                      # failure was AT close
+    assert out.read_bytes() == canonical                       # complete bytes present
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -1058,3 +1058,89 @@ def test_cli_identity_inspection_failure_fails_closed_exit_3(
     assert log_path.read_bytes() == log_before
     assert out.read_bytes() == out_before
     assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+# ---------------------------------------------------------------------------
+# Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
+# 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
+# the expected exit-4 operational-write lane — distinct from PUBLIC
+# filesystem behavior and never a public-reachability claim. Stage counters
+# assert the intended operation (open/write/close) actually fired, so no pin
+# can pass by triggering the wrong stage.
+# ---------------------------------------------------------------------------
+
+
+class _StageProxy:
+    def __init__(self, raw, fail_write_at=None, fail_close=False):
+        self._raw = raw
+        self._fail_at = fail_write_at
+        self._fail_close = fail_close
+        self.writes_ok = 0
+        self.close_attempted = False
+
+    def write(self, data):
+        if self._fail_at is not None and self.writes_ok + 1 >= self._fail_at:
+            raise OSError(28, "injected write failure")
+        n = self._raw.write(data)
+        self.writes_ok += 1
+        return n
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close_attempted = True
+        self._raw.__exit__(*exc)
+        if self._fail_close and exc[0] is None:
+            raise OSError(5, "injected close failure")
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def _patch_output_stage(monkeypatch, victim_resolved, *, deny_open=False,
+                        fail_write_at=None, fail_close=False):
+    """Patch ONLY the victim path's binary-write open; returns stage state."""
+    state = {"opens": 0, "proxy": None}
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
+            state["opens"] += 1
+            if deny_open:
+                raise PermissionError(13, "injected open denial")
+            raw = real_open(self, mode, *args, **kwargs)
+            state["proxy"] = _StageProxy(raw, fail_write_at, fail_close)
+            return state["proxy"]
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    return state
+
+
+def _stage_exit4_receipt(capsys):
+    captured = capsys.readouterr()
+    lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Close-time failure (streamed writer): every streamed row write
+    succeeds, only the context exit raises — the destination equals the
+    canonical successful output byte-for-byte although the CLI returns 4."""
+    log_path = _two_entry_log(tmp_path)
+    canon = tmp_path / "canonical.out"
+    assert main(["--log", str(log_path), "--out", str(canon)]) == 0
+    capsys.readouterr()
+    canonical = canon.read_bytes()
+    out = tmp_path / "stage_pin.out"
+    log_before = log_path.read_bytes()
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_close=True)
+    assert main(["--log", str(log_path), "--out", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None
+    assert state["proxy"].writes_ok == 2          # 1 pair row + 1 aggregate row
+    assert state["proxy"].close_attempted          # failure was AT close, not write
+    assert out.read_bytes() == canonical           # complete canonical stream
+    assert log_path.read_bytes() == log_before

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -770,3 +770,125 @@ def test_cli_identity_inspection_failure_fails_closed_exit_4(
     assert log.read_bytes() == log_before
     assert out.read_bytes() == out_before
     assert sorted(p.name for p in tmp_path.iterdir()) == entries_before
+
+
+# ---------------------------------------------------------------------------
+# Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
+# 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
+# the expected exit-4 operational-write lane — distinct from PUBLIC
+# filesystem behavior and never a public-reachability claim. Stage counters
+# assert the intended operation (open/write/close) actually fired, so no pin
+# can pass by triggering the wrong stage.
+# ---------------------------------------------------------------------------
+
+
+class _StageProxy:
+    def __init__(self, raw, fail_write_at=None, fail_close=False):
+        self._raw = raw
+        self._fail_at = fail_write_at
+        self._fail_close = fail_close
+        self.writes_ok = 0
+        self.close_attempted = False
+
+    def write(self, data):
+        if self._fail_at is not None and self.writes_ok + 1 >= self._fail_at:
+            raise OSError(28, "injected write failure")
+        n = self._raw.write(data)
+        self.writes_ok += 1
+        return n
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close_attempted = True
+        self._raw.__exit__(*exc)
+        if self._fail_close and exc[0] is None:
+            raise OSError(5, "injected close failure")
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def _patch_output_stage(monkeypatch, victim_resolved, *, deny_open=False,
+                        fail_write_at=None, fail_close=False):
+    """Patch ONLY the victim path's binary-write open; returns stage state."""
+    state = {"opens": 0, "proxy": None}
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
+            state["opens"] += 1
+            if deny_open:
+                raise PermissionError(13, "injected open denial")
+            raw = real_open(self, mode, *args, **kwargs)
+            state["proxy"] = _StageProxy(raw, fail_write_at, fail_close)
+            return state["proxy"]
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    return state
+
+
+def _stage_exit4_receipt(capsys):
+    captured = capsys.readouterr()
+    lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_output_open_denial_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Open denial: no truncation ever happened — existing destination,
+    inputs and directory inventory all byte-identical; exit 4, one line."""
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "stage_pin.out"
+    out.write_text("pre-existing destination\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [log] + [out]}
+    inv = sorted(p.name for p in tmp_path.iterdir())
+    state = _patch_output_stage(monkeypatch, out.resolve(), deny_open=True)
+    assert main([str(log), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is None  # failed AT open
+    for p, b in before.items():
+        assert p.read_bytes() == b
+    assert sorted(p.name for p in tmp_path.iterdir()) == inv
+
+
+def test_cli_post_open_write_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Post-open failure of the FIRST whole-buffer write: open succeeded,
+    zero writes completed, destination truncated to empty; inputs
+    unchanged; exit 4 with one concise line."""
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "stage_pin.out"
+    out.write_text("stale bytes to observe truncation\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [log]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_write_at=1)
+    assert main([str(log), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None  # open SUCCEEDED
+    assert state["proxy"].writes_ok == 0                       # first write failed
+    assert out.exists() and out.stat().st_size == 0            # truncated-empty
+    for p, b in before.items():
+        assert p.read_bytes() == b
+
+
+def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Close-time failure: every write succeeded, the context exit raised —
+    the destination holds the COMPLETE canonical serialized bytes although
+    the run reports exit 4."""
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    canon = tmp_path / "canonical.out"
+    assert main([str(log), "--output", str(canon)]) == 0          # capture canonical success bytes
+    capsys.readouterr()
+    canonical = canon.read_bytes()
+    out = tmp_path / "stage_pin.out"
+    before = {p: p.read_bytes() for p in [log]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_close=True)
+    assert main([str(log), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None
+    assert state["proxy"].writes_ok == 1                       # whole buffer written
+    assert state["proxy"].close_attempted                      # failure was AT close
+    assert out.read_bytes() == canonical                       # complete bytes present
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -995,3 +995,128 @@ def test_cli_unexpected_errors_are_not_hidden(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(lab_module, "build_lab_report", boom)
     with pytest.raises(RuntimeError, match="sentinel propagation probe"):
         main([str(log), str(protocol)])
+
+
+# ---------------------------------------------------------------------------
+# Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
+# 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
+# the expected exit-4 operational-write lane — distinct from PUBLIC
+# filesystem behavior and never a public-reachability claim. Stage counters
+# assert the intended operation (open/write/close) actually fired, so no pin
+# can pass by triggering the wrong stage.
+# ---------------------------------------------------------------------------
+
+
+class _StageProxy:
+    def __init__(self, raw, fail_write_at=None, fail_close=False):
+        self._raw = raw
+        self._fail_at = fail_write_at
+        self._fail_close = fail_close
+        self.writes_ok = 0
+        self.close_attempted = False
+
+    def write(self, data):
+        if self._fail_at is not None and self.writes_ok + 1 >= self._fail_at:
+            raise OSError(28, "injected write failure")
+        n = self._raw.write(data)
+        self.writes_ok += 1
+        return n
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close_attempted = True
+        self._raw.__exit__(*exc)
+        if self._fail_close and exc[0] is None:
+            raise OSError(5, "injected close failure")
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def _patch_output_stage(monkeypatch, victim_resolved, *, deny_open=False,
+                        fail_write_at=None, fail_close=False):
+    """Patch ONLY the victim path's binary-write open; returns stage state."""
+    state = {"opens": 0, "proxy": None}
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "w" in mode and "b" in mode and self.resolve() == victim_resolved:
+            state["opens"] += 1
+            if deny_open:
+                raise PermissionError(13, "injected open denial")
+            raw = real_open(self, mode, *args, **kwargs)
+            state["proxy"] = _StageProxy(raw, fail_write_at, fail_close)
+            return state["proxy"]
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    return state
+
+
+def _stage_exit4_receipt(capsys):
+    captured = capsys.readouterr()
+    lines = [l for l in captured.err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in captured.err
+
+
+def test_cli_output_open_denial_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Open denial: no truncation ever happened — existing destination,
+    inputs and directory inventory all byte-identical; exit 4, one line."""
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    out = tmp_path / "stage_pin.out"
+    out.write_text("pre-existing destination\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [log, protocol] + [out]}
+    inv = sorted(p.name for p in tmp_path.iterdir())
+    state = _patch_output_stage(monkeypatch, out.resolve(), deny_open=True)
+    assert main([str(log), str(protocol), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is None  # failed AT open
+    for p, b in before.items():
+        assert p.read_bytes() == b
+    assert sorted(p.name for p in tmp_path.iterdir()) == inv
+
+
+def test_cli_post_open_write_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Post-open failure of the FIRST whole-buffer write: open succeeded,
+    zero writes completed, destination truncated to empty; inputs
+    unchanged; exit 4 with one concise line."""
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    out = tmp_path / "stage_pin.out"
+    out.write_text("stale bytes to observe truncation\n", encoding="utf-8")
+    before = {p: p.read_bytes() for p in [log, protocol]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_write_at=1)
+    assert main([str(log), str(protocol), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None  # open SUCCEEDED
+    assert state["proxy"].writes_ok == 0                       # first write failed
+    assert out.exists() and out.stat().st_size == 0            # truncated-empty
+    for p, b in before.items():
+        assert p.read_bytes() == b
+
+
+def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
+    """Close-time failure: every write succeeded, the context exit raised —
+    the destination holds the COMPLETE canonical serialized bytes although
+    the run reports exit 4."""
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    canon = tmp_path / "canonical.out"
+    assert main([str(log), str(protocol), "--output", str(canon)]) == 0          # capture canonical success bytes
+    capsys.readouterr()
+    canonical = canon.read_bytes()
+    out = tmp_path / "stage_pin.out"
+    before = {p: p.read_bytes() for p in [log, protocol]}
+    state = _patch_output_stage(monkeypatch, out.resolve(), fail_close=True)
+    assert main([str(log), str(protocol), "--output", str(out)]) == 4
+    _stage_exit4_receipt(capsys)
+    assert state["opens"] == 1 and state["proxy"] is not None
+    assert state["proxy"].writes_ok == 1                       # whole buffer written
+    assert state["proxy"].close_attempted                      # failure was AT close
+    assert out.read_bytes() == canonical                       # complete bytes present
+    for p, b in before.items():
+        assert p.read_bytes() == b


### PR DESCRIPTION
## What this is

Candidates **1 + 2** from the 2026-07-17 five-CLI output-write audit (findings **OWF-TG-1** and **OWF-DG-1**): thirteen output-write **stage pins** plus four contract-doc **destination-boundary paragraphs**. **Coverage pinning and documentation only — zero production changes; all thirteen pins pass against unchanged code.**

## The thirteen pins (INJECTED deterministic branch exercises — distinct from PUBLIC behavior, never a public-reachability claim)

| Pin | predictor | evaluator | replay lab | evidence packet | metrics |
|---|---|---|---|---|---|
| output-open denial | ✓ | ✓ | ✓ | ✓ | (pinned in #372) |
| post-open write failure | ✓ | ✓ | ✓ | ✓ | (mid-write pinned in #372) |
| close-time failure | ✓ | ✓ | ✓ | ✓ | ✓ **(the one missing pin)** |

Every pin patches **only the exact output path's binary-write open** and asserts **stage counters** (opens / successful writes / close-attempted), so no test can pass by triggering the wrong operation:

- **Open denial**: exit 4, one `error:` line, no traceback, `opens==1` with no file object created, existing destination byte-identical, all inputs and directory inventory unchanged.
- **Quartet post-open failure**: open **succeeded**, the first whole-buffer write failed (`writes_ok==0`), destination **truncated to the empty file**, inputs unchanged, exit 4 with one concise line.
- **Quartet close failure**: whole buffer written (`writes_ok==1`), close raised — destination holds the **complete canonical serialized bytes** (byte-equal to a captured success run) despite exit 4.
- **Metrics close failure**: both streamed rows written (`writes_ok==2`), only the context exit raised — destination **equals the canonical successful output byte-for-byte** while the CLI returns 4.

## The four documentation paragraphs

`NEXTNESS_PREDICTION_BASELINE.md` · `NEXTNESS_EVALUATOR_CONTRACT.md` · `NEXTNESS_REPLAY_LAB_CONTRACT.md` · `NEXTNESS_EVIDENCE_PACKET_CONTRACT.md` each gain one precise destination-boundary paragraph: at-or-before-open failures preserve an existing destination; after a successful direct **non-atomic** open, a later failure may truncate or leave partial output; a close failure may leave **complete canonical bytes although the run reports failure**; supplied-input preservation is bounded by the existing **TOCTOU non-claim**; **no atomic-write behavior is provided or implied**. (Metrics already documents its own boundary in design-doc §9.2.)

## Verification (fresh)

- Five targeted CLI test files: **329 passed, 16 skipped**
- Focused Nextness (10 files): **779 passed, 18 skipped**
- Full maintained suite: **1363 passed, 45 skipped**
- `py_compile` × 5 touched test files: OK · `git diff --check`: clean

## Boundary & collision

**Exactly ten files, +654/−10** — five test files + five contract docs (the four per-module contracts plus `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`, added by the follow-up repair). Branched from post-#373 `main = 925fff01`; collision inspected at branch, publish and repair time: #353, #356, Ian's #370 (`experiments/swarm_hunter_lab/**`, never entered), #375, #376 — zero overlap.

## Correction (follow-up commit `21637dc8`, ordinary child of `19938f02`)

Jack's audit of the initial nine-file head found three documentation defects, repaired docs-only — no production or test changes:

1. **`NEXTNESS_REPLAY_LAB_CONTRACT.md`** — the destination-boundary paragraph had been inserted mid-sentence, splitting “…`data/` tree (NP1's convention).” The sentence is restored in full and the paragraph now follows it.
2. **`NEXTNESS_PREDICTION_BASELINE.md`** — the paragraph sat flush-left inside the Write boundary bullet list (a Markdown lazy continuation of the preceding bullet). It is now an explicit list item with correctly indented continuation lines.
3. **`docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`** (boundary expansion, this file only) — the “Unexpected-error propagation” section claimed universally that unexpected programming errors propagate. Replaced with the source-exact bounded statement: exceptions outside each CLI's documented catch classes propagate; plain `ValueError` is broadly mapped to exit 2 in predictor, metrics, monitor, replay lab and evidence packet (their catch clauses name the base class); the evaluator catches its typed `EvaluatorInputError`, not arbitrary plain `ValueError`; the focused pins prove exactly their sentinel-`RuntimeError` and read-side-`OSError` lanes; no claim that every possible programming error propagates.

Post-repair verification: targeted five test files **329 passed / 16 skipped** (unchanged), `py_compile` × 12 (six CLIs + six suites) OK, `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
