### PR TITLE
fix(monitor): typed input boundary — catch MonitorInputError, let plain ValueError propagate (pilot)

### DIFF
--- a/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
+++ b/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
@@ -17,7 +17,7 @@ test suites named per row.
 |---|---|---|---|---|---|---|---|
 | `nextness_predictor` | **0/2/3/4/5** | 0 (report → stdout or `--output`) | 2 missing log, out-of-bounds config (`ValueError`) · 3 insufficient history (`InsufficientHistoryError`) | 4 (`WriteOutsideLogDirError`: containment, `data/` tree, input alias by resolved path + `os.path.samefile`, fail-closed identity) | 4 (write-lane `OSError`: directory target, unwritable destination) | 5 (`ReportTooLargeError`, 64 KiB fail-closed) | `error:` |
 | `nextness_metrics` | **0/1/2/3/4** | 0 (summary → stdout; derived JSONL written) | **1 missing log** · 2 malformed JSONL / bad config (`ValueError`/`FileNotFoundError`) | **3 with `safety error:`** (`WriteOutsideLogDirError`: containment, directory target, input alias, fail-closed identity — all pre-read, pre-compute) | **4** (`MetricsOutputWriteError`: typed `OSError` region = output-parent creation + binary open/write/close) | — (no serialized ceiling) | `error:`; **`safety error:` on the 3-lane only** |
-| `nextness_monitor` | **0/2/3** | 0 (receipt → stdout; writes no files on any path) | 2 missing log, `ValueError` incl. `MonitorInputError` | — (no output lane exists) | — | — | `error:` |
+| `nextness_monitor` | **0/2/3** | 0 (receipt → stdout; writes no files on any path) | 2 missing log, typed `MonitorInputError` (plain `ValueError` propagates — monitor typed-boundary pilot) | — (no output lane exists) | — | — | `error:` |
 | `nextness_evaluator` | **0/2/4/5** | 0 (evaluation → stdout or `--output`) | 2 missing/oversized/malformed/unknown-variant artifact, `EvaluatorInputError` | 4 (`WriteOutsideLogDirError`: primary-dir containment, `data/` tree, alias of ANY supplied role, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`EvaluationTooLargeError`) | `error:` |
 | `nextness_replay_lab` | **0/2/3/4/5** | 0 (lab report → stdout or `--output`) | 2 missing input, malformed/oversized protocol (`LabInputError`) · 3 insufficient history | 4 (`WriteOutsideLogDirError`: containment, both-input alias, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`LabReportTooLargeError`) | `error:` |
 | `nextness_evidence_packet` | **0/2/4/5** | 0 (packet → stdout or `--output`) | 2 none/missing/oversized artifact, `PacketInputError`, wrapped validators | 4 (`WriteOutsideLogDirError`: primary-dir containment, alias of any of the six roles, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`PacketTooLargeError`) | `error:` |
@@ -74,22 +74,27 @@ focused suites assert code 2, the `usage:` prefix, and no traceback.
 ## Unexpected-error propagation (bounded by each catch set)
 
 Each CLI's `main()` catches its **documented catch classes**; exceptions
-outside those classes propagate. The catch sets differ, and in five of the
+outside those classes propagate. The catch sets differ, and in four of the
 six they are broader than the typed subclasses alone:
 
 - **Plain `ValueError` is broadly mapped to exit 2** in predictor, metrics,
-  monitor, replay lab and evidence packet: their typed input errors subclass
-  `ValueError` and the catch clause names the base class, so a plain
-  `ValueError` escaping a call inside the `try` region takes the documented
-  data-failure lane rather than propagating.
-- The **evaluator catches its typed `EvaluatorInputError`** (alongside its
-  typed write-safety and ceiling classes), **not arbitrary plain
-  `ValueError`**; a plain `ValueError` raised inside its `try` region
-  propagates.
+  replay lab and evidence packet: the catch clause names the base class
+  (predictor and metrics raise plain `ValueError` directly; replay lab and
+  evidence packet catch it as the base of their typed subclasses), so a
+  plain `ValueError` escaping a call inside the `try` region takes the
+  documented data-failure lane rather than propagating.
+- The **evaluator catches its typed `EvaluatorInputError`** and — since the
+  monitor typed-boundary pilot — the **monitor catches its typed
+  `MonitorInputError`** (each alongside its other typed classes), **not
+  arbitrary plain `ValueError`**; in both, a plain `ValueError` raised
+  inside the `try` region propagates. Each is that module's own decision,
+  per this document's non-harmonizing rule.
 - The focused propagation pins prove **their exact lanes only**: a sentinel
   `RuntimeError` propagating in predictor, monitor, evaluator, replay lab
