### PR TITLE
fix(nextness): monitor exact-string field boundary + hook-free diagnostics (Batch 4)

### DIFF
--- a/docs/NEXTNESS_MONITOR_CONTRACT.md
+++ b/docs/NEXTNESS_MONITOR_CONTRACT.md
@@ -113,12 +113,21 @@ four required fields were substitutable this way; a colliding key whose
 `__eq__` raised escaped instead. A genuine field coexisting with a
 colliding foreign key now wins, and the foreign key is discarded.
 
-**Refusal diagnostics are hook-free** on both lanes: a refusal never
-reads an attribute of the rejected value or of its class — in particular
-never `type(value).__name__`, an overridable **metaclass** property whose
-getter would run caller code from inside error formatting. Builtin type
-names come from a literal identity table; anything else is described as
-`non-builtin value`.
+**The two supplied-value type-refusal diagnostics repaired in this batch
+are hook-free**: they inspect the rejected value no further than exact
+type identity and never inspect its class. This is **not** a module-wide
+hook-free-totality claim; other DIRECT-API validation surfaces and the
+caller-controlled outer `records` sequence remain outside Batch 4.
+
+Reading `type(value).__name__` is what made those two unsafe: `__name__`
+is an overridable **metaclass** property, so its getter can run
+caller-controlled code from inside error formatting and escape the typed
+refusal. Builtin type names now come from a bounded literal identity
+table scanned by `is` comparison; anything not on it is described as
+`non-builtin value`. The scan is deliberately **not** a dictionary
+lookup — `mapping.get(type(value))` would hash the caller's class object
+and could itself execute a hostile metaclass `__hash__`, reopening the
+hole this repair closes.
 
 ## CLI expected-failure contract (inherited from NP1)
 

--- a/docs/NEXTNESS_MONITOR_CONTRACT.md
+++ b/docs/NEXTNESS_MONITOR_CONTRACT.md
@@ -87,6 +87,39 @@ float thresholds ∈ (0, 1)).
   the bridge's inherited NP1 options (`smoothing`, `holdout_fraction`)
   keep NP1's exact bounds and fail closed on violation.
 
