### PR TITLE
fix(replay-lab): typed input boundary — catch LabInputError, translate the reader's typed bounds (final pilot)

### DIFF
--- a/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
+++ b/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
@@ -88,21 +88,33 @@ broadly catch plain `ValueError`**:
   propagates. Each map remains that module's own decision, per this
   document's non-harmonizing rule — the shared end state is a fact, not
   a convention.
-- **Inner input-validation boundaries may deliberately translate known
-  input failures** into the module's typed class: metrics wraps the
-  read-region `UnicodeDecodeError` and the malformed-JSONL
-  `json.JSONDecodeError`; the replay lab translates the shared reader's
-  `PredictorInputError` at the reader call (message byte-identical,
-  cause preserved); the evidence packet wraps its imported validators;
-  the evaluator wraps stdlib parse errors. These are named, exact-class
-  boundaries — none reintroduces a broad `ValueError` catch.
+- **Inner input-validation regions may still deliberately catch or
+  translate base `ValueError` locally.** The six typed `main()` clauses
+  above are the top-level catch boundary; beneath them, some tightly
+  scoped validation regions retain base-class wrappers by design: the
+  replay lab's protocol loader catches base `ValueError` in its
+  JSON-parse and `MonitorConfig.validate` input-validation regions
+  (→ `LabInputError`); the evidence packet's bounded JSON loader
+  retains a scoped base-`ValueError` wrapper (→ `PacketInputError`);
+  the evaluator's artifact loader and exact-float helpers do the same
+  (→ `EvaluatorInputError`). Other inner boundaries are exact-class:
+  metrics wraps the read-region `UnicodeDecodeError` and the
+  malformed-JSONL `json.JSONDecodeError`; the replay lab translates the
+  shared reader's `PredictorInputError` at the reader call (message
+  byte-identical, cause preserved). **These existing local boundaries
+  are distinct from the six `main()` catch clauses and were not
+  normalized by the typed-boundary train.**
 - The focused propagation pins prove **their exact lanes only**: a sentinel
   `RuntimeError` propagating in predictor, monitor, evaluator, replay lab
   and evidence packet, a read-side `OSError` propagating in metrics
   (PR #372's pin), and a sentinel plain `ValueError` propagating in the
   monitor, the predictor, metrics, the evidence packet and the replay
-  lab (the pilots' pins). They establish those lanes, not a general
-  theorem.
+  lab (the pilots' pins). They prove **their named seams only** — a
+  sentinel injected at the established build/core seam of each module —
+  not every possible origin of a plain `ValueError` (a plain
+  `ValueError` arising *inside* one of the scoped inner validation
+  regions above is translated there by design, never reaching
+  `main()`).
 
 **No claim is made that every possible programming error propagates**;
 propagation is exactly the complement of each CLI's documented catch set,

--- a/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
+++ b/docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md
@@ -19,7 +19,7 @@ test suites named per row.
 | `nextness_metrics` | **0/1/2/3/4** | 0 (summary → stdout; derived JSONL written) | **1 missing log** · 2 malformed JSONL / invalid-UTF-8 log / bad config (typed `MetricsInputError` — five direct raises plus the narrow invalid-UTF-8 wrapping boundary; `FileNotFoundError` race lane retained; plain `ValueError` propagates — metrics typed-boundary pilot) | **3 with `safety error:`** (`WriteOutsideLogDirError`: containment, directory target, input alias, fail-closed identity — all pre-read, pre-compute) | **4** (`MetricsOutputWriteError`: typed `OSError` region = output-parent creation + binary open/write/close) | — (no serialized ceiling) | `error:`; **`safety error:` on the 3-lane only** |
 | `nextness_monitor` | **0/2/3** | 0 (receipt → stdout; writes no files on any path) | 2 missing log, typed `MonitorInputError` (plain `ValueError` propagates — monitor typed-boundary pilot) | — (no output lane exists) | — | — | `error:` |
 | `nextness_evaluator` | **0/2/4/5** | 0 (evaluation → stdout or `--output`) | 2 missing/oversized/malformed/unknown-variant artifact, `EvaluatorInputError` | 4 (`WriteOutsideLogDirError`: primary-dir containment, `data/` tree, alias of ANY supplied role, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`EvaluationTooLargeError`) | `error:` |
-| `nextness_replay_lab` | **0/2/3/4/5** | 0 (lab report → stdout or `--output`) | 2 missing input, malformed/oversized protocol (`LabInputError`), or out-of-bounds reader configuration (`PredictorInputError` from the imported reader, carried by this CLI's documented broad `ValueError` catch) · 3 insufficient history | 4 (`WriteOutsideLogDirError`: containment, both-input alias, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`LabReportTooLargeError`) | `error:` |
+| `nextness_replay_lab` | **0/2/3/4/5** | 0 (lab report → stdout or `--output`) | 2 missing input, malformed/oversized protocol, or out-of-bounds reader configuration — all typed `LabInputError` (reader bounds translated from `PredictorInputError` at the reader call, message byte-identical; plain `ValueError` propagates — replay-lab typed-boundary pilot) · 3 insufficient history | 4 (`WriteOutsideLogDirError`: containment, both-input alias, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`LabReportTooLargeError`) | `error:` |
 | `nextness_evidence_packet` | **0/2/4/5** | 0 (packet → stdout or `--output`) | 2 none/missing/oversized artifact — typed `PacketInputError`, incl. wrapped validators (plain `ValueError` propagates — evidence-packet typed-boundary pilot) | 4 (`WriteOutsideLogDirError`: primary-dir containment, alias of any of the six roles, fail-closed identity) | 4 (write-lane `OSError`) | 5 (`PacketTooLargeError`) | `error:` |
 
 Monitor's exit 3 is `InsufficientHistoryError` — the same *insufficiency*
@@ -74,34 +74,35 @@ focused suites assert code 2, the `usage:` prefix, and no traceback.
 ## Unexpected-error propagation (bounded by each catch set)
 
 Each CLI's `main()` catches its **documented catch classes**; exceptions
-outside those classes propagate. The catch sets differ, and in one of the
-six — the replay lab — the catch is broader than the typed subclasses
-alone:
+outside those classes propagate. **Zero of the six `main()` catch clauses
+broadly catch plain `ValueError`**:
 
-- **Plain `ValueError` is broadly mapped to exit 2 in the replay lab
-  only**: its catch clause names the base class (`LabInputError`'s
-  parent), so a plain `ValueError` escaping a call inside its `try`
-  region takes the documented data-failure lane rather than propagating.
-  That broad lane also carries the predictor's typed reader-bound errors
-  (`PredictorInputError`, a `ValueError` subclass) from the imported
-  `read_dominant_sequence` — same exit, same messages (test-pinned).
 - The **evaluator catches its typed `EvaluatorInputError`**, and — via
   their typed-boundary pilots — the **monitor catches its typed
   `MonitorInputError`**, the **predictor its typed
   `PredictorInputError`**, **metrics its typed `MetricsInputError`
-  (plus the `FileNotFoundError` validation-to-read race lane)**, and the
-  **evidence packet its typed `PacketInputError`** (whose existing
-  wrapping boundaries deliver every wrapped validator error as that
-  class) — each alongside its other typed classes, **not arbitrary
-  plain `ValueError`**; in all five, a plain `ValueError` raised inside
-  the `try` region propagates. Each is that module's own decision, per
-  this document's non-harmonizing rule.
+  (plus the `FileNotFoundError` validation-to-read race lane)**, the
+  **evidence packet its typed `PacketInputError`**, and the **replay lab
+  its typed `LabInputError`** — each alongside its other typed classes.
+  In all six, a plain `ValueError` raised inside the `try` region
+  propagates. Each map remains that module's own decision, per this
+  document's non-harmonizing rule — the shared end state is a fact, not
+  a convention.
+- **Inner input-validation boundaries may deliberately translate known
+  input failures** into the module's typed class: metrics wraps the
+  read-region `UnicodeDecodeError` and the malformed-JSONL
+  `json.JSONDecodeError`; the replay lab translates the shared reader's
+  `PredictorInputError` at the reader call (message byte-identical,
+  cause preserved); the evidence packet wraps its imported validators;
+  the evaluator wraps stdlib parse errors. These are named, exact-class
+  boundaries — none reintroduces a broad `ValueError` catch.
 - The focused propagation pins prove **their exact lanes only**: a sentinel
   `RuntimeError` propagating in predictor, monitor, evaluator, replay lab
   and evidence packet, a read-side `OSError` propagating in metrics
   (PR #372's pin), and a sentinel plain `ValueError` propagating in the
-  monitor, the predictor, metrics and the evidence packet (the pilots'
-  pins). They establish those lanes, not a general theorem.
+  monitor, the predictor, metrics, the evidence packet and the replay
+  lab (the pilots' pins). They establish those lanes, not a general
+  theorem.
 
 **No claim is made that every possible programming error propagates**;
 propagation is exactly the complement of each CLI's documented catch set,

--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -160,6 +160,21 @@ insufficient history · `4` write-boundary/unwritable · `5` report over
 the ceiling. Expected failures print one concise `error:` line, never a
 traceback.
 
+**Typed input boundary (replay-lab pilot)**: the exit-2 catch is
+exactly the typed `LabInputError`. The shared reader's typed
+`PredictorInputError` (this lab publicly re-exposes `--max-rows`/
+`--max-line-bytes`) is **translated at the single reader call** —
+`except PredictorInputError` exactly, never broad `ValueError` —
+into `LabInputError` with the message byte-identical (`str(e)`) and
+the original error preserved as `__cause__`. A plain `ValueError`,
+like any exception outside the documented catch classes, **propagates**
+(test-pinned beside the standing `RuntimeError` pin); a plain
+`ValueError` from the reader seam is deliberately not wrapped.
+Direct-Python note: callers catching `ValueError` remain compatible
+(`LabInputError` subclasses it); `read_dominant_sequence` called
+directly still raises `PredictorInputError`. This is a lab-only
+decision; no family-wide convention is implied.
+
 ## Safety
 
 Offline; no network; imports only `nextness_predictor`,

--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -166,10 +166,14 @@ exactly the typed `LabInputError`. The shared reader's typed
 `--max-line-bytes`) is **translated at the single reader call** —
 `except PredictorInputError` exactly, never broad `ValueError` —
 into `LabInputError` with the message byte-identical (`str(e)`) and
-the original error preserved as `__cause__`. A plain `ValueError`,
-like any exception outside the documented catch classes, **propagates**
-(test-pinned beside the standing `RuntimeError` pin); a plain
-`ValueError` from the reader seam is deliberately not wrapped.
+the original error preserved as `__cause__`. A plain `ValueError`
+**reaching `main()` outside the existing scoped input-validation
+translations propagates** (the committed build-seam and reader-seam
+pins prove those exact lanes; a plain `ValueError` from the reader seam
+is deliberately not wrapped). No claim is made that every inner
+validation helper lacks a local base-class wrapper — the protocol
+loader's JSON-parse and `MonitorConfig.validate` regions deliberately
+catch base `ValueError` and translate it to `LabInputError`.
 Direct-Python note: callers catching `ValueError` remain compatible
 (`LabInputError` subclasses it); `read_dominant_sequence` called
 directly still raises `PredictorInputError`. This is a lab-only

--- a/scripts/nextness_replay_lab.py
+++ b/scripts/nextness_replay_lab.py
@@ -88,6 +88,7 @@ from scripts.nextness_predictor import (
     SMOOTHING_DEFAULT,
     SMOOTHING_MAX,
     InsufficientHistoryError,
+    PredictorInputError,
     empirical_prior_distribution,
     first_order_distribution,
     persistence_distribution,
@@ -469,9 +470,19 @@ def build_lab_report(
     field, by contract.
     """
     protocol = load_protocol(protocol_path)
-    sequence, rejections, rows_read = read_dominant_sequence(
-        log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
-    )
+    # Typed reader-bound translation: the shared reader raises the
+    # predictor's typed PredictorInputError for out-of-bounds
+    # max_rows/max_line_bytes (this lab re-exposes both publicly).
+    # Translate EXACTLY that class — never broad ValueError — into this
+    # module's own typed input error, message byte-identical via str(e),
+    # provenance kept in __cause__. A plain ValueError from the reader
+    # seam is not wrapped and propagates.
+    try:
+        sequence, rejections, rows_read = read_dominant_sequence(
+            log_path, max_rows=max_rows, max_line_bytes=max_line_bytes
+        )
+    except PredictorInputError as e:
+        raise LabInputError(str(e)) from e
     # Replay bound BEFORE any observation allocation: the holdout
     # length is fully determined by the already-bounded sequence length
     # and the protocol's holdout_fraction (the same floor arithmetic
@@ -671,11 +682,14 @@ def main(argv: list[str] | None = None) -> int:
     Every expected failure prints one concise ``error:`` line to stderr —
     never a traceback. The documented catch set is exactly
     ``WriteOutsideLogDirError``, ``InsufficientHistoryError``,
-    ``LabReportTooLargeError``, plain ``ValueError`` (the exit-2 lane,
-    which includes ``LabInputError``) and the write-lane ``OSError``;
-    exceptions outside it propagate. Because the base ``ValueError``
-    class is part of the catch set, no claim is made that every
-    programming error propagates.
+    ``LabReportTooLargeError``, the typed ``LabInputError`` (the exit-2
+    lane — the shared reader's typed ``PredictorInputError`` is
+    translated to it at the reader call, message byte-identical) and the
+    write-lane ``OSError``. Exceptions outside it — including plain
+    ``ValueError`` — propagate (replay-lab typed-boundary pilot;
+    test-pinned). Direct-Python note: callers catching ``ValueError``
+    remain compatible (``LabInputError`` subclasses it); the reader
+    itself still raises ``PredictorInputError`` when called directly.
     """
     args = _build_parser().parse_args(argv)
     for label, path in (("log", args.log_path), ("protocol", args.protocol_path)):
@@ -700,7 +714,7 @@ def main(argv: list[str] | None = None) -> int:
     except LabReportTooLargeError as e:
         print(f"error: {e}", file=sys.stderr)
         return 5
-    except ValueError as e:  # includes LabInputError (its subclass)
+    except LabInputError as e:  # reader-bound errors arrive translated
         print(f"error: {e}", file=sys.stderr)
         return 2
     serialized = serialize_lab_report(report)

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -998,6 +998,77 @@ def test_cli_unexpected_errors_are_not_hidden(tmp_path, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Replay-lab typed-input-boundary pilot (gated; the family's final module;
+# docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md). Failing-first target: a sentinel
+# plain ValueError at the internal build_lab_report seam must PROPAGATE
+# through public main(), never convert to the documented exit-2 lane.
+# Preservation controls pin every genuine public lane.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_internal_plain_valueerror_propagates(tmp_path, monkeypatch) -> None:
+    """Pilot pin: an internal plain ValueError from the build seam is an
+    unexpected programming error and must propagate — not masquerade as
+    a concise exit-2 input failure. (LabInputError — and the reader's
+    typed PredictorInputError, translated at the reader call — remain
+    the documented exit-2 lane.)"""
+    import scripts.nextness_replay_lab as lab_module
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+
+    def boom(*args, **kwargs):
+        raise ValueError("sentinel plain ValueError probe")
+
+    monkeypatch.setattr(lab_module, "build_lab_report", boom)
+    with pytest.raises(ValueError, match="sentinel plain ValueError probe"):
+        main([str(log), str(protocol)])
+
+
+def test_cli_pilot_preservation_controls(tmp_path, capsys) -> None:
+    """Byte-exact public lanes: malformed protocol (LabInputError),
+    reader bounds, insufficient history exit 3; inputs untouched."""
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    bad_protocol = tmp_path / "bad_protocol.json"
+    bad_protocol.write_text(
+        protocol.read_text(encoding="utf-8").replace(
+            '"nextness-replay-protocol-v1"', '"nextness-replay-protocol-v9"'),
+        encoding="utf-8")
+    (tmp_path / "tiny").mkdir()
+    tiny = _write_log(tmp_path / "tiny", [A])
+    before = {p: p.read_bytes() for p in (log, protocol, bad_protocol, tiny)}
+    cases = (
+        ([str(log), str(bad_protocol)], 2, None),
+        ([str(log), str(protocol), "--max-rows", "0"], 2,
+         "error: max_rows must be in (0, 1000000], got 0"),
+        ([str(log), str(protocol), "--max-line-bytes", "0"], 2,
+         "error: max_line_bytes must be positive, got 0"),
+        ([str(tiny), str(protocol)], 3, None),
+    )
+    for argv, code, expected in cases:
+        assert main(argv) == code
+        err = capsys.readouterr().err
+        lines = [l for l in err.strip().splitlines() if l.strip()]
+        assert len(lines) == 1 and lines[0].startswith("error:")
+        if expected is not None:
+            assert lines == [expected]
+        assert "Traceback" not in err
+    for p_, b_ in before.items():
+        assert p_.read_bytes() == b_
+
+
+def test_cli_pilot_output_determinism_control(tmp_path, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    out1, out2 = tmp_path / "r1.json", tmp_path / "r2.json"
+    assert main([str(log), str(protocol), "--output", str(out1)]) == 0
+    assert main([str(log), str(protocol), "--output", str(out2)]) == 0
+    capsys.readouterr()
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+# ---------------------------------------------------------------------------
 # Output-write STAGE pins (see docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md and the
 # 2026-07-17 output-write audit). INJECTED deterministic branch exercises of
 # the expected exit-4 operational-write lane — distinct from PUBLIC
@@ -1171,3 +1242,33 @@ def test_reader_bound_error_is_predictor_typed_through_broad_lane(tmp_path, caps
     assert "Traceback" not in err
     for p, b in before.items():
         assert p.read_bytes() == b
+
+
+def test_typed_reader_bound_translation_boundary(tmp_path, monkeypatch) -> None:
+    """Direct-API pins for the reader-bound translation boundary:
+    the reader itself still raises PredictorInputError; build_lab_report
+    translates exactly that class to LabInputError with the message
+    byte-identical and the cause preserved; a sentinel plain ValueError
+    from the reader seam is NOT wrapped and propagates."""
+    import scripts.nextness_replay_lab as lab_module
+    from scripts.nextness_predictor import PredictorInputError
+    from scripts.nextness_replay_lab import LabInputError, build_lab_report
+
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+
+    with pytest.raises(PredictorInputError) as reader_exc:
+        read_dominant_sequence(log, max_rows=0)
+
+    with pytest.raises(LabInputError) as lab_exc:
+        build_lab_report(log, protocol, max_rows=0)
+    assert str(lab_exc.value) == str(reader_exc.value)  # byte-identical message
+    assert isinstance(lab_exc.value.__cause__, PredictorInputError)
+
+    def plain_boom(*args, **kwargs):
+        raise ValueError("sentinel plain ValueError from reader seam")
+
+    monkeypatch.setattr(lab_module, "read_dominant_sequence", plain_boom)
+    with pytest.raises(ValueError, match="sentinel plain ValueError from reader seam") as esc:
+        build_lab_report(log, protocol)
+    assert type(esc.value) is ValueError  # not wrapped into LabInputError

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -1194,10 +1194,11 @@ def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Cross-module compatibility controls for the predictor typed-input-
-# boundary pilot: the lab publicly re-exposes the imported reader's
-# bounds (--max-rows / --max-line-bytes), so their public exit-2 lanes
-# are pinned byte-for-byte here. No replay-lab production change.
+# Cross-module compatibility controls: the original predictor pilot
+# established the lab's public reader-bound lanes (--max-rows /
+# --max-line-bytes), pinned byte-for-byte here; the replay-lab pilot
+# (#384) now preserves them through the typed translation boundary at
+# the reader call.
 # ---------------------------------------------------------------------------
 
 
@@ -1222,11 +1223,12 @@ def test_cli_reader_bound_public_lanes_exit_2(tmp_path, capsys) -> None:
         assert p.read_bytes() == b
 
 
-def test_reader_bound_error_is_predictor_typed_through_broad_lane(tmp_path, capsys) -> None:
-    """Cross-module compatibility pin: the predictor's typed reader-bound
-    error (PredictorInputError) subclasses ValueError, so it continues
-    through this CLI's documented broad exit-2 lane unchanged — same
-    message, one concise line, no traceback, inputs untouched."""
+def test_reader_bound_error_is_translated_to_lab_input_lane(tmp_path, capsys) -> None:
+    """Cross-module compatibility pin: the direct reader raises
+    PredictorInputError; build_lab_report translates it to LabInputError
+    at the reader call; the public CLI retains the identical exit-2
+    text — it no longer travels through a broad main() catch (the
+    translation-boundary test below pins message/cause exactly)."""
     from scripts.nextness_predictor import PredictorInputError
 
     assert issubclass(PredictorInputError, ValueError)


### PR DESCRIPTION
## What this is

The **fifth and final typed-boundary pilot** per the Kev-gated migration study (monitor #378, predictor #379, metrics #381+#383, evidence packet #382 — all merged): narrow the replay-lab CLI's exit-2 catch from broad `except ValueError` to the typed `except LabInputError`, with the one genuinely shared lane — the reader bounds this lab publicly re-exposes — handled by an **exact-class translation boundary** at the single `read_dominant_sequence` call. With this pilot, **zero of the six `main()` catch clauses broadly catch plain `ValueError`** — recorded in the fact table as a fact, not a convention; the non-harmonizing rule stands.

## Failing-first receipt

`test_cli_internal_plain_valueerror_propagates` (sentinel plain `ValueError` at the established `build_lab_report` seam, beside the standing sentinel-`RuntimeError` pin) **failed for the intended reason against unchanged production**: the broad catch converted the sentinel to concise exit 2 — `DID NOT RAISE <class 'ValueError'>`. **1 failed / 61 passed / 2 skipped**, with the banked preservation controls green: malformed protocol via `LabInputError`; byte-exact `--max-rows`/`--max-line-bytes` messages; insufficient-history exit 3; input bytes; output determinism (safety exit 4, operational write exit 4, ceiling exit 5 and argparse lanes covered by the standing suite, all green).

## Production change

1. `PredictorInputError` imported from `nextness_predictor`.
2. At the single reader call in `build_lab_report`: `except PredictorInputError as e: raise LabInputError(str(e)) from e` — **exactly that class, never broad `ValueError`**; reader-bound messages **byte-identical**; provenance kept in `__cause__`.
3. `main()`: `except ValueError` -> `except LabInputError`; plain internal `ValueError` and `RuntimeError` both propagate.
4. Every protocol-validation wrapper and unrelated exception contract retained.

## Direct-API pins (all passing)

- direct `read_dominant_sequence` with invalid bounds **still raises `PredictorInputError`**
- `build_lab_report` translates exactly that typed failure to `LabInputError` — **identical message**, `__cause__` is `PredictorInputError`
- a sentinel plain `ValueError` from the reader seam is **not wrapped** and propagates (`type(e) is ValueError` pinned)

## Docs

- `docs/NEXTNESS_REPLAY_LAB_CONTRACT.md`: typed-boundary paragraph (lab-only; translation boundary described precisely).
- `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`: replay-lab row -> typed `LabInputError` incl. translated reader bounds; the bounded propagation section now records **zero of six top-level `main()` clauses broad**, with the precise caveat that tightly scoped inner input-validation regions may still deliberately catch or translate base `ValueError` locally (lab protocol loader, packet bounded JSON loader, evaluator helpers — distinct from the six `main()` clauses and not normalized by this train), and that the propagation pins prove their named seams only.

## Verification

- Replay-lab + predictor compatibility suites: **124 passed, 4 skipped**
- Focused Nextness battery (10 files): **824 passed, 21 skipped**
- Full maintained suite: **1408 passed, 48 skipped**
- `py_compile`: OK - `git diff --check`: clean
- Boundary: exactly 4 files, +161/-30

## Boundary & collision

Branched from post-#383 `main = 70087148` (post-merge CI + CodeQL green). Collision-checked: #380 (calibration), #370, #356, #353 — disjoint, untouched.

Draft; not to be merged without Kev's word and Jack's audit.

## Receipt correction (follow-up commit `93970781`, ordinary child of `b84f6d21`)

Jack's audit found three stale receipt statements — corrected, documentation/test-text only (3 files +41/-23; no production-code behavior change; the exact reader translation, message and cause claims preserved):

1. **Tests**: the cross-module section comment no longer says "No replay-lab production change" (true when the predictor pilot wrote it; stale since this PR); the CLI-lane test is renamed `test_reader_bound_error_is_translated_to_lab_input_lane` with a current docstring — direct reader raises `PredictorInputError`; `build_lab_report` translates to `LabInputError`; the public CLI keeps identical exit-2 text; no broad `main()` catch involved. Assertions preserved; the direct-API translation test is not duplicated.
2. **Fact table**: zero-of-six statement kept for the **top-level** clauses; the universal "named, exact-class boundaries" wording replaced with the accurate distinction — scoped inner validation regions (lab protocol loader JSON/`MonitorConfig.validate`; packet bounded JSON loader; evaluator loader/helpers) deliberately retain local base-`ValueError` wrappers and were not normalized; pins prove named seams only.
3. **Lab contract**: "plain `ValueError` propagates" qualified to *reaching `main()` outside the scoped input-validation translations*, with the committed build- and reader-seam pins named as the proof.

**Repaired head**: `939707817ba5e9db58854cb210c6d5d4d83eac67`. Batteries: lab+predictor **124/4** - focused **824/21** - full **1408/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