-  and evidence packet, and a read-side `OSError` propagating in metrics
-  (PR #372's pin). They establish those lanes, not a general theorem.
+  and evidence packet, a read-side `OSError` propagating in metrics
+  (PR #372's pin), and a sentinel plain `ValueError` propagating in the
+  monitor (the pilot's pin). They establish those lanes, not a general
+  theorem.
 
 **No claim is made that every possible programming error propagates**;
 propagation is exactly the complement of each CLI's documented catch set,

--- a/docs/NEXTNESS_MONITOR_CONTRACT.md
+++ b/docs/NEXTNESS_MONITOR_CONTRACT.md
@@ -94,6 +94,18 @@ options) · `3` insufficient history. Every expected failure prints one
 concise `error:` line to stderr — never a traceback. The monitor writes
 no files on any path, success or failure.
 
+**Typed input boundary (monitor pilot)**: the exit-2 catch is exactly
+the typed `MonitorInputError` — the two CLI-reachable validation raises
+(smoothing and holdout-fraction bounds) raise it with their message text
+unchanged. A plain `ValueError`, like any exception outside the
+documented catch classes, **propagates** rather than being reported as a
+concise input failure (test-pinned alongside the standing `RuntimeError`
+propagation pin). Direct-Python note: callers catching `ValueError`
+remain compatible because `MonitorInputError` subclasses it, but the
+exact exception type at those two reclassified sites is now
+`MonitorInputError`. This is a monitor-only decision; no family-wide
+convention is implied.
+
 ## A finding worth keeping (from the test suite)
 
 With NP1's default Laplace smoothing (α = 1.0 over 16 tokens), a

--- a/scripts/nextness_monitor.py
+++ b/scripts/nextness_monitor.py
@@ -405,11 +405,16 @@ def observations_from_log(
         raise MonitorInputError(f"model {model!r} not in fixed allowlist {MODEL_ALLOWLIST}")
     # Inherited NP1 option bounds (same messages as run_evaluation) —
     # out-of-bounds options must fail closed here too, never reach the
-    # distribution builders as silent garbage.
+    # distribution builders as silent garbage. Typed as MonitorInputError
+    # (message text unchanged) so the CLI's exit-2 catch can be exactly
+    # the typed class: these two are the only CLI-reachable input raises
+    # on this path.
     if not 0.0 < smoothing <= SMOOTHING_MAX:
-        raise ValueError(f"smoothing must be in (0, {SMOOTHING_MAX}], got {smoothing}")
+        raise MonitorInputError(
+            f"smoothing must be in (0, {SMOOTHING_MAX}], got {smoothing}"
+        )
     if not HOLDOUT_FRACTION_MIN <= holdout_fraction <= HOLDOUT_FRACTION_MAX:
-        raise ValueError(
+        raise MonitorInputError(
             f"holdout_fraction must be in [{HOLDOUT_FRACTION_MIN}, "
             f"{HOLDOUT_FRACTION_MAX}], got {holdout_fraction}"
         )
@@ -494,10 +499,14 @@ def main(argv: list[str] | None = None) -> int:
 
     Every expected failure prints one concise ``error:`` line to stderr —
     never a traceback. The documented catch set is exactly
-    ``InsufficientHistoryError`` and plain ``ValueError`` (the exit-2
-    lane, which includes ``MonitorInputError``); exceptions outside it
-    propagate. Because the base ``ValueError`` class is part of the
-    catch set, no claim is made that every programming error propagates.
+    ``InsufficientHistoryError`` (exit 3) and the typed
+    ``MonitorInputError`` (exit 2); exceptions outside it — including
+    plain ``ValueError`` — propagate (monitor typed-input-boundary
+    pilot; test-pinned). Direct-Python note: callers catching
+    ``ValueError`` remain compatible because ``MonitorInputError``
+    subclasses it, but the exact exception type at the two reclassified
+    validation sites (smoothing, holdout fraction) is now
+    ``MonitorInputError``.
     """
     args = _build_parser().parse_args(argv)
     if not args.log_path.is_file():
@@ -522,7 +531,7 @@ def main(argv: list[str] | None = None) -> int:
     except InsufficientHistoryError as e:
         print(f"error: {e}", file=sys.stderr)
         return 3
-    except ValueError as e:  # includes MonitorInputError (its subclass)
+    except MonitorInputError as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
     sys.stdout.write(serialize_receipt(receipt))

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -640,3 +640,83 @@ def test_cli_unexpected_errors_are_not_hidden(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(monitor_module, "build_receipt", boom)
     with pytest.raises(RuntimeError, match="sentinel propagation probe"):
         main([str(log)])
+
+
+# ---------------------------------------------------------------------------
+# Monitor typed-input-boundary pilot (gated; docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md).
+# Failing-first target: a sentinel plain ValueError escaping the
+# post-validation monitor core must PROPAGATE, never convert to the
+# documented exit-2 input lane. Preservation controls pin the exact
+# public behavior of every genuine lane, byte-for-byte.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_internal_plain_valueerror_propagates(tmp_path, monkeypatch) -> None:
+    """Pilot pin: an internal plain ValueError from the post-validation
+    core (decide_abstention) is an unexpected programming error and must
+    propagate — not masquerade as a concise exit-2 input failure."""
+    import scripts.nextness_monitor as monitor_module
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    before = log.read_bytes()
+
+    def boom(*args, **kwargs):
+        raise ValueError("sentinel plain ValueError probe")
+
+    monkeypatch.setattr(monitor_module, "decide_abstention", boom)
+    with pytest.raises(ValueError, match="sentinel plain ValueError probe"):
+        main([str(log)])
+    assert log.read_bytes() == before
+
+
+def test_cli_monitor_input_error_still_exit_2(tmp_path, monkeypatch, capsys) -> None:
+    """Typed MonitorInputError remains the documented exit-2 lane: one
+    concise error: line, no traceback, supplied input untouched."""
+    import scripts.nextness_monitor as monitor_module
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    before = log.read_bytes()
+
+    def typed_boom(*args, **kwargs):
+        raise MonitorInputError("sentinel typed input failure")
+
+    monkeypatch.setattr(monitor_module, "observations_from_log", typed_boom)
+    assert main([str(log)]) == 2
+    err = capsys.readouterr().err
+    lines = [l for l in err.strip().splitlines() if l.strip()]
+    assert lines == ["error: sentinel typed input failure"]
+    assert "Traceback" not in err
+    assert log.read_bytes() == before
+
+
+def test_cli_smoothing_and_holdout_bounds_exact_public_behavior(tmp_path, capsys) -> None:
+    """The two reclassified validation lanes keep their public behavior
+    byte-for-byte: exact message, single stderr line, exit 2, no
+    traceback, input untouched."""
+    log = _write_log(tmp_path, [A, B] * 30)
+    before = log.read_bytes()
+    for argv, expected in (
+        ([str(log), "--smoothing", "0.0"],
+         "error: smoothing must be in (0, 1000.0], got 0.0"),
+        ([str(log), "--holdout-fraction", "0.9"],
+         "error: holdout_fraction must be in [0.05, 0.5], got 0.9"),
+    ):
+        assert main(argv) == 2
+        err = capsys.readouterr().err
+        lines = [l for l in err.strip().splitlines() if l.strip()]
+        assert lines == [expected]
+        assert "Traceback" not in err
+    assert log.read_bytes() == before
+
+
+def test_cli_insufficient_history_still_exit_3(tmp_path, capsys) -> None:
+    """InsufficientHistoryError keeps its own exit-3 clause: one concise
+    error: line, no traceback, input untouched."""
+    log = _write_log(tmp_path, [A])
+    before = log.read_bytes()
+    assert main([str(log)]) == 3
+    err = capsys.readouterr().err
+    lines = [l for l in err.strip().splitlines() if l.strip()]
+    assert len(lines) == 1 and lines[0].startswith("error:")
+    assert "Traceback" not in err
+    assert log.read_bytes() == before


### PR DESCRIPTION
## What this is

The **monitor-only pilot** of the typed-input-exception migration study (Kev-gated; study in the operator's records): narrow the monitor CLI's exit-2 catch from broad `except ValueError` to the typed `except MonitorInputError`, so an internal plain `ValueError` propagates as the unexpected programming error it is instead of masquerading as a concise input failure. **No family-wide convention is implied** — the fact table's non-harmonizing rule stands; each other module's lane is its own gated decision.

## Failing-first receipt

`test_cli_internal_plain_valueerror_propagates` (sentinel plain `ValueError` injected at the post-validation core, `decide_abstention`) **failed for the intended reason against unchanged post-#377 main**: `main()` returned 2 and printed `error: sentinel plain ValueError probe` — `DID NOT RAISE <class 'ValueError'>`. The four preservation controls (typed-error lane, exact bounds messages, insufficient-history lane, input integrity) all passed unchanged before the repair: 1 failed / 43 passed.

## Production change (2 raises + 1 clause; nothing else)

1. The **two CLI-reachable validation raises** in `observations_from_log` — smoothing and holdout-fraction bounds — reclassified from plain `ValueError` to the **existing** `MonitorInputError`, message text **byte-identical**.
2. `main()`'s exit-2 clause narrowed: `except ValueError` -> `except MonitorInputError`.
3. Plain internal `ValueError` and `RuntimeError` now both propagate. No helper normalization; the defensive validators (window bound, receipt-side checks) are untouched.

## Preservation proven (post-repair, all passing)

- the failing-first sentinel now **propagates**
- `MonitorInputError` remains exit 2: one concise `error:` line, no traceback
- invalid smoothing / holdout fraction: **byte-for-byte** identical public behavior (`error: smoothing must be in (0, 1000.0], got 0.0` / `error: holdout_fraction must be in [0.05, 0.5], got 0.9`), exit 2, single line
- `InsufficientHistoryError` remains exit 3
- standing `RuntimeError` propagation pin unchanged
- supplied input byte-identical in every lane

## Direct-Python API compatibility (exact statement)

Callers catching `ValueError` remain compatible because `MonitorInputError` subclasses it. The change is observable to consumers of exact exception identity: at the two reclassified sites the type is now `MonitorInputError` (class name in reprs/tracebacks differs; `type(e) is ValueError` is now False there). CLI messages and exit codes are unchanged byte-for-byte.

## Docs

- `docs/NEXTNESS_MONITOR_CONTRACT.md`: typed-boundary paragraph (monitor-only; no family convention).
- `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`: monitor row -> typed `MonitorInputError`; bounded propagation section now lists monitor beside the evaluator on the typed side ("four of the six" broad), adds the pilot's committed plain-ValueError propagation pin, and sharpens the broad-catch bullet (predictor/metrics raise plain `ValueError` directly; replay lab/evidence packet catch it as the base of their typed subclasses). Descriptive only.

## Verification

- Targeted monitor suite: **44 passed** (43 + the repaired failing-first pin)
- Focused Nextness battery (10 files): **783 passed, 18 skipped**
- Full maintained suite: **1367 passed, 45 skipped**
- `py_compile` (module + suite): OK - `git diff --check`: clean
- Boundary: exactly 4 files, +126/-20

## Boundary & collision

Branched from post-#377 `main = 2f8488f4`. Collision-checked against every open PR: #375 (`ec852f00`, observer) and #376 (`34fa972c`, validator) are Ian-lane, disjoint, untouched; #353, #356, #370 untouched.

Draft; not to be merged without Kev's word and Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