+### Exact-string field boundary (reachability stated separately)
+
+**PUBLIC CLI lane** — observations reach the monitor from the JSONL log
+via NP1's bounded reader, so every record key is a `json`-produced
+builtin `str`. **No CLI-reachable behavior changes**, and every public
+diagnostic is byte-identical.
+
+**DIRECT Python-API lane** — a caller may pass records built in memory,
+whose keys are arbitrary objects. A proven-exact record is therefore
+traversed by **item iteration only**: just the exact builtin `str` keys
+on the allowlist are copied into a **fresh owned dict**, and every
+required field is read from that dict alone. A foreign key is never
+hashed, compared, stringified or represented, and counts as exactly one
+discarded field under the existing discard-and-count policy.
+
+This is a **soundness** boundary, not only a hook boundary. The previous
+`set(record)` / `record["confidence"]` / `record.get("hit")` /
+`"prev_seen" in record` sequence hashed the field names and compared them
+against whatever shared their buckets, so a non-`str` key whose
+`__hash__` collided with a field name had its `__eq__` invoked — and an
+`__eq__` returning `True` let that foreign key **satisfy the field and
+supply its own value as the reading the receipt is computed from**. All
+four required fields were substitutable this way; a colliding key whose
+`__eq__` raised escaped instead. A genuine field coexisting with a
+colliding foreign key now wins, and the foreign key is discarded.
+
+**Refusal diagnostics are hook-free** on both lanes: a refusal never
+reads an attribute of the rejected value or of its class — in particular
+never `type(value).__name__`, an overridable **metaclass** property whose
+getter would run caller code from inside error formatting. Builtin type
+names come from a literal identity table; anything else is described as
+`non-builtin value`.
+
 ## CLI expected-failure contract (inherited from NP1)
 
 `0` success · `2` validation failure (missing log file or out-of-bounds

--- a/scripts/nextness_monitor.py
+++ b/scripts/nextness_monitor.py
@@ -141,12 +141,43 @@ class MonitorConfig:
 # ---------------------------------------------------------------------------
 
 
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description for error messages.
+
+    ``type(value).__name__`` consults the metaclass — a hostile class can
+    override ``__name__`` so that reading it raises from inside error
+    formatting, escaping the typed-error promise. Identity comparison
+    against builtin types runs no user code, and anything that is not one
+    of these builtins is described generically instead of executing a hook
+    merely to improve a message.
+    """
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
+
+
 def _require_exact_int(name: str, value: Any) -> None:
     """Exact builtin ``int`` only — bool, float and int subclasses are
     configuration errors, not values to coerce."""
     if type(value) is not int:
         raise ValueError(
-            f"{name} must be a builtin int, got {type(value).__name__}"
+            f"{name} must be a builtin int, got {_describe_type(value)}"
         )
 
 
@@ -158,7 +189,7 @@ def _bounded_float(value: Any, field: str, low: float, high: float) -> float:
     conversion hook (__float__/__index__) is ever invoked."""
     if type(value) is not int and type(value) is not float:
         raise MonitorInputError(
-            f"{field}: expected a builtin real number, got {type(value).__name__}"
+            f"{field}: expected a builtin real number, got {_describe_type(value)}"
         )
     try:
         as_float = float(value)
@@ -181,27 +212,45 @@ def validate_observations(
     are discarded (counted), missing/invalid required fields fail
     closed. Values are read exactly once into owned plain objects — no
     caller container is retained.
+
+    The proven-exact record is traversed by ITEM ITERATION only, and just
+    the exact builtin ``str`` keys on the allowlist are copied into a
+    fresh owned dict from which every required field is then read. This
+    is a soundness boundary, not only a hook boundary: the previous
+    ``set(record)`` / ``record["confidence"]`` / ``record.get("hit")`` /
+    ``"prev_seen" in record`` sequence hashed and compared caller keys, so
+    a non-``str`` key whose ``__hash__`` collided with a field name had
+    its ``__eq__`` invoked — and an ``__eq__`` returning True let that
+    foreign key SATISFY the field and supply its own value as the reading
+    the receipt is computed from. A foreign or unknown key is now simply
+    one discarded field.
     """
     observations: list[dict[str, Any]] = []
     discarded = 0
     for i, record in enumerate(records):
         if type(record) is not dict:
             raise MonitorInputError(f"observation {i}: expected builtin dict")
-        unknown = set(record) - OBSERVATION_FIELDS
-        discarded += len(unknown)
+        fields: dict[str, Any] = {}
+        for key, value in record.items():
+            # Identity first: a foreign key short-circuits before any
+            # hash, comparison, str or repr of it can occur.
+            if type(key) is str and key in OBSERVATION_FIELDS:
+                fields[key] = value
+            else:
+                discarded += 1
         try:
-            confidence = _bounded_float(record["confidence"], "confidence", 0.0, 1.0)
-            p_actual = _bounded_float(record["p_actual"], "p_actual", 0.0, 1.0)
+            confidence = _bounded_float(fields["confidence"], "confidence", 0.0, 1.0)
+            p_actual = _bounded_float(fields["p_actual"], "p_actual", 0.0, 1.0)
         except KeyError as e:
             raise MonitorInputError(f"observation {i}: missing field {e.args[0]!r}") from e
-        hit = record.get("hit")
+        hit = fields.get("hit")
         if type(hit) is not bool:
             raise MonitorInputError(f"observation {i}: hit must be a builtin bool")
-        if "prev_seen" not in record:
+        if "prev_seen" not in fields:
             # Fail closed — defaulting a missing prev_seen to True would
             # silently mask unseen_state abstention.
             raise MonitorInputError(f"observation {i}: missing field 'prev_seen'")
-        prev_seen = record["prev_seen"]
+        prev_seen = fields["prev_seen"]
         if type(prev_seen) is not bool:
             raise MonitorInputError(f"observation {i}: prev_seen must be a builtin bool")
         observations.append(

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -849,3 +849,258 @@ def test_cli_receipt_ceiling_exit_5_injected(tmp_path, monkeypatch, capsys) -> N
             config=monitor_module.MonitorConfig(),
         )
     monkeypatch.undo()
+
+
+# ---------------------------------------------------------------------------
+# Batch 4 — exact-string field boundary + hook-free diagnostics.
+#
+# Reachability: the PUBLIC CLI feeds observations parsed from the JSONL log,
+# whose object keys are always builtin str, so none of the hazards below are
+# CLI-reachable. They are DIRECT-Python-API only — a caller passing records
+# built in memory. The repair is defensive totality on that lane.
+# ---------------------------------------------------------------------------
+
+
+_GOOD_OBS = {"confidence": 0.5, "p_actual": 0.5, "hit": True, "prev_seen": True}
+_SUBSTITUTE = {"confidence": 0.99, "p_actual": 0.01, "hit": False, "prev_seen": False}
+_REQUIRED_FIELDS = ("confidence", "p_actual", "hit", "prev_seen")
+
+
+class _ObsRaisingMeta(type):
+    """Metaclass whose __name__ property raises."""
+
+    ran = False
+
+    @property
+    def __name__(cls):
+        _ObsRaisingMeta.ran = True
+        raise RuntimeError("metaclass __name__ hook executed")
+
+
+class _ObsMetaBomb(metaclass=_ObsRaisingMeta):
+    pass
+
+
+class _SoftFieldKey:
+    """Hash-collides with a field name AND compares equal — used to satisfy
+    that field and supply its own value."""
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return True
+
+
+class _HardFieldKey:
+    """Hash-collides with a field name; comparison/representation armed.
+    __hash__ is inert until armed so the collision can be planted."""
+
+    fired: list[str] = []
+    armed = False
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        if _HardFieldKey.armed:
+            _HardFieldKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
+        return self._h
+
+    def __eq__(self, other):
+        _HardFieldKey.fired.append("__eq__")
+        raise RuntimeError("__eq__ hook executed")
+
+    def __repr__(self):
+        _HardFieldKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+class _DistinctCollidingKey:
+    """Hash-collides with a field name but compares UNEQUAL, so it coexists
+    with the genuine key instead of merging at construction."""
+
+    fired: list[str] = []
+
+    def __init__(self, target: str) -> None:
+        self._h = hash(target)
+
+    def __hash__(self) -> int:
+        return self._h
+
+    def __eq__(self, other):
+        return False
+
+    def __repr__(self):
+        _DistinctCollidingKey.fired.append("__repr__")
+        raise RuntimeError("__repr__ hook executed")
+
+
+def _obs_arm() -> None:
+    _ObsRaisingMeta.ran = False
+    _HardFieldKey.fired.clear()
+    _HardFieldKey.armed = False
+    _DistinctCollidingKey.fired.clear()
+
+
+def _without(field: str) -> dict:
+    return {k: v for k, v in _GOOD_OBS.items() if k != field}
+
+
+def test_soft_colliding_key_cannot_substitute_any_required_field() -> None:
+    """A foreign key colliding with a field name and comparing equal used to
+    SATISFY that field and supply the value the receipt is computed from."""
+    from scripts.nextness_monitor import MonitorInputError, validate_observations
+
+    expected = {
+        "confidence": "observation 0: missing field 'confidence'",
+        "p_actual": "observation 0: missing field 'p_actual'",
+        "hit": "observation 0: hit must be a builtin bool",
+        "prev_seen": "observation 0: missing field 'prev_seen'",
+    }
+    for field in _REQUIRED_FIELDS:
+        record = _without(field)
+        record[_SoftFieldKey(field)] = _SUBSTITUTE[field]
+        with pytest.raises(MonitorInputError) as excinfo:
+            validate_observations([record])
+        assert str(excinfo.value) == expected[field], field
+
+
+def test_hard_colliding_key_runs_no_hook_for_any_required_field() -> None:
+    """The record is traversed by item iteration, so a colliding foreign key
+    is never hashed, compared or represented by the validator."""
+    from scripts.nextness_monitor import MonitorInputError, validate_observations
+
+    for field in _REQUIRED_FIELDS:
+        _obs_arm()
+        record = _without(field)
+        record[_HardFieldKey(field)] = _SUBSTITUTE[field]
+        _HardFieldKey.armed = True          # planted; nothing may touch it now
+        try:
+            with pytest.raises(MonitorInputError):
+                validate_observations([record])
+            assert _HardFieldKey.fired == [], field
+        finally:
+            _HardFieldKey.armed = False
+
+
+def test_absent_required_field_keeps_the_established_refusal() -> None:
+    """With no genuine key at all, the established typed refusals stand."""
+    from scripts.nextness_monitor import MonitorInputError, validate_observations
+
+    for field, message in (
+        ("confidence", "observation 0: missing field 'confidence'"),
+        ("p_actual", "observation 0: missing field 'p_actual'"),
+        ("hit", "observation 0: hit must be a builtin bool"),
+        ("prev_seen", "observation 0: missing field 'prev_seen'"),
+    ):
+        with pytest.raises(MonitorInputError) as excinfo:
+            validate_observations([_without(field)])
+        assert str(excinfo.value) == message
+
+
+def test_genuine_field_wins_beside_a_foreign_colliding_key() -> None:
+    """A genuine exact-string field coexisting with a colliding foreign key
+    is used; the foreign key is counted once as a discarded field and none
+    of its hooks run."""
+    from scripts.nextness_monitor import validate_observations
+
+    _obs_arm()
+    record = dict(_GOOD_OBS)
+    record[_DistinctCollidingKey("confidence")] = 0.99
+    assert len(record) == len(_GOOD_OBS) + 1  # genuinely two separate entries
+
+    observations, discarded = validate_observations([record])
+    assert observations == [_GOOD_OBS]
+    assert observations[0]["confidence"] == 0.5   # genuine value, not 0.99
+    assert discarded == 1
+    assert _DistinctCollidingKey.fired == []
+
+
+def test_hostile_metaclass_never_consulted_by_either_diagnostic() -> None:
+    """Both raw type(value).__name__ diagnostics could execute a hostile
+    metaclass property from inside error formatting."""
+    from scripts.nextness_monitor import (
+        MonitorInputError,
+        _bounded_float,
+        _require_exact_int,
+    )
+
+    _obs_arm()
+    with pytest.raises(ValueError) as excinfo:
+        _require_exact_int("n", _ObsMetaBomb())
+    assert str(excinfo.value) == "n must be a builtin int, got non-builtin value"
+    assert _ObsRaisingMeta.ran is False
+
+    _obs_arm()
+    with pytest.raises(MonitorInputError) as excinfo:
+        _bounded_float(_ObsMetaBomb(), "f", 0.0, 1.0)
+    assert str(excinfo.value) == "f: expected a builtin real number, got non-builtin value"
+    assert _ObsRaisingMeta.ran is False
+
+
+def test_builtin_diagnostic_messages_are_byte_identical() -> None:
+    """Builtin supplied values keep their exact pre-existing messages."""
+    from scripts.nextness_monitor import (
+        MonitorInputError,
+        _bounded_float,
+        _require_exact_int,
+    )
+
+    for value, name in (("x", "str"), (1.5, "float"), ([], "list"), (None, "NoneType")):
+        with pytest.raises(ValueError) as excinfo:
+            _require_exact_int("n", value)
+        assert str(excinfo.value) == f"n must be a builtin int, got {name}"
+
+    for value, name in (("x", "str"), ([], "list"), (None, "NoneType"), (True, "bool")):
+        with pytest.raises(MonitorInputError) as excinfo:
+            _bounded_float(value, "f", 0.0, 1.0)
+        assert str(excinfo.value) == f"f: expected a builtin real number, got {name}"
+
+
+def test_describe_type_names_builtins_and_falls_back_generically() -> None:
+    from scripts.nextness_monitor import _describe_type
+
+    assert _describe_type(True) == "bool"  # before int
+    assert _describe_type(1) == "int"
+    assert _describe_type(1.0) == "float"
+    assert _describe_type("s") == "str"
+    assert _describe_type([]) == "list"
+    assert _describe_type({}) == "dict"
+    assert _describe_type(()) == "tuple"
+    assert _describe_type(set()) == "set"
+    assert _describe_type(b"") == "bytes"
+    assert _describe_type(None) == "NoneType"
+
+    class _IntSub(int):
+        pass
+
+    assert _describe_type(_IntSub(1)) == "non-builtin value"
+    _obs_arm()
+    assert _describe_type(_ObsMetaBomb()) == "non-builtin value"
+    assert _ObsRaisingMeta.ran is False
+
+
+def test_valid_direct_input_and_discard_policy_unchanged() -> None:
+    """Valid DIRECT records normalize exactly as before, and the documented
+    discard-and-count policy for unknown string fields is preserved."""
+    from scripts.nextness_monitor import MonitorInputError, validate_observations
+
+    observations, discarded = validate_observations([dict(_GOOD_OBS)])
+    assert observations == [_GOOD_OBS]
+    assert discarded == 0
+
+    observations, discarded = validate_observations(
+        [{**_GOOD_OBS, "zzz": 1, "extra": 2}]
+    )
+    assert observations == [_GOOD_OBS]
+    assert discarded == 2
+
+    # The record guard itself is unchanged.
+    with pytest.raises(MonitorInputError) as excinfo:
+        validate_observations([["not", "a", "dict"]])
+    assert str(excinfo.value) == "observation 0: expected builtin dict"

--- a/tests/test_nextness_monitor.py
+++ b/tests/test_nextness_monitor.py
@@ -921,19 +921,31 @@ class _HardFieldKey:
 
 
 class _DistinctCollidingKey:
-    """Hash-collides with a field name but compares UNEQUAL, so it coexists
-    with the genuine key instead of merging at construction."""
+    """Hash-collides with a field name but compares UNEQUAL while disarmed,
+    so it coexists with the genuine key instead of merging at construction.
+
+    Once armed, EVERY hook — ``__hash__``, ``__eq__`` and ``__repr__`` —
+    records itself and raises, so the validator is held to touching none of
+    them. Construction-time observations are cleared before arming.
+    """
 
     fired: list[str] = []
+    armed = False
 
     def __init__(self, target: str) -> None:
         self._h = hash(target)
 
     def __hash__(self) -> int:
+        if _DistinctCollidingKey.armed:
+            _DistinctCollidingKey.fired.append("__hash__")
+            raise RuntimeError("__hash__ hook executed")
         return self._h
 
     def __eq__(self, other):
-        return False
+        if _DistinctCollidingKey.armed:
+            _DistinctCollidingKey.fired.append("__eq__")
+            raise RuntimeError("__eq__ hook executed")
+        return False  # distinct from the genuine key while disarmed
 
     def __repr__(self):
         _DistinctCollidingKey.fired.append("__repr__")
@@ -945,6 +957,7 @@ def _obs_arm() -> None:
     _HardFieldKey.fired.clear()
     _HardFieldKey.armed = False
     _DistinctCollidingKey.fired.clear()
+    _DistinctCollidingKey.armed = False
 
 
 def _without(field: str) -> dict:
@@ -1014,11 +1027,19 @@ def test_genuine_field_wins_beside_a_foreign_colliding_key() -> None:
     record[_DistinctCollidingKey("confidence")] = 0.99
     assert len(record) == len(_GOOD_OBS) + 1  # genuinely two separate entries
 
-    observations, discarded = validate_observations([record])
+    # Construction is done; drop anything the dict build observed, then arm
+    # so that ANY hook the validator might reach records itself and raises.
+    _DistinctCollidingKey.fired.clear()
+    _DistinctCollidingKey.armed = True
+    try:
+        observations, discarded = validate_observations([record])
+    finally:
+        _DistinctCollidingKey.armed = False
+
     assert observations == [_GOOD_OBS]
     assert observations[0]["confidence"] == 0.5   # genuine value, not 0.99
-    assert discarded == 1
-    assert _DistinctCollidingKey.fired == []
+    assert discarded == 1                          # foreign key counted once
+    assert _DistinctCollidingKey.fired == []       # zero hooks fired
 
 
 def test_hostile_metaclass_never_consulted_by_either_diagnostic() -> None:


### PR DESCRIPTION
## Batch 4 — monitor exact-string field boundary + hook-free diagnostics

Three files. **Merged** with Kev's authorization after Jack's completed audit as squash `e8d425f0b1cb6dc2e7e644c8e506be9667825372` on 2026-07-20. No review-thread actions were taken. Base `498f8c8b01e96569d9961614608c191f4be5d5d1` (main, post-#398).

Found by asking *"where does a caller-supplied mapping decide **what data we use**?"* rather than *"where do we render a type name?"* — the substitution lens, applied deliberately.

### The defect

`validate_observations()` proved each record was an exact builtin `dict`, then consumed it with `set(record)`, `record["confidence"]`, `record.get("hit")` and `"prev_seen" in record`. Every one of those hashes the field name and compares it against whatever shares its bucket.

### Failing-first evidence (DIRECT Python API, against `498f8c8b`)

**1 — Value substitution on all four required fields.** A foreign key whose `__hash__` collides with a field name and whose `__eq__` returns `True` **satisfied that field and supplied its own value**:

| field absent, foreign key planted | pre-repair result |
|---|---|
| `confidence` | **ACCEPTED** → `{'confidence': 0.99, …}`, `discarded=0` |
| `p_actual` | **ACCEPTED** → `{'p_actual': 0.01, …}`, `discarded=0` |
| `hit` | **ACCEPTED** → `{'hit': False, …}`, `discarded=0` |
| `prev_seen` | **ACCEPTED** → `{'prev_seen': False, …}`, `discarded=0` |

`discarded_field_count` reported **0** in every case — the substitution was not even *counted*. `confidence` and `p_actual` are the values the receipt is computed from.

**2 — Hook escape on all four fields.** A colliding key whose `__eq__` raises escaped as a raw `RuntimeError: __eq__ hook executed` from `confidence`, `p_actual`, `hit` and `prev_seen`.

**3 — Both type-name diagnostics.** `_require_exact_int` and `_bounded_float` each executed a hostile metaclass `__name__` property from inside error formatting (`RuntimeError: metaclass __name__ hook executed`).

### Post-repair

| probe | after |
|---|---|
| soft collision, `confidence` / `p_actual` / `prev_seen` | `observation 0: missing field '<field>'` |
| soft collision, `hit` | `observation 0: hit must be a builtin bool` |
| hard collision, all four fields | typed refusal, **zero hooks fired** |
| `_require_exact_int(metaclass bomb)` | `n must be a builtin int, got non-builtin value`, metaclass never consulted |
| `_bounded_float(metaclass bomb)` | `f: expected a builtin real number, got non-builtin value`, metaclass never consulted |
| builtin diagnostics | **byte-identical** (`got str`, `got float`, `got list`, `got NoneType`, `got bool`) |
| valid record | unchanged, `discarded=0` |
| unknown string fields | unchanged, counted (`discarded=2` for two extras) |

### Repair (narrow)

- The exact builtin-`dict` **record guard is retained unchanged**.
- Each proven-exact record is traversed by **item iteration only**.
- Only exact builtin `str` keys **on the allowlist** are copied into a **fresh owned dict**; every required field is read from that dict alone.
- A foreign key is **never hashed, compared, stringified or represented**, and counts as exactly **one discarded field** under the existing discard-and-count policy.
- A **module-local** literal builtin-type identity table and hook-free `_describe_type` replace the two type-name diagnostics — no shared module, no new import edge.
- Every existing builtin-type message is **byte-for-byte preserved**; non-builtin supplied values are described generically without consulting their class.

**Not expanded** into the outer `records` sequence, downstream receipt mappings, `params_schema`, `orchestrator`, or any family-wide helper.

### Reachability (stated separately, as required)

- **PUBLIC CLI** — observations arrive from the JSONL log through NP1's bounded reader, so record keys are always `json`-produced builtin `str`. **No CLI-reachable behavior changes**; every public diagnostic is byte-identical.
- **DIRECT Python API** — a caller may pass in-memory records with arbitrary keys. That is the only lane where the defects above were reachable, and the only lane whose malformed-input behavior changes.

### Tests, docs, numstat

**+8 regressions (monitor 48 → 56):** soft and hard collisions across all four required fields; the established typed refusal when no genuine field is present; a genuine field winning beside a colliding foreign key (constructed with an `__eq__`-false collider so both entries genuinely coexist) counted once as discarded with no hook run; hostile-metaclass values at both diagnostic sites; builtin diagnostic-message identity; the `_describe_type` table; and unchanged valid-input, discard-count and record-guard behavior.

**Docs:** `NEXTNESS_MONITOR_CONTRACT.md` documents the exact-string field boundary with PUBLIC CLI and DIRECT API reachability stated separately, and records the soundness hole that is now closed.

**Scope of the hook-free claim (corrected).** The contract previously said *"refusal diagnostics are hook-free on both lanes"*, which reads as a **module-wide hook-free-totality claim this batch does not establish**. It is now scoped to the two supplied-value type-refusal diagnostics actually repaired here, and states explicitly that other DIRECT-API validation surfaces and the caller-controlled outer `records` sequence remain **outside Batch 4**.

**Why the identity table is a scan, not a dict.** A review suggestion proposed making `_BUILTIN_TYPE_NAMES` a dictionary for an O(1) `.get()` lookup. That is **declined**: `mapping.get(type(value))` **hashes the caller's class object**, so a hostile metaclass `__hash__` would execute — reopening precisely the hole this repair closes. The bounded tuple scanned by `is` comparison is retained deliberately, and the contract now records the reason.

**Collision pin strengthened.** `_DistinctCollidingKey` previously instrumented only `__repr__`, so the "genuine field wins" test proved less than it appeared to. It now instruments `__hash__`, `__eq__` and `__repr__`: equality returns `False` while disarmed so the foreign key coexists with the genuine one at construction, construction-time observations are cleared, the key is armed immediately before `validate_observations`, every armed hook records and raises, and it is disarmed in a `finally`. The test proves validation used the genuine value (`0.5`, not `0.99`), counted the foreign key exactly once as discarded, and fired **zero hooks** — against an **unchanged production implementation**.

**Suites:** monitor **56 passed** · focused Nextness **976 / 26** · full suite **1571 passed / 48 skipped** (from 1563/48 on main) · `compileall` OK. The follow-up commit changes documentation and tests only; `scripts/nextness_monitor.py` is byte-identical to the reviewed implementation.

**Exact per-file numstat vs `main` — 3 files, cumulative +376/−9:**

| file | added | removed |
|---|---|---|
| `scripts/nextness_monitor.py` | +58 | −9 |
| `tests/test_nextness_monitor.py` | +276 | −0 |
| `docs/NEXTNESS_MONITOR_CONTRACT.md` | +42 | −0 |
| **cumulative** | **+376** | **−9** |

### Boundary

Only the three files above. **Untouched:** evaluator, replay lab, evidence packet, params_schema, orchestrator, calibration, artifact_validation, predictor, metrics, `experiments/swarm_hunter_lab/**`, Ian's lane, and the preserved #391/#392 threads. No merge, reviewer request, comment, reaction, label or thread action.

### Remaining family work

Batch 5 (`params_schema`) remains. **Orchestrator (380/387/393) remains MANDATORY re-audit work** — not a descriptor swap.


