### PR TITLE
fix(evidence-packet): typed input boundary — catch PacketInputError, let plain ValueError propagate (pilot)

### DIFF
--- a/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
+++ b/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
@@ -20,7 +20,7 @@ test suites named per row.
 | `nextness_monitor` | **0/2/3** | 0 (receipt → stdout; writes no files on any path) | 2 missing log, typed `MonitorInputError` (plain `ValueError` propagates — monitor typed-boundary pilot) | — (no output lane exists) | — | — | `error:` |
 | `nextness_evaluator` | **0/2/4/5** | 0 (evaluation → stdout or `--output`) | 2 missing/oversized/malformed/unknown-variant artifact, `EvaluatorInputError` | 4 (`WriteOutsideLogDirError`: primary-dir containment, `data/` tree, alias of ANY supplied role, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`EvaluationTooLargeError`) | `error:` |
 | `nextness_replay_lab` | **0/2/3/4/5** | 0 (lab report → stdout or `--output`) | 2 missing input, malformed/oversized protocol (`LabInputError`), or out-of-bounds reader configuration (`PredictorInputError` from the imported reader, carried by this CLI's documented broad `ValueError` catch) · 3 insufficient history | 4 (`WriteOutsideLogDirError`: containment, both-input alias, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`LabReportTooLargeError`) | `error:` |
-| `nextness_evidence_packet` | **0/2/4/5** | 0 (packet → stdout or `--output`) | 2 none/missing/oversized artifact, `PacketInputError`, wrapped validators | 4 (`WriteOutsideLogDirError`: primary-dir containment, alias of any of the six roles, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`PacketTooLargeError`) | `error:` |
+| `nextness_evidence_packet` | **0/2/4/5** | 0 (packet → stdout or `--output`) | 2 none/missing/oversized artifact — typed `PacketInputError`, incl. wrapped validators (plain `ValueError` propagates — evidence-packet typed-boundary pilot) | 4 (`WriteOutsideLogDirError`: primary-dir containment, alias of any of the six roles, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`PacketTooLargeError`) | `error:` |
 
 Monitor's exit 3 is `InsufficientHistoryError` — the same *insufficiency*
 semantics as predictor and replay lab. The evaluator **deliberately has no
@@ -74,32 +74,34 @@ focused suites assert code 2, the `usage:` prefix, and no traceback.
 ## Unexpected-error propagation (bounded by each catch set)
 
 Each CLI's `main()` catches its **documented catch classes**; exceptions
-outside those classes propagate. The catch sets differ, and in two of the
-six they are broader than the typed subclasses alone:
+outside those classes propagate. The catch sets differ, and in one of the
+six — the replay lab — the catch is broader than the typed subclasses
+alone:
 
-- **Plain `ValueError` is broadly mapped to exit 2** in replay lab and
-  evidence packet: the catch clause names the base class (both catch it as
-  the base of their typed subclasses), so a plain `ValueError` escaping a
-  call inside the `try` region takes the documented data-failure lane
-  rather than propagating. The replay lab's broad lane also carries the
-  predictor's typed reader-bound errors (`PredictorInputError`, a
-  `ValueError` subclass) from the imported `read_dominant_sequence` —
-  same exit, same messages (test-pinned).
+- **Plain `ValueError` is broadly mapped to exit 2 in the replay lab
+  only**: its catch clause names the base class (`LabInputError`'s
+  parent), so a plain `ValueError` escaping a call inside its `try`
+  region takes the documented data-failure lane rather than propagating.
+  That broad lane also carries the predictor's typed reader-bound errors
+  (`PredictorInputError`, a `ValueError` subclass) from the imported
+  `read_dominant_sequence` — same exit, same messages (test-pinned).
 - The **evaluator catches its typed `EvaluatorInputError`**, and — via
   their typed-boundary pilots — the **monitor catches its typed
   `MonitorInputError`**, the **predictor its typed
