### PR TITLE
fix(nextness): evaluator hook-free type diagnostics + exact-string key partition (Batch 1)

### DIFF
--- a/docs/NEXTNESS_EVALUATOR_CONTRACT.md
+++ b/docs/NEXTNESS_EVALUATOR_CONTRACT.md
@@ -184,6 +184,26 @@ Gate precedence (the typed reason names the first failed gate):
   invoked; non-finite and overflow-scale numbers are rejected;
   **exact key sets** (unknown keys = unknown variant = rejected;
   missing keys = rejected); unknown `schema` strings rejected.
+- **Hook-free refusal diagnostics (DIRECT Python API included).** A
+  refusal never reads an attribute of the rejected value or of its
+  class — in particular never `type(value).__name__`, since `__name__`
+  is an overridable **metaclass** property whose getter would run
+  caller-controlled code from inside error formatting and escape the
+  typed `EvaluatorInputError`. Builtin type names come from a literal
+  identity table; anything else is described as `non-builtin value`.
+  Public CLI/artifact messages are unaffected: `json.loads` yields only
+  builtins, so every reachable-lane diagnostic is byte-identical to
+  before.
+- **Exact-string key partition.** A proven-exact `dict` is iterated
+  *without* hashing, comparing, stringifying or representing an
+  unproven key; only exact builtin `str` keys enter a set, and set
+  membership, difference, comparison and sorting run on those strings
+  alone. Non-string keys are reported as `<non-builtin value>` and
+  always force a mismatch. This closes a **soundness** hole as well as
+  a hook path: a non-string key whose `__hash__` collides with an
+  expected name previously had its `__eq__` invoked by the key-set
+  comparison, and an `__eq__` returning `True` let that key *satisfy* a
+  required name and pass validation.
 - NP1 internal-accounting identities re-checked (rejections sum,
   row-count inequality, split arithmetic): an artifact violating them
   is not a v1 report, whatever its schema string says.

