### PR TITLE
fix(nextness): exact builtin-int max_rows + hook-free bound diagnostics (F1/F2/F3)

### DIFF
--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -586,6 +586,20 @@ decision, metrics now enforces explicit per-invocation JSONL bounds:
 
 This closes §9's previously unenforced "both are small" assumption.
 
+**Exact-type integer bounds (direct-API policy amendment,
+2026-07-19)**: `max_rows` and `max_line_bytes` accept only **exact
+builtin `int`** values — bool and custom `int` subclasses are refused.
+Type and range validation are split; a non-builtin-int is reported by
+its **safe type name only** (`max_rows must be a builtin int, got
+bool`) — the rejected object is never compared, converted, indexed,
+stringified or repr'd, so no user-controlled hook (comparison,
+conversion, `__index__`, `__str__`, `__repr__`) can execute during
+validation or its diagnostic. **Public-CLI qualification**: this is
+direct-API hardening only — argparse's `type=int` already delivers
+builtin ints, so public CLI behavior and the pinned builtin-integer
+messages are unchanged. Defaults, ceilings, exit codes and output
+bytes are untouched.
+
 ## 10. Open questions for AURA + Jack
 
 1. **CCI composition**: I've defined it as a product of three factors in $[0, 1]$. An alternative is a weighted geometric mean, $\text{CCI} = (B^{w_1} \cdot R^{w_2} \cdot (1-H)^{w_3})^{1/(w_1+w_2+w_3)}$. The product is simpler and has the right "any factor zero → CCI zero" property. Weighted GM lets us emphasize boundary rate over balance if calibration suggests we should. Recommend starting with the simple product; revisit in PR #4 if calibration shows it's miscalibrated.

--- a/PHASE_19_PR3_METRICS_PIPELINE.md
+++ b/PHASE_19_PR3_METRICS_PIPELINE.md
@@ -589,16 +589,19 @@ This closes §9's previously unenforced "both are small" assumption.
 **Exact-type integer bounds (direct-API policy amendment,
 2026-07-19)**: `max_rows` and `max_line_bytes` accept only **exact
 builtin `int`** values — bool and custom `int` subclasses are refused.
-Type and range validation are split; a non-builtin-int is reported by
-its **safe type name only** (`max_rows must be a builtin int, got
-bool`) — the rejected object is never compared, converted, indexed,
-stringified or repr'd, so no user-controlled hook (comparison,
-conversion, `__index__`, `__str__`, `__repr__`) can execute during
-validation or its diagnostic. **Public-CLI qualification**: this is
-direct-API hardening only — argparse's `type=int` already delivers
-builtin ints, so public CLI behavior and the pinned builtin-integer
-messages are unchanged. Defaults, ceilings, exit codes and output
-bytes are untouched.
+Type and range validation are split; a non-builtin-int is refused with
+a **generic supplied-type-free message** (`max_rows must be a builtin
+int`) — **no attribute of the rejected object or its class is
+inspected or reported** beyond the `type(value) is int` identity test:
+the object is never compared, converted, indexed, stringified or
+repr'd, and not even the class `__name__` is read (a hostile metaclass
+property can sit behind it), so no user-controlled hook (comparison,
+conversion, `__index__`, `__str__`, `__repr__`, metaclass) can execute
+during validation or its diagnostic. **Public-CLI qualification**:
+this is direct-API hardening only — argparse's `type=int` already
+delivers builtin ints, so public CLI behavior and the pinned
+builtin-integer messages are unchanged. Defaults, ceilings, exit codes
+and output bytes are untouched.
 
 ## 10. Open questions for AURA + Jack
 

--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -179,7 +179,19 @@ the typed `PredictorInputError` — the four CLI-reachable validation
 raises (`max_rows`, `max_line_bytes`, `smoothing`, `holdout_fraction`
 bounds) raise it (the `max_line_bytes` message states the
 `[1, 16777216]` acceptance range since the boundary-totality repair;
-the other three message texts are unchanged). A plain
+the builtin-integer out-of-range message texts are unchanged).
+
+**Exact-type integer bounds (direct-API policy, 2026-07-19)**:
+`max_rows` and `max_line_bytes` accept only **exact builtin `int`**
+values — bool and custom `int` subclasses included in the refusal.
+Type and range are validated split, and the type refusal renders only
+the safe type NAME (`max_rows must be a builtin int, got bool`) — the
+rejected object is never compared, converted, indexed, stringified or
+repr'd, so **no user-controlled hook can execute** during validation
+or its diagnostic. **Public-CLI qualification**: this hardening is
+reachable only through the direct Python API — argparse's `type=int`
+already delivers builtin ints, so public CLI behavior and its pinned
+messages are unchanged. A plain
 `ValueError` — like any exception outside the documented catch
 classes — **propagates** rather than being reported as a concise input
 failure (test-pinned); `evaluate_predictions`' equal-length/non-empty

