### PR TITLE
fix(medusa): launch the REST API as a package module so its imports resolve

### DIFF
--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -18,7 +18,12 @@ Endpoints:
   GET /api/health          — Simple health check
 
 Usage:
-  python scripts/medusa_api.py [--port 8080]
+  python -m scripts.medusa_api [--port 8080]
+
+Must be launched as a package module from the repository root: this module
+imports ``scripts.tuning_api`` / ``scripts.event_bus`` at import time, and
+running it by file path leaves the repository root off ``sys.path``, which
+fails with ``ModuleNotFoundError: No module named 'scripts'``.
 """
 
 from __future__ import annotations

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -79,8 +79,20 @@ def build_command(config: dict) -> list:
     (``python -u -m pkg.mod``) so the repository root stays importable;
     a service declaring ``script`` keeps the file-path form. The API needs
     the module form because it imports ``scripts.*`` at import time.
+
+    Exactly one of the two must be declared. A configuration carrying
+    NEITHER would otherwise surface as a bare ``KeyError: 'script'``, and
+    one carrying BOTH would silently pick a launch form the author did not
+    choose. Both are configuration errors, refused with one generic message
+    that reports no supplied value.
     """
-    if "module" in config:
+    has_module = "module" in config
+    has_script = "script" in config
+    if has_module == has_script:  # neither, or both
+        raise ValueError(
+            "Service configuration must define exactly one of 'module' or 'script'."
+        )
+    if has_module:
         args = [PYTHON, "-u", "-m", config["module"]]
     else:
         args = [PYTHON, "-u", str(PROJECT_ROOT / config["script"])]

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -35,10 +35,15 @@ SERVICES = {
         "marker": "watchdog.py",
         "description": "Watchdog Daemon (Phase 14d)",
     },