-  `PredictorInputError`**, and **metrics its typed `MetricsInputError`
-  (plus the `FileNotFoundError` validation-to-read race lane)** — each
-  alongside its other typed classes, **not arbitrary plain
-  `ValueError`**; in all four, a plain `ValueError` raised inside the
-  `try` region propagates. Each is that module's own decision, per this
-  document's non-harmonizing rule.
+  `PredictorInputError`**, **metrics its typed `MetricsInputError`
+  (plus the `FileNotFoundError` validation-to-read race lane)**, and the
+  **evidence packet its typed `PacketInputError`** (whose existing
+  wrapping boundaries deliver every wrapped validator error as that
+  class) — each alongside its other typed classes, **not arbitrary
+  plain `ValueError`**; in all five, a plain `ValueError` raised inside
+  the `try` region propagates. Each is that module's own decision, per
+  this document's non-harmonizing rule.
 - The focused propagation pins prove **their exact lanes only**: a sentinel
   `RuntimeError` propagating in predictor, monitor, evaluator, replay lab
   and evidence packet, a read-side `OSError` propagating in metrics
   (PR #372's pin), and a sentinel plain `ValueError` propagating in the
-  monitor, the predictor and metrics (the pilots' pins). They establish
-  those lanes, not a general theorem.
+  monitor, the predictor, metrics and the evidence packet (the pilots'
+  pins). They establish those lanes, not a general theorem.
 
 **No claim is made that every possible programming error propagates**;
 propagation is exactly the complement of each CLI's documented catch set,

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -62,10 +62,13 @@ verification.
 **Self-check**: the emitted packet is validated against NP9's
 `validate_evidence_packet` before serialization. A failure there is an
 **internal programming/contract failure, not user input**: it is
-re-raised as a plain `RuntimeError` at the boundary (never the
-documented exit-2 input lane, which `ArtifactValidationError`'s
-`ValueError` ancestry would otherwise trigger) and propagates loudly.
-Malformed **external** artifacts keep the concise exit-2 contract.
+re-raised as a plain `RuntimeError` — retained as a **stable
+internal-failure classification independent of exception ancestry**.
+Both a raw `ArtifactValidationError` and the converted `RuntimeError`
+lie outside `main()`'s typed `PacketInputError` catch, so the internal
+failure propagates loudly either way. Malformed **external** artifacts
+are wrapped as `PacketInputError` at validation and keep the concise
+exit-2 contract.
 Provenance links remain independently recomputed by this module;
 structural validation never converts a broken link into success.
 

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -137,6 +137,21 @@ unknown-variant artifact, or none provided) · `4` output-path failure ·
 `5` packet over the ceiling. One concise `error:` line per expected
 failure, never a traceback.
 
+**Typed input boundary (evidence-packet pilot)**: the exit-2 catch is
+exactly the typed `PacketInputError` — **not arbitrary `ValueError`**.
+Every established input failure already arrives as `PacketInputError`
+through the existing wrapping boundaries (bounded JSON loading; the
+`EvaluatorInputError`/`LabInputError` conversion; the NP9
+`ArtifactValidationError` conversion), so **established input failures
+retain byte-identical messages and exit 2**. A plain `ValueError` — like
+any exception outside the documented catch classes — now **propagates**
+through public `main()` (test-pinned beside the standing
+sentinel-`RuntimeError` pin), consistent with the self-check's existing
+`RuntimeError` re-raise. No raise was retyped, no new exception class
+was introduced, no validator behavior changed; `build_packet`'s
+direct-Python behavior and its existing typed failures are unchanged.
+This is a packet-only decision; no family-wide convention is implied.
+
 ## Safety
 
 Offline; no network; imports only the four Nextness instrument modules

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -641,14 +641,16 @@ def main(argv: list[str] | None = None) -> int:
     none provided) · ``4`` output-path failure · ``5`` packet over the
     ceiling. One concise ``error:`` line per expected failure — never a
     traceback. The documented catch set is exactly