--- a/scripts/nextness_evaluator.py
+++ b/scripts/nextness_evaluator.py
@@ -250,24 +250,63 @@ def _not_computable(reason: str, requires: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Exact-type validators (hostile input boundary; no conversion hooks,
 # no stringification, no traversal before the type is proven)
+#
+# Diagnostics are hook-free on the DIRECT Python API as well as on the public
+# CLI/artifact lanes: a refusal never reads an attribute of the rejected value
+# or of its class. In particular it never reads ``type(value).__name__`` —
+# ``__name__`` is an overridable METACLASS property, so reading it merely to
+# improve a message can execute caller-controlled code and escape the typed
+# refusal. Type names come from an identity table of builtins; anything else
+# is described generically.
 # ---------------------------------------------------------------------------
+
+
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description for error messages.
+
+    ``type(value).__name__`` consults the metaclass — a hostile class can
+    override ``__name__`` so that reading it raises from inside error
+    formatting, escaping the validator's typed-error promise. Identity
+    comparison against builtin types runs no user code, and anything that
+    is not one of these builtins is described generically instead of
+    executing a hook merely to improve a message.
+    """
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
 
 
 def _exact_str(value: Any, field: str) -> str:
     if type(value) is not str:
-        raise EvaluatorInputError(f"{field}: expected builtin str, got {type(value).__name__}")
+        raise EvaluatorInputError(f"{field}: expected builtin str, got {_describe_type(value)}")
     return value
 
 
 def _exact_bool(value: Any, field: str) -> bool:
     if type(value) is not bool:
-        raise EvaluatorInputError(f"{field}: expected builtin bool, got {type(value).__name__}")
+        raise EvaluatorInputError(f"{field}: expected builtin bool, got {_describe_type(value)}")
     return value
 
 
 def _exact_int(value: Any, field: str, low: int, high: int | None = None) -> int:
     if type(value) is not int:
-        raise EvaluatorInputError(f"{field}: expected builtin int, got {type(value).__name__}")
+        raise EvaluatorInputError(f"{field}: expected builtin int, got {_describe_type(value)}")
     if value < low or (high is not None and value > high):
         bound = f"[{low}, {high}]" if high is not None else f">= {low}"
         raise EvaluatorInputError(f"{field}: {value} outside {bound}")
@@ -287,7 +326,7 @@ def _exact_float(
     """
     if type(value) is not int and type(value) is not float:
         raise EvaluatorInputError(
-            f"{field}: expected a builtin real number, got {type(value).__name__}"
+            f"{field}: expected a builtin real number, got {_describe_type(value)}"
         )
     try:
         as_float = float(value)
@@ -302,15 +341,33 @@ def _exact_float(
 
 def _exact_dict(value: Any, field: str, keys: frozenset[str]) -> dict[str, Any]:
     """Builtin dict with EXACTLY the given key set (unknown keys are an
-    unknown variant; missing keys are missing evidence — both fail closed)."""
+    unknown variant; missing keys are missing evidence — both fail closed).
+
+    The proven-exact dict is iterated WITHOUT hashing, comparing,
+    stringifying or representing an unproven key, and only exact builtin
+    ``str`` keys ever enter a set. This matters beyond message formatting:
+    a non-str key whose ``__hash__`` collides with an expected name would
+    otherwise have its ``__eq__`` invoked by the set comparison — executing
+    caller-controlled code, and, were that ``__eq__`` to return True,
+    letting the hostile key SATISFY a required name and pass validation.
+    Non-str keys are described by the hook-free ``_describe_type`` and
+    always force a mismatch.
+    """
     if type(value) is not dict:
-        raise EvaluatorInputError(f"{field}: expected builtin dict, got {type(value).__name__}")
-    present = set(value)
-    if present != keys:
-        # Non-str keys are named by type only — never repr'd/str'd, so a
-        # hostile key's __repr__ can never run in the error path.
-        unknown = sorted(k if type(k) is str else f"<{type(k).__name__}>" for k in present - keys)
-        missing = sorted(keys - present)
+        raise EvaluatorInputError(f"{field}: expected builtin dict, got {_describe_type(value)}")
+    # Iteration alone: no hash, no comparison, no str/repr of any key.
+    str_keys: set[str] = set()
+    foreign: list[str] = []
+    for key in value:
+        if type(key) is str:
+            str_keys.add(key)
+        else:
+            foreign.append(f"<{_describe_type(key)}>")
+    if foreign or str_keys != keys:
+        # Set algebra and sorting run on exact builtin strings only; the
+        # foreign placeholders are already plain strings.
+        unknown = sorted(list(str_keys - keys) + foreign)
+        missing = sorted(keys - str_keys)
         raise EvaluatorInputError(
             f"{field}: key set mismatch (unknown={unknown}, missing={missing})"
         )
@@ -554,7 +611,7 @@ def validate_receipt_series(obj: Any) -> list[dict[str, Any]]:
     if type(obj) is not list:
         raise EvaluatorInputError(
             f"receipts: expected a receipt object or an array of receipts, "
-            f"got {type(obj).__name__}"
+            f"got {_describe_type(obj)}"
         )
     if not obj:
         raise EvaluatorInputError("receipts: series is empty (no evidence to evaluate)")

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1739,15 +1739,26 @@ class _MetaBomb(metaclass=_RaisingMeta):
 
 class _ArmedCollisionKey(metaclass=_RaisingMeta):
     """A non-str key hashing EXACTLY like a target str, with every comparison
-    and representation hook armed. Only __hash__ is inert, so the collision
-    can be planted at all."""
+    and representation hook armed.
+
+    ``__hash__`` is inert *only* until the key is armed, which permits the
+    single hash needed to plant the collision in a dict. Once armed — after
+    construction — the validator is held to the stricter promise that it must
+    not hash the key either: any further ``__hash__`` records itself and
+    raises, alongside the already-armed ``__eq__``, ``__repr__`` and
+    metaclass ``__name__``.
+    """
 
     fired: list[str] = []
+    armed = False
 
     def __init__(self, target: str) -> None:
         self._h = hash(target)
 
     def __hash__(self) -> int:
+        if _ArmedCollisionKey.armed:
+            _ArmedCollisionKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
         return self._h
 
     def __eq__(self, other):
@@ -1779,6 +1790,7 @@ _KEYS = frozenset({"alpha", "beta"})
 def _arm() -> None:
     _RaisingMeta.ran = False
     _ArmedCollisionKey.fired.clear()
+    _ArmedCollisionKey.armed = False
 
 
 def test_hostile_metaclass_never_consulted_at_any_evaluator_site() -> None:
@@ -1821,20 +1833,30 @@ def test_hostile_metaclass_never_consulted_at_any_evaluator_site() -> None:
 
 def test_armed_collision_key_runs_no_comparison_or_representation_hook() -> None:
     """A non-str key whose hash collides with an expected name must never have
-    __eq__/__repr__/metaclass __name__ invoked: the proven-exact dict is
-    partitioned by identity and only builtin strings ever enter a set."""
+    __hash__/__eq__/__repr__/metaclass __name__ invoked by the validator: the
+    proven-exact dict is partitioned by identity and only builtin strings ever
+    enter a set.
+
+    The key is armed *after* the dict is built, so the one hash needed to
+    plant the collision is permitted and every hook the validator might reach
+    thereafter — hashing included — is forbidden.
+    """
     from scripts.nextness_evaluator import _exact_dict
 
     _arm()
     payload = {_ArmedCollisionKey("alpha"): 1, "beta": 2}
-    with pytest.raises(EvaluatorInputError) as excinfo:
-        _exact_dict(payload, "f", _KEYS)
-    assert type(excinfo.value) is EvaluatorInputError
-    assert str(excinfo.value) == (
-        "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
-    )
-    assert _ArmedCollisionKey.fired == []
-    assert _RaisingMeta.ran is False
+    _ArmedCollisionKey.armed = True  # construction done: no further hash allowed
+    try:
+        with pytest.raises(EvaluatorInputError) as excinfo:
+            _exact_dict(payload, "f", _KEYS)
+        assert type(excinfo.value) is EvaluatorInputError
+        assert str(excinfo.value) == (
+            "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
+        )
+        assert _ArmedCollisionKey.fired == []
+        assert _RaisingMeta.ran is False
+    finally:
+        _ArmedCollisionKey.armed = False
 
 
 def test_collision_key_can_never_satisfy_a_required_key_name() -> None:

--- a/tests/test_nextness_evaluator.py
+++ b/tests/test_nextness_evaluator.py
@@ -1711,3 +1711,206 @@ def test_report_config_max_line_bytes_ceiling() -> None:
         report["config"]["max_line_bytes"] = bad
         with pytest.raises(EvaluatorInputError, match="outside"):
             validate_report(report)
+
+
+# ---------------------------------------------------------------------------
+# Batch 1 — hook-free type diagnostics + exact-string key partition
+# (Jack re-audit 2026-07-19). Every refusal below must be a typed
+# EvaluatorInputError whose formatting reads NO attribute of the rejected
+# value or of its class, and no key hook may run inside _exact_dict.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingMeta(type):
+    """Metaclass whose __name__ property raises — even type(x).__name__ is a
+    user-controlled hook."""
+
+    ran = False
+
+    @property
+    def __name__(cls):
+        _RaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _MetaBomb(metaclass=_RaisingMeta):
+    pass
+
+
+class _ArmedCollisionKey(metaclass=_RaisingMeta):
+    """A non-str key hashing EXACTLY like a target str, with every comparison
+    and representation hook armed. Only __hash__ is inert, so the collision
+    can be planted at all."""
+
+    fired: list[str] = []
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        _ArmedCollisionKey.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _ArmedCollisionKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _SoftCollisionKey:
+    """Hash-collides with a target str AND compares equal — the soundness
+    variant that used to SATISFY a required key name."""
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return True
+
+
+_KEYS = frozenset({"alpha", "beta"})
+
+
+def _arm() -> None:
+    _RaisingMeta.ran = False
+    _ArmedCollisionKey.fired.clear()
+
+
+def test_hostile_metaclass_never_consulted_at_any_evaluator_site() -> None:
+    """All seven supplied-value diagnostics refuse with the exact typed error
+    and the generic description, without consulting the metaclass."""
+    from scripts.nextness_evaluator import (
+        _exact_bool,
+        _exact_dict,
+        _exact_float,
+        _exact_int,
+        _exact_str,
+    )
+
+    cases = [
+        (lambda: _exact_str(_MetaBomb(), "f"),
+         "f: expected builtin str, got non-builtin value"),
+        (lambda: _exact_bool(_MetaBomb(), "f"),
+         "f: expected builtin bool, got non-builtin value"),
+        (lambda: _exact_int(_MetaBomb(), "f", 0),
+         "f: expected builtin int, got non-builtin value"),
+        (lambda: _exact_float(_MetaBomb(), "f", 0.0, 1.0),
+         "f: expected a builtin real number, got non-builtin value"),
+        (lambda: _exact_dict(_MetaBomb(), "f", _KEYS),
+         "f: expected builtin dict, got non-builtin value"),
+        (lambda: _exact_dict({_MetaBomb(): 1}, "f", _KEYS),
+         "f: key set mismatch (unknown=['<non-builtin value>'], "
+         "missing=['alpha', 'beta'])"),
+        (lambda: validate_receipt_series(_MetaBomb()),
+         "receipts: expected a receipt object or an array of receipts, "
+         "got non-builtin value"),
+    ]
+    for call, expected in cases:
+        _arm()
+        with pytest.raises(EvaluatorInputError) as excinfo:
+            call()
+        assert type(excinfo.value) is EvaluatorInputError
+        assert str(excinfo.value) == expected
+        assert _RaisingMeta.ran is False
+
+
+def test_armed_collision_key_runs_no_comparison_or_representation_hook() -> None:
+    """A non-str key whose hash collides with an expected name must never have
+    __eq__/__repr__/metaclass __name__ invoked: the proven-exact dict is
+    partitioned by identity and only builtin strings ever enter a set."""
+    from scripts.nextness_evaluator import _exact_dict
+
+    _arm()
+    payload = {_ArmedCollisionKey("alpha"): 1, "beta": 2}
+    with pytest.raises(EvaluatorInputError) as excinfo:
+        _exact_dict(payload, "f", _KEYS)
+    assert type(excinfo.value) is EvaluatorInputError
+    assert str(excinfo.value) == (
+        "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
+    )
+    assert _ArmedCollisionKey.fired == []
+    assert _RaisingMeta.ran is False
+
+
+def test_collision_key_can_never_satisfy_a_required_key_name() -> None:
+    """Soundness: a hash-colliding key whose __eq__ returns True was ACCEPTED
+    as the expected name before this repair. It must now be refused."""
+    from scripts.nextness_evaluator import _exact_dict
+
+    payload = {_SoftCollisionKey("alpha"): 1, "beta": 2}
+    with pytest.raises(EvaluatorInputError) as excinfo:
+        _exact_dict(payload, "f", _KEYS)
+    assert str(excinfo.value) == (
+        "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
+    )
+
+
+def test_builtin_lane_diagnostics_are_byte_identical() -> None:
+    """PUBLIC/ARTIFACT lane (json.loads yields only builtins) keeps every
+    pre-existing message byte-for-byte, unknown/missing formatting included."""
+    from scripts.nextness_evaluator import (
+        _exact_bool,
+        _exact_dict,
+        _exact_float,
+        _exact_int,
+        _exact_str,
+    )
+
+    matrix = [
+        (lambda: _exact_str(123, "f"), "f: expected builtin str, got int"),
+        (lambda: _exact_bool("x", "f"), "f: expected builtin bool, got str"),
+        (lambda: _exact_int("x", "f", 0), "f: expected builtin int, got str"),
+        (lambda: _exact_float("x", "f", 0.0, 1.0),
+         "f: expected a builtin real number, got str"),
+        (lambda: _exact_dict([], "f", _KEYS), "f: expected builtin dict, got list"),
+        (lambda: _exact_dict({"alpha": 1, "zeta": 2}, "f", _KEYS),
+         "f: key set mismatch (unknown=['zeta'], missing=['beta'])"),
+        (lambda: _exact_dict({"alpha": 1, "beta": 2, "zz": 3}, "f", _KEYS),
+         "f: key set mismatch (unknown=['zz'], missing=[])"),
+        (lambda: _exact_dict({"alpha": 1}, "f", _KEYS),
+         "f: key set mismatch (unknown=[], missing=['beta'])"),
+        (lambda: validate_receipt_series(42),
+         "receipts: expected a receipt object or an array of receipts, got int"),
+    ]
+    for call, expected in matrix:
+        with pytest.raises(EvaluatorInputError) as excinfo:
+            call()
+        assert str(excinfo.value) == expected
+
+
+def test_describe_type_is_hook_free_and_names_builtins() -> None:
+    """Identity table only: builtins by literal name, everything else generic."""
+    from scripts.nextness_evaluator import _describe_type
+
+    assert _describe_type(True) == "bool"  # before int: bool subclasses int
+    assert _describe_type(1) == "int"
+    assert _describe_type(1.0) == "float"
+    assert _describe_type("s") == "str"
+    assert _describe_type([]) == "list"
+    assert _describe_type({}) == "dict"
+    assert _describe_type(()) == "tuple"
+    assert _describe_type(set()) == "set"
+    assert _describe_type(b"") == "bytes"
+    assert _describe_type(None) == "NoneType"
+
+    class _IntSub(int):
+        pass
+
+    assert _describe_type(_IntSub(1)) == "non-builtin value"
+    assert _describe_type(int) == "non-builtin value"  # a class object itself
+    _arm()
+    assert _describe_type(_MetaBomb()) == "non-builtin value"
+    assert _RaisingMeta.ran is False
+
+
+def test_exact_dict_still_accepts_the_exact_builtin_key_set() -> None:
+    """Accepted inputs are unchanged and the caller's dict is returned as-is."""
+    from scripts.nextness_evaluator import _exact_dict
+
+    payload = {"alpha": 1, "beta": 2}
+    assert _exact_dict(payload, "f", _KEYS) is payload


### PR DESCRIPTION
## Batch 1 — evaluator hook-free type diagnostics + exact-string key partition

Lab-free, three files. **Merged** with Kev's authorization after Jack's completed audit as squash `d0bf6a290183892a1af53f8a985838e03ce37d69` on 2026-07-19. No review-thread actions were taken. Base `0bfc84243bda5d34ee7746bb01192a67b19e516e` (sealed main, #393). First batch of the Option-B family policy accepted from the family-wide diagnostic-hook inventory, with **both of Jack's re-audit corrections applied**.

### What this closes

**(a) Hook-bearing type diagnostics — 7 sites.** Every evaluator refusal that rendered a supplied value's type read `type(value).__name__`. `__name__` is an overridable **metaclass** property, so reading it merely to improve a message can execute caller-controlled code *from inside error formatting* and escape the typed `EvaluatorInputError`.

**(b) Jack Correction 2 — the adjacent hash-collision `__eq__` path.** A `type(k).__name__` swap alone was explicitly rejected, and rightly: `_exact_dict` built `set(value)` from unproven keys and then compared/differenced it. A non-string key whose `__hash__` **collides** with an expected name lands in the same bucket, so CPython invokes that key's **`__eq__`** during the set comparison — before any formatting is reached.

This is a **soundness** defect, not only a hook leak. Failing-first proved a colliding key whose `__eq__` returns `True` was **ACCEPTED**, letting a hostile non-string key *satisfy a required key name* and pass validation.

### Repair

1. Module-local **literal builtin-type identity table** + hook-free `_describe_type`, lifted from the proven `nextness_artifact_validation` implementation. **No shared module, no new import edge** (`Final`/`Any` already imported).
2. All **seven** supplied-value diagnostics replaced (258/264/270/290/307/312/557).
3. **`_exact_dict` redesigned.** The proven-exact dict is iterated *without hashing, comparing, stringifying or representing* an unproven key; exact builtin `str` keys are partitioned into a set; **set membership, difference, comparison and sorting run on exact builtin strings only**; non-string keys are described through `_describe_type` and **always force a mismatch** (they can no longer be compared into satisfying a name).
4. Corrected the false comment claiming a hostile key's `__repr__` "can never run", and documented the DIRECT-API hook-free guarantee in the contract.

### Frozen semantics / byte equivalence

Public CLI behavior, schemas, algorithms, ceilings, exit mapping and accepted-output bytes are **unchanged**. Builtin-lane (PUBLIC/ARTIFACT) diagnostics are **byte-identical** — `json.loads` yields only builtins, so the non-string partition is empty on every reachable lane. Pinned in a 9-case message matrix including unknown-only, missing-only and combined key formatting.

### Failing-first vs unmodified `0bfc8424`

| case | before | after |
|---|---|---|
| 7 metaclass sites (258/264/270/290/307/312/557) | raw `RuntimeError: metaclass __name__ hook executed` **escapes** the typed refusal | typed `EvaluatorInputError`, `got non-builtin value`, metaclass never consulted |
| armed collision key (`__eq__`/`__repr__`/metaclass armed) | `RuntimeError: __eq__ hook executed` **escapes** | typed refusal, **zero hooks fired** |
| soft collision key (`__eq__` → `True`) | **ACCEPTED — returned the dict** (validation bypass) | typed refusal `unknown=['<non-builtin value>'], missing=['alpha']` |
| builtin wrong-type + unknown/missing matrix (9 cases) | baseline | **byte-identical** |

### Tests, docs, diffstat

- **+6 focused regressions (evaluator 98 → 104):** hostile-metaclass pins for all seven sites with exact `EvaluatorInputError` text and a `ran` flag proving the metaclass was never consulted; armed hash-collision key proving `__eq__`/`__repr__`/metaclass never execute inside `_exact_dict`; the soundness pin that a colliding key can never satisfy a required name; the 9-case byte-identity matrix; `_describe_type` builtin-name/generic-fallback table (incl. `int` subclass and class objects); accepted-input identity unchanged.
- **Docs:** `NEXTNESS_EVALUATOR_CONTRACT.md` input contract records the hook-free refusal guarantee and the exact-string key partition, including the closed soundness hole.
- **Suites:** evaluator **104 passed / 3 skipped** · focused Nextness **941 / 26** · full suite **1525 passed / 48 skipped** (from 1519/48) · `compileall` OK.
- **Diffstat (exactly 3 files):** `scripts/nextness_evaluator.py +70/−13`, `tests/test_nextness_evaluator.py +203`, `docs/NEXTNESS_EVALUATOR_CONTRACT.md +20` — **293 insertions, 13 deletions**.

### Boundary

Only the three files above. **Untouched:** the other five inventoried modules, `scripts/orchestrator.py`, `experiments/swarm_hunter_lab/**`, #394 / Ian's lane, and the preserved #391/#392 threads. No thread action, comment, reaction, reviewer request or label change was performed.

### Carried forward (not in this PR)

Jack's **Correction 1** stands recorded in the audit artifact: `ToolRouter.execute` is **not** proven escape-proof — line 393 formats a caught exception with `{e}`, invoking a caller-influenced `__str__` inside the handler. Orchestrator sites 380/387/393 are reclassified as **mandatory re-audit work** and were deliberately **not edited here**.