+    # The API must be launched as a PACKAGE MODULE. Running it by absolute
+    # file path leaves the repository root off sys.path, so its
+    # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
+    # and the service exits immediately. The marker matches the module form
+    # of the command line so detection/status stay coherent.
     "api": {
-        "script": "scripts/medusa_api.py",
+        "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
-        "marker": "medusa_api.py",
+        "marker": "scripts.medusa_api",
         "description": "REST API (Phase 16a)",
     },
     "geometry": {
@@ -67,6 +72,22 @@ def find_process(marker: str) -> list:
         return []
 
 
+def build_command(config: dict) -> list:
+    """Build the launch argv for one service.
+
+    A service declaring ``module`` is launched as a package module
+    (``python -u -m pkg.mod``) so the repository root stays importable;
+    a service declaring ``script`` keeps the file-path form. The API needs
+    the module form because it imports ``scripts.*`` at import time.
+    """
+    if "module" in config:
+        args = [PYTHON, "-u", "-m", config["module"]]
+    else:
+        args = [PYTHON, "-u", str(PROJECT_ROOT / config["script"])]
+    args.extend(config.get("args", []))
+    return args
+
+
 def start_service(name: str, config: dict) -> int:
     """Start a service as a hidden background process."""
     # Check if already running
@@ -75,8 +96,7 @@ def start_service(name: str, config: dict) -> int:
         print(f"  [{name}] Already running (PID {existing[0]})")
         return existing[0]
 
-    args = [PYTHON, "-u", str(PROJECT_ROOT / config["script"])]
-    args.extend(config.get("args", []))
+    args = build_command(config)
 
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -1,0 +1,96 @@
+"""Phase 16c launch-path contract: the REST API must start as a package module.
+
+Launching ``scripts/medusa_api.py`` by absolute file path leaves the repository
+root off ``sys.path``, so the module's import-time ``from scripts.tuning_api
+import ...`` fails with ``ModuleNotFoundError: No module named 'scripts'`` and
+the API exits before serving anything. These tests pin the module form, the
+process marker that matches that command line, and the unchanged watchdog /
+geometry launch shape.
+
+Nothing here binds a port, starts a server, restarts or stops any process, or
+touches live data. The only subprocess is ``--help``, which parses arguments
+and exits.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from scripts.medusa_start import PROJECT_ROOT, PYTHON, SERVICES, build_command
+
+
+def test_api_launches_as_a_package_module() -> None:
+    """The API command is ``python -u -m scripts.medusa_api --port 8080``."""
+    cmd = build_command(SERVICES["api"])
+    assert cmd[:4] == [PYTHON, "-u", "-m", "scripts.medusa_api"]
+    assert cmd[4:] == ["--port", "8080"]
+
+
+def test_api_command_carries_no_file_path_form() -> None:
+    """The defective file-path invocation must not reappear in any position."""
+    cmd = build_command(SERVICES["api"])
+    assert not any(str(arg).endswith("medusa_api.py") for arg in cmd)
+    assert "script" not in SERVICES["api"]
+
+
+def test_api_marker_matches_the_module_command() -> None:
+    """Process detection/status must be able to find the module-form process."""
+    marker = SERVICES["api"]["marker"]
+    assert marker == "scripts.medusa_api"
+    assert marker in " ".join(build_command(SERVICES["api"]))
+
+
+def test_watchdog_and_geometry_launch_behaviour_unchanged() -> None:
+    """Only the API moves to module form; the others keep the file-path form."""
+    for name, script_name in (
+        ("watchdog", "watchdog.py"),
+        ("geometry", "geometry_daemon.py"),
+    ):
+        config = SERVICES[name]
+        cmd = build_command(config)
+        assert "module" not in config
+        assert cmd[:2] == [PYTHON, "-u"]
+        assert cmd[2] == str(PROJECT_ROOT / config["script"])
+        assert "-m" not in cmd
+        assert config["marker"] == script_name
+        assert config["marker"] in cmd[2]
+
+
+def test_every_service_marker_appears_in_its_own_command() -> None:
+    """Status/stop rely on the marker matching the launched command line."""
+    for name, config in SERVICES.items():
+        assert config["marker"] in " ".join(build_command(config)), name
+
+
+def test_api_module_help_resolves_imports() -> None:
+    """The module form actually imports cleanly.
+
+    ``--help`` only: argparse prints usage and exits 0 without binding a port
+    or constructing the server. The event bus is disabled so no publisher
+    socket is created.
+    """
+    env = os.environ.copy()
+    env["MEDUSA_EVENT_BUS_DISABLED"] = "1"
+    env["PYTHONUNBUFFERED"] = "1"
+    proc = subprocess.run(
+        [sys.executable, "-u", "-m", "scripts.medusa_api", "--help"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ModuleNotFoundError" not in proc.stderr
+    assert "No module named 'scripts'" not in proc.stderr
+    assert "--port" in proc.stdout
+    assert "--host" in proc.stdout
+
+
+def test_api_usage_text_documents_the_module_invocation() -> None:
+    """The module's own usage line must not advertise the broken form."""
+    src = (PROJECT_ROOT / "scripts" / "medusa_api.py").read_text(encoding="utf-8")
+    assert "python -m scripts.medusa_api" in src
+    assert "python scripts/medusa_api.py" not in src

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -18,7 +18,11 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 from scripts.medusa_start import PROJECT_ROOT, PYTHON, SERVICES, build_command
+
+_EXACTLY_ONE = "Service configuration must define exactly one of 'module' or 'script'."
 
 
 def test_api_launches_as_a_package_module() -> None:
@@ -94,3 +98,41 @@ def test_api_usage_text_documents_the_module_invocation() -> None:
     src = (PROJECT_ROOT / "scripts" / "medusa_api.py").read_text(encoding="utf-8")
     assert "python -m scripts.medusa_api" in src
     assert "python scripts/medusa_api.py" not in src
+
+
+def test_build_command_rejects_a_configuration_declaring_neither() -> None:
+    """A config with no launch form must not surface as a bare KeyError."""
+    with pytest.raises(ValueError) as excinfo:
+        build_command({"marker": "x", "description": "d"})
+    assert type(excinfo.value) is ValueError
+    assert str(excinfo.value) == _EXACTLY_ONE
+
+
+def test_build_command_rejects_a_configuration_declaring_both() -> None:
+    """Declaring both would silently pick a form the author did not choose."""
+    with pytest.raises(ValueError) as excinfo:
+        build_command(
+            {"module": "scripts.x", "script": "scripts/x.py", "marker": "x"}
+        )
+    assert type(excinfo.value) is ValueError
+    assert str(excinfo.value) == _EXACTLY_ONE
+
+
+def test_launch_form_refusal_reports_no_supplied_value() -> None:
+    """The message is generic: it names neither the module nor the script."""
+    for config in (
+        {},
+        {"module": "scripts.secret", "script": "scripts/secret.py"},
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            build_command(config)
+        message = str(excinfo.value)
+        assert message == _EXACTLY_ONE
+        assert "secret" not in message
+
+
+def test_every_real_service_declares_exactly_one_launch_form() -> None:
+    """The shipped registry satisfies the invariant the guard enforces."""
+    for name, config in SERVICES.items():
+        assert ("module" in config) != ("script" in config), name
+        build_command(config)  # constructs without raising


### PR DESCRIPTION
## Repair the broken REST API launch path

Three files. **Merged** with Kev's authorization after Jack's completed audit as squash `7afe241584a67c206afb8eacf451ee599e180aa3` on 2026-07-20. No review-thread actions were taken. Base `0552af65df88dbeef08e69a067a16acc9313ae5d` (main, post-#396).

The optional REST API has been offline because of its **launcher**, not the service. The engine, telemetry, watchdog, snapshots and geometry exporter were never affected.

### Reproduced defect (on main, before this change)

`medusa_start.py` launched the API by absolute file path:

```
python -u <repo>/scripts/medusa_api.py --port 8080
```

That execution mode leaves the repository root off `sys.path`, so `medusa_api.py`'s import-time `from scripts.tuning_api import ...` (line 336) fails and the process exits immediately:

```
$ python -u scripts/medusa_api.py --help
  File ".../scripts/medusa_api.py", line 336, in <module>
    from scripts.tuning_api import TuningState as _TuningState
ModuleNotFoundError: No module named 'scripts'
```

The module form resolves cleanly (exit 0):

```
$ MEDUSA_EVENT_BUS_DISABLED=1 python -u -m scripts.medusa_api --help
usage: python.exe -m scripts.medusa_api [-h] [--port PORT] [--host HOST]
```

### Repair

1. The API service declares `module: "scripts.medusa_api"` and launches as **`python -u -m scripts.medusa_api --port 8080`**.
2. Its process marker becomes **`scripts.medusa_api`**, which matches the module-form command line — so `--status` detection and `--stop` remain coherent. (The old `medusa_api.py` marker would never match a `-m` command line.)
3. Launch construction is factored into **`build_command()`**: a service declaring `module` gets the `-m` form, one declaring `script` keeps the file-path form. **Watchdog and geometry launch behavior is therefore unchanged**, which the tests pin explicitly.
4. `medusa_api.py`'s usage text now documents the supported module invocation and states why the file-path form fails.

### Scope

**No engine file, tuning policy, endpoint, schema or network-binding change.** The API is **not restarted** by this PR — deployment remains a separate authorization after Jack's audit.

### Tests (+11, new `tests/test_medusa_start.py`)

- API command is exactly `[python, -u, -m, scripts.medusa_api, --port, 8080]`.
- No `medusa_api.py` file-path form survives in any argv position; the `script` key is gone from the API service.
- Marker equals `scripts.medusa_api` and appears in the built command.
- Watchdog + geometry keep the file-path form, carry no `module` key and no `-m`, and their markers still match their commands.
- Every service's marker appears in its own command (status/stop coherence).
- Subprocess `--help` smoke test under `MEDUSA_EVENT_BUS_DISABLED=1` asserting exit 0, no `ModuleNotFoundError`, and `--port`/`--host` present.
- Usage-text pin: module form present, file-path form absent.

**No test binds a port, starts a server, restarts Medusa, stops any process, or alters live data.** The single subprocess is `--help`, which parses arguments and exits.

**Follow-up — exactly one launch form (closes the review thread's concern).** `build_command()` previously fell through to `config["script"]` whenever `"module"` was absent, so a configuration declaring **neither** surfaced as a bare `KeyError: 'script'`, and one declaring **both** silently picked the module form without the author choosing it. Both are now refused up front with one generic message that reports no supplied value:

```
Service configuration must define exactly one of 'module' or 'script'.
```

The API's module command, every marker, the argument lists and the watchdog/geometry file-path commands are unchanged, and all seven original regressions still pass. Added pins: neither-declared, both-declared, a **genericity** pin asserting the message leaks no supplied module/script value, and a registry invariant proving every shipped service declares exactly one form and builds.

### Totals

Focused `tests/test_medusa_start.py` **11 passed** · related API/tuning/event-bus **69 passed / 5 skipped** · full suite **1542 passed / 48 skipped** (from 1531/48 on main) · `compileall` OK.

**Exact per-file numstat vs `main` — 3 files, cumulative +180/−5:**

| file | added | removed |
|---|---|---|
| `scripts/medusa_api.py` | +6 | −1 |
| `scripts/medusa_start.py` | +36 | −4 |
| `tests/test_medusa_start.py` | +138 | −0 |
| **cumulative** | **+180** | **−5** |

**Checks: 7 current runs, all passing** — Analyze Python · CodeQL · agent-safety · frontend-quality ×2 · verify-python ×2.

*(Corrections of record: an earlier relay quoted this PR's diffstat as +30/−5 — a pre-staging two-file view omitting the untracked new test file; the correct pre-follow-up figure was 3 files, +126/−5. A later relay also quoted per-file figures of +40/−5 and +7/−1, which were `--stat` combined changed-line counts rather than numstat. The table above is the exact numstat.)*