-    ``WriteOutsideLogDirError``, ``PacketTooLargeError``, plain
-    ``ValueError`` (the exit-2 lane, which includes ``PacketInputError``
-    and wrapped validator errors) and the write-lane ``OSError``;
-    exceptions outside it propagate — ``build_packet``'s self-check
-    deliberately re-raises its internal validation failure as
-    ``RuntimeError`` for exactly that reason. Because the base
-    ``ValueError`` class is part of the catch set, no claim is made that
-    every programming error propagates.
+    ``WriteOutsideLogDirError``, ``PacketTooLargeError``, the typed
+    ``PacketInputError`` (the exit-2 lane — every wrapped validator
+    error arrives as ``PacketInputError`` at the existing wrapping
+    boundaries) and the write-lane ``OSError``. Exceptions outside it —
+    including plain ``ValueError`` — propagate (evidence-packet
+    typed-boundary pilot; test-pinned), consistent with
+    ``build_packet``'s self-check deliberately re-raising its internal
+    validation failure as ``RuntimeError``. Direct-Python note:
+    ``build_packet`` and its existing typed failures are unchanged; no
+    raise was retyped and no new exception class was introduced.
     """
     args = _build_parser().parse_args(argv)
     paths = {
@@ -672,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
     except PacketTooLargeError as e:
         print(f"error: {e}", file=sys.stderr)
         return 5
-    except ValueError as e:  # includes PacketInputError and wrapped validators
+    except PacketInputError as e:  # wrapped validators arrive as PacketInputError
         print(f"error: {e}", file=sys.stderr)
         return 2
     serialized = serialize_packet(packet)

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -523,11 +523,12 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
     }
     # Self-check: the emitted packet must satisfy its own public
     # structural validator before serialization. A failure here is an
-    # internal programming/contract failure, NOT malformed user input —
-    # and ArtifactValidationError inherits ValueError, which the CLI
-    # catches as the documented exit-2 input lane. Re-raise as a plain
-    # RuntimeError at this boundary so the internal failure propagates
-    # loudly instead of masquerading as a concise input error.
+    # internal programming/contract failure, NOT malformed user input.
+    # The explicit conversion to a plain RuntimeError is retained as a
+    # stable internal-failure classification independent of exception
+    # ancestry: both a raw ArtifactValidationError and the converted
+    # RuntimeError lie outside main()'s typed PacketInputError catch,
+    # so the internal failure propagates loudly either way.
     validation = _np9()
     try:
         validation.validate_evidence_packet(packet)

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -748,8 +748,9 @@ def test_self_validation_failure_is_internal_not_input_error(chain, monkeypatch,
     # A failure while validating the packet NP8 JUST EMITTED is an
     # internal programming/contract failure — it must propagate loudly,
     # never masquerade as the documented exit-2 "malformed user input"
-    # lane (ArtifactValidationError inherits ValueError, which main
-    # catches for external artifacts).
+    # lane. External validator failures are wrapped as PacketInputError
+    # at _validate_role (that is the exit-2 lane); the emitted-packet
+    # self-check deliberately becomes RuntimeError instead.
     import scripts.nextness_artifact_validation as validation_module
     from scripts.nextness_artifact_validation import ArtifactValidationError
 

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -854,6 +854,47 @@ def test_cli_unexpected_errors_are_not_hidden(chain, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Evidence-packet typed-input-boundary pilot (gated;
+# docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md). Failing-first target: a sentinel
+# plain ValueError escaping the internal build seam must PROPAGATE through
+# public main(), never convert to the documented exit-2 input lane. Uses the
+# same build_packet monkeypatch seam as the sentinel-RuntimeError pin above.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_internal_plain_valueerror_propagates(chain, monkeypatch) -> None:
+    """Pilot pin: an internal plain ValueError from the packet's build
+    seam is an unexpected programming error and must propagate — not
+    masquerade as a concise exit-2 input failure. (PacketInputError and
+    the wrapped validator errors remain the documented exit-2 lane.)"""
+    import scripts.nextness_evidence_packet as packet_module
+
+    def boom(*args, **kwargs):
+        raise ValueError("sentinel plain ValueError probe")
+
+    monkeypatch.setattr(packet_module, "build_packet", boom)
+    with pytest.raises(ValueError, match="sentinel plain ValueError probe"):
+        main(_chain_args(chain))
+
+
+def test_cli_packet_input_error_still_exit_2(chain, monkeypatch, capsys) -> None:
+    """Typed PacketInputError remains the documented exit-2 lane: one
+    concise error: line, byte-identical message shape, no traceback."""
+    import scripts.nextness_evidence_packet as packet_module
+    from scripts.nextness_evidence_packet import PacketInputError
+
+    def typed_boom(*args, **kwargs):
+        raise PacketInputError("sentinel typed input failure")
+
+    monkeypatch.setattr(packet_module, "build_packet", typed_boom)
+    assert main(_chain_args(chain)) == 2
+    err = capsys.readouterr().err
+    lines = [l for l in err.strip().splitlines() if l.strip()]
+    assert lines == ["error: sentinel typed input failure"]
+    assert "Traceback" not in err
+
+
+# ---------------------------------------------------------------------------
 # Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
 # 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
 # the expected exit-4 operational-write lane — distinct from PUBLIC


### PR DESCRIPTION
## What this is

The **fourth typed-boundary pilot** per the Kev-gated migration study (monitor #378, predictor #379, metrics #381 all merged): narrow the evidence-packet CLI's exit-2 catch from broad `except ValueError` to the typed `except PacketInputError`. **Deliberately tiny**: the packet already delivers every genuine input failure as `PacketInputError` through its existing wrapping boundaries, so the entire production diff is one catch clause plus its docstring. **No family-wide convention is implied** — the fact table's non-harmonizing rule stands; the replay lab (the last broad module) remains its own future gated decision.

## Failing-first receipt

`test_cli_internal_plain_valueerror_propagates` (sentinel plain `ValueError` at the established `build_packet` monkeypatch seam, placed beside the standing sentinel-`RuntimeError` propagation pin) **failed for the intended reason against unchanged post-#381 main**: the broad `except ValueError` converted the sentinel into the concise exit-2 lane — `DID NOT RAISE <class 'ValueError'>`. **1 failed / 68 passed / 7 skipped.**

## Production change (1 clause; nothing else)

- `main()`: `except ValueError` -> `except PacketInputError`; the `error:` message shape and return code 2 unchanged.
- **No new exception class. No retyped raises. No validator behavior change.** Every existing `PacketInputError` wrapping boundary preserved (bounded JSON loading; the `EvaluatorInputError`/`LabInputError` conversion; the NP9 `ArtifactValidationError` conversion — #376's artifact-validation work untouched). The self-check's internal `RuntimeError` re-raise preserved. Output safety, write-failure, ceiling, argparse, determinism, input-integrity and TOCTOU contracts unchanged.
- Direct-Python behavior of `build_packet` and its existing typed failures is unchanged; the sole public CLI change is that an unexpected plain `ValueError` is no longer disguised as ordinary bad input.

## Preservation proven (post-repair, all passing)

- the failing-first sentinel now **propagates**; the standing `RuntimeError` pin unchanged
- typed `PacketInputError` control: exit 2, one concise `error:` line, no traceback
- **every established public input lane retains byte-identical messages and exit 2** (complete packet suite green, incl. all wrapped-validator, refusal, stage-pin and whole-chain byte-identity lanes)

## Docs

- `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md`: typed-boundary paragraph (packet-only; established failures keep byte-identical messages and exit 2).
- `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`: packet row -> typed `PacketInputError`; the bounded propagation section now reads **one of six broad — replay lab only**, with the packet added to the typed side and the pilots' committed plain-ValueError pins list updated. Descriptive only.

## Verification

- Complete evidence-packet suite: **69 passed, 7 skipped**
- Focused Nextness battery (10 files): **818 passed, 21 skipped**
- Full maintained suite: **1402 passed, 48 skipped**
- `py_compile`: OK - `git diff --check`: clean
- Boundary: exactly 4 files, +89/-29

## Boundary & collision

Branched from post-#381 `main = 323dbc99` (post-merge CI + CodeQL green). Collision-checked against every open PR: #380 (calibration), #370 (Ian, `experiments/swarm_hunter_lab/**`, never entered), #356, #353 — all disjoint, all untouched.

Draft; not to be merged without Kev's word and Jack's audit.

## Correction (follow-up commit `b0ff1de3`, ordinary child of `10fc35ef`)

Jack's audit found three stale explanatory statements that still described the OLD broad catch — claiming `ArtifactValidationError`'s `ValueError` ancestry would reach the CLI's exit-2 lane. Corrected (documentation/comments only, 3 files +16/-11, no executable behavior change; test assertions untouched):

1. **`scripts/nextness_evidence_packet.py`** self-check comment: the `RuntimeError` conversion is retained as a **stable internal-failure classification independent of exception ancestry** — both raw `ArtifactValidationError` and the converted `RuntimeError` lie outside `main()`'s typed `PacketInputError` catch.
2. **`docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md`** Self-check paragraph: same current truth; malformed **external** artifacts are wrapped as `PacketInputError` at validation and keep concise exit 2.
3. **`tests/test_nextness_evidence_packet.py`** `test_self_validation_failure_is_internal_not_input_error` comment: external validator failures wrap at `_validate_role`; the emitted-packet self-check deliberately becomes `RuntimeError`.

Sweep of the three files + fact table found no other ancestry-based claim. **Repaired head**: `b0ff1de3ac26268e566e62f96dc23761651229b8`. Post-repair batteries: packet **69/7** - focused **818/21** - full **1402/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

