### PR TITLE
fix(nextness): evidence-packet hook-free type diagnostics + exact-string field lookup (Batch 3)

### DIFF
--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -141,6 +141,47 @@ as the field's content**. A foreign key can now never satisfy a
 required string field, and a container holding both a foreign key and
 the genuine string field returns the genuine value.
 
+**Exact role-map boundary (top level).** The same class of defect existed
+one level up, in the **outer role map** passed to `build_packet()` and
+`validate_output_path()`. Both consumed the caller's mapping directly —
+`set(paths)`, `role in paths`, `paths[role]`, `inputs[role]` and, in the
+unknown-roles message, list rendering that `repr`'d every key.
+
+**Reachability**: the **PUBLIC CLI is unaffected** — it constructs this
+map itself with exact builtin `str` roles, so none of the hazards below
+are reachable from the command line. They are **DIRECT-Python-API only**.
+
+Failing-first evidence (Jack's outer-role-map audit), all reproduced
+against the pre-repair tree:
+
+| probe | pre-repair |
+|---|---|
+| foreign role key whose `__repr__` raises | escaped `build_packet()` as a raw `RuntimeError` |
+| key colliding with `"report"`, `__eq__` → `True` | **satisfied the role and supplied its own value** — reached `_validate_role` and parsed the file |
+| colliding key whose `__eq__` raises | escaped `validate_output_path()` |
+| soft-colliding key in `validate_output_path()` | **accepted**, supplying the primary input that anchors the whole write boundary |
+| `dict` **subclass** with armed iteration hooks | `__iter__` executed in `build_packet()`; accepted outright by `validate_output_path()` |
+
+Both entry points now normalize through **one shared private boundary**
+before any membership test, lookup or key rendering. It accepts only an
+exact builtin `dict` (refusing anything else generically, naming no
+supplied type), inspects a rejected mapping or key no further than exact
+type identity, traverses by item iteration only, admits a key solely on
+exact builtin `str` identity — never hashing, comparing, stringifying or
+representing a foreign key — and returns a **fresh exact dict** that is
+the only thing later membership, lookup, `.get()` and primary-role
+selection ever see. A foreign key is **rejected even when a genuine role
+is also present**, never silently dropped. Messages for no artifacts, the
+artifact ceiling and unknown exact-string roles are unchanged, as is
+behavior for valid CLI inputs and valid exact-dict direct inputs.
+
+**Correction of record.** An earlier note accompanying the field-lookup
+repair stated that it removed *"the only mechanism by which a hostile key
+could raise anything here."* That claim was **too strong**: it accounted
+for the per-container field lookup but not for this outer role map, which
+remained a live DIRECT-API hole. The claim is withdrawn and superseded by
+this section.
+
 ## Write boundary
 
 Default output is **stdout**. `--output` must resolve inside the

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -255,10 +255,12 @@ retain byte-identical messages and exit 2**. A plain `ValueError` — like
 any exception outside the documented catch classes — now **propagates**
 through public `main()` (test-pinned beside the standing
 sentinel-`RuntimeError` pin), consistent with the self-check's existing
-`RuntimeError` re-raise. No raise was retyped, no new exception class
-was introduced, no validator behavior changed; `build_packet`'s
-direct-Python behavior and its existing typed failures are unchanged.
-This is a packet-only decision; no family-wide convention is implied.
+`RuntimeError` re-raise. That exception-boundary change retyped no
+raise, introduced no new exception class, and left the established
+typed failures byte-identical. The later outer role-map hardening above
+deliberately changes malformed DIRECT-API behavior; valid exact-dict
+direct input remains byte-identical. This is a packet-only decision; no
+family-wide convention is implied.
 
 ## Safety
 

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -114,6 +114,33 @@ timestamps, no random identifiers, no absolute paths; byte-identical
 across repeated runs; manifest order is the fixed role order regardless
 of invocation order.
 
+**Hook-free refusal diagnostics (DIRECT Python API included).** A refusal
+never reads an attribute of the rejected value or of its class — in
+particular never `type(value).__name__`, since `__name__` is an
+overridable **metaclass** property whose getter would run
+caller-controlled code from inside error formatting and escape the typed
+`PacketInputError`. Builtin type names come from a literal identity
+table; anything else is described as `non-builtin value`. Public
+CLI/artifact messages, exception types and range messages are
+unaffected: `json.loads` yields only builtins, so every reachable-lane
+diagnostic is byte-identical to before.
+
+**Exact-string field lookup.** A required field is fetched from a
+proven-exact builtin `dict` by **item iteration only**: an unproven key
+is never hashed, compared, stringified or represented, only exact
+builtin `str` keys are compared against the field name, and the matched
+value is taken **straight from the iteration** — never from a second
+subscript, which would re-enter the hash table and could meet a
+colliding hostile key. This is a **soundness** boundary, not only a hook
+boundary: the previous `field not in container` / `container[field]`
+pair hashed the field name and compared it against whatever shared its
+bucket, so a non-string key whose `__hash__` collided with a required
+name had its `__eq__` invoked — and an `__eq__` returning `True` let
+that hostile key **satisfy the required field and supply its own value
+as the field's content**. A foreign key can now never satisfy a
+required string field, and a container holding both a foreign key and
+the genuine string field returns the genuine value.
+
 ## Write boundary
 
 Default output is **stdout**. `--output` must resolve inside the

--- a/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md
@@ -171,16 +171,49 @@ exact builtin `str` identity — never hashing, comparing, stringifying or
 representing a foreign key — and returns a **fresh exact dict** that is
 the only thing later membership, lookup, `.get()` and primary-role
 selection ever see. A foreign key is **rejected even when a genuine role
-is also present**, never silently dropped. Messages for no artifacts, the
-artifact ceiling and unknown exact-string roles are unchanged, as is
-behavior for valid CLI inputs and valid exact-dict direct inputs.
+is also present**, never silently dropped.
 
-**Correction of record.** An earlier note accompanying the field-lookup
-repair stated that it removed *"the only mechanism by which a hostile key
-could raise anything here."* That claim was **too strong**: it accounted
-for the per-container field lookup but not for this outer role map, which
-remained a live DIRECT-API hole. The claim is withdrawn and superseded by
-this section.
+**The boundary enforces the COMPLETE role-map grammar**, in this order:
+
+1. exact builtin `dict` identity;
+2. **emptiness**, using the established no-artifacts message;
+3. the **artifact-count ceiling**, using the established count message —
+   decided with exact-dict operations **before any key is traversed**;
+4. item iteration admitting **exact builtin `str` keys only**;
+5. **unknown exact-string roles**, refused with the established sorted
+   unknown-role message;
+6. a **fresh dict containing only proven known roles**.
+
+`build_packet()` and `validate_output_path()` rely on this boundary
+**exclusively** and repeat none of its checks.
+
+A second round of failing-first evidence drove steps 2–6:
+
+| probe | pre-repair | post-repair |
+|---|---|---|
+| 9 exact-string unknown roles | traversed and listed: `unknown artifact roles: [...]` (78 chars) | `9 artifacts exceed the 8 bound` (30 chars) |
+| 10 000 exact-string unknown roles | an **88 914-character** diagnostic naming every key | 34 characters, no key listing |
+| `validate_output_path(out, {"report": …, "bogus": out})` | **returned successfully** — the alias sweep walks only ROLES, so an unknown role naming the output path was skipped entirely, defeating the alias boundary | `unknown artifact roles: ['bogus']` |
+| output validation with no known role | escaped as bare **`StopIteration`** | typed `PacketInputError` |
+| output validation with an empty map | escaped as bare **`StopIteration`** | `no artifacts provided: nothing to package` |
+
+**PUBLIC CLI behavior is unchanged** — it builds this map itself from
+known roles, so no CLI-reachable path changes. **DIRECT-API behavior is
+deliberately CHANGED, not preserved**: a direct caller that previously
+received an unknown-role listing for an oversized map now receives the
+short ceiling refusal, and one that previously reached `StopIteration`,
+or silently skipped an unknown role while validating an output path, now
+receives a typed refusal. Valid exact-dict direct input is unaffected and
+still produces byte-identical packets.
+
+**Correction of record.** The note accompanying the field-lookup repair
+claimed it removed *"the only mechanism by which a hostile key could
+raise anything here."* That was **false as written**: it accounted for
+the per-container field lookup but not for this outer role map, which
+remained a live DIRECT-API hole — and the role map turned out to carry
+both a hook-escape and two data-substitution defects. The claim is
+withdrawn, and the accompanying assertion that direct behavior was
+"unchanged" is withdrawn with it.
 
 ## Write boundary
 

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -206,12 +206,62 @@ def _load_bounded_json(path: pathlib.Path) -> tuple[Any, str, int]:
     return parsed, hashlib.sha256(raw).hexdigest(), len(raw)
 
 
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description for error messages.
+
+    ``type(value).__name__`` consults the metaclass — a hostile class can
+    override ``__name__`` so that reading it raises from inside error
+    formatting, escaping the validator's typed-error promise. Identity
+    comparison against builtin types runs no user code, and anything that
+    is not one of these builtins is described generically instead of
+    executing a hook merely to improve a message.
+    """
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
+
+
 def _exact_dict_field(container: Any, field: str, context: str) -> Any:
+    """Fetch ``field`` from a proven-exact builtin dict, hook-free.
+
+    The container is proven an exact builtin ``dict`` first, then traversed
+    by ITEM ITERATION only: an unproven key is never hashed, compared,
+    stringified or represented, and only exact builtin ``str`` keys are
+    compared against ``field``. The matched value comes straight out of the
+    iteration — never from a second subscript, which would re-enter the hash
+    table and could meet a colliding hostile key.
+
+    This is a soundness boundary, not only a hook boundary. Previously
+    ``field not in container`` hashed ``field`` and compared it against
+    whatever shared its bucket, so a non-str key whose ``__hash__`` collided
+    with a required name had its ``__eq__`` invoked — and an ``__eq__``
+    returning True let that hostile key SATISFY the required field and
+    supply its own value as the field's content.
+    """
     if type(container) is not dict:
-        raise PacketInputError(f"{context}: expected builtin dict, got {type(container).__name__}")
-    if field not in container:
-        raise PacketInputError(f"{context}: missing field {field!r}")
-    return container[field]
+        raise PacketInputError(f"{context}: expected builtin dict, got {_describe_type(container)}")
+    for key, value in container.items():
+        # Identity test first: a foreign key short-circuits before any
+        # comparison, so no caller-controlled hook can run.
+        if type(key) is str and key == field:
+            return value
+    raise PacketInputError(f"{context}: missing field {field!r}")
 
 
 def _exact_sha256(value: Any, context: str) -> str:
@@ -368,7 +418,7 @@ def _evaluation_link(
     if type(provided) is not bool:
         raise PacketInputError(
             f"evaluation.artifacts.{counterpart_role}.provided: expected "
-            f"builtin bool, got {type(provided).__name__}"
+            f"builtin bool, got {_describe_type(provided)}"
         )
     if provided is False:
         return _not_computable_link(
@@ -398,7 +448,7 @@ def _recorded_reader_bounds(lab: Mapping[str, Any]) -> tuple[int, int]:
     max_rows = _exact_dict_field(cfg, "max_rows", "lab.config")
     if type(max_rows) is not int:
         raise PacketInputError(
-            f"lab.config.max_rows: expected builtin int, got {type(max_rows).__name__}"
+            f"lab.config.max_rows: expected builtin int, got {_describe_type(max_rows)}"
         )
     if not 0 < max_rows <= MAX_ROWS_CEILING:
         raise PacketInputError(
@@ -407,7 +457,7 @@ def _recorded_reader_bounds(lab: Mapping[str, Any]) -> tuple[int, int]:
     max_line_bytes = _exact_dict_field(cfg, "max_line_bytes", "lab.config")
     if type(max_line_bytes) is not int:
         raise PacketInputError(
-            f"lab.config.max_line_bytes: expected builtin int, got {type(max_line_bytes).__name__}"
+            f"lab.config.max_line_bytes: expected builtin int, got {_describe_type(max_line_bytes)}"
         )
     if not 1 <= max_line_bytes <= MAX_LINE_BYTES_CEILING:
         # Defensive ceiling: enforced here at extraction even if

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -264,6 +264,46 @@ def _exact_dict_field(container: Any, field: str, context: str) -> Any:
     raise PacketInputError(f"{context}: missing field {field!r}")
 
 
+def _exact_role_map(mapping: Any) -> dict[str, Any]:
+    """Normalize the TOP-LEVEL role map once, at the DIRECT-API boundary.
+
+    The public CLI always builds this map itself with exact builtin ``str``
+    roles, so every hazard below is DIRECT-API-only. A direct caller,
+    however, may pass any mapping, and the outer map used to be consumed
+    with ``set(paths)``, ``role in paths``, ``paths[role]`` and
+    ``inputs[role]`` — each of which hashes and compares caller-controlled
+    keys, while the unknown-roles message rendered them inside a list and
+    therefore ``repr``'d them.
+
+    Three things could follow: a foreign key's ``__hash__``/``__eq__``/
+    ``__repr__`` could execute and escape; a foreign key colliding with a
+    real role and comparing equal could SATISFY that role and supply its
+    own value as the artifact (or as the primary input); and a ``dict``
+    subclass could interpose its own iteration hooks.
+
+    This boundary refuses anything that is not an exact builtin ``dict``
+    without inspecting it beyond that identity test, traverses by item
+    iteration only, admits a key only on exact builtin ``str`` identity —
+    never hashing, comparing, stringifying or representing a foreign key —
+    and returns a FRESH exact dict. Every later membership test, lookup,
+    ``.get()`` and primary-role selection uses only that normalized dict.
+    A foreign key is rejected even when a genuine role is also present; it
+    is never silently dropped.
+    """
+    if type(mapping) is not dict:
+        raise PacketInputError("artifact role map: expected a builtin dict")
+    normalized: dict[str, Any] = {}
+    foreign = False
+    for key, value in mapping.items():
+        if type(key) is str:
+            normalized[key] = value
+        else:
+            foreign = True
+    if foreign:
+        raise PacketInputError("artifact role map: role keys must be builtin strings")
+    return normalized
+
+
 def _exact_sha256(value: Any, context: str) -> str:
     if type(value) is not str or len(value) != 64 or not set(value) <= _HEX64:
         raise PacketInputError(f"{context}: expected a 64-char lowercase hex sha256")
@@ -533,6 +573,10 @@ def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
     Manifest order is the fixed ROLES order regardless of invocation
     order — determinism over convenience.
     """
+    # Normalize the outer role map ONCE, before any membership test,
+    # lookup or key rendering: every check below then operates on a fresh
+    # exact dict whose keys are proven exact builtin strings.
+    paths = _exact_role_map(paths)
     unknown = sorted(set(paths) - set(ROLES))
     if unknown:
         raise PacketInputError(f"unknown artifact roles: {unknown}")
@@ -622,6 +666,10 @@ def validate_output_path(
     by file identity (hard links included). Identity is verified at
     validation time only; the same residual filesystem race as the NP6
     lab applies and no stronger claim is made."""
+    # Same normalization as build_packet: primary-role selection below
+    # must never hash, compare or render a caller-controlled key, and a
+    # foreign key must never be able to supply the primary input.
+    inputs = _exact_role_map(inputs)
     primary = next(inputs[role] for role in ROLES if role in inputs)
     primary_dir = primary.resolve().parent
     out_resolved = out_path.resolve()

--- a/scripts/nextness_evidence_packet.py
+++ b/scripts/nextness_evidence_packet.py
@@ -289,9 +289,33 @@ def _exact_role_map(mapping: Any) -> dict[str, Any]:
     ``.get()`` and primary-role selection uses only that normalized dict.
     A foreign key is rejected even when a genuine role is also present; it
     is never silently dropped.
+
+    This boundary enforces the COMPLETE role-map grammar, in order: exact
+    builtin ``dict`` identity · emptiness · the artifact-count ceiling
+    (both decided with exact-dict operations BEFORE any key is traversed)
+    · item iteration admitting exact builtin ``str`` keys only · unknown
+    exact-string roles · a fresh dict containing only proven known roles.
+    Both public entry points rely on it exclusively and repeat none of it.
+
+    DIRECT-API behavior is therefore deliberately CHANGED, not preserved:
+    a direct caller that previously got an unknown-role listing for an
+    oversized map now gets the short ceiling refusal, and one that
+    previously reached ``StopIteration`` (or silently skipped an unknown
+    role while validating an output path) now gets a typed refusal. The
+    PUBLIC CLI is unaffected — it builds this map itself from known roles.
     """
     if type(mapping) is not dict:
         raise PacketInputError("artifact role map: expected a builtin dict")
+    # Emptiness and the artifact ceiling are decided with exact-dict
+    # operations BEFORE any key is traversed, so an oversized map can
+    # never be iterated, rendered, or reach a hostile key's hooks — and
+    # its diagnostic stays short instead of listing every supplied key.
+    if not mapping:
+        raise PacketInputError("no artifacts provided: nothing to package")
+    if len(mapping) > MAX_PACKET_ARTIFACTS:
+        raise PacketInputError(
+            f"{len(mapping)} artifacts exceed the {MAX_PACKET_ARTIFACTS} bound"
+        )
     normalized: dict[str, Any] = {}
     foreign = False
     for key, value in mapping.items():
@@ -301,6 +325,10 @@ def _exact_role_map(mapping: Any) -> dict[str, Any]:
             foreign = True
     if foreign:
         raise PacketInputError("artifact role map: role keys must be builtin strings")
+    # Unknown roles are decided on proven exact strings only.
+    unknown = sorted(set(normalized) - set(ROLES))
+    if unknown:
+        raise PacketInputError(f"unknown artifact roles: {unknown}")
     return normalized
 
 
@@ -566,26 +594,19 @@ def _lab_sequence_link(
 # ---------------------------------------------------------------------------
 
 
-def build_packet(paths: Mapping[str, pathlib.Path]) -> dict[str, Any]:
+def build_packet(paths: dict[str, pathlib.Path]) -> dict[str, Any]:
     """One deterministic ``nextness-evidence-packet-v1`` manifest.
 
-    ``paths`` maps roles (subset of ROLES, at least one) to files.
-    Manifest order is the fixed ROLES order regardless of invocation
-    order — determinism over convenience.
+    ``paths`` must be an EXACT builtin ``dict`` mapping known roles
+    (subset of ROLES, at least one, at most ``MAX_PACKET_ARTIFACTS``) to
+    files. Manifest order is the fixed ROLES order regardless of
+    invocation order — determinism over convenience.
+
+    The whole role-map grammar — exact-dict identity, emptiness, the
+    artifact ceiling, exact-string keys and known roles — is enforced by
+    ``_exact_role_map`` and is NOT repeated here.
     """
-    # Normalize the outer role map ONCE, before any membership test,
-    # lookup or key rendering: every check below then operates on a fresh
-    # exact dict whose keys are proven exact builtin strings.
     paths = _exact_role_map(paths)
-    unknown = sorted(set(paths) - set(ROLES))
-    if unknown:
-        raise PacketInputError(f"unknown artifact roles: {unknown}")
-    if not paths:
-        raise PacketInputError("no artifacts provided: nothing to package")
-    if len(paths) > MAX_PACKET_ARTIFACTS:
-        raise PacketInputError(
-            f"{len(paths)} artifacts exceed the {MAX_PACKET_ARTIFACTS} bound"
-        )
 
     entries: dict[str, dict[str, Any]] = {}
     parsed_by_role: dict[str, Any] = {}
@@ -658,17 +679,25 @@ def _repo_data_dir() -> pathlib.Path:
 
 
 def validate_output_path(
-    out_path: pathlib.Path, inputs: Mapping[str, pathlib.Path]
+    out_path: pathlib.Path, inputs: dict[str, pathlib.Path]
 ) -> None:
     """--output must resolve inside the primary input's directory (first
     provided role in ROLES order), never inside the repository data/
     tree, and never on a path aliasing ANY input — by resolved path or
     by file identity (hard links included). Identity is verified at
     validation time only; the same residual filesystem race as the NP6
-    lab applies and no stronger claim is made."""
-    # Same normalization as build_packet: primary-role selection below
-    # must never hash, compare or render a caller-controlled key, and a
-    # foreign key must never be able to supply the primary input.
+    lab applies and no stronger claim is made.
+
+    ``inputs`` must be an EXACT builtin ``dict`` of known roles: the same
+    complete grammar ``build_packet`` uses. That matters here beyond hook
+    safety — the alias sweep below only walks ROLES, so an UNKNOWN role
+    key used to be skipped entirely and could name the output path
+    itself, defeating the alias boundary; and a map with no known role
+    used to fall out of the primary-role selection as ``StopIteration``.
+    Both are now typed refusals from the shared boundary."""
+    # Same complete normalization as build_packet: primary-role selection
+    # below must never hash, compare or render a caller-controlled key,
+    # and no unknown or foreign key may reach the alias sweep.
     inputs = _exact_role_map(inputs)
     primary = next(inputs[role] for role in ROLES if role in inputs)
     primary_dir = primary.resolve().parent

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1476,3 +1476,133 @@ def test_role_map_preserves_public_messages_and_valid_inputs(chain) -> None:
     packet = build_packet(chain)
     assert packet["schema"] == PACKET_SCHEMA
     validate_output_path(chain["report"].parent / "packet.json", chain)
+
+
+# ---------------------------------------------------------------------------
+# Complete role-map grammar: exact-dict identity, emptiness and the artifact
+# ceiling are decided BEFORE any key is traversed; unknown roles are refused
+# on proven exact strings. Both entry points rely on this boundary alone.
+# ---------------------------------------------------------------------------
+
+
+class _ArmableRoleKey:
+    """A foreign key that can be planted (inert hash) and then armed, so a
+    test can prove the ceiling refuses before ANY key hook executes."""
+
+    fired: list[str] = []
+    armed = False
+
+    def __hash__(self) -> int:
+        if _ArmableRoleKey.armed:
+            _ArmableRoleKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
+        return 0
+
+    def __eq__(self, other):
+        _ArmableRoleKey.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _ArmableRoleKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+def test_role_map_ceiling_refuses_before_any_key_hook(chain) -> None:
+    """A nine-entry map is refused by the exact-dict ceiling before the map
+    is traversed, so a hostile key planted inside it is never touched."""
+    from scripts.nextness_evidence_packet import (
+        MAX_PACKET_ARTIFACTS,
+        PacketInputError,
+        build_packet,
+    )
+
+    _ArmableRoleKey.fired.clear()
+    _ArmableRoleKey.armed = False
+    payload = {f"r{i}": chain["report"] for i in range(8)}
+    payload[_ArmableRoleKey()] = chain["report"]  # planted while inert
+    _ArmableRoleKey.armed = True
+    try:
+        assert len(payload) == MAX_PACKET_ARTIFACTS + 1
+        with pytest.raises(PacketInputError) as excinfo:
+            build_packet(payload)
+        assert str(excinfo.value) == f"9 artifacts exceed the {MAX_PACKET_ARTIFACTS} bound"
+        assert _ArmableRoleKey.fired == []
+    finally:
+        _ArmableRoleKey.armed = False
+
+
+def test_role_map_large_map_diagnostic_stays_short(chain) -> None:
+    """An oversized map must not be rendered: the refusal names a count, not
+    ten thousand keys."""
+    from scripts.nextness_evidence_packet import (
+        MAX_PACKET_ARTIFACTS,
+        PacketInputError,
+        build_packet,
+    )
+
+    payload = {f"r{i}": chain["report"] for i in range(10_000)}
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet(payload)
+    message = str(excinfo.value)
+    assert message == f"10000 artifacts exceed the {MAX_PACKET_ARTIFACTS} bound"
+    assert len(message) < 64
+    assert "r0" not in message and "r9999" not in message
+
+
+def test_output_alias_refused_for_an_unknown_role(chain) -> None:
+    """The alias sweep only walks ROLES, so an UNKNOWN role naming the output
+    path used to slip past it entirely and validate successfully."""
+    from scripts.nextness_evidence_packet import PacketInputError, validate_output_path
+
+    out = chain["report"].parent / "packet.json"
+    out.write_bytes(b"PRE-EXISTING")
+    before_out = out.read_bytes()
+    before_report = chain["report"].read_bytes()
+
+    with pytest.raises(PacketInputError) as excinfo:
+        validate_output_path(out, {"report": chain["report"], "bogus": out})
+    assert str(excinfo.value) == "unknown artifact roles: ['bogus']"
+    assert out.read_bytes() == before_out
+    assert chain["report"].read_bytes() == before_report
+
+
+def test_output_validation_unknown_only_is_typed_not_stopiteration(chain) -> None:
+    """A map with no known role used to fall out of primary-role selection as
+    a bare StopIteration."""
+    from scripts.nextness_evidence_packet import PacketInputError, validate_output_path
+
+    out = chain["report"].parent / "packet.json"
+    with pytest.raises(PacketInputError) as excinfo:
+        validate_output_path(out, {"bogus": chain["report"]})
+    assert type(excinfo.value) is PacketInputError
+    assert str(excinfo.value) == "unknown artifact roles: ['bogus']"
+
+    with pytest.raises(PacketInputError):  # never StopIteration
+        validate_output_path(out, {"nope": chain["report"], "alsonope": chain["report"]})
+
+
+def test_output_validation_empty_map_uses_the_no_artifacts_message(chain) -> None:
+    """An empty map reaches the established no-artifacts refusal, not
+    StopIteration."""
+    from scripts.nextness_evidence_packet import PacketInputError, validate_output_path
+
+    out = chain["report"].parent / "packet.json"
+    with pytest.raises(PacketInputError) as excinfo:
+        validate_output_path(out, {})
+    assert str(excinfo.value) == "no artifacts provided: nothing to package"
+
+
+def test_valid_exact_dict_behaviour_is_unchanged(chain) -> None:
+    """Valid exact-dict input still builds identically and still validates."""
+    from scripts.nextness_evidence_packet import (
+        build_packet,
+        serialize_packet,
+        validate_output_path,
+    )
+
+    first = serialize_packet(build_packet(chain))
+    second = serialize_packet(build_packet(dict(chain)))
+    assert first == second  # byte-identical across repeated runs
+    validate_output_path(chain["report"].parent / "packet.json", chain)
+    # A single-role exact dict remains acceptable.
+    assert build_packet({"log": chain["log"]})["schema"] == PACKET_SCHEMA

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1066,3 +1066,218 @@ def test_cli_read_side_oserror_propagates(chain, tmp_path, monkeypatch, capsys) 
     assert not out.exists()
     for p, b in before.items():
         assert p.read_bytes() == b
+
+
+# ---------------------------------------------------------------------------
+# Batch 3 — hook-free type diagnostics + exact-string field lookup
+# (Option-B family policy). Refusals must be typed PacketInputError whose
+# formatting reads NO attribute of the rejected value or of its class, and
+# _exact_dict_field must never run a hook of an unproven key — nor let a
+# hash-colliding foreign key satisfy a required string field.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingMeta(type):
+    """Metaclass whose __name__ property raises — even type(x).__name__ is a
+    user-controlled hook."""
+
+    ran = False
+
+    @property
+    def __name__(cls):
+        _RaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _MetaBomb(metaclass=_RaisingMeta):
+    pass
+
+
+class _StrictCollisionKey(metaclass=_RaisingMeta):
+    """A non-str key hashing EXACTLY like a target str, every hook armed.
+
+    ``__hash__`` is inert only until armed, permitting the single hash needed
+    to plant the collision in a dict; after arming the lookup must not hash,
+    compare or represent it either.
+    """
+
+    fired: list[str] = []
+    armed = False
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        if _StrictCollisionKey.armed:
+            _StrictCollisionKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
+        return self._h
+
+    def __eq__(self, other):
+        _StrictCollisionKey.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _StrictCollisionKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _SoftCollisionKey:
+    """Hash-collides with a target str AND compares equal — the soundness
+    variant that used to satisfy a required field and supply its value."""
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return True
+
+
+def _packet_arm() -> None:
+    _RaisingMeta.ran = False
+    _StrictCollisionKey.fired.clear()
+    _StrictCollisionKey.armed = False
+
+
+def test_packet_hostile_metaclass_never_consulted_at_any_site() -> None:
+    """All four supplied-value diagnostics refuse with the exact typed error
+    and the generic description, without consulting the metaclass."""
+    from scripts.nextness_evidence_packet import (
+        PacketInputError,
+        _evaluation_link,
+        _exact_dict_field,
+        _recorded_reader_bounds,
+    )
+
+    cases = [
+        (lambda: _exact_dict_field(_MetaBomb(), "x", "ctx"),
+         "ctx: expected builtin dict, got non-builtin value"),
+        (lambda: _evaluation_link({"artifacts": {"lab": {"provided": _MetaBomb()}}}, "lab", None),
+         "evaluation.artifacts.lab.provided: expected builtin bool, "
+         "got non-builtin value"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": _MetaBomb(),
+                                                     "max_line_bytes": 1}}),
+         "lab.config.max_rows: expected builtin int, got non-builtin value"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": 1,
+                                                     "max_line_bytes": _MetaBomb()}}),
+         "lab.config.max_line_bytes: expected builtin int, got non-builtin value"),
+    ]
+    for call, expected in cases:
+        _packet_arm()
+        with pytest.raises(PacketInputError) as excinfo:
+            call()
+        assert type(excinfo.value) is PacketInputError
+        assert str(excinfo.value) == expected
+        assert _RaisingMeta.ran is False
+
+
+def test_packet_strict_collision_key_runs_no_hook_at_all() -> None:
+    """A foreign key colliding with a required field name must never have
+    __hash__/__eq__/__repr__/metaclass __name__ invoked by the lookup."""
+    from scripts.nextness_evidence_packet import PacketInputError, _exact_dict_field
+
+    _packet_arm()
+    container = {_StrictCollisionKey("schema"): 1}
+    _StrictCollisionKey.armed = True  # planted: no further hash allowed
+    try:
+        with pytest.raises(PacketInputError) as excinfo:
+            _exact_dict_field(container, "schema", "ctx")
+        assert type(excinfo.value) is PacketInputError
+        assert str(excinfo.value) == "ctx: missing field 'schema'"
+        assert _StrictCollisionKey.fired == []
+        assert _RaisingMeta.ran is False
+    finally:
+        _StrictCollisionKey.armed = False
+
+
+def test_packet_collision_key_can_never_satisfy_a_required_field() -> None:
+    """Soundness: a colliding key whose __eq__ returns True previously
+    satisfied the field AND supplied its own value as the field's content."""
+    from scripts.nextness_evidence_packet import PacketInputError, _exact_dict_field
+
+    container = {_SoftCollisionKey("schema"): "HOSTILE-VALUE"}
+    with pytest.raises(PacketInputError) as excinfo:
+        _exact_dict_field(container, "schema", "ctx")
+    assert str(excinfo.value) == "ctx: missing field 'schema'"
+
+
+def test_packet_genuine_field_wins_beside_a_foreign_key() -> None:
+    """A container carrying both a hostile foreign key and the genuine exact
+    string field returns the genuine value, firing no hook."""
+    from scripts.nextness_evidence_packet import _exact_dict_field
+
+    _packet_arm()
+    container = {_MetaBomb(): "HOSTILE", "schema": "GENUINE"}
+    assert _exact_dict_field(container, "schema", "ctx") == "GENUINE"
+    assert _RaisingMeta.ran is False
+    assert _StrictCollisionKey.fired == []
+
+
+def test_packet_builtin_lane_diagnostics_are_byte_identical() -> None:
+    """PUBLIC/ARTIFACT lane keeps every message, exception type and range
+    message byte-for-byte."""
+    from scripts.nextness_evidence_packet import (
+        PacketInputError,
+        _evaluation_link,
+        _exact_dict_field,
+        _recorded_reader_bounds,
+    )
+
+    matrix = [
+        (lambda: _exact_dict_field([], "x", "ctx"),
+         "ctx: expected builtin dict, got list"),
+        (lambda: _exact_dict_field({}, "x", "ctx"),
+         "ctx: missing field 'x'"),
+        (lambda: _evaluation_link({"artifacts": {"lab": {"provided": 1}}}, "lab", None),
+         "evaluation.artifacts.lab.provided: expected builtin bool, got int"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": "x", "max_line_bytes": 1}}),
+         "lab.config.max_rows: expected builtin int, got str"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": 0, "max_line_bytes": 1}}),
+         "lab.config.max_rows: 0 outside (0, 1000000]"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": 1, "max_line_bytes": "x"}}),
+         "lab.config.max_line_bytes: expected builtin int, got str"),
+        (lambda: _recorded_reader_bounds({"config": {"max_rows": 1, "max_line_bytes": 0}}),
+         "lab.config.max_line_bytes: 0 outside [1, 16777216]"),
+    ]
+    for call, expected in matrix:
+        with pytest.raises(PacketInputError) as excinfo:
+            call()
+        assert type(excinfo.value) is PacketInputError
+        assert str(excinfo.value) == expected
+
+
+def test_packet_exact_dict_field_returns_the_value_unchanged() -> None:
+    """Accepted lookups are unaffected and return the stored object itself."""
+    from scripts.nextness_evidence_packet import _exact_dict_field
+
+    sentinel = {"nested": 1}
+    container = {"a": 0, "x": sentinel}
+    assert _exact_dict_field(container, "x", "ctx") is sentinel
+
+
+def test_packet_describe_type_is_hook_free_and_names_builtins() -> None:
+    """Identity table only: builtins by literal name, everything else generic."""
+    from scripts.nextness_evidence_packet import _describe_type
+
+    assert _describe_type(True) == "bool"  # before int
+    assert _describe_type(1) == "int"
+    assert _describe_type(1.0) == "float"
+    assert _describe_type("s") == "str"
+    assert _describe_type([]) == "list"
+    assert _describe_type({}) == "dict"
+    assert _describe_type(()) == "tuple"
+    assert _describe_type(set()) == "set"
+    assert _describe_type(b"") == "bytes"
+    assert _describe_type(None) == "NoneType"
+
+    class _IntSub(int):
+        pass
+
+    assert _describe_type(_IntSub(1)) == "non-builtin value"
+    assert _describe_type(int) == "non-builtin value"
+    _packet_arm()
+    assert _describe_type(_MetaBomb()) == "non-builtin value"
+    assert _RaisingMeta.ran is False

--- a/tests/test_nextness_evidence_packet.py
+++ b/tests/test_nextness_evidence_packet.py
@@ -1281,3 +1281,198 @@ def test_packet_describe_type_is_hook_free_and_names_builtins() -> None:
     _packet_arm()
     assert _describe_type(_MetaBomb()) == "non-builtin value"
     assert _RaisingMeta.ran is False
+
+
+# ---------------------------------------------------------------------------
+# Outer role-map boundary (DIRECT API only — the public CLI builds this map
+# itself with exact builtin str roles). build_packet() and
+# validate_output_path() previously consumed the caller's mapping directly
+# via set(), `in`, subscript and list rendering.
+# ---------------------------------------------------------------------------
+
+
+_ROLE_MAP_NOT_DICT = "artifact role map: expected a builtin dict"
+_ROLE_MAP_FOREIGN_KEY = "artifact role map: role keys must be builtin strings"
+
+
+class _ReprBombKey:
+    """Foreign role key whose __repr__ raises — the unknown-roles message
+    rendered the key list, which repr()s every element."""
+
+    fired: list[str] = []
+
+    def __repr__(self):
+        _ReprBombKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _SoftCollidingRole:
+    """Collides with a real role AND compares equal: used to satisfy that
+    role and supply its own value."""
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return True
+
+
+class _HardCollidingRole:
+    """Collides with a real role; every comparison/representation raises."""
+
+    fired: list[str] = []
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        _HardCollidingRole.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _HardCollidingRole.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _HostileRoleDict(dict):
+    """An exact-dict SUBCLASS whose iteration hooks are armed."""
+
+    fired: list[str] = []
+
+    def items(self):
+        _HostileRoleDict.fired.append("items")
+        raise RuntimeError("items hook executed")
+
+    def keys(self):
+        _HostileRoleDict.fired.append("keys")
+        raise RuntimeError("keys hook executed")
+
+    def __iter__(self):
+        _HostileRoleDict.fired.append("__iter__")
+        raise RuntimeError("__iter__ hook executed")
+
+
+def _role_map_arm() -> None:
+    _ReprBombKey.fired.clear()
+    _HardCollidingRole.fired.clear()
+    _HostileRoleDict.fired.clear()
+
+
+def test_role_map_foreign_key_repr_never_runs(chain) -> None:
+    """A foreign role key whose __repr__ raises used to escape from
+    build_packet() when the unknown-roles message rendered the key list."""
+    from scripts.nextness_evidence_packet import PacketInputError, build_packet
+
+    _role_map_arm()
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet({_ReprBombKey(): chain["report"]})
+    assert str(excinfo.value) == _ROLE_MAP_FOREIGN_KEY
+    assert _ReprBombKey.fired == []
+
+
+def test_role_map_collision_cannot_satisfy_a_role_in_build_packet(chain) -> None:
+    """A key colliding with 'report' and comparing equal used to satisfy that
+    role and supply its own value as the artifact."""
+    from scripts.nextness_evidence_packet import PacketInputError, build_packet
+
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet({_SoftCollidingRole("report"): chain["report"]})
+    assert str(excinfo.value) == _ROLE_MAP_FOREIGN_KEY
+
+
+def test_role_map_hard_collision_runs_no_hook_in_validate_output_path(chain, tmp_path) -> None:
+    """Primary-role selection used to hash and compare caller keys."""
+    from scripts.nextness_evidence_packet import PacketInputError, validate_output_path
+
+    _role_map_arm()
+    out = chain["report"].parent / "packet.json"
+    with pytest.raises(PacketInputError) as excinfo:
+        validate_output_path(out, {_HardCollidingRole("report"): chain["report"]})
+    assert str(excinfo.value) == _ROLE_MAP_FOREIGN_KEY
+    assert _HardCollidingRole.fired == []
+
+
+def test_role_map_collision_cannot_supply_the_primary_input(chain) -> None:
+    """A soft-colliding key used to be ACCEPTED by validate_output_path and
+    supply the primary input that anchors the whole write boundary."""
+    from scripts.nextness_evidence_packet import PacketInputError, validate_output_path
+
+    out = chain["report"].parent / "packet.json"
+    with pytest.raises(PacketInputError) as excinfo:
+        validate_output_path(out, {_SoftCollidingRole("report"): chain["report"]})
+    assert str(excinfo.value) == _ROLE_MAP_FOREIGN_KEY
+
+
+def test_role_map_foreign_key_is_rejected_beside_a_genuine_role(chain) -> None:
+    """A foreign key must be refused, never silently ignored, even when a
+    genuine role is present in the same mapping."""
+    from scripts.nextness_evidence_packet import PacketInputError, build_packet
+
+    _role_map_arm()
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet({_ReprBombKey(): chain["report"], "report": chain["report"]})
+    assert str(excinfo.value) == _ROLE_MAP_FOREIGN_KEY
+    assert _ReprBombKey.fired == []
+
+
+def test_role_map_dict_subclass_iteration_hooks_never_run(chain) -> None:
+    """Only an exact builtin dict is accepted, so a subclass is refused
+    before any of its iteration hooks can interpose."""
+    from scripts.nextness_evidence_packet import (
+        PacketInputError,
+        build_packet,
+        validate_output_path,
+    )
+
+    out = chain["report"].parent / "packet.json"
+    for call in (
+        lambda: build_packet(_HostileRoleDict({"report": chain["report"]})),
+        lambda: validate_output_path(out, _HostileRoleDict({"report": chain["report"]})),
+    ):
+        _role_map_arm()
+        with pytest.raises(PacketInputError) as excinfo:
+            call()
+        assert str(excinfo.value) == _ROLE_MAP_NOT_DICT
+        assert _HostileRoleDict.fired == []
+
+
+def test_role_map_refusals_report_no_supplied_type_name(chain) -> None:
+    """Both refusals are generic: neither names the supplied type."""
+    from scripts.nextness_evidence_packet import PacketInputError, build_packet
+
+    for bad in ([("report", chain["report"])], ("report",), None):
+        with pytest.raises(PacketInputError) as excinfo:
+            build_packet(bad)
+        message = str(excinfo.value)
+        assert message == _ROLE_MAP_NOT_DICT
+        for leaked in ("list", "tuple", "NoneType", "non-builtin"):
+            assert leaked not in message
+
+
+def test_role_map_preserves_public_messages_and_valid_inputs(chain) -> None:
+    """Valid exact-dict DIRECT inputs and every pre-existing public message
+    are unchanged."""
+    from scripts.nextness_evidence_packet import (
+        PacketInputError,
+        build_packet,
+        validate_output_path,
+    )
+
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet({})
+    assert str(excinfo.value) == "no artifacts provided: nothing to package"
+
+    with pytest.raises(PacketInputError) as excinfo:
+        build_packet({"bogus": chain["report"]})
+    assert str(excinfo.value) == "unknown artifact roles: ['bogus']"
+
+    # A valid exact dict still builds, and the write boundary still accepts.
+    packet = build_packet(chain)
+    assert packet["schema"] == PACKET_SCHEMA
+    validate_output_path(chain["report"].parent / "packet.json", chain)


### PR DESCRIPTION
## Batch 3 — evidence-packet exact-type boundaries (NP8)

Three files. **Merged** with Kev's authorization after Jack's completed audit as squash `498f8c8b01e96569d9961614608c191f4be5d5d1` on 2026-07-20. No review-thread actions were taken. Reconciled with `main` by ordinary merge commit; histories file-disjoint.

This PR closes one class of defect at three depths in NP8: **a caller-supplied mapping deciding which data the module uses**, plus the hook-bearing type diagnostics that first drew attention to it.

### What it fixes

**1 — Hook-bearing type diagnostics (4 sites).** `_exact_dict_field` container refusal, `_evaluation_link` provided-bool, and both `_recorded_reader_bounds` refusals rendered `type(value).__name__`. `__name__` is an overridable **metaclass** property, so reading it to improve a message can execute caller code inside error formatting and escape the typed `PacketInputError`. Replaced with a module-local literal builtin-type identity table and hook-free `_describe_type` (no shared module, no new import edge).

**2 — Per-field lookup substitution.** `_exact_dict_field` did `field not in container` then `container[field]`; both hash the field name and compare it against whatever shares its bucket. The lookup now proves the exact builtin `dict`, traverses by **item iteration only**, compares **only exact builtin `str` keys**, and returns the matched value **straight from the iteration** — never a second subscript.

**3 — Outer role-map substitution and grammar.** `build_packet()` and `validate_output_path()` consumed the caller's top-level role map directly. Both now normalize through one shared private boundary, `_exact_role_map()`, which enforces the **complete grammar in order**: exact builtin `dict` identity → **emptiness** (established message) → **artifact-count ceiling** (established message), both decided with exact-dict operations **before any key is traversed** → item iteration admitting **exact builtin `str` keys only** → **unknown exact-string roles** (established sorted message) → a **fresh dict of proven known roles only**. Both entry points rely on it exclusively; their redundant later checks are removed and both annotations state the exact-`dict` contract.

### Failing-first evidence (historical — reproduced against the pre-repair trees)

| probe | pre-repair | post-repair |
|---|---|---|
| 4 metaclass diagnostic sites | raw `RuntimeError` **escapes** the typed refusal | typed `PacketInputError`, `got non-builtin value`, metaclass never consulted |
| strict collision key, armed post-construction | `__eq__ hook executed` **escapes** | `missing field 'schema'`, **zero hooks** |
| **soft collision key on a required field** | **RETURNED `'HOSTILE-VALUE'`** — satisfied the field *and supplied its content* | `missing field 'schema'` |
| foreign key whose `__repr__` raises | **escaped** `build_packet()` (unknown-roles message repr'd the key list) | refused, zero hooks |
| **soft collision on `"report"`** | **satisfied the role and supplied its value** — reached `_validate_role` and parsed the file | refused |
| colliding key whose `__eq__` raises | **escaped** `validate_output_path()` | refused, zero hooks |
| **soft collision in `validate_output_path()`** | **ACCEPTED** — supplied the primary input anchoring the whole write boundary | refused |
| `dict` **subclass** with armed iteration hooks | `__iter__` **ran** in `build_packet()`; accepted outright by `validate_output_path()` | refused before any hook |
| 9 exact-string unknown roles | traversed and listed (78 chars) | `9 artifacts exceed the 8 bound` (30 chars) |
| 10 000 exact-string unknown roles | an **88 914-character** diagnostic naming every key | 34 chars, no key listing |
| **`validate_output_path(out, {"report": …, "bogus": out})`** | **RETURNED SUCCESSFULLY** — the alias sweep walks only `ROLES`, so an *unknown* role naming the output path was skipped entirely and the output was allowed to alias an input | `unknown artifact roles: ['bogus']`; both files byte-identical |
| output validation with no known role / with an empty map | bare **`StopIteration`** | typed `PacketInputError` / `no artifacts provided: nothing to package` |

Three of those rows are **data-substitution** defects, not crashes: a caller-supplied key standing in for legitimate data.

### Reachability and behavior change

**PUBLIC CLI behavior is unchanged** — the CLI builds the role map itself from known roles and supplies JSON-derived (always-`str`) keys, so no CLI-reachable path changes and every public message is byte-identical.

**Malformed DIRECT-API behavior is deliberately CHANGED, not preserved.** A direct caller that previously received an unknown-role listing for an oversized map now receives the short ceiling refusal; one that previously reached `StopIteration`, or silently skipped an unknown role while validating an output path, now receives a typed refusal. **Valid exact-dict direct input remains byte-identical**, producing identical packets across repeated builds.

Preserved byte-for-byte: `no artifacts provided: nothing to package` · `unknown artifact roles: [...]` · the artifact-count message · every builtin-type diagnostic · `max_rows`/`max_line_bytes` range messages and exception types · schema, algorithm and output bytes.

### Bounded audit of caught-exception formatting — no second-order escape

Every `{e}`-formatting handler sees only stdlib or in-repo exceptions raised from **path- and json-derived** data: `parsed` comes from `_load_bounded_json(path)`, so its keys are always `str` and no caller-supplied object reaches those `try` blocks. The contrived route — a caller subclassing `EvaluatorInputError` and raising it from a hostile `__eq__` — is unreachable for the same reason. The two broad catches (`ValueError`, `OSError`) do not format `{e}` at all.

### Corrections of record

- An earlier revision of this description asserted, in the present tense, that the field-lookup repair removed *"the only mechanism by which a hostile key could raise anything here."* **False as written** — it did not account for the outer role map. That sentence was removed at source rather than left standing and contradicted.
- The accompanying claim that DIRECT `build_packet()` behavior was *unchanged* is withdrawn; see the reachability section above.
- The contract's typed-input-boundary paragraph carried the same stale "unchanged" wording and has been scoped to what the exception-boundary change actually did.

### Totals

Evidence packet **93 passed / 7 skipped** · focused Nextness **968 / 26** · full suite **1563 passed / 48 skipped** · `compileall` OK · all direct probes clean.

**Exact per-file numstat vs `main` — 3 files:**

| file | added | removed |
|---|---|---|
| `scripts/nextness_evidence_packet.py` | +149 | −22 |
| `tests/test_nextness_evidence_packet.py` | +540 | −0 |
| `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md` | +107 | −4 |
| **cumulative** | **+796** | **−26** |

### Boundary

Only the three files above. **Untouched:** evaluator, replay lab, monitor, params_schema, orchestrator, calibration, artifact_validation, predictor, metrics, `experiments/swarm_hunter_lab/**`, Ian's lane, and the preserved #391/#392 threads. No thread action, comment, reaction, reviewer request or label change.

### Remaining family work

Batches 4–5 (monitor, params_schema) remain. **Orchestrator (380/387/393) remains MANDATORY re-audit work** — not a descriptor swap. A read-only audit has since found a live data-substitution defect in `nextness_monitor.validate_observations`, which Batch 4 addresses.

