### PR TITLE
docs(nextness): bound docstring propagation claims to the exact catch sets

### DIFF
--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -640,7 +640,15 @@ def main(argv: list[str] | None = None) -> int:
     failure (missing/oversized/malformed/unknown-variant artifact, or
     none provided) · ``4`` output-path failure · ``5`` packet over the
     ceiling. One concise ``error:`` line per expected failure — never a
-    traceback; unexpected programming errors propagate loudly.
+    traceback. The documented catch set is exactly
+    ``WriteOutsideLogDirError``, ``PacketTooLargeError``, plain
+    ``ValueError`` (the exit-2 lane, which includes ``PacketInputError``
+    and wrapped validator errors) and the write-lane ``OSError``;
+    exceptions outside it propagate — ``build_packet``'s self-check
+    deliberately re-raises its internal validation failure as
+    ``RuntimeError`` for exactly that reason. Because the base
+    ``ValueError`` class is part of the catch set, no claim is made that
+    every programming error propagates.
     """
     args = _build_parser().parse_args(argv)
     paths = {

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -51,8 +51,10 @@ CLI:
     failure (``error:``; argparse usage errors also exit 2) · 3 pre-write
     containment/identity/directory safety refusal (``safety error:``) ·
     4 operational output-write failure (``error:``). Expected failures
-    print one concise line, never a traceback; unexpected errors
-    (including read-side OSErrors) propagate loudly.
+    print one concise line, never a traceback. Plain ``ValueError`` is
+    part of the documented exit-2 catch set; exceptions outside the
+    documented catch set — including read-side OSErrors — propagate
+    rather than being reclassified.
 """
 from __future__ import annotations
 
@@ -625,8 +627,14 @@ def main(argv: list[str] | None = None) -> int:
       direct streamed non-atomic output may be truncated or partial if
       a later write/close fails — no atomic-write claim is made.
 
-    Unexpected programming errors (including read-side OSErrors)
-    propagate loudly rather than being reclassified.
+    The documented catch set is exactly ``MetricsOutputWriteError``
+    (exit 4), ``WriteOutsideLogDirError`` (exit 3, ``safety error:``)
+    and plain ``ValueError``/``FileNotFoundError`` (exit 2, the data
+    lane — malformed JSONL raises plain ``ValueError`` directly).
+    Exceptions outside that set propagate: read-side ``OSError``
+    exceptions in particular are never reclassified as output failures
+    (test-pinned). Because the base ``ValueError`` class is part of the
+    catch set, no claim is made that every programming error propagates.
     """
     args = _build_parser().parse_args(argv)
     log_path = pathlib.Path(args.log)

--- a/scripts/nextness_monitor.py
+++ b/scripts/nextness_monitor.py
@@ -493,7 +493,11 @@ def main(argv: list[str] | None = None) -> int:
     - ``3`` insufficient history for a train/holdout split
 
     Every expected failure prints one concise ``error:`` line to stderr —
-    never a traceback. Unexpected programming errors propagate loudly.
+    never a traceback. The documented catch set is exactly
+    ``InsufficientHistoryError`` and plain ``ValueError`` (the exit-2
+    lane, which includes ``MonitorInputError``); exceptions outside it
+    propagate. Because the base ``ValueError`` class is part of the
+    catch set, no claim is made that every programming error propagates.
     """
     args = _build_parser().parse_args(argv)
     if not args.log_path.is_file():

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -633,9 +633,13 @@ def main(argv: list[str] | None = None) -> int:
     - ``5`` report exceeds MAX_REPORT_BYTES (fail closed)
 
     Every expected failure prints one concise ``error:`` line to stderr —
-    never a traceback. Only the expected error types above are caught;
-    unexpected programming errors propagate loudly rather than
-    masquerade as clean exits.
+    never a traceback. The documented catch set is exactly
+    ``WriteOutsideLogDirError``, ``InsufficientHistoryError``,
+    ``ReportTooLargeError``, plain ``ValueError`` (the exit-2 lane —
+    out-of-bounds configuration raises it directly) and the write-lane
+    ``OSError``. Exceptions outside that set propagate; because the base
+    ``ValueError`` class is part of the catch set, no claim is made that
+    every programming error propagates.
     """
     args = _build_parser().parse_args(argv)
     if not args.log_path.is_file():

--- a/scripts/nextness_replay_lab.py
+++ b/scripts/nextness_replay_lab.py
@@ -669,7 +669,13 @@ def main(argv: list[str] | None = None) -> int:
     - ``5`` lab report exceeds MAX_LAB_REPORT_BYTES (fail closed)
 
     Every expected failure prints one concise ``error:`` line to stderr —
-    never a traceback; unexpected programming errors propagate loudly.
+    never a traceback. The documented catch set is exactly
+    ``WriteOutsideLogDirError``, ``InsufficientHistoryError``,
+    ``LabReportTooLargeError``, plain ``ValueError`` (the exit-2 lane,
+    which includes ``LabInputError``) and the write-lane ``OSError``;
+    exceptions outside it propagate. Because the base ``ValueError``
+    class is part of the catch set, no claim is made that every
+    programming error propagates.
     """
     args = _build_parser().parse_args(argv)
     for label, path in (("log", args.log_path), ("protocol", args.protocol_path)):


