### PR TITLE
test(nextness): commit the post-train audit's probe-only propagation claims as pins

### DIFF
--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1652,28 +1652,44 @@ def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None
     with pytest.raises(PermissionError) as excinfo:
         main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(out)])
     monkeypatch.undo()
-    assert "injected read denial" in str(excinfo.value)
     assert type(excinfo.value) is PermissionError
-    err = capsys.readouterr().err
-    assert err == ""  # no misleading concise conversion
+    assert excinfo.value.errno == 13
+    assert excinfo.value.strerror == "injected read denial"
+    captured = capsys.readouterr()
+    assert captured.out == ""  # the CLI emitted nothing
+    assert captured.err == ""  # no misleading concise conversion
     assert not out.exists()
     for p, b in before.items():
         assert p.read_bytes() == b
 
 
-def test_cli_internal_plain_valueerror_propagates(tmp_path, monkeypatch) -> None:
+def test_cli_internal_plain_valueerror_propagates(tmp_path, monkeypatch, capsys) -> None:
     """Committed pin for the post-train audit's probe-only claim: the
     evaluator's typed-only boundary predates the pilots, so it had no
     committed plain-ValueError propagation pin. A sentinel plain
     ValueError at the established core seam (evaluate) propagates
-    unchanged through public main()."""
+    unchanged through public main() — exact type and message, inputs
+    byte-identical, the supplied destination never created, and no
+    stdout/stderr emitted."""
     import scripts.nextness_evaluator as evaluator_module
 
     report_file, receipts_file = _write_artifacts(tmp_path)
+    before = {p: p.read_bytes() for p in (report_file, receipts_file)}
+    out = tmp_path / "never_written.out"
 
     def boom(*args, **kwargs):
         raise ValueError("sentinel plain ValueError probe")
 
     monkeypatch.setattr(evaluator_module, "evaluate", boom)
-    with pytest.raises(ValueError, match="sentinel plain ValueError probe"):
-        main(["--report", str(report_file), "--receipts", str(receipts_file)])
+    with pytest.raises(ValueError) as excinfo:
+        main(["--report", str(report_file), "--receipts", str(receipts_file),
+              "--output", str(out)])
+    monkeypatch.undo()
+    assert type(excinfo.value) is ValueError
+    assert str(excinfo.value) == "sentinel plain ValueError probe"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert not out.exists()
+    for p_, b_ in before.items():
+        assert p_.read_bytes() == b_

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1622,3 +1622,58 @@ def test_cli_close_time_failure_pinned(tmp_path, capsys, monkeypatch) -> None:
     assert out.read_bytes() == canonical                       # complete bytes present
     for p, b in before.items():
         assert p.read_bytes() == b
+
+
+# ---------------------------------------------------------------------------
+# Read-side propagation pin (commits the post-train audit's probe-only
+# claim): an argument-conditional read-side PermissionError on the
+# primary input propagates unchanged through public main() — exact
+# identity and message, no concise stderr conversion, inputs
+# byte-identical, no destination created. The patch matches ONLY the
+# resolved victim path in a read mode, so output-write lanes are never
+# accidentally exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None:
+    report_file, receipts_file = _write_artifacts(tmp_path)
+    out = tmp_path / "never_written.out"
+    inputs = [report_file, receipts_file]
+    before = {p: p.read_bytes() for p in inputs}
+    victim = report_file.resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "w" not in mode and self.resolve() == victim:
+            raise PermissionError(13, "injected read denial")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError) as excinfo:
+        main(["--report", str(report_file), "--receipts", str(receipts_file), "--output", str(out)])
+    monkeypatch.undo()
+    assert "injected read denial" in str(excinfo.value)
+    assert type(excinfo.value) is PermissionError
+    err = capsys.readouterr().err
+    assert err == ""  # no misleading concise conversion
+    assert not out.exists()
+    for p, b in before.items():
+        assert p.read_bytes() == b
+
+
+def test_cli_internal_plain_valueerror_propagates(tmp_path, monkeypatch) -> None:
+    """Committed pin for the post-train audit's probe-only claim: the
+    evaluator's typed-only boundary predates the pilots, so it had no
+    committed plain-ValueError propagation pin. A sentinel plain
+    ValueError at the established core seam (evaluate) propagates
+    unchanged through public main()."""
+    import scripts.nextness_evaluator as evaluator_module
+
+    report_file, receipts_file = _write_artifacts(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise ValueError("sentinel plain ValueError probe")
+
+    monkeypatch.setattr(evaluator_module, "evaluate", boom)
+    with pytest.raises(ValueError, match="sentinel plain ValueError probe"):
+        main(["--report", str(report_file), "--receipts", str(receipts_file)])

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1044,10 +1044,12 @@ def test_cli_read_side_oserror_propagates(chain, tmp_path, monkeypatch, capsys) 
     with pytest.raises(PermissionError) as excinfo:
         main(_chain_args(chain) + ["--output", str(out)])
     monkeypatch.undo()
-    assert "injected read denial" in str(excinfo.value)
     assert type(excinfo.value) is PermissionError
-    err = capsys.readouterr().err
-    assert err == ""  # no misleading concise conversion
+    assert excinfo.value.errno == 13
+    assert excinfo.value.strerror == "injected read denial"
+    captured = capsys.readouterr()
+    assert captured.out == ""  # the CLI emitted nothing
+    assert captured.err == ""  # no misleading concise conversion
     assert not out.exists()
     for p, b in before.items():
         assert p.read_bytes() == b

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1015,3 +1015,39 @@ def test_cli_close_time_failure_pinned(chain, tmp_path, capsys, monkeypatch) -> 
     assert out.read_bytes() == canonical                       # complete bytes present
     for p, b in before.items():
         assert p.read_bytes() == b
+
+
+# ---------------------------------------------------------------------------
+# Read-side propagation pin (commits the post-train audit's probe-only
+# claim): an argument-conditional read-side PermissionError on the
+# primary input propagates unchanged through public main() — exact
+# identity and message, no concise stderr conversion, inputs
+# byte-identical, no destination created. The patch matches ONLY the
+# resolved victim path in a read mode, so output-write lanes are never
+# accidentally exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_side_oserror_propagates(chain, tmp_path, monkeypatch, capsys) -> None:
+    out = tmp_path / "never_written.out"
+    inputs = list(chain.values())
+    before = {p: p.read_bytes() for p in inputs}
+    victim = chain["report"].resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "w" not in mode and self.resolve() == victim:
+            raise PermissionError(13, "injected read denial")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError) as excinfo:
+        main(_chain_args(chain) + ["--output", str(out)])
+    monkeypatch.undo()
+    assert "injected read denial" in str(excinfo.value)
+    assert type(excinfo.value) is PermissionError
+    err = capsys.readouterr().err
+    assert err == ""  # no misleading concise conversion
+    assert not out.exists()
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -720,3 +720,38 @@ def test_cli_insufficient_history_still_exit_3(tmp_path, capsys) -> None:
     assert len(lines) == 1 and lines[0].startswith("error:")
     assert "Traceback" not in err
     assert log.read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# Read-side propagation pin (commits the post-train audit's probe-only
+# claim): an argument-conditional read-side PermissionError on the
+# primary input propagates unchanged through public main() — exact
+# identity and message, no concise stderr conversion, inputs
+# byte-identical, no destination created. The patch matches ONLY the
+# resolved victim path in a read mode, so output-write lanes are never
+# accidentally exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    inputs = [log]
+    before = {p: p.read_bytes() for p in inputs}
+    victim = log.resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "w" not in mode and self.resolve() == victim:
+            raise PermissionError(13, "injected read denial")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError) as excinfo:
+        main([str(log)])
+    monkeypatch.undo()
+    assert "injected read denial" in str(excinfo.value)
+    assert type(excinfo.value) is PermissionError
+    err = capsys.readouterr().err
+    assert err == ""  # no misleading concise conversion
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -749,9 +749,11 @@ def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None
     with pytest.raises(PermissionError) as excinfo:
         main([str(log)])
     monkeypatch.undo()
-    assert "injected read denial" in str(excinfo.value)
     assert type(excinfo.value) is PermissionError
-    err = capsys.readouterr().err
-    assert err == ""  # no misleading concise conversion
+    assert excinfo.value.errno == 13
+    assert excinfo.value.strerror == "injected read denial"
+    captured = capsys.readouterr()
+    assert captured.out == ""  # the CLI emitted nothing
+    assert captured.err == ""  # no misleading concise conversion
     for p, b in before.items():
         assert p.read_bytes() == b

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -1036,10 +1036,12 @@ def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None
     with pytest.raises(PermissionError) as excinfo:
         main([str(log), "--output", str(out)])
     monkeypatch.undo()
-    assert "injected read denial" in str(excinfo.value)
     assert type(excinfo.value) is PermissionError
-    err = capsys.readouterr().err
-    assert err == ""  # no misleading concise conversion
+    assert excinfo.value.errno == 13
+    assert excinfo.value.strerror == "injected read denial"
+    captured = capsys.readouterr()
+    assert captured.out == ""  # the CLI emitted nothing
+    assert captured.err == ""  # no misleading concise conversion
     assert not out.exists()
     for p, b in before.items():
         assert p.read_bytes() == b

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -1006,3 +1006,40 @@ def test_typed_identity_at_the_four_reclassified_sites(tmp_path) -> None:
     with pytest.raises(ValueError) as excinfo:
         evaluate_predictions([], [])
     assert type(excinfo.value) is ValueError  # plain, deliberately untyped
+
+
+# ---------------------------------------------------------------------------
+# Read-side propagation pin (commits the post-train audit's probe-only
+# claim): an argument-conditional read-side PermissionError on the
+# primary input propagates unchanged through public main() — exact
+# identity and message, no concise stderr conversion, inputs
+# byte-identical, no destination created. The patch matches ONLY the
+# resolved victim path in a read mode, so output-write lanes are never
+# accidentally exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None:
+    log = _write_log(tmp_path, _dominant_rows(_FIXTURE_SEQUENCE))
+    out = tmp_path / "never_written.out"
+    inputs = [log]
+    before = {p: p.read_bytes() for p in inputs}
+    victim = log.resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "w" not in mode and self.resolve() == victim:
+            raise PermissionError(13, "injected read denial")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError) as excinfo:
+        main([str(log), "--output", str(out)])
+    monkeypatch.undo()
+    assert "injected read denial" in str(excinfo.value)
+    assert type(excinfo.value) is PermissionError
+    err = capsys.readouterr().err
+    assert err == ""  # no misleading concise conversion
+    assert not out.exists()
+    for p, b in before.items():
+        assert p.read_bytes() == b

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -1305,10 +1305,12 @@ def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None
     with pytest.raises(PermissionError) as excinfo:
         main([str(log), str(protocol), "--output", str(out)])
     monkeypatch.undo()
-    assert "injected read denial" in str(excinfo.value)
     assert type(excinfo.value) is PermissionError
-    err = capsys.readouterr().err
-    assert err == ""  # no misleading concise conversion
+    assert excinfo.value.errno == 13
+    assert excinfo.value.strerror == "injected read denial"
+    captured = capsys.readouterr()
+    assert captured.out == ""  # the CLI emitted nothing
+    assert captured.err == ""  # no misleading concise conversion
     assert not out.exists()
     for p, b in before.items():
         assert p.read_bytes() == b

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -1274,3 +1274,41 @@ def test_typed_reader_bound_translation_boundary(tmp_path, monkeypatch) -> None:
     with pytest.raises(ValueError, match="sentinel plain ValueError from reader seam") as esc:
         build_lab_report(log, protocol)
     assert type(esc.value) is ValueError  # not wrapped into LabInputError
+
+
+# ---------------------------------------------------------------------------
+# Read-side propagation pin (commits the post-train audit's probe-only
+# claim): an argument-conditional read-side PermissionError on the
+# primary input propagates unchanged through public main() — exact
+# identity and message, no concise stderr conversion, inputs
+# byte-identical, no destination created. The patch matches ONLY the
+# resolved victim path in a read mode, so output-write lanes are never
+# accidentally exercised.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_read_side_oserror_propagates(tmp_path, monkeypatch, capsys) -> None:
+    log = _write_log(tmp_path, [A, B] * 30)
+    protocol = _write_protocol(tmp_path, [_config_entry("a", min_history=5)])
+    out = tmp_path / "never_written.out"
+    inputs = [log, protocol]
+    before = {p: p.read_bytes() for p in inputs}
+    victim = log.resolve()
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        if "r" in mode and "w" not in mode and self.resolve() == victim:
+            raise PermissionError(13, "injected read denial")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    with pytest.raises(PermissionError) as excinfo:
+        main([str(log), str(protocol), "--output", str(out)])
+    monkeypatch.undo()
+    assert "injected read denial" in str(excinfo.value)
+    assert type(excinfo.value) is PermissionError
+    err = capsys.readouterr().err
+    assert err == ""  # no misleading concise conversion
+    assert not out.exists()
+    for p, b in before.items():
+        assert p.read_bytes() == b


### PR DESCRIPTION
## What this is

Tests-only companion to the six-CLI post-train catch-boundary audit: it **commits as deterministic pins the two classes of claims the audit flagged as supported only by local probes** (no committed regression pin). Zero production or documentation changes.

## Pins added (all pass against unchanged production)

1. **Evaluator plain-`ValueError` seam propagation** — the evaluator's typed-only boundary predates the five pilots, so it was the one module whose plain-ValueError propagation had no committed pin. A sentinel at the established core seam (`evaluate`) now has one, beside its standing RuntimeError pin.
2. **Read-side `OSError` propagation x5** — predictor, monitor, evaluator, replay lab, evidence packet (metrics excluded: PR #372's committed pin already covers it). Each pin uses an **argument-conditional patch matching only the resolved victim input path in a read mode**, so output-write lanes are never accidentally exercised, and asserts: exact exception identity (`type(e) is PermissionError`) and message; **empty stderr** (no misleading concise conversion); input bytes unchanged; **no destination created**.

No redundant seam-form typed-injection tests were added where existing public-input tests already pin exit 2 (per the audit's non-redundancy note).

## Verification

- Five targeted suites: **338 passed, 14 skipped**
- Focused Nextness battery (10 files): **872 passed, 21 skipped**
- Full maintained suite: **1456 passed, 48 skipped**
- `py_compile`: OK - `git diff --check`: clean
- Boundary: exactly 5 test files, +201/-0

## Boundary & collision

Branched from refreshed `main = f72e35a1`; **independent of Candidate A** (not stacked; the two branches share no files — this one touches only the five non-metrics test suites). Board at branch time: #385 (Candidate A, disjoint), #356, #353 — untouched.

Draft; not to be merged without Kev's word and Jack's audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