--- a/docs/NEXTNESS_PREDICTION_BASELINE.md
+++ b/docs/NEXTNESS_PREDICTION_BASELINE.md
@@ -184,14 +184,17 @@ the builtin-integer out-of-range message texts are unchanged).
 **Exact-type integer bounds (direct-API policy, 2026-07-19)**:
 `max_rows` and `max_line_bytes` accept only **exact builtin `int`**
 values — bool and custom `int` subclasses included in the refusal.
-Type and range are validated split, and the type refusal renders only
-the safe type NAME (`max_rows must be a builtin int, got bool`) — the
-rejected object is never compared, converted, indexed, stringified or
-repr'd, so **no user-controlled hook can execute** during validation
-or its diagnostic. **Public-CLI qualification**: this hardening is
-reachable only through the direct Python API — argparse's `type=int`
-already delivers builtin ints, so public CLI behavior and its pinned
-messages are unchanged. A plain
+Type and range are validated split, and the type refusal carries a
+**generic supplied-type-free message** (`max_rows must be a builtin
+int`) — **no attribute of the rejected object or its class is
+inspected or reported** beyond the identity test itself: the object
+is never compared, converted, indexed, stringified or repr'd, and not
+even the class `__name__` is read (it can be a hostile metaclass
+property), so **no user-controlled hook can execute** during
+validation or its diagnostic. **Public-CLI qualification**: this
+hardening is reachable only through the direct Python API —
+argparse's `type=int` already delivers builtin ints, so public CLI
+behavior and its pinned messages are unchanged. A plain
 `ValueError` — like any exception outside the documented catch
 classes — **propagates** rather than being reported as a concise input
 failure (test-pinned); `evaluate_predictions`' equal-length/non-empty

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -678,21 +678,32 @@ def compute_run_metrics(
             f"boundary_delta must be finite and positive, got {boundary_delta!r}"
         )
 
-    # Input-work bounds: validated typed BEFORE any input reading (the
-    # log is never opened for an invalid bound).
-    if (isinstance(max_rows, bool) or not isinstance(max_rows, int)
-            or not 0 < max_rows <= MAX_ROWS_CEILING):
+    # Input-work bounds: exact-type integer parameters (Jack policy
+    # 2026-07-19), validated typed BEFORE any input reading. Type and
+    # range are SPLIT: a non-builtin-int (bool and custom int
+    # subclasses included) is reported by its safe type NAME only —
+    # the object is never interpolated, stringified or repr'd, so no
+    # comparison/conversion/indexing/string/representation hook can
+    # execute; the numeric value is rendered only after exact
+    # builtin-int identity is established.
+    if type(max_rows) is not int:
+        raise MetricsInputError(
+            f"max_rows must be a builtin int, got {type(max_rows).__name__}"
+        )
+    if not 1 <= max_rows <= MAX_ROWS_CEILING:
         raise MetricsInputError(
             f"max_rows must be a non-boolean integer in "
             f"(0, {MAX_ROWS_CEILING}], got {max_rows!r}"
         )