### PR DESCRIPTION
## What this is

The documentation-only follow-through to the fact-table correction merged in #374 (`docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`, "Unexpected-error propagation (bounded by each catch set)") and to the 2026-07-18 six-CLI ValueError catch-boundary audit: the five broad-catch modules' docstrings still carried the unqualified claim that "unexpected programming errors propagate loudly." For a plain `ValueError` escaping a post-validation internal call, that claim is false in all five — the audit's 18-record probe matrix demonstrated the base-class catch reports it as the documented exit-2 data lane (one concise `error:` line, indistinguishable from malformed input), while the evaluator (typed `EvaluatorInputError` only) lets it propagate.

This PR bounds each docstring's claim to that module's exact catch set. **Documentation text only.**

## Changes (docstrings only, six sites in five files)

| File | Site | Statement now |
|---|---|---|
| `scripts/nextness_predictor.py` | `main` docstring | catch set named exactly (`WriteOutsideLogDirError` / `InsufficientHistoryError` / `ReportTooLargeError` / plain `ValueError` / write-lane `OSError`); plain `ValueError` = documented exit-2 lane; no universal-propagation claim |
| `scripts/nextness_metrics.py` | module docstring + `main` docstring | catch set named exactly (`MetricsOutputWriteError` / `WriteOutsideLogDirError` / plain `ValueError`+`FileNotFoundError`); **read-side `OSError` propagation statement preserved accurately (test-pinned)**; no universal claim |
| `scripts/nextness_monitor.py` | `main` docstring | catch set = `InsufficientHistoryError` + plain `ValueError` (includes `MonitorInputError`); no universal claim |
| `scripts/nextness_replay_lab.py` | `main` docstring | catch set named exactly incl. plain `ValueError` (includes `LabInputError`); no universal claim |
| `scripts/nextness_evidence_packet.py` | `main` docstring | catch set named exactly incl. plain `ValueError` (includes `PacketInputError` + wrapped validators); `build_packet`'s self-check `RuntimeError` re-raise named as the explicit internal boundary |

No statement suggests the five modules use typed input exceptions uniformly — predictor and metrics raise plain `ValueError` directly; monitor/replay-lab/packet catch it as the base class of their typed subclasses; only the evaluator is typed-only (unchanged, not in this boundary).

## Proof that only documentation changed

For every file: the docstring-stripped AST is structurally identical to main when source-location attributes are excluded (`ast.dump(..., include_attributes=False)`) — comparison performed after removing the leading string-constant expression of every Module/FunctionDef/AsyncFunctionDef/ClassDef body: five/five `identical=True`. (Line/column attributes necessarily shift when docstring text changes length; the structural comparison is the correct executable-equivalence proof.) No executable statement, behavior, test, schema, dependency or workflow change of any kind.

## Verification

- Six focused suites (predictor, metrics, monitor, evaluator, replay lab, evidence packet): **369 passed, 16 skipped**
- Final CI receipt at head `002b5246`: **eight successful check entries** — CI `verify-python` ×2 and `frontend-quality` ×2 (the `opened` and `synchronize` event run pairs), Agent Safety Suite `agent-safety`, Theory Tripwire `tripwire`, CodeQL (Python baseline) `Analyze Python`, and the `CodeQL` check entry — ALL SUCCESS, zero non-success
- `py_compile` x 5 modules: OK - `git diff --check`: clean
- Boundary: exactly 5 files, +40/-10, docstring text only

## Boundary & collision

Branched from post-#374 `main = 07b83325`. Collision-checked against every open PR: #375 (observer, Ian-lane) and #376 (validator, Ian-lane) touch disjoint files and are untouched; #353, #356, #370 untouched.

Draft; not to be merged without Kev's word and Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

