### PR TITLE
fix(s1-lab): snapshot invocation ceiling (F1) + hook-free exact-container input boundary (F2)

### DIFF
--- a/docs/SWARM_HUNTER_V1_PREFLIGHT.md
+++ b/docs/SWARM_HUNTER_V1_PREFLIGHT.md
@@ -321,13 +321,18 @@ immutable inputs to a findings artifact.
   types are proven at the direct-Python boundary before any caller `len`/iteration/
   `keys`/`.get`/subscript hook can run, so a `list`/`tuple`/`dict` subclass with a
   hostile hook is refused (existing `invalid_input`/`invalid_provenance`/
-  `invalid_sha256_format`) without executing it. **Inside each exact dict, every
-  key is proven an exact built-in `str`** (via hash-free iteration) before any
-  `set(...keys())`/membership/lookup hashes or compares it, and the provenance
-  **`source` discriminator is proven an exact built-in `str`** before the
-  `!= "synthetic"` comparison — so a hostile *stored key* `__hash__`/`__eq__` or a
-  hostile *scalar* `__eq__` cannot execute (a non-str key or non-str source →
-  `invalid_input`). Each snapshot is in-memory arrays —
+  `invalid_sha256_format`) without executing it. **Each exact dict's cardinality
+  is checked first** (hook-free `len()` on a proven exact dict): a dict exceeding
+  its closed key budget (snapshot 4, provenance 7, `sha256_triple` 3) is refused
+  in O(1) *before* key traversal or `set(...)` allocation, so arbitrarily many
+  junk keys cannot force unbounded per-object work (`MAX_SNAPSHOTS` bounds the
+  outer sequence but not this nested cardinality). **Then, inside each exact
+  dict, every key is proven an exact built-in `str`** (via hash-free iteration)
+  before any `set(...keys())`/membership/lookup hashes or compares it, and the
+  provenance **`source` discriminator is proven an exact built-in `str`** before
+  the `!= "synthetic"` comparison — so a hostile *stored key* `__hash__`/`__eq__`
+  or a hostile *scalar* `__eq__` cannot execute (a non-str key or non-str source
+  → `invalid_input`). Each snapshot is in-memory arrays —
   `states: u8[N³]` (5-state,
   `memory.rs:19–24` semantics), optional `memory: f32[8][N³]` channel-first, optional
   `inactivity_steps: i16[N³]` (source-exact name, `voxel_lattice.rs:18`) — plus a

--- a/docs/SWARM_HUNTER_V1_PREFLIGHT.md
+++ b/docs/SWARM_HUNTER_V1_PREFLIGHT.md
@@ -321,7 +321,13 @@ immutable inputs to a findings artifact.
   types are proven at the direct-Python boundary before any caller `len`/iteration/
   `keys`/`.get`/subscript hook can run, so a `list`/`tuple`/`dict` subclass with a
   hostile hook is refused (existing `invalid_input`/`invalid_provenance`/
-  `invalid_sha256_format`) without executing it. Each snapshot is in-memory arrays —
+  `invalid_sha256_format`) without executing it. **Inside each exact dict, every
+  key is proven an exact built-in `str`** (via hash-free iteration) before any
+  `set(...keys())`/membership/lookup hashes or compares it, and the provenance
+  **`source` discriminator is proven an exact built-in `str`** before the
+  `!= "synthetic"` comparison — so a hostile *stored key* `__hash__`/`__eq__` or a
+  hostile *scalar* `__eq__` cannot execute (a non-str key or non-str source →
+  `invalid_input`). Each snapshot is in-memory arrays —
   `states: u8[N³]` (5-state,
   `memory.rs:19–24` semantics), optional `memory: f32[8][N³]` channel-first, optional
   `inactivity_steps: i16[N³]` (source-exact name, `voxel_lattice.rs:18`) — plus a

--- a/docs/SWARM_HUNTER_V1_PREFLIGHT.md
+++ b/docs/SWARM_HUNTER_V1_PREFLIGHT.md
@@ -300,8 +300,8 @@ production physics; using confidence scores as authorization.
 | 9 | Missed structure | thresholds too tight | known-cluster fixture recall | report absence honestly; no "clean" claim beyond fixtures | single-cluster fixture | medium — inherent | no |
 | 10 | Repeated-event double counting | same structure found each snapshot | stable finding IDs + dedup (§5) | dedup by (region-hash, persistence chain) | two-snapshot same-cluster fixture | low | no |
 | 11 | Toroidal-boundary mistakes | treating wrapped cluster as two | periodic-aware components (§6) | torus fixtures mandatory | wraparound-cluster fixture | low | no |
-| 12 | Unbounded memory | pathological component counts | hard caps (§5) | truncate + explicit truncation flag | worst-case checkerboard fixture | low | no |
-| 13 | Unbounded runtime | quadratic pair scans | complexity budget; caps | abort + partial-result flag | resource-bound fixture | low | no |
+| 12 | Unbounded memory | pathological component counts **or unbounded snapshot count** | hard caps + **1–64 snapshot invocation ceiling** (§5) | component cap → truncate + flag; over-ceiling → `invalid_input` refusal (not a truncation) | worst-case checkerboard fixture; **65-snapshot fixture** | low | **closed (Amendment 3)** |
+| 13 | Unbounded runtime | quadratic pair scans **or unbounded snapshot count** | complexity budget; caps; **1–64 snapshot invocation ceiling** (§5) | budget → truncate + flag; over-ceiling → `invalid_input` refusal | resource-bound fixture; **65-snapshot fixture** | low | **closed (Amendment 3)** |
 | 14 | Active-region bias | analyzing only "interesting" regions | whole-lattice pass in v1 (no sampling) | if sampling ever added: deterministic keying (§9) | — | deferred | no |
 | 15 | Threshold overfitting | tuning thresholds to one organism epoch | thresholds recorded per finding; S3 cross-validation | evidence classes; no generalization claim | disjoint-epoch fixtures (S2+) | medium | no |
 | 16 | Accidental canonical claims | excited prose | keyword sweep (Pass 12 discipline); Jack audit | evidence-class labels mandatory | doc grep | low | no |