-    if (type(max_line_bytes) is not int
-            or not 1 <= max_line_bytes <= MAX_LINE_BYTES_CEILING):
-        # Exact builtin type (bool and custom int subclasses both
-        # refused — matching the family's exact-type pattern); ceiling
-        # included so the bounded readline's max_line_bytes + 2 can
-        # never overflow an index-sized integer (the OverflowError is
-        # made unreachable, not caught); raised before any read.
+    if type(max_line_bytes) is not int:
+        raise MetricsInputError(
+            f"max_line_bytes must be a builtin int, "
+            f"got {type(max_line_bytes).__name__}"
+        )
+    # Ceiling keeps the bounded readline's max_line_bytes + 2 safely
+    # index-representable (the OverflowError is unreachable, not
+    # caught).
+    if not 1 <= max_line_bytes <= MAX_LINE_BYTES_CEILING:
         raise MetricsInputError(
             f"max_line_bytes must be a non-boolean integer in "
             f"[1, {MAX_LINE_BYTES_CEILING}], got {max_line_bytes!r}"

--- a/scripts/nextness_metrics.py
+++ b/scripts/nextness_metrics.py
@@ -680,26 +680,22 @@ def compute_run_metrics(
 
     # Input-work bounds: exact-type integer parameters (Jack policy
     # 2026-07-19), validated typed BEFORE any input reading. Type and
-    # range are SPLIT: a non-builtin-int (bool and custom int
-    # subclasses included) is reported by its safe type NAME only —
-    # the object is never interpolated, stringified or repr'd, so no
-    # comparison/conversion/indexing/string/representation hook can
-    # execute; the numeric value is rendered only after exact
-    # builtin-int identity is established.
+    # range are SPLIT, and the type refusal carries a GENERIC
+    # supplied-type-free message — nothing of the rejected object or
+    # its class is inspected beyond the identity test itself (even
+    # type(value).__name__ can execute a hostile metaclass property),
+    # so no comparison/conversion/indexing/string/representation/
+    # metaclass hook can run; the numeric value is rendered only after
+    # exact builtin-int identity is established.
     if type(max_rows) is not int:
-        raise MetricsInputError(
-            f"max_rows must be a builtin int, got {type(max_rows).__name__}"
-        )
+        raise MetricsInputError("max_rows must be a builtin int")
     if not 1 <= max_rows <= MAX_ROWS_CEILING:
         raise MetricsInputError(
             f"max_rows must be a non-boolean integer in "
             f"(0, {MAX_ROWS_CEILING}], got {max_rows!r}"
         )
     if type(max_line_bytes) is not int:
-        raise MetricsInputError(
-            f"max_line_bytes must be a builtin int, "
-            f"got {type(max_line_bytes).__name__}"
-        )
+        raise MetricsInputError("max_line_bytes must be a builtin int")
     # Ceiling keeps the bounded readline's max_line_bytes + 2 safely
     # index-representable (the OverflowError is unreachable, not
     # caught).

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -218,25 +218,22 @@ def read_dominant_sequence(
     """
     # Exact-type integer bounds (Jack policy 2026-07-19): parameters
     # that bound reads or loops must be exact builtin ints, refused
-    # WITHOUT invoking their comparison, conversion, indexing, string
-    # or representation hooks. Type and range are validated SPLIT: a
-    # non-builtin-int is reported by its safe type NAME only (the
-    # object is never interpolated, stringified or repr'd); the
-    # numeric value is rendered only after exact builtin-int identity
-    # is established. Both refusals fire BEFORE the input is opened.
+    # WITHOUT invoking any hook of the rejected object OR its class.
+    # Type and range are validated SPLIT, and the type refusal carries
+    # a GENERIC supplied-type-free message — nothing of the object is
+    # inspected beyond the identity test itself (even
+    # type(value).__name__ can execute a hostile metaclass property);
+    # the numeric value is rendered only after exact builtin-int
+    # identity is established. Both refusals fire BEFORE the input is
+    # opened.
     if type(max_rows) is not int:
-        raise PredictorInputError(
-            f"max_rows must be a builtin int, got {type(max_rows).__name__}"
-        )
+        raise PredictorInputError("max_rows must be a builtin int")
     if not 1 <= max_rows <= MAX_ROWS_CEILING:
         raise PredictorInputError(
             f"max_rows must be in (0, {MAX_ROWS_CEILING}], got {max_rows}"
         )
     if type(max_line_bytes) is not int:
-        raise PredictorInputError(
-            f"max_line_bytes must be a builtin int, "
-            f"got {type(max_line_bytes).__name__}"
-        )
+        raise PredictorInputError("max_line_bytes must be a builtin int")
     # Ceiling keeps the bounded readline's max_line_bytes + 2 safely
     # index-representable (the OverflowError is unreachable, not
     # caught).

--- a/scripts/nextness_predictor.py
+++ b/scripts/nextness_predictor.py
@@ -216,23 +216,34 @@ def read_dominant_sequence(
     counted ``duplicate_generation``; a smaller one is counted
     ``out_of_order_generation``. Neither is silently reordered.
     """
-    if not 0 < max_rows <= MAX_ROWS_CEILING:
+    # Exact-type integer bounds (Jack policy 2026-07-19): parameters
+    # that bound reads or loops must be exact builtin ints, refused
+    # WITHOUT invoking their comparison, conversion, indexing, string
+    # or representation hooks. Type and range are validated SPLIT: a
+    # non-builtin-int is reported by its safe type NAME only (the
+    # object is never interpolated, stringified or repr'd); the
+    # numeric value is rendered only after exact builtin-int identity
+    # is established. Both refusals fire BEFORE the input is opened.
+    if type(max_rows) is not int:
+        raise PredictorInputError(
+            f"max_rows must be a builtin int, got {type(max_rows).__name__}"
+        )
+    if not 1 <= max_rows <= MAX_ROWS_CEILING:
         raise PredictorInputError(
             f"max_rows must be in (0, {MAX_ROWS_CEILING}], got {max_rows}"
         )
-    # Total line-bound validation: only a non-boolean builtin int in
-    # [1, MAX_LINE_BYTES_CEILING] reaches the bounded readline call, so
-    # the probe arithmetic (max_line_bytes + 2) can never overflow an
-    # index-sized integer — the OverflowError is made unreachable, not
-    # caught. Raised BEFORE the input is opened.
-    if (type(max_line_bytes) is not int
-            or not 1 <= max_line_bytes <= MAX_LINE_BYTES_CEILING):
-        # Exact builtin type: bool AND custom int subclasses are both
-        # refused (an isinstance check would admit subclasses whose
-        # overridden hooks the bounded reader must never execute).
+    if type(max_line_bytes) is not int:
+        raise PredictorInputError(
+            f"max_line_bytes must be a builtin int, "
+            f"got {type(max_line_bytes).__name__}"
+        )
+    # Ceiling keeps the bounded readline's max_line_bytes + 2 safely
+    # index-representable (the OverflowError is unreachable, not
+    # caught).
+    if not 1 <= max_line_bytes <= MAX_LINE_BYTES_CEILING:
         raise PredictorInputError(
             f"max_line_bytes must be a non-boolean integer in "
-            f"[1, {MAX_LINE_BYTES_CEILING}], got {max_line_bytes!r}"
+            f"[1, {MAX_LINE_BYTES_CEILING}], got {max_line_bytes}"
         )
 
     sequence: list[str] = []

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -2431,9 +2431,10 @@ def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
     """Exact-type max_rows (Jack policy 2026-07-19): the isinstance
     form admitted int subclasses whose comparison hooks executed inside
     the row-budget loop (audit receipts MET-DIR-MAXROWS-06/07). Now:
-    every non-builtin-int is exactly MetricsInputError with a safe
-    type-name-only diagnostic, before the log is opened, zero hostile
-    hooks executed; builtin boundaries and pinned refusals unchanged."""
+    every non-builtin-int is exactly MetricsInputError with a generic
+    supplied-type-free diagnostic, before the log is opened, zero
+    hostile hooks executed; builtin boundaries and pinned refusals
+    unchanged."""
     from scripts.nextness_metrics import MetricsInputError
 
     class _SubInt(int):

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -2398,8 +2398,9 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     with pytest.raises(MetricsInputError) as excinfo:
         compute_run_metrics(log, out, max_line_bytes=_SubInt(65_536))
     assert type(excinfo.value) is MetricsInputError
-    # hook-free diagnostic: safe type NAME only, never the object
-    assert str(excinfo.value) == "max_line_bytes must be a builtin int, got _SubInt"
+    # hook-free generic diagnostic: nothing of the object or its
+    # class is inspected or reported
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int"
 
     # lower inclusive boundary: parameter accepted -> the LINE lane
     # fires (located message), not the parameter lane
@@ -2464,7 +2465,7 @@ def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
         with pytest.raises(MetricsInputError) as excinfo:
             compute_run_metrics(log, tmp_path / "n2.jsonl", max_rows=bad)
         assert type(excinfo.value) is MetricsInputError
-        assert "must be a builtin int, got" in str(excinfo.value)
+        assert str(excinfo.value) == "max_rows must be a builtin int"
     # builtin out-of-range keep the pinned concise refusals
     for bad in (0, -1, 1_000_001):
         with pytest.raises(MetricsInputError) as excinfo:
@@ -2478,8 +2479,8 @@ def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
 
 def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
     """Finding F3 closed: a repr-raiser is refused with exactly
-    MetricsInputError — the diagnostic renders only the safe type name
-    and never invokes the representation hook."""
+    MetricsInputError — the generic diagnostic never invokes the
+    representation hook."""
     from scripts.nextness_metrics import MetricsInputError
 
     _HostileHooks.ran = False
@@ -2489,10 +2490,64 @@ def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
         compute_run_metrics(log, tmp_path / "f3_out.jsonl",
                             max_line_bytes=_HostileHooks())
     assert type(excinfo.value) is MetricsInputError
-    assert str(excinfo.value) == (
-        "max_line_bytes must be a builtin int, got _HostileHooks")
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int"
     assert _HostileHooks.ran is False
     assert not (tmp_path / "f3_out.jsonl").exists()
+
+
+class _RaisingMeta(type):
+    """Metaclass whose __name__ property raises — even
+    type(value).__name__ is a user-controlled hook."""
+    ran = False
+
+    @property
+    def __name__(cls):
+        _RaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _MetaBomb(metaclass=_RaisingMeta):
+    pass
+
+
+def test_bound_diagnostics_never_touch_the_metaclass(
+    tmp_path, monkeypatch
+) -> None:
+    """Metaclass-__name__ repair: refusing a non-builtin-int must not
+    inspect the rejected object OR its class beyond the identity test —
+    a hostile-metaclass object receives exactly MetricsInputError with
+    the generic message, without opening the input or creating
+    output."""
+    from scripts.nextness_metrics import MetricsInputError
+
+    log = tmp_path / "meta.jsonl"
+    log.write_bytes((_bounds_row(1, 120) + "\n").encode())
+    out = tmp_path / "meta_out.jsonl"
+    victim = log.resolve()
+    opened: list[str] = []
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        try:
+            if self.resolve() == victim:
+                opened.append(mode)
+        except OSError:
+            pass
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    for param, message in (("max_rows", "max_rows must be a builtin int"),
+                           ("max_line_bytes",
+                            "max_line_bytes must be a builtin int")):
+        _RaisingMeta.ran = False
+        with pytest.raises(MetricsInputError) as excinfo:
+            compute_run_metrics(log, out, **{param: _MetaBomb()})
+        assert type(excinfo.value) is MetricsInputError
+        assert str(excinfo.value) == message
+        assert _RaisingMeta.ran is False  # the metaclass was never asked
+    monkeypatch.undo()
+    assert opened == []
+    assert not out.exists()
 
 
 def test_cli_huge_max_line_bytes_typed_exit_2(tmp_path, capsys) -> None:

--- a/tests/test_nextness_metrics.py
+++ b/tests/test_nextness_metrics.py
@@ -2398,7 +2398,8 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     with pytest.raises(MetricsInputError) as excinfo:
         compute_run_metrics(log, out, max_line_bytes=_SubInt(65_536))
     assert type(excinfo.value) is MetricsInputError
-    assert "non-boolean integer" in str(excinfo.value)
+    # hook-free diagnostic: safe type NAME only, never the object
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int, got _SubInt"
 
     # lower inclusive boundary: parameter accepted -> the LINE lane
     # fires (located message), not the parameter lane
@@ -2409,6 +2410,89 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     # upper inclusive boundary: accepted end-to-end (tiny input)
     compute_run_metrics(log, out, max_line_bytes=MAX_LINE_BYTES_CEILING)
     assert out.exists()
+
+
+class _HostileHooks:
+    """Every observable hook raises — comparison, conversion, indexing,
+    string AND representation. The exact-type refusal must complete
+    without executing any of them (Jack policy 2026-07-19)."""
+    ran = False
+
+    def _boom(self, *args):
+        type(self).ran = True
+        raise RuntimeError("hostile hook executed")
+
+    __lt__ = __le__ = __gt__ = __ge__ = _boom
+    __index__ = __int__ = __str__ = __repr__ = _boom
+
+
+def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
+    """Exact-type max_rows (Jack policy 2026-07-19): the isinstance
+    form admitted int subclasses whose comparison hooks executed inside
+    the row-budget loop (audit receipts MET-DIR-MAXROWS-06/07). Now:
+    every non-builtin-int is exactly MetricsInputError with a safe
+    type-name-only diagnostic, before the log is opened, zero hostile
+    hooks executed; builtin boundaries and pinned refusals unchanged."""
+    from scripts.nextness_metrics import MetricsInputError
+
+    class _SubInt(int):
+        pass
+
+    log = tmp_path / "rows_exact.jsonl"
+    log.write_bytes((_bounds_row(1, 120) + "\n").encode())
+    out = tmp_path / "rows_exact_out.jsonl"
+    # builtin boundaries accepted (tiny fixture; max_rows=1 fits it)
+    compute_run_metrics(log, out, max_rows=1)
+    assert out.exists()
+    compute_run_metrics(log, out, max_rows=1_000_000)
+
+    victim = log.resolve()
+    opened: list[str] = []
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        try:
+            if self.resolve() == victim:
+                opened.append(mode)
+        except OSError:
+            pass
+        return real_open(self, mode, *args, **kwargs)
+
+    _HostileHooks.ran = False
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    for bad in (True, False, 2.5, "10", None, _SubInt(3), _HostileHooks()):
+        with pytest.raises(MetricsInputError) as excinfo:
+            compute_run_metrics(log, tmp_path / "n2.jsonl", max_rows=bad)
+        assert type(excinfo.value) is MetricsInputError
+        assert "must be a builtin int, got" in str(excinfo.value)
+    # builtin out-of-range keep the pinned concise refusals
+    for bad in (0, -1, 1_000_001):
+        with pytest.raises(MetricsInputError) as excinfo:
+            compute_run_metrics(log, tmp_path / "n2.jsonl", max_rows=bad)
+        assert "non-boolean integer in (0, 1000000]" in str(excinfo.value)
+    monkeypatch.undo()
+    assert opened == []  # every refusal fired before the log was opened
+    assert _HostileHooks.ran is False
+    assert not (tmp_path / "n2.jsonl").exists()
+
+
+def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
+    """Finding F3 closed: a repr-raiser is refused with exactly
+    MetricsInputError — the diagnostic renders only the safe type name
+    and never invokes the representation hook."""
+    from scripts.nextness_metrics import MetricsInputError
+
+    _HostileHooks.ran = False
+    log = tmp_path / "f3.jsonl"
+    log.write_bytes((_bounds_row(1, 120) + "\n").encode())
+    with pytest.raises(MetricsInputError) as excinfo:
+        compute_run_metrics(log, tmp_path / "f3_out.jsonl",
+                            max_line_bytes=_HostileHooks())
+    assert type(excinfo.value) is MetricsInputError
+    assert str(excinfo.value) == (
+        "max_line_bytes must be a builtin int, got _HostileHooks")
+    assert _HostileHooks.ran is False
+    assert not (tmp_path / "f3_out.jsonl").exists()
 
 
 def test_cli_huge_max_line_bytes_typed_exit_2(tmp_path, capsys) -> None:

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -1199,7 +1199,8 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     with pytest.raises(PredictorInputError) as excinfo:
         read_dominant_sequence(log, max_line_bytes=_SubInt(65_536))
     assert type(excinfo.value) is PredictorInputError
-    assert "non-boolean integer" in str(excinfo.value)
+    # hook-free diagnostic: safe type NAME only, never the object
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int, got _SubInt"
 
     # lower inclusive boundary: parameter accepted, reading proceeds
     seq, rej, rows = read_dominant_sequence(log, max_line_bytes=1)
@@ -1208,6 +1209,91 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     seq, rej, rows = read_dominant_sequence(
         log, max_line_bytes=MAX_LINE_BYTES_CEILING)
     assert seq == [A, B, A]
+
+
+class _HostileHooks:
+    """Every observable hook raises — comparison, conversion, indexing,
+    string AND representation. The exact-type refusal must complete
+    without executing any of them (Jack policy 2026-07-19)."""
+    ran = False
+
+    def _boom(self, *args):
+        type(self).ran = True
+        raise RuntimeError("hostile hook executed")
+
+    __lt__ = __le__ = __gt__ = __ge__ = _boom
+    __index__ = __int__ = __str__ = __repr__ = _boom
+
+
+def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
+    """Exact-type max_rows (Jack policy 2026-07-19): only a builtin int
+    in [1, 1_000_000] is accepted. The failing-first receipts on
+    unrepaired main: True ACCEPTED as one row, 2.5 ACCEPTED as a
+    fractional loop budget, int subclasses ACCEPTED with comparison
+    hooks executing, string/None raising raw TypeError. Now: every
+    non-builtin-int is the exact typed refusal, before the log is
+    opened, with ZERO hostile hooks executed."""
+    from scripts.nextness_predictor import MAX_ROWS_CEILING, PredictorInputError
+
+    class _SubInt(int):
+        pass
+
+    log = _write_log(tmp_path, _dominant_rows([A, B, A]))
+    # builtin boundaries accepted on tiny fixtures
+    seq, rej, rows = read_dominant_sequence(log, max_rows=1)
+    assert rows == 1
+    seq, rej, rows = read_dominant_sequence(log, max_rows=MAX_ROWS_CEILING)
+    assert seq == [A, B, A]
+    # builtin out-of-range keep the pinned concise refusals
+    for bad, needle in ((0, "got 0"), (-1, "got -1"), (1_000_001, "got 1000001")):
+        with pytest.raises(PredictorInputError) as excinfo:
+            read_dominant_sequence(log, max_rows=bad)
+        assert "max_rows must be in (0, 1000000]" in str(excinfo.value)
+        assert needle in str(excinfo.value)
+
+    victim = log.resolve()
+    opened: list[str] = []
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        try:
+            if self.resolve() == victim:
+                opened.append(mode)
+        except OSError:
+            pass
+        return real_open(self, mode, *args, **kwargs)
+
+    _HostileHooks.ran = False
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    for bad in (True, False, 2.5, "10", None, _SubInt(3), _HostileHooks()):
+        with pytest.raises(PredictorInputError) as excinfo:
+            read_dominant_sequence(log, max_rows=bad)
+        assert type(excinfo.value) is PredictorInputError
+        assert "must be a builtin int, got" in str(excinfo.value)
+    monkeypatch.undo()
+    assert opened == []          # refusals fire before the log opens
+    assert _HostileHooks.ran is False  # zero hostile hooks executed
+    # safe type-name-only diagnostic
+    with pytest.raises(PredictorInputError) as excinfo:
+        read_dominant_sequence(log, max_rows=_HostileHooks())
+    assert str(excinfo.value) == "max_rows must be a builtin int, got _HostileHooks"
+    assert _HostileHooks.ran is False
+
+
+def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
+    """Finding F3 closed: an object whose __repr__ raises is refused
+    with the exact typed exception — the diagnostic renders only the
+    safe type name and never invokes the representation hook."""
+    from scripts.nextness_predictor import PredictorInputError
+
+    _HostileHooks.ran = False
+    log = _write_log(tmp_path, _dominant_rows([A, B, A]))
+    with pytest.raises(PredictorInputError) as excinfo:
+        read_dominant_sequence(log, max_line_bytes=_HostileHooks())
+    assert type(excinfo.value) is PredictorInputError
+    assert str(excinfo.value) == (
+        "max_line_bytes must be a builtin int, got _HostileHooks")
+    assert _HostileHooks.ran is False
 
 
 def test_cli_huge_max_line_bytes_typed_exit_2(tmp_path, capsys) -> None:

--- a/tests/test_nextness_predictor.py
+++ b/tests/test_nextness_predictor.py
@@ -1199,8 +1199,9 @@ def test_max_line_bytes_exact_builtin_type_pins(tmp_path) -> None:
     with pytest.raises(PredictorInputError) as excinfo:
         read_dominant_sequence(log, max_line_bytes=_SubInt(65_536))
     assert type(excinfo.value) is PredictorInputError
-    # hook-free diagnostic: safe type NAME only, never the object
-    assert str(excinfo.value) == "max_line_bytes must be a builtin int, got _SubInt"
+    # hook-free generic diagnostic: nothing of the object or its
+    # class is inspected or reported
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int"
 
     # lower inclusive boundary: parameter accepted, reading proceeds
     seq, rej, rows = read_dominant_sequence(log, max_line_bytes=1)
@@ -1269,21 +1270,21 @@ def test_max_rows_exact_builtin_type_totality(tmp_path, monkeypatch) -> None:
         with pytest.raises(PredictorInputError) as excinfo:
             read_dominant_sequence(log, max_rows=bad)
         assert type(excinfo.value) is PredictorInputError
-        assert "must be a builtin int, got" in str(excinfo.value)
+        assert str(excinfo.value) == "max_rows must be a builtin int"
     monkeypatch.undo()
     assert opened == []          # refusals fire before the log opens
     assert _HostileHooks.ran is False  # zero hostile hooks executed
-    # safe type-name-only diagnostic
+    # generic supplied-type-free diagnostic
     with pytest.raises(PredictorInputError) as excinfo:
         read_dominant_sequence(log, max_rows=_HostileHooks())
-    assert str(excinfo.value) == "max_rows must be a builtin int, got _HostileHooks"
+    assert str(excinfo.value) == "max_rows must be a builtin int"
     assert _HostileHooks.ran is False
 
 
 def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
     """Finding F3 closed: an object whose __repr__ raises is refused
-    with the exact typed exception — the diagnostic renders only the
-    safe type name and never invokes the representation hook."""
+    with the exact typed exception — the generic diagnostic never
+    invokes the representation hook."""
     from scripts.nextness_predictor import PredictorInputError
 
     _HostileHooks.ran = False
@@ -1291,9 +1292,60 @@ def test_max_line_bytes_diagnostic_is_hook_free(tmp_path) -> None:
     with pytest.raises(PredictorInputError) as excinfo:
         read_dominant_sequence(log, max_line_bytes=_HostileHooks())
     assert type(excinfo.value) is PredictorInputError
-    assert str(excinfo.value) == (
-        "max_line_bytes must be a builtin int, got _HostileHooks")
+    assert str(excinfo.value) == "max_line_bytes must be a builtin int"
     assert _HostileHooks.ran is False
+
+
+class _RaisingMeta(type):
+    """Metaclass whose __name__ property raises — even
+    type(value).__name__ is a user-controlled hook."""
+    ran = False
+
+    @property
+    def __name__(cls):
+        _RaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _MetaBomb(metaclass=_RaisingMeta):
+    pass
+
+
+def test_bound_diagnostics_never_touch_the_metaclass(
+    tmp_path, monkeypatch
+) -> None:
+    """Metaclass-__name__ repair: refusing a non-builtin-int must not
+    inspect the rejected object OR its class beyond the identity test —
+    an object whose metaclass raises on __name__ access still receives
+    the exact typed exception with the generic message, without opening
+    the input or creating output."""
+    from scripts.nextness_predictor import PredictorInputError
+
+    log = _write_log(tmp_path, _dominant_rows([A, B, A]))
+    victim = log.resolve()
+    opened: list[str] = []
+    real_open = pathlib.Path.open
+
+    def patched(self, mode="r", *args, **kwargs):
+        try:
+            if self.resolve() == victim:
+                opened.append(mode)
+        except OSError:
+            pass
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", patched)
+    for param, message in (("max_rows", "max_rows must be a builtin int"),
+                           ("max_line_bytes",
+                            "max_line_bytes must be a builtin int")):
+        _RaisingMeta.ran = False
+        with pytest.raises(PredictorInputError) as excinfo:
+            read_dominant_sequence(log, **{param: _MetaBomb()})
+        assert type(excinfo.value) is PredictorInputError
+        assert str(excinfo.value) == message
+        assert _RaisingMeta.ran is False  # the metaclass was never asked
+    monkeypatch.undo()
+    assert opened == []
 
 
 def test_cli_huge_max_line_bytes_typed_exit_2(tmp_path, capsys) -> None:


### PR DESCRIPTION
## What this is

The **exact-type integer-bound completion** (Kev-authorized; implements Jack's 2026-07-19 policy decision on numeric-bound audit findings **F1/F2/F3**): *numeric parameters that bound reads or loops must be exact built-in integers, refused without invoking any hook of the rejected object or its class.* **Direct-API hardening only** — argparse `type=int` already delivers builtin ints; no claim of public-CLI reachability is made, and public CLI behavior with its pinned builtin-integer messages is unchanged.

**Base** `fc3671b2` (post-#392 main) · **head `785d33b754d8e9c66dc4b2e623cd6ecb545d87e2`** · **exactly six files, +351/−26**: `scripts/nextness_predictor.py`, `scripts/nextness_metrics.py`, both test files, `docs/NEXTNESS_PREDICTION_BASELINE.md`, `PHASE_19_PR3_METRICS_PIPELINE.md`.

### Three ordinary commits (descending from `fc3671b2`)

1. `4afa4271` — exact builtin-int `max_rows` in predictor (`[1, 1_000_000]`) and metrics; split type/range validation for both parameters in both modules (closes F1/F2, and F3 for `max_line_bytes`).
2. `f1eeedfc` — **metaclass-`__name__` repair**: the type-branch diagnostics read `type(value).__name__`, and `__name__` can be a hostile **metaclass** property (pre-repair receipt: `RuntimeError("metaclass __name__ hook executed")` escaped all four boundaries — predictor/metrics × `max_rows`/`max_line_bytes`). Refusals now carry **generic supplied-type-free messages** with no attribute of the rejected object or its class inspected.
3. `785d33b7` — one-docstring cleanup aligning a stale "safe type-name-only" description with the generic-diagnostic truth (no code/assertion/behavior change).

## Repair (final form at head `785d33b7`)

1. **Exact-type `max_rows`** (predictor `[1, 1_000_000]`, metrics) and **exact-type `max_line_bytes`** — each module keeps its own typed exception (`PredictorInputError` / `MetricsInputError`).
2. **Generic supplied-type-free type refusals**: on `type(value) is not int`, **nothing of the rejected object or its class is inspected or reported** beyond the identity test itself — not compared, converted, indexed, stringified or repr'd, and **not even the class `__name__` is read** (it can be a hostile metaclass property). Messages are exactly `max_rows must be a builtin int` / `max_line_bytes must be a builtin int`. Type and range are validated **split**: the numeric value is rendered only after exact builtin-int identity is established.
3. Builtin-integer **range messages preserved byte-for-byte** where pinned (`(0, 1000000], got 0` · `[1, 16777216], got 0` · the huge-value CLI lines).
4. Inherited direct-reader lanes (monitor bridge, replay lab) receive the typed predictor refusal — suites pass unchanged.
5. **No schema, exit-code, ceiling, default, algorithm or output change.**

## Post-repair matrix

`bool` / float / string / `None` / custom `int` subclass / `__index__` carrier / comparison-raiser / **repr-raiser** / **hostile-metaclass `__name__`** → all exact typed exceptions with the generic message · **zero hostile hooks execute** (flag-asserted, incl. the metaclass provably never asked) · refusal **before input open** (spy-asserted) and before output creation · builtin 1 and 1,000,000 accepted on tiny fixtures · 0 / −1 / 1,000,001 keep the pinned concise refusals · predictor/lab/metrics default outputs **byte-identical** pre/post (three-way comparison). Regression pins cover **both modules × both parameters** for every hostile case above.

## Verification (current head `785d33b7`)

predictor+metrics **179 passed / 4 skipped** · four-reader battery (incl. monitor/replay inherited lanes) **291/6** · focused Nextness **935 / 26** · **full suite 1519 passed / 48 skipped** · compileall OK · diff clean · six-file boundary verified · all seven current-head GitHub checks conclusive-pass.

## Failing-first evidence (historical — vs the unrepaired tree)

- predictor `max_rows=True` **ACCEPTED as one row** (bridge-receipted through the monitor) · `max_rows=2.5` **ACCEPTED as a fractional loop budget** (audit receipts PRE-DIR-MAXROWS-04/-08).
- both modules **ACCEPTED custom int subclasses** with **comparison hooks executing** — 6 receipted calls inside validation and the row loops (PRE-DIR-MAXROWS-07, MET-DIR-MAXROWS-07).
- a **repr-raiser ESCAPED as raw `RuntimeError`** from the `got {value!r}` diagnostics before the typed exception existed (appended receipts …-REPRBOMB, F3).
- after commit ①, a **hostile-metaclass object still ESCAPED** via `type(value).__name__` — closed by commit ② (generic messages).
- fresh failing runs on the unrepaired scripts confirmed each pin fails first; receipts preserved in the local audit artifacts.

## Boundary & collision

Branched from merged `main = fc3671b2` (#392's squash). Ian-lane / Swarm-Hunter work is untouched. #392's two outdated threads and #391's late thread remain untouched.

Merged with Kev's authorization after Jack's completed audit as squash 0bfc84243bda5d34ee7746bb01192a67b19e516e on 2026-07-19. No review-thread actions were taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

