### PR TITLE
fix(nextness): replay-lab hook-free type diagnostics + exact-string key partition (Batch 2)

### DIFF
--- a/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
+++ b/docs/NEXTNESS_REPLAY_LAB_CONTRACT.md
@@ -83,6 +83,27 @@ Threshold validation is **delegated to NP2's own
 monitor itself would reject. Unknown schema strings, unknown keys,
 duplicate labels and out-of-bounds values all fail closed.
 
+**Hook-free refusal diagnostics (DIRECT Python API included).** A refusal
+never reads an attribute of the rejected value or of its class — in
+particular never `type(value).__name__`, since `__name__` is an
+overridable **metaclass** property whose getter would run
+caller-controlled code from inside error formatting and escape the typed
+`LabInputError`. Builtin type names come from a literal identity table;
+anything else is described as `non-builtin value`. Public CLI/artifact
+messages are unaffected: `json.loads` yields only builtins, so every
+reachable-lane diagnostic is byte-identical to before.
+
+**Exact-string key partition.** A proven-exact `dict` is iterated
+*without* hashing, comparing, stringifying or representing an unproven
+key; only exact builtin `str` keys enter a set, and set membership,
+difference, comparison and sorting run on those strings alone.
+Non-string keys are reported as `<non-builtin value>` and always force a
+mismatch. This closes a **soundness** hole as well as a hook path: a
+non-string key whose `__hash__` collided with an expected name
+previously had its `__eq__` invoked by the key-set comparison, and an
+`__eq__` returning `True` let that key *satisfy* a required name and
+pass validation.
+
 ## Trajectory summary (per configuration)
 
 `step_count` · `abstention_step_rate` · `reason_step_counts` (fixed

--- a/scripts/nextness_replay_lab.py
+++ b/scripts/nextness_replay_lab.py
@@ -156,25 +156,64 @@ class LabReportTooLargeError(RuntimeError):
 
 # ---------------------------------------------------------------------------
 # Protocol loading and validation (exact-type, fail-closed)
+#
+# Diagnostics are hook-free on the DIRECT Python API as well as on the public
+# CLI/artifact lanes: a refusal never reads an attribute of the rejected value
+# or of its class. In particular it never reads ``type(value).__name__`` —
+# ``__name__`` is an overridable METACLASS property, so reading it merely to
+# improve a message can execute caller-controlled code and escape the typed
+# refusal. Type names come from an identity table of builtins; anything else
+# is described generically.
 # ---------------------------------------------------------------------------
+
+
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description for error messages.
+
+    ``type(value).__name__`` consults the metaclass — a hostile class can
+    override ``__name__`` so that reading it raises from inside error
+    formatting, escaping the validator's typed-error promise. Identity
+    comparison against builtin types runs no user code, and anything that
+    is not one of these builtins is described generically instead of
+    executing a hook merely to improve a message.
+    """
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
 
 
 def _exact_str(value: Any, field: str) -> str:
     if type(value) is not str:
-        raise LabInputError(f"{field}: expected builtin str, got {type(value).__name__}")
+        raise LabInputError(f"{field}: expected builtin str, got {_describe_type(value)}")
     return value
 
 
 def _exact_int(value: Any, field: str) -> int:
     if type(value) is not int:
-        raise LabInputError(f"{field}: expected builtin int, got {type(value).__name__}")
+        raise LabInputError(f"{field}: expected builtin int, got {_describe_type(value)}")
     return value
 
 
 def _exact_real(value: Any, field: str) -> float:
     if type(value) is not int and type(value) is not float:
         raise LabInputError(
-            f"{field}: expected a builtin real number, got {type(value).__name__}"
+            f"{field}: expected a builtin real number, got {_describe_type(value)}"
         )
     try:
         as_float = float(value)
@@ -186,12 +225,33 @@ def _exact_real(value: Any, field: str) -> float:
 
 
 def _exact_dict(value: Any, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    """Builtin dict with EXACTLY the given key set (fail closed both ways).
+
+    The proven-exact dict is iterated WITHOUT hashing, comparing,
+    stringifying or representing an unproven key, and only exact builtin
+    ``str`` keys ever enter a set. This matters beyond message formatting:
+    a non-str key whose ``__hash__`` collides with an expected name would
+    otherwise have its ``__eq__`` invoked by the set comparison — executing
+    caller-controlled code, and, were that ``__eq__`` to return True,
+    letting the hostile key SATISFY a required name and pass validation.
+    Non-str keys are described by the hook-free ``_describe_type`` and
+    always force a mismatch.
+    """
     if type(value) is not dict:
-        raise LabInputError(f"{field}: expected builtin dict, got {type(value).__name__}")
-    present = set(value)
-    if present != keys:
-        unknown = sorted(k if type(k) is str else f"<{type(k).__name__}>" for k in present - keys)
-        missing = sorted(keys - present)
+        raise LabInputError(f"{field}: expected builtin dict, got {_describe_type(value)}")
+    # Iteration alone: no hash, no comparison, no str/repr of any key.
+    str_keys: set[str] = set()
+    foreign: list[str] = []
+    for key in value:
+        if type(key) is str:
+            str_keys.add(key)
+        else:
+            foreign.append(f"<{_describe_type(key)}>")
+    if foreign or str_keys != keys:
+        # Set algebra and sorting run on exact builtin strings only; the
+        # foreign placeholders are already plain strings.
+        unknown = sorted(list(str_keys - keys) + foreign)
+        missing = sorted(keys - str_keys)
         raise LabInputError(
             f"{field}: key set mismatch (unknown={unknown}, missing={missing})"
         )

--- a/tests/test_nextness_replay_lab.py
+++ b/tests/test_nextness_replay_lab.py
@@ -1369,3 +1369,213 @@ def test_cli_huge_max_line_bytes_translated_typed_exit_2(tmp_path, capsys) -> No
     assert "Traceback" not in captured.err
     for p_, b_ in before.items():
         assert p_.read_bytes() == b_
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — hook-free type diagnostics + exact-string key partition
+# (Option-B family policy, following the audited evaluator pattern). Every
+# refusal below must be a typed LabInputError whose formatting reads NO
+# attribute of the rejected value or of its class, and no key hook may run
+# inside _exact_dict.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingMeta(type):
+    """Metaclass whose __name__ property raises — even type(x).__name__ is a
+    user-controlled hook."""
+
+    ran = False
+
+    @property
+    def __name__(cls):
+        _RaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _MetaBomb(metaclass=_RaisingMeta):
+    pass
+
+
+class _StrictCollisionKey(metaclass=_RaisingMeta):
+    """A non-str key hashing EXACTLY like a target str, with every hook armed.
+
+    ``__hash__`` is inert only until the key is armed, which permits the single
+    hash needed to plant the collision in a dict. Once armed — after
+    construction — the validator must not hash the key either: any further
+    ``__hash__`` records itself and raises, alongside the armed ``__eq__``,
+    ``__repr__`` and metaclass ``__name__``.
+    """
+
+    fired: list[str] = []
+    armed = False
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        if _StrictCollisionKey.armed:
+            _StrictCollisionKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
+        return self._h
+
+    def __eq__(self, other):
+        _StrictCollisionKey.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _StrictCollisionKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _SoftCollisionKey:
+    """Hash-collides with a target str AND compares equal — the soundness
+    variant that used to SATISFY a required key name."""
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return True
+
+
+_LAB_KEYS = frozenset({"alpha", "beta"})
+
+
+def _lab_arm() -> None:
+    _RaisingMeta.ran = False
+    _StrictCollisionKey.fired.clear()
+    _StrictCollisionKey.armed = False
+
+
+def test_lab_hostile_metaclass_never_consulted_at_any_site() -> None:
+    """All five supplied-value diagnostics refuse with the exact typed error
+    and the generic description, without consulting the metaclass."""
+    from scripts.nextness_replay_lab import (
+        LabInputError,
+        _exact_dict,
+        _exact_int,
+        _exact_real,
+        _exact_str,
+    )
+
+    cases = [
+        (lambda: _exact_str(_MetaBomb(), "f"),
+         "f: expected builtin str, got non-builtin value"),
+        (lambda: _exact_int(_MetaBomb(), "f"),
+         "f: expected builtin int, got non-builtin value"),
+        (lambda: _exact_real(_MetaBomb(), "f"),
+         "f: expected a builtin real number, got non-builtin value"),
+        (lambda: _exact_dict(_MetaBomb(), "f", _LAB_KEYS),
+         "f: expected builtin dict, got non-builtin value"),
+        (lambda: _exact_dict({_MetaBomb(): 1}, "f", _LAB_KEYS),
+         "f: key set mismatch (unknown=['<non-builtin value>'], "
+         "missing=['alpha', 'beta'])"),
+    ]
+    for call, expected in cases:
+        _lab_arm()
+        with pytest.raises(LabInputError) as excinfo:
+            call()
+        assert type(excinfo.value) is LabInputError
+        assert str(excinfo.value) == expected
+        assert _RaisingMeta.ran is False
+
+
+def test_lab_strict_collision_key_runs_no_hook_at_all() -> None:
+    """A non-str key whose hash collides with an expected name must never have
+    __hash__/__eq__/__repr__/metaclass __name__ invoked by the validator. The
+    key is armed AFTER dict construction, so the one hash needed to plant the
+    collision is permitted and everything thereafter is forbidden."""
+    from scripts.nextness_replay_lab import LabInputError, _exact_dict
+
+    _lab_arm()
+    payload = {_StrictCollisionKey("alpha"): 1, "beta": 2}
+    _StrictCollisionKey.armed = True  # construction done: no further hash allowed
+    try:
+        with pytest.raises(LabInputError) as excinfo:
+            _exact_dict(payload, "f", _LAB_KEYS)
+        assert type(excinfo.value) is LabInputError
+        assert str(excinfo.value) == (
+            "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
+        )
+        assert _StrictCollisionKey.fired == []
+        assert _RaisingMeta.ran is False
+    finally:
+        _StrictCollisionKey.armed = False
+
+
+def test_lab_collision_key_can_never_satisfy_a_required_key_name() -> None:
+    """Soundness: a hash-colliding key whose __eq__ returns True was ACCEPTED
+    as the expected name before this repair. It must now be refused."""
+    from scripts.nextness_replay_lab import LabInputError, _exact_dict
+
+    payload = {_SoftCollisionKey("alpha"): 1, "beta": 2}
+    with pytest.raises(LabInputError) as excinfo:
+        _exact_dict(payload, "f", _LAB_KEYS)
+    assert str(excinfo.value) == (
+        "f: key set mismatch (unknown=['<non-builtin value>'], missing=['alpha'])"
+    )
+
+
+def test_lab_builtin_lane_diagnostics_are_byte_identical() -> None:
+    """PUBLIC/ARTIFACT lane (json.loads yields only builtins) keeps every
+    pre-existing message byte-for-byte, unknown/missing formatting included."""
+    from scripts.nextness_replay_lab import (
+        LabInputError,
+        _exact_dict,
+        _exact_int,
+        _exact_real,
+        _exact_str,
+    )
+
+    matrix = [
+        (lambda: _exact_str(123, "f"), "f: expected builtin str, got int"),
+        (lambda: _exact_int("x", "f"), "f: expected builtin int, got str"),
+        (lambda: _exact_real("x", "f"), "f: expected a builtin real number, got str"),
+        (lambda: _exact_dict([], "f", _LAB_KEYS), "f: expected builtin dict, got list"),
+        (lambda: _exact_dict({"alpha": 1, "zeta": 2}, "f", _LAB_KEYS),
+         "f: key set mismatch (unknown=['zeta'], missing=['beta'])"),
+        (lambda: _exact_dict({"alpha": 1, "beta": 2, "zz": 3}, "f", _LAB_KEYS),
+         "f: key set mismatch (unknown=['zz'], missing=[])"),
+        (lambda: _exact_dict({"alpha": 1}, "f", _LAB_KEYS),
+         "f: key set mismatch (unknown=[], missing=['beta'])"),
+    ]
+    for call, expected in matrix:
+        with pytest.raises(LabInputError) as excinfo:
+            call()
+        assert str(excinfo.value) == expected
+
+
+def test_lab_describe_type_is_hook_free_and_names_builtins() -> None:
+    """Identity table only: builtins by literal name, everything else generic."""
+    from scripts.nextness_replay_lab import _describe_type
+
+    assert _describe_type(True) == "bool"  # before int: bool subclasses int
+    assert _describe_type(1) == "int"
+    assert _describe_type(1.0) == "float"
+    assert _describe_type("s") == "str"
+    assert _describe_type([]) == "list"
+    assert _describe_type({}) == "dict"
+    assert _describe_type(()) == "tuple"
+    assert _describe_type(set()) == "set"
+    assert _describe_type(b"") == "bytes"
+    assert _describe_type(None) == "NoneType"
+
+    class _IntSub(int):
+        pass
+
+    assert _describe_type(_IntSub(1)) == "non-builtin value"
+    assert _describe_type(int) == "non-builtin value"  # a class object itself
+    _lab_arm()
+    assert _describe_type(_MetaBomb()) == "non-builtin value"
+    assert _RaisingMeta.ran is False
+
+
+def test_lab_exact_dict_still_accepts_the_exact_builtin_key_set() -> None:
+    """Accepted inputs are unchanged and the caller's dict is returned as-is."""
+    from scripts.nextness_replay_lab import _exact_dict
+
+    payload = {"alpha": 1, "beta": 2}
+    assert _exact_dict(payload, "f", _LAB_KEYS) is payload


### PR DESCRIPTION
## Batch 2 — replay-lab hook-free type diagnostics + exact-string key partition

Three files. **Merged** with Kev's authorization after Jack's completed audit as squash `0552af65df88dbeef08e69a067a16acc9313ae5d` on 2026-07-19. No review-thread actions were taken. Base `d0bf6a290183892a1af53f8a985838e03ce37d69` (main, post-#395). Applies the **audited evaluator pattern** from Batch 1 (#395) to the replay lab, per the Option-B family policy.

### What this closes

**(a) Hook-bearing type diagnostics — 5 sites.** Every replay-lab refusal that rendered a supplied value's type read `type(value).__name__`. `__name__` is an overridable **metaclass** property, so reading it merely to improve a message can execute caller-controlled code *from inside error formatting* and escape the typed `LabInputError`.

**(b) The adjacent hash-collision `__eq__` path.** `_exact_dict` built `set(value)` from unproven keys and then compared/differenced it. A non-string key whose `__hash__` **collides** with an expected name lands in the same bucket, so CPython invokes that key's **`__eq__`** during the set comparison — before any formatting is reached. This is a **soundness** defect, not only a hook leak: failing-first proved a colliding key whose `__eq__` returns `True` was **ACCEPTED**, letting a hostile non-string key *satisfy a required key name*.

### Repair

1. Module-local **literal builtin-type identity table** + hook-free `_describe_type`. **No shared module, no new cross-module import edge** (`Final`/`Any` already imported).
2. All **five** supplied-value diagnostics replaced: `_exact_str`, `_exact_int`, `_exact_real`, `_exact_dict` value refusal, `_exact_dict` non-string-key reporting.
3. **`_exact_dict` redesigned** on the audited evaluator pattern: the proven-exact dict is iterated *without invoking any hook of an unproven key*; exact builtin `str` keys are partitioned; **hashing, comparison, set algebra and sorting run on exact builtin strings only**; foreign keys are described through `_describe_type` and **always force refusal**, so a hash-colliding non-string key can never satisfy a required string name.
4. Contract updated with the DIRECT-API hook-free and exact-string-key-partition guarantees.

### Frozen semantics / byte equivalence

Public CLI behavior, schemas, algorithms, ceilings, exit mapping and accepted-output bytes **unchanged**. Builtin-lane (PUBLIC/ARTIFACT) diagnostics are **byte-identical** — `json.loads` yields only builtins, so the non-string partition is empty on every reachable lane. Accepted exact-builtin dicts are returned identically (identity preserved).

### Failing-first vs unmodified `d0bf6a29`

| case | before | after |
|---|---|---|
| 5 metaclass sites (`_exact_str`/`_exact_int`/`_exact_real`/`_exact_dict` value/key) | raw `RuntimeError: metaclass __name__ hook executed` **escapes** | typed `LabInputError`, `got non-builtin value`, metaclass never consulted |
| strict collision key, **armed after dict construction** (`__hash__`/`__eq__`/`__repr__`/metaclass all forbidden) | `RuntimeError: __eq__ hook executed` **escapes** | typed refusal, **zero hooks fired — including no hashing** |
| soft collision key (`__eq__` → `True`) | **ACCEPTED — returned the dict** (validation bypass) | typed refusal `unknown=['<non-builtin value>'], missing=['alpha']` |
| builtin diagnostic matrix (7 cases) | baseline | **byte-identical** |
| accepted exact builtin dict | identity preserved | identity preserved |

### Tests, docs, diffstat

- **+6 focused regressions (replay lab 66 → 72):** hostile-metaclass pins at all five sites with exact `LabInputError` text and a `ran` flag proving the metaclass was never consulted; strict collision key armed post-construction proving `__hash__`/`__eq__`/`__repr__`/metaclass never execute; the soundness pin that a colliding key can never satisfy a required name; the 7-case byte-identity matrix; `_describe_type` builtin-name/generic-fallback table (incl. `int` subclass and class objects); accepted-input identity unchanged.
- **Docs:** `NEXTNESS_REPLAY_LAB_CONTRACT.md` protocol contract records both guarantees, including the closed soundness hole.
- **Suites:** replay lab **72 passed / 2 skipped** · focused Nextness **947 / 26** · full suite **1531 passed / 48 skipped** (from 1525/48) · `compileall` OK.
- **Diffstat (exactly 3 files):** `scripts/nextness_replay_lab.py +68/−8`, `tests/test_nextness_replay_lab.py +210`, `docs/NEXTNESS_REPLAY_LAB_CONTRACT.md +21` — **299 insertions, 8 deletions**.

### Boundary

Only the three files above. **Untouched:** evaluator (sealed in #395), orchestrator, params_schema, monitor, evidence_packet, calibration, artifact_validation, predictor, metrics, `experiments/swarm_hunter_lab/**`, #394 / Ian's lane, and the preserved #391/#392 threads. No thread action, comment, reaction, reviewer request or label change.

### Remaining family work (not in this PR)

Batches 3–5 (evidence_packet, monitor, params_schema) remain unbuilt. **Orchestrator (380/387/393) remains MANDATORY re-audit work** — not a descriptor swap — per the audit artifact's Correction 1: its first exception is caught, but second-order caught-exception formatting can escape.