@@ -315,7 +315,14 @@ No risk blocks a **toy-only** v1; several (7, 15) shape the S2/S3 gates. `[PROP]
 **Shape:** an offline candidate detector (per §2 resolution): a pure function from
 immutable inputs to a findings artifact.
 
-- **Allowed inputs (v1/S1, toy-only):** in-memory arrays — `states: u8[N³]` (5-state,
+- **Allowed inputs (v1/S1, toy-only):** an **exact built-in `list` or `tuple` of 1
+  to `MAX_SNAPSHOTS` (= 64)** snapshots; each snapshot, its provenance, and its
+  supplied `sha256_triple` are **exact built-in `dict`s** — these exact-container
+  types are proven at the direct-Python boundary before any caller `len`/iteration/
+  `keys`/`.get`/subscript hook can run, so a `list`/`tuple`/`dict` subclass with a
+  hostile hook is refused (existing `invalid_input`/`invalid_provenance`/
+  `invalid_sha256_format`) without executing it. Each snapshot is in-memory arrays —
+  `states: u8[N³]` (5-state,
   `memory.rs:19–24` semantics), optional `memory: f32[8][N³]` channel-first, optional
   `inactivity_steps: i16[N³]` (source-exact name, `voxel_lattice.rs:18`) — plus a
   provenance dict. **No file, network, API, or `data/` access in S1.** S2 (real
@@ -327,9 +334,18 @@ immutable inputs to a findings artifact.
 - **Deterministic ordering:** cells row-major (`z·N²+y·N+x`, matching
   `voxel_lattice.rs:56–62`); components labeled by minimum member index; findings
   sorted by (label, first-seen generation); no hash-map iteration order may leak.
-- **Bounded resources:** ≤ 64³ lattices in S1; component count cap (default 4,096) and
-  runtime budget with **explicit truncation flags** when hit — truncation is a
-  reported result, not an error.
+- **Bounded resources:** a **fixed 1–64 snapshot invocation ceiling**
+  (`MAX_SNAPSHOTS = 64`) bounds validation, discovery, `run.snapshot_ids`,
+  `run.generations`, persistence observation lists and serialization — exceeding
+  it is unsupported input yielding the existing `invalid_input` structured refusal
+  (decided before item inspection; **not** a truncation and **not** partial
+  processing); ≤ 64³ lattices in S1; component count cap (default 4,096) and
+  runtime budget with **explicit truncation flags** when hit — cap/budget
+  truncation is a reported result, not an error. **Honesty note (unchanged):** the
+  deterministic per-invocation operation counter is an input-size proxy for the
+  cap/budget mechanism, **not** a wall-clock or adversarial-runtime security bound;
+  because it scales with snapshot count it cannot bound count on its own, which is
+  precisely why the explicit `MAX_SNAPSHOTS` ceiling exists (Amendment 3).
 - **Output schema (JSONL, one finding per line):** `{finding_id, detector: {name,
   version}, snapshot: provenance, label: <deterministic component label — the
   minimum row-major member cell index, the same key used for ordering>, region:
@@ -392,7 +408,10 @@ Fixtures (all synthetic arrays, ≤ 32³ unless stated; expectations labeled
 Property tests: input-order independence (fixture dict order shuffled); replay identity
 (byte-equal artifacts); **translation invariance on the torus** (same cluster shifted ⇒
 same counts/shape, different absolute bbox, `wraps` consistent); stable IDs across
-runs; dedup across snapshot chains; bounded output size; input hashes unchanged; no
+runs; dedup across snapshot chains; bounded output size (the `MAX_SNAPSHOTS` = 64
+invocation ceiling bounds header `snapshot_ids`/`generations` and observation lists,
+alongside the component cap; over-ceiling input is an `invalid_input` refusal — see §5);
+input hashes unchanged; no
 network (no socket imports); no filesystem writes outside the explicit artifact.
 
 ## 8. LeanCTX artifact contract (Pass 7) `[PROP]` — metaphor → engineering

--- a/experiments/swarm_hunter_lab/README.md
+++ b/experiments/swarm_hunter_lab/README.md
@@ -21,12 +21,16 @@ asserted by tests **in both directions**.
   refused (with the existing `invalid_input` / `invalid_provenance` /
   `invalid_sha256_format` reasons) before any `len`/iteration/`keys`/`.get`/
   subscript hook runs, so a hostile container cannot execute code at the
-  boundary. Inside each exact dict, **every key is proven an exact built-in
-  `str`** (by hash-free iteration) before any `set(...keys())`/membership/lookup
-  hashes or compares it, and the provenance **`source` discriminator is proven
-  an exact built-in `str`** before it is compared with `"synthetic"` — so a
-  hostile stored key's `__hash__`/`__eq__` or a hostile scalar's `__eq__` never
-  runs (a non-str key or non-str source → the existing `invalid_input` refusal).
+  boundary. Each exact dict's **cardinality is checked first** (hook-free
+  `len()`): a dict with more than its closed key budget (snapshot 4, provenance
+  7, `sha256_triple` 3) is refused in O(1) *before* any key traversal or set
+  allocation, so arbitrarily many junk keys cannot force unbounded work. Then
+  inside each exact dict, **every key is proven an exact built-in `str`** (by
+  hash-free iteration) before any `set(...keys())`/membership/lookup hashes or
+  compares it, and the provenance **`source` discriminator is proven an exact
+  built-in `str`** before it is compared with `"synthetic"` — so a hostile
+  stored key's `__hash__`/`__eq__` or a hostile scalar's `__eq__` never runs (a
+  non-str key or non-str source → the existing `invalid_input` refusal).
   An empty sequence or more than 64 snapshots is unsupported input
   → the existing `invalid_input` structured refusal (decided before any item
   is inspected; **not** a truncation). Each snapshot is `states: uint8 (N,N,N)`

--- a/experiments/swarm_hunter_lab/README.md
+++ b/experiments/swarm_hunter_lab/README.md
@@ -14,7 +14,16 @@ asserted by tests **in both directions**.
 
 ## Contract (frozen)
 
-- Input: an ordered sequence of snapshots — `states: uint8 (N,N,N)`
+- Input: an ordered sequence of **1 to `MAX_SNAPSHOTS` (= 64)** snapshots.
+  At the direct-Python boundary the top-level container must be an **exact
+  built-in `list` or `tuple`**, and each snapshot, its provenance, and its
+  supplied `sha256_triple` must be **exact built-in `dict`s** — subclasses are
+  refused (with the existing `invalid_input` / `invalid_provenance` /
+  `invalid_sha256_format` reasons) before any `len`/iteration/`keys`/`.get`/
+  subscript hook runs, so a hostile container cannot execute code at the
+  boundary. An empty sequence or more than 64 snapshots is unsupported input
+  → the existing `invalid_input` structured refusal (decided before any item
+  is inspected; **not** a truncation). Each snapshot is `states: uint8 (N,N,N)`
   (`[z][y][x]`, flat convention `z·N²+y·N+x`), optional
   `memory: float32 (8,N,N,N)`, optional `inactivity_steps: int16 (N,N,N)`,
   and a closed provenance dict (`source="synthetic"` only; caller-supplied

--- a/experiments/swarm_hunter_lab/README.md
+++ b/experiments/swarm_hunter_lab/README.md
@@ -21,7 +21,13 @@ asserted by tests **in both directions**.
   refused (with the existing `invalid_input` / `invalid_provenance` /
   `invalid_sha256_format` reasons) before any `len`/iteration/`keys`/`.get`/
   subscript hook runs, so a hostile container cannot execute code at the
-  boundary. An empty sequence or more than 64 snapshots is unsupported input
+  boundary. Inside each exact dict, **every key is proven an exact built-in
+  `str`** (by hash-free iteration) before any `set(...keys())`/membership/lookup
+  hashes or compares it, and the provenance **`source` discriminator is proven
+  an exact built-in `str`** before it is compared with `"synthetic"` — so a
+  hostile stored key's `__hash__`/`__eq__` or a hostile scalar's `__eq__` never
+  runs (a non-str key or non-str source → the existing `invalid_input` refusal).
+  An empty sequence or more than 64 snapshots is unsupported input
   → the existing `invalid_input` structured refusal (decided before any item
   is inspected; **not** a truncation). Each snapshot is `states: uint8 (N,N,N)`
   (`[z][y][x]`, flat convention `z·N²+y·N+x`), optional

--- a/experiments/swarm_hunter_lab/detector.py
+++ b/experiments/swarm_hunter_lab/detector.py
@@ -23,7 +23,7 @@ import dataclasses
 import hashlib
 import json
 import struct
-from typing import Mapping, Optional, Sequence
+from typing import Optional
 
 import numpy as np
 
@@ -34,6 +34,14 @@ DETECTOR_VERSION = "s1.0.0"
 SCHEMA_ID = schema.SCHEMA_ID
 
 MAX_N = 64
+#: Fixed invocation ceiling: detect_structures accepts 1..MAX_SNAPSHOTS
+#: snapshots per call. This is a hard resource control (S0 §4 risks 12-13,
+#: §5 bounded-resource contract, §7 bounded output): the deterministic
+#: op-budget scales with snapshot count and so can never truncate on count
+#: alone, so the ceiling is enforced explicitly. Exceeding it is
+#: unsupported/malformed input (existing ``invalid_input`` refusal), not a
+#: truncation. Deliberately equal to MAX_N; the two bounds are independent.
+MAX_SNAPSHOTS = 64
 MAX_GENERATION = 2 ** 64 - 1
 LEANCTX_MAX_BYTES = 64 * 1024
 LEANCTX_MAX_RECORDS = 200
@@ -146,14 +154,17 @@ def _validate_states(arr, sid: Optional[str]) -> int:
 
 def _validate_snapshot(item, ctx):
     """Stages 3a-3h for one snapshot. Returns the validated snapshot dict."""
-    if not isinstance(item, Mapping):
+    # exact built-in dict proven before item.keys()/subscript/get, so a dict
+    # SUBCLASS with a hostile keys()/__getitem__ cannot execute its hooks here.
+    if type(item) is not dict:
         raise _Refusal("invalid_input")
     keys = set(item.keys())
     if not keys <= _ALLOWED_SNAPSHOT_KEYS or "states" not in keys or "provenance" not in keys:
         raise _Refusal("invalid_input")
 
     prov = item["provenance"]
-    if not isinstance(prov, Mapping) or set(prov.keys()) != _PROVENANCE_KEYS:
+    # exact built-in dict proven (short-circuit) before prov.keys()/subscript.
+    if type(prov) is not dict or set(prov.keys()) != _PROVENANCE_KEYS:
         raise _Refusal("invalid_provenance")
 
     sid = _validate_identifier(prov["snapshot_id"])
@@ -197,7 +208,8 @@ def _validate_snapshot(item, ctx):
             raise _Refusal("invalid_optional_data", sid)
 
     supplied = prov["sha256_triple"]
-    if (not isinstance(supplied, Mapping)
+    # exact built-in dict proven (short-circuit) before supplied.keys()/subscript.
+    if (type(supplied) is not dict
             or set(supplied.keys()) != schema.SHA256_TRIPLE_KEYS):
         raise _Refusal("invalid_sha256_format", sid)
     for slot in sorted(schema.SHA256_TRIPLE_KEYS):
@@ -390,9 +402,20 @@ def detect_structures(snapshots, config: DetectorConfig = DetectorConfig()) -> F
     try:
         _validate_config(config)                                   # stage 1
         config_valid = True
-        if (isinstance(snapshots, (str, bytes, Mapping))
-                or not isinstance(snapshots, Sequence) or len(snapshots) == 0):
-            raise _Refusal("invalid_input")                        # stage 2
+        # stage 2 — exact built-in container + invocation ceiling, all proven
+        # before any caller-controlled len/iteration/item hook can run. type()
+        # identity rejects list/tuple SUBCLASSES (whose __len__/__iter__ could
+        # be hostile) up front, so the builtin len() calls below are hook-free.
+        # The 1..MAX_SNAPSHOTS domain is public input policy: an over-limit or
+        # empty sequence is unsupported/malformed input (existing invalid_input
+        # refusal), decided before iteration or item validation — never a
+        # truncation and never partial processing.
+        if type(snapshots) is not list and type(snapshots) is not tuple:
+            raise _Refusal("invalid_input")                        # stage 2a
+        if len(snapshots) == 0:
+            raise _Refusal("invalid_input")                        # stage 2b
+        if len(snapshots) > MAX_SNAPSHOTS:
+            raise _Refusal("invalid_input")                        # stage 2c
         validated = [_validate_snapshot(item, ctx) for item in snapshots]  # 3
 
         ids = [s["snapshot_id"] for s in validated]                # stage 4

--- a/experiments/swarm_hunter_lab/detector.py
+++ b/experiments/swarm_hunter_lab/detector.py
@@ -152,26 +152,51 @@ def _validate_states(arr, sid: Optional[str]) -> int:
     return n
 
 
+def _require_str_keys(mapping, reason, sid=None):
+    """Prove every key of an exact built-in ``dict`` is itself an exact built-in
+    ``str`` BEFORE any set construction / membership / lookup / ``.get`` hashes
+    or compares those keys. Plain dict iteration yields keys WITHOUT hashing
+    them, so a hostile stored key's ``__hash__``/``__eq__`` never runs here (the
+    exact-container guard alone does not cover keys *inside* an exact dict). A
+    non-str key is structurally malformed JSON-shaped input -> the caller's
+    reason (``invalid_input`` at every level)."""
+    for k in mapping:
+        if type(k) is not str:
+            raise _Refusal(reason, sid)
+
+
 def _validate_snapshot(item, ctx):
     """Stages 3a-3h for one snapshot. Returns the validated snapshot dict."""
     # exact built-in dict proven before item.keys()/subscript/get, so a dict
     # SUBCLASS with a hostile keys()/__getitem__ cannot execute its hooks here.
     if type(item) is not dict:
         raise _Refusal("invalid_input")
+    # then prove every stored key is an exact str before set(item.keys()) hashes
+    # them — a hostile key inside an exact dict would otherwise fire __hash__.
+    _require_str_keys(item, "invalid_input")
     keys = set(item.keys())
     if not keys <= _ALLOWED_SNAPSHOT_KEYS or "states" not in keys or "provenance" not in keys:
         raise _Refusal("invalid_input")
 
     prov = item["provenance"]
-    # exact built-in dict proven (short-circuit) before prov.keys()/subscript.
-    if type(prov) is not dict or set(prov.keys()) != _PROVENANCE_KEYS:
+    # exact built-in dict proven first (subclass -> invalid_provenance), then
+    # every stored key proven exact str before set(prov.keys()) hashes them.
+    if type(prov) is not dict:
+        raise _Refusal("invalid_provenance")
+    _require_str_keys(prov, "invalid_input")
+    if set(prov.keys()) != _PROVENANCE_KEYS:
         raise _Refusal("invalid_provenance")
 
     sid = _validate_identifier(prov["snapshot_id"])
     ctx["ids_seen"].append(sid)
     clv = _validate_identifier(prov["channel_layout_version"])
 
-    if prov["source"] != "synthetic":
+    source = prov["source"]
+    # prove exact str before the "synthetic" comparison, so a hostile scalar's
+    # __eq__ cannot run at this discriminator.
+    if type(source) is not str:
+        raise _Refusal("invalid_input", sid)
+    if source != "synthetic":
         raise _Refusal("s2_gated", sid)
 
     states = item["states"]
@@ -208,9 +233,12 @@ def _validate_snapshot(item, ctx):
             raise _Refusal("invalid_optional_data", sid)
 
     supplied = prov["sha256_triple"]
-    # exact built-in dict proven (short-circuit) before supplied.keys()/subscript.
-    if (type(supplied) is not dict
-            or set(supplied.keys()) != schema.SHA256_TRIPLE_KEYS):
+    # exact built-in dict proven first (subclass -> invalid_sha256_format), then
+    # every stored key proven exact str before set(supplied.keys()) hashes them.
+    if type(supplied) is not dict:
+        raise _Refusal("invalid_sha256_format", sid)
+    _require_str_keys(supplied, "invalid_input", sid)
+    if set(supplied.keys()) != schema.SHA256_TRIPLE_KEYS:
         raise _Refusal("invalid_sha256_format", sid)
     for slot in sorted(schema.SHA256_TRIPLE_KEYS):
         if not schema.is_hex64(supplied[slot]):

--- a/experiments/swarm_hunter_lab/detector.py
+++ b/experiments/swarm_hunter_lab/detector.py
@@ -171,6 +171,14 @@ def _validate_snapshot(item, ctx):
     # SUBCLASS with a hostile keys()/__getitem__ cannot execute its hooks here.
     if type(item) is not dict:
         raise _Refusal("invalid_input")
+    # cardinality gate BEFORE any key traversal / set allocation: len() is
+    # hook-free on a proven exact dict, and a closed snapshot has at most
+    # len(_ALLOWED_SNAPSHOT_KEYS) keys — so an over-size dict (arbitrarily many
+    # ordinary junk str keys) is refused here in O(1) rather than traversed and
+    # copied into a temporary set. Over-cardinality, not equality: smaller
+    # dicts stay bounded and flow to the exact-str + closed-key checks below.
+    if len(item) > len(_ALLOWED_SNAPSHOT_KEYS):
+        raise _Refusal("invalid_input")
     # then prove every stored key is an exact str before set(item.keys()) hashes
     # them — a hostile key inside an exact dict would otherwise fire __hash__.
     _require_str_keys(item, "invalid_input")
@@ -182,6 +190,8 @@ def _validate_snapshot(item, ctx):
     # exact built-in dict proven first (subclass -> invalid_provenance), then
     # every stored key proven exact str before set(prov.keys()) hashes them.
     if type(prov) is not dict:
+        raise _Refusal("invalid_provenance")
+    if len(prov) > len(_PROVENANCE_KEYS):
         raise _Refusal("invalid_provenance")
     _require_str_keys(prov, "invalid_input")
     if set(prov.keys()) != _PROVENANCE_KEYS:
@@ -236,6 +246,8 @@ def _validate_snapshot(item, ctx):
     # exact built-in dict proven first (subclass -> invalid_sha256_format), then
     # every stored key proven exact str before set(supplied.keys()) hashes them.
     if type(supplied) is not dict:
+        raise _Refusal("invalid_sha256_format", sid)
+    if len(supplied) > len(schema.SHA256_TRIPLE_KEYS):
         raise _Refusal("invalid_sha256_format", sid)
     _require_str_keys(supplied, "invalid_input", sid)
     if set(supplied.keys()) != schema.SHA256_TRIPLE_KEYS:

--- a/experiments/swarm_hunter_lab/tests/test_properties.py
+++ b/experiments/swarm_hunter_lab/tests/test_properties.py
@@ -12,7 +12,7 @@ from swarm_hunter_lab import (
     DetectorConfig, FindingsArtifact, compute_sha256_triple,
     detect_structures, fixtures, leanctx_summary, lp, schema,
 )
-from swarm_hunter_lab.detector import _axis_interval
+from swarm_hunter_lab.detector import MAX_SNAPSHOTS, _axis_interval
 
 
 def refusal_of(snaps, config=DetectorConfig()):
@@ -525,3 +525,167 @@ def test_max_lattice_64_cubed_measured():
     warnings.warn(
         f"S1-64cubed-observation: runtime={elapsed:.3f}s "
         f"tracemalloc_peak={peak / 1e6:.1f}MB (observation, not a promise)")
+
+
+# ---------------------------------------------------------------------------
+# S1 Amendment 3 — snapshot invocation ceiling (F1) + hook-free exact-container
+# input boundary (F2). MAX_SNAPSHOTS=64 is public input policy: 1..64 is the
+# accepted domain; >64, empty, non-list/tuple top-levels, and container
+# subclasses with hostile hooks all yield the EXISTING structured invalid_input
+# refusal (no new reason) BEFORE any caller-controlled len/iter/keys/get/subscript
+# hook runs. Accepted-input bytes are unchanged (the fixture + determinism tests
+# above still pass byte-for-byte). Hook-execution is proven zero via a counter
+# whose hooks also raise if ever reached; no broad exception catching is used.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_snap(i):
+    states = fixtures.block(fixtures.empty_lattice(4), 1, 1, 1, 2, 2, 2)
+    return fixtures.snapshot(states, f"amd3-s{i}", i + 1)
+
+
+class _HookFlag:
+    def __init__(self):
+        self.n = 0
+
+
+def test_amd3_exactly_64_snapshots_accepted():
+    snaps = [_tiny_snap(i) for i in range(MAX_SNAPSHOTS)]  # 64
+    header = detect_structures(snaps).records()[0]
+    assert header["kind"] == "header"
+    assert header["counts"]["refusals"] == 0
+    assert header["run"]["snapshot_count"] == 64
+
+
+def test_amd3_65_snapshots_refused_invalid_input_deterministically():
+    snaps = [_tiny_snap(i) for i in range(MAX_SNAPSHOTS + 1)]  # 65
+    _, refusal = refusal_of(snaps)
+    assert refusal["reason"] == "invalid_input"
+    assert detect_structures(snaps).jsonl == detect_structures(snaps).jsonl
+
+
+def test_amd3_over_limit_decided_before_item_inspection():
+    flag = _HookFlag()
+
+    class _HostileFirst(dict):
+        def keys(self):
+            flag.n += 1
+            raise AssertionError("keys() ran despite over-limit ceiling")
+
+        def __getitem__(self, k):
+            flag.n += 1
+            raise AssertionError("__getitem__ ran despite over-limit ceiling")
+
+    snaps = [_HostileFirst(_tiny_snap(0))] + [_tiny_snap(i)
+                                              for i in range(1, MAX_SNAPSHOTS + 1)]
+    assert len(snaps) == MAX_SNAPSHOTS + 1
+    _, refusal = refusal_of(snaps)
+    assert refusal["reason"] == "invalid_input"
+    assert flag.n == 0  # ceiling refused before the hostile first item was touched
+
+
+def test_amd3_invalid_config_wins_over_container_and_count():
+    snaps = [_tiny_snap(i) for i in range(MAX_SNAPSHOTS + 1)]  # over-limit
+    _, refusal = refusal_of(snaps, DetectorConfig(component_cap=0))
+    assert refusal["reason"] == "invalid_config"
+
+
+def test_amd3_exact_list_and_tuple_accepted():
+    for ctor in (list, tuple):
+        header = detect_structures(ctor([_tiny_snap(0)])).records()[0]
+        assert header["kind"] == "header"
+
+
+def test_amd3_list_tuple_subclass_hostile_hooks_refused_no_execution():
+    flag = _HookFlag()
+
+    class _HLenList(list):
+        def __len__(self):
+            flag.n += 1
+            raise AssertionError("__len__ ran")
+
+    class _HIterTuple(tuple):
+        def __iter__(self):
+            flag.n += 1
+            raise AssertionError("__iter__ ran")
+
+    for hostile in (_HLenList([_tiny_snap(0)]), _HIterTuple((_tiny_snap(0),))):
+        _, refusal = refusal_of(hostile)
+        assert refusal["reason"] == "invalid_input"
+    assert flag.n == 0
+
+
+def test_amd3_snapshot_dict_subclass_hostile_hooks_refused_no_execution():
+    flag = _HookFlag()
+
+    class _HKeys(dict):
+        def keys(self):
+            flag.n += 1
+            raise AssertionError("keys() ran")
+
+    class _HGet(dict):
+        def __getitem__(self, k):
+            flag.n += 1
+            raise AssertionError("__getitem__ ran")
+
+    for hostile in (_HKeys(_tiny_snap(0)), _HGet(_tiny_snap(0))):
+        _, refusal = refusal_of([hostile])
+        assert refusal["reason"] == "invalid_input"
+    assert flag.n == 0
+
+
+def test_amd3_nested_provenance_and_triple_subclass_refused_no_execution():
+    flag = _HookFlag()
+
+    class _HKeys(dict):
+        def keys(self):
+            flag.n += 1
+            raise AssertionError("keys() ran")
+
+    # provenance dict subclass -> invalid_provenance at its structured stage
+    s = _tiny_snap(0)
+    s["provenance"] = _HKeys(s["provenance"])
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "invalid_provenance"
+    # supplied sha256_triple dict subclass -> invalid_sha256_format at its stage
+    s2 = _tiny_snap(0)
+    s2["provenance"]["sha256_triple"] = _HKeys(s2["provenance"]["sha256_triple"])
+    _, refusal2 = refusal_of([s2])
+    assert refusal2["reason"] == "invalid_sha256_format"
+    assert flag.n == 0
+
+
+def test_amd3_ordinary_malformed_containers_keep_reasons_and_precedence():
+    for bad in ("xx", {"a": 1}, (x for x in [1])):
+        _, refusal = refusal_of(bad)
+        assert refusal["reason"] == "invalid_input"
+    _, refusal = refusal_of([])
+    assert refusal["reason"] == "invalid_input"
+    s = _tiny_snap(0)
+    del s["provenance"]["sha256_triple"]
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "invalid_provenance"
+
+
+def test_amd3_no_input_mutation_or_io(monkeypatch):
+    def boom(*args, **kwargs):
+        raise AssertionError("file I/O attempted")
+    monkeypatch.setattr(builtins, "open", boom)
+    snaps = [_tiny_snap(i) for i in range(3)]
+    before = [s["states"].copy() for s in snaps]
+    detect_structures(snaps)
+    for s, b in zip(snaps, before):
+        assert np.array_equal(s["states"], b)
+
+
+def test_amd3_valid_kinds_and_leanctx_still_accepted():
+    cases = (
+        detect_structures(fixtures.fx_single()),
+        detect_structures(fixtures.fx_malformed_provenance()),
+        detect_structures(fixtures.fx_checkerboard(),
+                          DetectorConfig(min_component_size=1, component_cap=64)),
+        detect_structures(fixtures.fx_single(), DetectorConfig(op_budget_multiplier=1)),
+    )
+    for art in cases:
+        assert schema.validate_records(list(art.records())) == []
+        assert b"leanctx-header" in leanctx_summary(art, "run-1")

--- a/experiments/swarm_hunter_lab/tests/test_properties.py
+++ b/experiments/swarm_hunter_lab/tests/test_properties.py
@@ -692,6 +692,84 @@ def test_amd3_valid_kinds_and_leanctx_still_accepted():
 
 
 # ---------------------------------------------------------------------------
+# S1 Amendment 3 follow-up (Jack resource-bound P2) — per-object dictionary
+# CARDINALITY gate. `len()` on a proven exact dict is hook-free, and each closed
+# dict has a fixed key budget (snapshot 4, provenance 7, sha256_triple 3), so an
+# over-size exact dict (arbitrarily many ordinary str junk keys) is refused in
+# O(1) BEFORE `_require_str_keys()` traverses it or `set(...keys())` copies it.
+# The spy records the identity of every dict handed to `_require_str_keys`; an
+# over-size dict must NOT appear (it was refused by the cardinality gate first).
+# Small over-size inputs + a spy are used, not manufactured enormous inputs.
+# ---------------------------------------------------------------------------
+
+
+def _spy_require_str_keys(monkeypatch, seen):
+    import swarm_hunter_lab.detector as _d
+    real = _d._require_str_keys
+
+    def spy(mapping, reason, sid=None):
+        seen.append(id(mapping))
+        return real(mapping, reason, sid)
+
+    monkeypatch.setattr(_d, "_require_str_keys", spy)
+
+
+def test_amd3_over_cardinality_snapshot_refused_before_traversal(monkeypatch):
+    seen = []
+    _spy_require_str_keys(monkeypatch, seen)
+    item = dict(_amd3_tiny())          # 2 keys
+    for i in range(50):
+        item[f"junk{i}"] = i           # 52 keys > 4
+    _, refusal = refusal_of([item])
+    assert refusal["reason"] == "invalid_input"
+    assert id(item) not in seen        # gate refused before _require_str_keys / set
+
+
+def test_amd3_over_cardinality_provenance_refused_before_traversal(monkeypatch):
+    seen = []
+    _spy_require_str_keys(monkeypatch, seen)
+    s = _amd3_tiny()
+    s["provenance"] = dict(s["provenance"])
+    for i in range(50):
+        s["provenance"][f"junk{i}"] = i    # 57 keys > 7
+    prov_id = id(s["provenance"])
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "invalid_provenance"
+    assert prov_id not in seen             # prov gate before its traversal/allocation
+    assert id(s) in seen                   # the in-bound snapshot dict was traversed
+
+
+def test_amd3_over_cardinality_supplied_triple_refused_before_traversal(monkeypatch):
+    seen = []
+    _spy_require_str_keys(monkeypatch, seen)
+    s = _amd3_tiny()
+    s["provenance"]["sha256_triple"] = dict(s["provenance"]["sha256_triple"])
+    for i in range(50):
+        s["provenance"]["sha256_triple"][f"junk{i}"] = i   # 53 keys > 3
+    triple_id = id(s["provenance"]["sha256_triple"])
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "invalid_sha256_format"
+    assert triple_id not in seen           # triple gate before its traversal/allocation
+
+
+def test_amd3_boundary_cardinalities_pass_to_normal_validation():
+    # exactly 4 snapshot keys (states, provenance, memory, inactivity_steps) is
+    # the boundary (not > 4) -> flows to normal validation and is accepted; the
+    # standard 7-key provenance and 3-key sha256_triple are likewise == the bound.
+    n = 4
+    states = fixtures.block(fixtures.empty_lattice(n), 1, 1, 1, 2, 2, 2)
+    memory = np.zeros((8, n, n, n), dtype=np.float32)
+    inactivity = np.zeros((n, n, n), dtype=np.int16)
+    snap = fixtures.snapshot(states, "amd3c-4key", 1,
+                             memory=memory, inactivity_steps=inactivity)
+    assert len(snap) == 4
+    assert len(snap["provenance"]) == 7
+    assert len(snap["provenance"]["sha256_triple"]) == 3
+    header = detect_structures([snap]).records()[0]
+    assert header["kind"] == "header" and header["counts"]["refusals"] == 0
+
+
+# ---------------------------------------------------------------------------
 # S1 Amendment 3 follow-up (Jack P2) — hostile KEYS stored inside an exact
 # built-in dict, and a hostile provenance `source` scalar. The exact-container
 # guards prove the container type but not the safety of keys/values inside it:
@@ -752,10 +830,15 @@ def test_amd3_snapshot_dict_armed_hostile_key_refused_no_hash():
 
 
 def test_amd3_provenance_dict_armed_hostile_key_refused_no_hash():
+    # WITHIN the 7-key cardinality bound (replace, don't add), so the hostile
+    # key is caught by _require_str_keys (not the cardinality gate) -> proves the
+    # hash-free exact-str key proof still refuses invalid_input with zero hooks.
     s = _amd3_tiny()
     key = _ArmedKey()
     s["provenance"] = dict(s["provenance"])
+    del s["provenance"]["num_states"]
     s["provenance"][key] = 1
+    assert len(s["provenance"]) == 7
     _ArmedKey.armed = True
     try:
         _, refusal = refusal_of([s])
@@ -765,10 +848,13 @@ def test_amd3_provenance_dict_armed_hostile_key_refused_no_hash():
 
 
 def test_amd3_supplied_triple_dict_armed_hostile_key_refused_no_hash():
+    # WITHIN the 3-key cardinality bound (replace, don't add).
     s = _amd3_tiny()
     key = _ArmedKey()
     s["provenance"]["sha256_triple"] = dict(s["provenance"]["sha256_triple"])
+    del s["provenance"]["sha256_triple"]["inactivity_steps"]
     s["provenance"]["sha256_triple"][key] = 1
+    assert len(s["provenance"]["sha256_triple"]) == 3
     _ArmedKey.armed = True
     try:
         _, refusal = refusal_of([s])

--- a/experiments/swarm_hunter_lab/tests/test_properties.py
+++ b/experiments/swarm_hunter_lab/tests/test_properties.py
@@ -689,3 +689,125 @@ def test_amd3_valid_kinds_and_leanctx_still_accepted():
     for art in cases:
         assert schema.validate_records(list(art.records())) == []
         assert b"leanctx-header" in leanctx_summary(art, "run-1")
+
+
+# ---------------------------------------------------------------------------
+# S1 Amendment 3 follow-up (Jack P2) — hostile KEYS stored inside an exact
+# built-in dict, and a hostile provenance `source` scalar. The exact-container
+# guards prove the container type but not the safety of keys/values inside it:
+# set(dict.keys()) hashes stored keys, and `source != "synthetic"` compares the
+# stored value, so an armed hostile `__hash__`/`__eq__` could fire. Every stored
+# key is now proven an exact built-in str (via hash-free dict iteration) and the
+# source is proven an exact str before those operations, all yielding the
+# existing invalid_input refusal with the hostile hook executing ZERO times.
+# ---------------------------------------------------------------------------
+
+
+class _ArmedKey:
+    """Hashable while disarmed (constant hash); once armed, both __hash__ and
+    __eq__ raise. Inserted into a dict while benign, then armed — exactly the
+    Jack-described attack. A boundary that hashes/compares it after arming
+    trips the AssertionError; a correct boundary refuses via type() first."""
+    armed = False
+
+    def __hash__(self):
+        if _ArmedKey.armed:
+            raise AssertionError("__hash__ ran on an armed hostile key")
+        return 0
+
+    def __eq__(self, other):
+        if _ArmedKey.armed:
+            raise AssertionError("__eq__ ran on an armed hostile key")
+        return self is other
+
+
+class _ArmedEq:
+    """Hashable scalar whose __eq__ raises once armed (a hostile `source`)."""
+    armed = False
+
+    def __eq__(self, other):
+        if _ArmedEq.armed:
+            raise AssertionError("__eq__ ran on an armed hostile source")
+        return False
+
+    def __hash__(self):
+        return 0
+
+
+def _amd3_tiny():
+    return fixtures.snapshot(
+        fixtures.block(fixtures.empty_lattice(4), 1, 1, 1, 2, 2, 2), "amd3b-s", 1)
+
+
+def test_amd3_snapshot_dict_armed_hostile_key_refused_no_hash():
+    key = _ArmedKey()
+    item = dict(_amd3_tiny())
+    item[key] = 1              # inserted while benign
+    _ArmedKey.armed = True     # armed afterward
+    try:
+        _, refusal = refusal_of([item])
+        assert refusal["reason"] == "invalid_input"
+    finally:
+        _ArmedKey.armed = False
+
+
+def test_amd3_provenance_dict_armed_hostile_key_refused_no_hash():
+    s = _amd3_tiny()
+    key = _ArmedKey()
+    s["provenance"] = dict(s["provenance"])
+    s["provenance"][key] = 1
+    _ArmedKey.armed = True
+    try:
+        _, refusal = refusal_of([s])
+        assert refusal["reason"] == "invalid_input"
+    finally:
+        _ArmedKey.armed = False
+
+
+def test_amd3_supplied_triple_dict_armed_hostile_key_refused_no_hash():
+    s = _amd3_tiny()
+    key = _ArmedKey()
+    s["provenance"]["sha256_triple"] = dict(s["provenance"]["sha256_triple"])
+    s["provenance"]["sha256_triple"][key] = 1
+    _ArmedKey.armed = True
+    try:
+        _, refusal = refusal_of([s])
+        assert refusal["reason"] == "invalid_input"
+    finally:
+        _ArmedKey.armed = False
+
+
+def test_amd3_provenance_source_hostile_eq_refused_no_compare():
+    s = _amd3_tiny()
+    s["provenance"]["source"] = _ArmedEq()
+    _ArmedEq.armed = True
+    try:
+        _, refusal = refusal_of([s])
+        assert refusal["reason"] == "invalid_input"
+    finally:
+        _ArmedEq.armed = False
+
+
+def test_amd3_str_subclass_key_and_source_refused():
+    # adjacent audit cases: a str SUBCLASS key/source (which could carry hostile
+    # __hash__/__eq__) is rejected by the exact-str type identity check.
+    class _S(str):
+        pass
+    item = dict(_amd3_tiny())
+    item[_S("extra")] = 1
+    _, refusal = refusal_of([item])
+    assert refusal["reason"] == "invalid_input"
+    s = _amd3_tiny()
+    s["provenance"]["source"] = _S("synthetic")
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "invalid_input"
+
+
+def test_amd3_valid_string_source_discriminator_preserved():
+    # the source proof must not change the existing str-source behavior:
+    # a valid non-synthetic string still yields s2_gated, synthetic still runs.
+    s = _amd3_tiny()
+    s["provenance"]["source"] = "snapshot"
+    _, refusal = refusal_of([s])
+    assert refusal["reason"] == "s2_gated"
+    assert detect_structures([_amd3_tiny()]).records()[0]["kind"] == "header"


### PR DESCRIPTION
## S1 Amendment 3 — snapshot invocation ceiling (F1) + hook-free exact-container input boundary (F2)

S1-only, four permitted files (three under `experiments/swarm_hunter_lab/` plus `docs/SWARM_HUNTER_V1_PREFLIGHT.md`, which lives outside the lab directory — so "S1-only," not "lab-only"). **Draft — do not merge.** Opened for Jack's audit. Closes the two defects Jack confirmed from the post-seal adversarial audit, plus the follow-up P2 (see the dated reconciliation at the bottom).

### F1 — CONFIRMED: no snapshot-count ceiling
S0 §4 risks 12–13, §5's bounded-resource contract and §7's bounded-output requirement promise hard resource controls, but `detect_structures()` had **no snapshot-count ceiling**. Both `required_ops` and `op_budget = multiplier × volume × len(snapshots)` scale linearly with count, so at the default multiplier `required_ops ≤ 4·volume·count` vs budget `16·volume·count` — every well-formed sequence passes regardless of length. Validation, discovery, `run.snapshot_ids`, `run.generations`, persistence observation lists and serialization grew without a ceiling.

**Failing-before (unmodified tree):** 65 valid tiny snapshots → `header + 1 finding`, `refusals=0`, `truncated=False`, `snapshot_ids` length 65 — accepted, no truncation.

**Repair:** fixed `MAX_SNAPSHOTS = 64` invocation ceiling at **stage 2** — `1..64` is the accepted public input domain; empty or `>64` is unsupported input → the **existing `invalid_input`** structured refusal, decided **before any item is inspected** (not a truncation, not partial processing, **no new refusal reason**). `required_ops`/`op_budget` arithmetic and component-cap semantics are unchanged.

**Post-repair:** 64 accepted · 65 → `invalid_input` (deterministic, byte-identical repeat) · 0 → `invalid_input` · a 65-sequence whose **first item is a hostile dict** still refuses `invalid_input` with **0 hooks executed** (ceiling decided before item inspection) · invalid config still wins.

### F2 — CONFIRMED: totality gap at the container boundary
The public boundary accepted arbitrary `Sequence`/`Mapping` and then invoked caller-controlled `len`/iteration/`keys`/`.get`/subscript hooks **before** establishing exact built-in containers, so a `list`/`tuple`/`dict` subclass with a hostile hook could escape a raw exception instead of the frozen structured refusal.

**Failing-before (unmodified tree), all escaped their sentinel:** `list`-subclass hostile `__len__`; `tuple`-subclass hostile `__iter__`; snapshot-`dict` hostile `keys()`; provenance-`dict` hostile `keys()`; `sha256_triple`-`dict` hostile `keys()`; snapshot-`dict` hostile `__getitem__`.

**Repair:** prove **exact built-in `list`/`tuple`** for the top-level container (before `len`/iteration) and **exact built-in `dict`** for each snapshot, its provenance, and its supplied `sha256_triple` (before `keys`/`.get`/subscript), via `type()` identity + `or`-short-circuit. Hostile subclasses are refused with their **existing** reasons (`invalid_input` / `invalid_provenance` / `invalid_sha256_format`).

**Post-repair (flag proves zero hook execution):** all six hostile cases refuse with the correct reason and **`hooks_ran = 0`**; plain `list` and `tuple` still accepted; ordinary malformed built-in containers keep their existing reasons and precedence.

### Frozen-semantics / accepted-byte equivalence
Accepted-input detector **and** LeanCTX bytes are **byte-identical** to the pre-amendment base — proven over **22 cases** (11 fixture artifacts + 11 LeanCTX summaries), **0 mismatches**. Unchanged: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, component-cap & op-budget arithmetic, `components_emitted`, hashing/canonicalization, LeanCTX behavior, S2/Lane-A gates. First-failure order preserved apart from the explicit stage-2 ceiling. The unused `typing.Mapping`/`Sequence` imports are dropped.

### Tests, docs, diffstat
- **Regressions: +11 focused tests (55 → 66 lab-local)** — ceiling (64 accept / 65 refuse / 0 refuse), over-limit-before-item-inspection, config precedence, exact list/tuple acceptance, list/tuple-subclass hostile-hook refusal with zero-execution flags, snapshot/provenance/`sha256_triple`-dict subclass refusal at proper stages, preserved reasons for ordinary malformed containers, no input mutation or I/O, and all four valid artifact classes + LeanCTX still accepted. No broad exception catching.
- **Docs:** `README.md` records the exact 1–64 invocation domain + exact-container requirement; preflight §4 risks 12–13 (marked closed), §5 bounded-resources (ceiling + retained honest op-counter disclosure), §7 bounded-output reconciled. Historical narrative and S2/Lane-A gates preserved.
- **Diffstat (exactly 4 files):** `detector.py +37`, `tests/test_properties.py +166`, `README.md +11`, `docs/SWARM_HUNTER_V1_PREFLIGHT.md +33`.
- CI: lab-local suite green (66); `swarm-hunter-lab` workflow gates it. Maintained `verify-python` scopes to `tests/` (lab excluded by design).

### Authority & fences
Kev (repo owner) personally authorized this exact package (four permitted files, MAX_SNAPSHOTS=64 + hook-free containers, failing-first regressions, doc corrections, one focused commit, one branch, one draft PR, `swarm-hunter` label, CI observation). **No merge, no thread actions.** Untouched: #393, S2 and all later Swarm Hunter stages, `components_emitted`, schema/version identifiers, services, machines, Ollama, and every other lane.

### Model identity
Authored by seat 84 = **Claude Opus 4.8** (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Reconciliation — follow-up commit for Jack's P2 (2026-07-19)

**Jack P2:** the exact-*container* guards above stop subclassed-container hooks, but they do not make the keys/values *stored inside* an exact built-in dict safe. `set(item.keys())` / `set(prov.keys())` / `set(supplied.keys())` **hash** every stored key (a custom hashable key inserted while benign, armed afterward, then raises from `__hash__`), and `prov["source"] != "synthetic"` **compares** the stored value before proving it is an exact `str` (a hostile scalar's `__eq__` can fire).

- **Old head:** `a3acedeb526696bd1e40e1308e43bc5f2259250b` · **New head:** `cd0e877b7b07ef752f4f207737da934cf03d3e33` (one focused follow-up commit; normal fast-forward, no rebase/force).
- **Failing-before (unmodified `a3acede`):** all four escaped their armed sentinel — snapshot-dict, provenance-dict, `sha256_triple`-dict hostile-key `__hash__`, and provenance-`source` `__eq__`.
- **Repair (`detector.py` only):** a new `_require_str_keys(mapping, reason, sid)` proves every key of an exact dict is an exact built-in `str` via **hash-free dict iteration** (iteration yields keys without hashing them), *before* any `set(...keys())`/membership/lookup runs — applied to the snapshot, provenance, and supplied-`sha256_triple` dicts; the existing set/exact-key logic is **retained, not** replaced with a key-view comparison. The provenance `source` is proven `type(source) is str` before the `!= "synthetic"` comparison. A non-str key or non-str source → the existing **`invalid_input`** structured refusal.
- **Bounded audit of the public path** (`detect_structures → _validate_snapshot → _validate_identifier/_validate_states`) confirms every *other* scalar comparison / hash already sits behind an exact-type proof (config fields; `lattice_size`/`num_states`/`generation` via `isinstance(bool)` + `type() is int`; arrays via `type() is np.ndarray`; hex values via `is_hex64`'s `type() is str`; identifiers via `is_safe_id`'s `type() is str`). These four were the only pre-proof hash/compare sites on hostile stored data.
- **Passing-after (flag-asserted, zero hook execution):** all four vectors → deterministic `invalid_input` with the armed `__hash__`/`__eq__` executing **0 times**; a `str`-subclass key/source is also refused (`type() is not str`); a valid non-`"synthetic"` **string** source still yields `s2_gated`.
- **Accepted-byte equivalence:** byte-identical to `a3acede` — **22 cases (11 fixture artifacts + 11 LeanCTX), 0 mismatches**. Unchanged: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, cap/budget arithmetic, `components_emitted`, hashing/canonicalization, LeanCTX; 1–64 ceiling, 65-item rejection, invalid-config precedence, no mutation/I/O, and all existing regressions retained.
- **Regressions: +6 (66 → 72 lab-local)** — armed hostile key in the snapshot / provenance / supplied-triple dicts, hostile `source` `__eq__`, str-subclass key & source rejection, and the preserved valid-string source discriminator. README + preflight §5 now state that exact built-in containers, **exact-string keys**, and the **exact-string `source` discriminator** are proven before hook-invoking operations.
- **Diffstat (this commit, exactly 4 files):** `detector.py +40`, `tests/test_properties.py +122`, `README.md +8`, `docs/SWARM_HUNTER_V1_PREFLIGHT.md +8`.
- **Fences:** amended the existing #394 branch (no new PR); draft/unmerged; the three Gemini threads left untouched (unreplied/unresolved/no reaction); #393 and every other lane untouched; no merge/ready/rebase/force/admin/settings.
- **Model:** Claude Opus 4.8 (`claude-opus-4-8`); a transient host "model temporarily unavailable" notice occurred mid-run (availability event, not a seat change) — recorded, seat unchanged.


---

## Reconciliation — resource-bound P2 (cardinality gates) — 2026-07-19

**Jack (resource-bound P2):** the hostile-key/source repair is correct, but there was **no dictionary-cardinality gate** before `_require_str_keys()` and `set(...)`. An exact built-in dict may hold arbitrarily many ordinary string junk keys, so a snapshot/provenance/`sha256_triple` dict could force **unbounded key traversal and temporary-set allocation** before refusal; `MAX_SNAPSHOTS=64` bounds the outer sequence but not this nested work.

- **Old head:** `cd0e877b7b07ef752f4f207737da934cf03d3e33` · **New head:** `10f462a4a7207d7f14fb23f527c32753a112ccaf` (one focused follow-up commit; normal fast-forward, remote reverified at `cd0e877` pre-push; no rebase/force; **not** updated from main).
- **Failing-before (spy on `_require_str_keys`, `cd0e877`):** snapshot of 102 keys / provenance of 107 / `sha256_triple` of 103 were each **fully traversed** before refusal.
- **Repair (`detector.py` only):** after each exact-dict proof (`len()` is hook-free on a proven exact dict) and **before** `_require_str_keys()`: snapshot `len > 4 → invalid_input`; provenance `len > 7 → invalid_provenance`; `sha256_triple` `len > 3 → invalid_sha256_format`. **Over-cardinality checks, not equality** — smaller malformed dicts stay bounded and continue to the existing exact-str + closed-key checks, preserving their established reasons. Capped at 4/7/3, key iteration and set allocation are constant-bounded.
- **Passing-after (same spy):** the over-size dicts are **no longer handed to `_require_str_keys`** (refused O(1) by the gate); only in-bound dicts (item 2, prov 7) are traversed. All armed hostile-key/source tests still pass with zero hook execution.
- **Accepted-byte equivalence:** byte-identical to `cd0e877` — **22 cases (11 fixture artifacts + 11 LeanCTX), 0 mismatches**. Unchanged: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, cap/budget arithmetic, `components_emitted`, hashing, LeanCTX; 1–64 ceiling, hook-free key/source proofs, invalid-config precedence, no mutation/I/O retained.

**Bounded-input table — every caller-controlled cardinality that is traversed or copied is now bounded:**

| Input object | Bound | Enforced by |
|---|---|---|
| snapshots sequence | ≤ 64 | stage-2c `MAX_SNAPSHOTS` ceiling (before iteration) |
| snapshot dict | ≤ 4 keys | **new** cardinality gate (`len > len(_ALLOWED_SNAPSHOT_KEYS)` → `invalid_input`) |
| provenance dict | ≤ 7 keys | **new** cardinality gate (`len > len(_PROVENANCE_KEYS)` → `invalid_provenance`) |
| `sha256_triple` dict | ≤ 3 keys | **new** cardinality gate (`len > len(schema.SHA256_TRIPLE_KEYS)` → `invalid_sha256_format`) |
| `states` array | ≤ 64³ cells | `_validate_states` (`n > MAX_N` → `lattice_too_large`; exact `(n,n,n)` shape) |
| `memory` array | (8, N, N, N), N ≤ 64 | exact shape check |
| `inactivity_steps` array | (N, N, N), N ≤ 64 | exact shape check |
| `snapshot_id` / `channel_layout_version` | ≤ 64 chars | `is_safe_id` grammar `{0,63}` fullmatch (longer fails in bounded steps) |
| `sha256_triple` values | 64 hex chars ×3 | `is_hex64` fullmatch |
| config | 3 int fields, bounded ranges | frozen `DetectorConfig` (3 fields) + `_validate_config` |
| `generation` | ≤ 2⁶⁴−1 | range check after exact-int proof |
| `source` | exact `str`, `== "synthetic"` | `type(source) is str` proof + equality |

- **Regressions: +4 (72 → 76 lab-local)** — over-cardinality snapshot / provenance / supplied-triple refused **before traversal** (spy asserts the over-size dict is never handed to `_require_str_keys`), and boundary cardinalities (4/7/3) still pass to normal validation. The two existing prov/supplied armed-hostile-key tests are restructured to stay **within** the bound (replace a key, not add) so they keep exercising the hash-free `_require_str_keys` path; the snapshot armed-key and source tests are unchanged. No broad exception catching; small over-size inputs + a spy (no manufactured enormous inputs).
- **Diffstat (this commit, exactly 4 files):** `detector.py +12/−0` · `tests/test_properties.py +86/−0` · `README.md +10/−6` · `docs/SWARM_HUNTER_V1_PREFLIGHT.md +12/−7` (total **+120/−13**).
- **Diffstat correction (prior commit):** the preceding follow-up `cd0e877`'s exact `+A/−D` is `detector.py +34/−6` · `tests/test_properties.py +122/−0` · `README.md +7/−1` · `docs/SWARM_HUNTER_V1_PREFLIGHT.md +7/−1` (total **+170/−8**) — the earlier reconciliation quoted the `--stat` bar display, not the true counts.
- **Current-main relationship:** main is `0bfc84243bda5d34ee7746bb01192a67b19e516e` (after #393 merged); #394 is **behind** and was deliberately **not** updated from main this repair.
- **Fences:** existing #394 branch/PR only; four permitted S1 files; draft/unmerged; no ready/merge/main-update/rebase/force/admin/settings; the three Gemini threads left untouched (no reply/resolve/reaction); merged #393 and every other lane untouched.
- **Model:** Claude Opus 4.8 (`claude-opus-4-8`).


---

## Merge reconciliation — 2026-07-19 (Jack final verdict + Kev's closure authorization)

**This section supersedes the "Draft — do not merge / opened for Jack's audit" gate above.** Jack's final audit is complete with **no remaining code findings**: the snapshot invocation ceiling, the exact-container boundary, the exact-string key/source proofs, and the 4/7/3 dictionary-cardinality gates are all **approved**. Kev personally authorized the update-and-merge closure.

- **Audited head:** `10f462a4a7207d7f14fb23f527c32753a112ccaf` · **branch point:** `fc3671b2f419a4ef3b832c0d3551aeb933231936`.
- **Updated head:** `c1d681ff1cb5c12cdabd42ff3135668bbd58f613` — one ordinary merge of current main `d0bf6a290183892a1af53f8a985838e03ce37d69` into the branch. No rebase, no rewritten commits, no force-push, no conflicts.
- **Equivalence receipt:** `git diff d0bf6a2..c1d681f` is **byte-identical** to the audited `git diff fc3671b..10f462a` — exactly the same four S1 files, **+502/−18**: `docs/SWARM_HUNTER_V1_PREFLIGHT.md +37/−7` · `experiments/swarm_hunter_lab/README.md +20/−1` · `experiments/swarm_hunter_lab/detector.py +72/−9` · `experiments/swarm_hunter_lab/tests/test_properties.py +373/−1`.
- **Main advance since branch point (disjointness gate):** #393 (`0bfc842`) and #395 (`d0bf6a2`) — both Nextness-only; **zero overlap** with the four S1 files, verified before the merge.
- **Fresh CI at `c1d681f` (all conclusive, none pending/neutral):** `swarm-hunter-lab` **76 passed** · `verify-python` success · `frontend-quality` success · `agent-safety` success. (Theory Tripwire already ran conclusively when the `swarm-hunter` label was applied; it triggers on `opened`/`reopened`/`labeled`, not `synchronize`, so it correctly does not re-fire on a branch update.)
- **What this PR lands (all three Jack findings closed):** F1 the fixed `MAX_SNAPSHOTS = 64` invocation ceiling; F2 the exact built-in `list`/`tuple` + `dict` container boundary proven before any `len`/iteration/`keys`/`.get`/subscript hook; P2 exact-`str` key proofs (hash-free iteration) and the exact-`str` `source` discriminator proven before any hash/compare; resource-P2 the per-object cardinality gates (4/7/3) before key traversal or set allocation. Accepted detector + LeanCTX bytes stayed byte-identical at every step. Unchanged throughout: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, component-cap/op-budget arithmetic, `components_emitted`, hashing/canonicalization, LeanCTX behavior, and all S2/Lane-A gates.
- **Merge:** marked ready + ordinary **protected head-pinned squash merge** pinned to `c1d681f` — no admin bypass, no auto-merge, no protection/settings change; source-branch deletion only via the repository's ordinary automatic setting.
- **Threads:** all **three** Gemini review threads (one current, two outdated) left **untouched** — unreplied, unresolved, no reactions. Label and the existing tripwire comment unchanged. The optional set-allocation micro-optimizations were deliberately **not** applied.
- **Fences:** merged #393/#395 and every other lane untouched; **S2 and all later Swarm Hunter stages remain hard-gated and unbegun.**
- **Model:** Claude Opus 4.8 (`claude-opus-4-8`).
