### PR TITLE
fix(medusa): select the API by bounded launch signatures, not a broad substring

### DIFF
--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -40,26 +40,36 @@ SERVICES = {
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
     # and the service exits immediately.
     #
-    # Detection must select the SERVICE, and only the service. Two launch
+    # Detection must select the SERVICE, and only the service. Several launch
     # forms exist during the migration, so the marker is a BOUNDED TUPLE of
     # actual launch signatures rather than a single broad substring:
     #
     #   "-m scripts.medusa_api"     the new module command
-    #   "\\scripts\\medusa_api.py"  a legacy orchestrator path command that
-    #                               an already-running process may still use
+    #   "\\scripts\\medusa_api.py"  a legacy path command as the orchestrator
+    #                               itself built it (pathlib renders Windows
+    #                               separators)
+    #   "/scripts/medusa_api.py"    the same legacy launch hand-typed with
+    #                               forward slashes, which Windows accepts
     #
-    # A bare substring such as "medusa_api" would also select unrelated
-    # commands that merely mention the module — notably
-    # ``python -m pytest tests/test_medusa_api.py`` — which ``--stop``
-    # would then kill. A module-form-only marker has the opposite fault:
-    # it misses a legacy process entirely, so status/stop/duplicate-start
-    # detection would start a second API beside the first.
+    # Both legacy separators are covered because the orchestrator-built and
+    # hand-typed forms are equally likely to still be running, and missing
+    # either one starts a SECOND API beside the first.
+    #
+    # Every signature stays bounded to a real launch fragment. Each legacy
+    # form carries its LEADING separator, so the signature is the
+    # "/scripts/medusa_api.py" path segment rather than a bare filename:
+    # ``python -m pytest tests/test_medusa_api.py`` and
+    # ``pytest scripts/medusa_api.py`` both fail to match. A bare substring
+    # such as "medusa_api" would select those, and ``--stop`` would kill an
+    # ordinary test run; a module-form-only marker has the opposite fault of
+    # missing every legacy process.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
         "marker": (
             "-m scripts.medusa_api",
             "\\scripts\\medusa_api.py",
+            "/scripts/medusa_api.py",
         ),
         "description": "REST API (Phase 16a)",
     },
@@ -83,7 +93,8 @@ def _signatures(marker) -> tuple:
 def build_process_filter(marker) -> str:
     """PowerShell ``Where-Object`` predicate for a service's launch signatures.
 
-    Shape: ``python.exe AND (matches A OR matches B)``. The alternatives are
+    Shape: ``python.exe AND (matches A OR matches B OR ...)`` — one query
+    however many signatures a service declares. The alternatives are
     PARENTHESIZED so the process-name test applies to all of them — without
     the parentheses, ``-and`` would bind to the first alternative only and
     every later signature would match any process of any name.

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -38,12 +38,20 @@ SERVICES = {
     # The API must be launched as a PACKAGE MODULE. Running it by absolute
     # file path leaves the repository root off sys.path, so its
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
-    # and the service exits immediately. The marker matches the module form
-    # of the command line so detection/status stay coherent.
+    # and the service exits immediately.
+    #
+    # The marker is the COMMON substring "medusa_api", which deliberately
+    # matches BOTH launch forms during migration: the new module command
+    # (``-m scripts.medusa_api``) and the legacy file-path command
+    # (``.../scripts/medusa_api.py``) an already-running process may still
+    # be using. A module-form-only marker such as "scripts.medusa_api"
+    # does not appear in the legacy command line, so status, stop and
+    # duplicate-start detection would all miss a legacy process — and a
+    # second API would be started alongside it.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
-        "marker": "scripts.medusa_api",
+        "marker": "medusa_api",
         "description": "REST API (Phase 16a)",
     },
     "geometry": {

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -40,18 +40,27 @@ SERVICES = {
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
     # and the service exits immediately.
     #
-    # The marker is the COMMON substring "medusa_api", which deliberately
-    # matches BOTH launch forms during migration: the new module command
-    # (``-m scripts.medusa_api``) and the legacy file-path command
-    # (``.../scripts/medusa_api.py``) an already-running process may still
-    # be using. A module-form-only marker such as "scripts.medusa_api"
-    # does not appear in the legacy command line, so status, stop and
-    # duplicate-start detection would all miss a legacy process — and a
-    # second API would be started alongside it.
+    # Detection must select the SERVICE, and only the service. Two launch
+    # forms exist during the migration, so the marker is a BOUNDED TUPLE of
+    # actual launch signatures rather than a single broad substring:
+    #
+    #   "-m scripts.medusa_api"     the new module command
+    #   "\\scripts\\medusa_api.py"  a legacy orchestrator path command that
+    #                               an already-running process may still use
+    #
+    # A bare substring such as "medusa_api" would also select unrelated
+    # commands that merely mention the module — notably
+    # ``python -m pytest tests/test_medusa_api.py`` — which ``--stop``
+    # would then kill. A module-form-only marker has the opposite fault:
+    # it misses a legacy process entirely, so status/stop/duplicate-start
+    # detection would start a second API beside the first.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
-        "marker": "medusa_api",
+        "marker": (
+            "-m scripts.medusa_api",
+            "\\scripts\\medusa_api.py",
+        ),
         "description": "REST API (Phase 16a)",
     },
     "geometry": {
@@ -62,19 +71,48 @@ SERVICES = {
 }
 
 
-def find_process(marker: str) -> list:
-    """Find running processes matching a marker string."""
+def _signatures(marker) -> tuple:
+    """Normalize a marker to a tuple of launch signatures.
+
+    A plain string is a single signature (engine, watchdog and geometry all
+    use that form and are unaffected); a tuple is used verbatim.
+    """
+    return (marker,) if isinstance(marker, str) else tuple(marker)
+
+
+def build_process_filter(marker) -> str:
+    """PowerShell ``Where-Object`` predicate for a service's launch signatures.
+
+    Shape: ``python.exe AND (matches A OR matches B)``. The alternatives are
+    PARENTHESIZED so the process-name test applies to all of them — without
+    the parentheses, ``-and`` would bind to the first alternative only and
+    every later signature would match any process of any name.
+    """
+    alternatives = " -or ".join(
+        f"$_.CommandLine -like '*{signature}*'" for signature in _signatures(marker)
+    )
+    return f"$_.Name -eq 'python.exe' -and ({alternatives})"
+
+
+def find_process(marker) -> list:
+    """Find running python.exe processes matching any of the launch signatures.
+
+    ``marker`` is a single signature string or a tuple of them. All
+    signatures are combined into ONE query, so a process matching more than
+    one is still reported once; the result is de-duplicated in order anyway.
+    """
     try:
         result = subprocess.run(
             ["powershell", "-Command",
-             f"Get-CimInstance Win32_Process | Where-Object {{$_.CommandLine -like '*{marker}*' -and $_.Name -eq 'python.exe'}} | Select-Object ProcessId | Format-List"],
+             f"Get-CimInstance Win32_Process | Where-Object {{{build_process_filter(marker)}}} | Select-Object ProcessId | Format-List"],
             capture_output=True, text=True, timeout=10,
         )
         pids = []
         for line in result.stdout.strip().split("\n"):
             if line.strip().startswith("ProcessId"):
                 pid = int(line.split(":")[-1].strip())
-                pids.append(pid)
+                if pid not in pids:
+                    pids.append(pid)
         return pids
     except Exception:
         return []

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -42,7 +42,7 @@ def test_api_command_carries_no_file_path_form() -> None:
 def test_api_marker_matches_the_module_command() -> None:
     """Process detection/status must be able to find the module-form process."""
     marker = SERVICES["api"]["marker"]
-    assert marker == "scripts.medusa_api"
+    assert marker == "medusa_api"
     assert marker in " ".join(build_command(SERVICES["api"]))
 
 
@@ -136,3 +136,124 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
     for name, config in SERVICES.items():
         assert ("module" in config) != ("script" in config), name
         build_command(config)  # constructs without raising
+
+
+# ---------------------------------------------------------------------------
+# Legacy-process compatibility during migration.
+#
+# The API's launch form changed from an absolute file path to a package
+# module. A process started under the OLD form may still be running, and its
+# command line contains ".../scripts/medusa_api.py" — which does NOT contain
+# the module-form string "scripts.medusa_api". A module-form-only marker
+# therefore makes a legacy process invisible to status, stop and
+# duplicate-start detection, and a second API would be started beside it.
+#
+# The marker is the common substring "medusa_api", which matches both forms.
+#
+# Nothing here inspects, starts, stops, restarts or kills a real process,
+# binds port 8080, deploys the API, or touches live telemetry: process
+# detection and Popen are both replaced.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_command() -> str:
+    """A representative pre-migration command line."""
+    return " ".join(
+        [PYTHON, "-u", str(PROJECT_ROOT / "scripts" / "medusa_api.py"), "--port", "8080"]
+    )
+
+
+def test_marker_matches_the_module_launch_command() -> None:
+    marker = SERVICES["api"]["marker"]
+    assert marker == "medusa_api"
+    assert marker in " ".join(build_command(SERVICES["api"]))
+
+
+def test_marker_matches_a_representative_legacy_command() -> None:
+    """The failing-first fact, pinned: the module-form-only marker does not
+    appear in the legacy command line, but the common marker does."""
+    legacy = _legacy_command()
+    assert legacy.endswith("--port 8080")
+    assert "medusa_api.py" in legacy
+
+    assert SERVICES["api"]["marker"] in legacy      # common marker: matches
+    assert "scripts.medusa_api" not in legacy       # module-form-only: misses
+
+
+def test_marker_matches_both_launch_forms_simultaneously() -> None:
+    marker = SERVICES["api"]["marker"]
+    module_command = " ".join(build_command(SERVICES["api"]))
+    assert marker in module_command and marker in _legacy_command()
+
+
+def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
+    """A still-running legacy process must be detected, so start_service
+    reports it and never launches a second API."""
+    import scripts.medusa_start as ms
+
+    def _detect(marker):
+        # Only the API marker resolves, and only to a mocked legacy PID.
+        return [4321] if marker == "medusa_api" else []
+
+    def _never_popen(*args, **kwargs):
+        raise AssertionError("Popen must not run while a process is already detected")
+
+    monkeypatch.setattr(ms, "find_process", _detect)
+    monkeypatch.setattr(ms.subprocess, "Popen", _never_popen)
+
+    pid = ms.start_service("api", ms.SERVICES["api"])
+    assert pid == 4321
+    assert "Already running" in capsys.readouterr().out
+
+
+def test_status_and_stop_pass_the_common_marker_to_detection(monkeypatch, capsys) -> None:
+    """status() and stop_service() both look the API up by the same common
+    marker, so a legacy process is visible to them too."""
+    import urllib.request
+
+    import scripts.medusa_start as ms
+
+    seen: list[str] = []
+
+    def _record(marker):
+        seen.append(marker)
+        return []  # nothing running: no taskkill path is ever entered
+
+    def _no_network(*args, **kwargs):
+        raise OSError("network disabled in tests")
+
+    monkeypatch.setattr(ms, "find_process", _record)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+
+    ms.status()
+    capsys.readouterr()
+    assert "medusa_api" in seen
+
+    seen.clear()
+    ms.stop_service("api", ms.SERVICES["api"])
+    capsys.readouterr()
+    assert seen == ["medusa_api"]
+
+
+def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys) -> None:
+    """Guard the guard: with no detected PID, no kill command is issued."""
+    import scripts.medusa_start as ms
+
+    def _never_run(*args, **kwargs):
+        raise AssertionError("subprocess.run must not be called with no detected PID")
+
+    monkeypatch.setattr(ms, "find_process", lambda marker: [])
+    monkeypatch.setattr(ms.subprocess, "run", _never_run)
+
+    ms.stop_service("api", ms.SERVICES["api"])
+    assert "Not running" in capsys.readouterr().out
+
+
+def test_watchdog_and_geometry_markers_are_unchanged() -> None:
+    """Only the API marker widens; the others keep their exact file names."""
+    assert SERVICES["watchdog"]["marker"] == "watchdog.py"
+    assert SERVICES["geometry"]["marker"] == "geometry_daemon.py"
+    for name in ("watchdog", "geometry"):
+        config = SERVICES[name]
+        assert config["marker"] in " ".join(build_command(config))
+        assert "medusa_api" not in config["marker"]

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -41,9 +41,10 @@ def test_api_command_carries_no_file_path_form() -> None:
 
 def test_api_marker_matches_the_module_command() -> None:
     """Process detection/status must be able to find the module-form process."""
-    marker = SERVICES["api"]["marker"]
-    assert marker == "medusa_api"
-    assert marker in " ".join(build_command(SERVICES["api"]))
+    from scripts.medusa_start import _signatures
+
+    module_command = " ".join(build_command(SERVICES["api"]))
+    assert any(s in module_command for s in _signatures(SERVICES["api"]["marker"]))
 
 
 def test_watchdog_and_geometry_launch_behaviour_unchanged() -> None:
@@ -63,9 +64,12 @@ def test_watchdog_and_geometry_launch_behaviour_unchanged() -> None:
 
 
 def test_every_service_marker_appears_in_its_own_command() -> None:
-    """Status/stop rely on the marker matching the launched command line."""
+    """Status/stop rely on at least one signature matching the launch command."""
+    from scripts.medusa_start import _signatures
+
     for name, config in SERVICES.items():
-        assert config["marker"] in " ".join(build_command(config)), name
+        command = " ".join(build_command(config))
+        assert any(s in command for s in _signatures(config["marker"])), name
 
 
 def test_api_module_help_resolves_imports() -> None:
@@ -139,51 +143,130 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Legacy-process compatibility during migration.
+# Process selection during the launch migration.
 #
-# The API's launch form changed from an absolute file path to a package
-# module. A process started under the OLD form may still be running, and its
-# command line contains ".../scripts/medusa_api.py" — which does NOT contain
-# the module-form string "scripts.medusa_api". A module-form-only marker
-# therefore makes a legacy process invisible to status, stop and
-# duplicate-start detection, and a second API would be started beside it.
+# Two launch forms exist while the migration completes:
+#   new    : python -u -m scripts.medusa_api --port 8080
+#   legacy : python -u <root>\scripts\medusa_api.py --port 8080
 #
-# The marker is the common substring "medusa_api", which matches both forms.
+# A module-form-only marker misses the legacy process entirely (status says
+# DOWN, stop never kills it, and a SECOND API is started beside it). A broad
+# substring like "medusa_api" has the opposite fault: it also selects
+# unrelated commands that merely mention the module — notably
+# `python -m pytest tests/test_medusa_api.py` — which `--stop` would kill.
 #
-# Nothing here inspects, starts, stops, restarts or kills a real process,
-# binds port 8080, deploys the API, or touches live telemetry: process
-# detection and Popen are both replaced.
+# Detection therefore uses a BOUNDED TUPLE of actual launch signatures, and
+# one PowerShell predicate of the shape:
+#     python.exe AND (matches A OR matches B)
+#
+# `-like '*X*'` is plain substring containment for wildcard-free X, which is
+# what every signature here is, so these tests model it with `in`.
+#
+# No test inspects, starts, stops or kills a real process, binds port 8080,
+# deploys the API, queries live telemetry, or reads the live data directory:
+# process detection, Popen, subprocess.run, urlopen and Path.glob are all
+# replaced.
 # ---------------------------------------------------------------------------
 
 
+_MODULE_SIGNATURE = "-m scripts.medusa_api"
+_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py"
+
+
+def _module_command() -> str:
+    return " ".join(build_command(SERVICES["api"]))
+
+
 def _legacy_command() -> str:
-    """A representative pre-migration command line."""
+    """A representative pre-migration command line (Windows separators)."""
     return " ".join(
         [PYTHON, "-u", str(PROJECT_ROOT / "scripts" / "medusa_api.py"), "--port", "8080"]
     )
 
 
-def test_marker_matches_the_module_launch_command() -> None:
+def _unrelated_pytest_commands() -> list[str]:
+    """Commands that merely MENTION the module and must never be selected."""
+    return [
+        f"{PYTHON} -m pytest tests/test_medusa_api.py",
+        f"{PYTHON} -m pytest tests{os.sep}test_medusa_api.py",
+        f"{PYTHON} -m pytest -k medusa_api",
+        f"{PYTHON} -c \"import scripts.medusa_api\"",
+    ]
+
+
+def _matching(command: str, marker) -> list[str]:
+    from scripts.medusa_start import _signatures
+
+    return [s for s in _signatures(marker) if s in command]
+
+
+def test_api_marker_is_a_bounded_tuple_of_launch_signatures() -> None:
     marker = SERVICES["api"]["marker"]
-    assert marker == "medusa_api"
-    assert marker in " ".join(build_command(SERVICES["api"]))
+    assert isinstance(marker, tuple)
+    assert marker == (_MODULE_SIGNATURE, _LEGACY_SIGNATURE)
 
 
-def test_marker_matches_a_representative_legacy_command() -> None:
-    """The failing-first fact, pinned: the module-form-only marker does not
-    appear in the legacy command line, but the common marker does."""
-    legacy = _legacy_command()
-    assert legacy.endswith("--port 8080")
-    assert "medusa_api.py" in legacy
-
-    assert SERVICES["api"]["marker"] in legacy      # common marker: matches
-    assert "scripts.medusa_api" not in legacy       # module-form-only: misses
+def test_module_command_matches_only_the_module_signature() -> None:
+    assert _matching(_module_command(), SERVICES["api"]["marker"]) == [_MODULE_SIGNATURE]
 
 
-def test_marker_matches_both_launch_forms_simultaneously() -> None:
+def test_legacy_command_matches_only_the_legacy_signature() -> None:
+    assert _matching(_legacy_command(), SERVICES["api"]["marker"]) == [_LEGACY_SIGNATURE]
+
+
+def test_unrelated_pytest_command_matches_no_signature() -> None:
+    """The false positive that made the broad marker dangerous: `--stop`
+    would have killed an ordinary test run."""
     marker = SERVICES["api"]["marker"]
-    module_command = " ".join(build_command(SERVICES["api"]))
-    assert marker in module_command and marker in _legacy_command()
+    for command in _unrelated_pytest_commands():
+        assert _matching(command, marker) == [], command
+        assert "medusa_api" in command  # it DOES mention the module...
+        # ...but mentioning it is not a launch signature.
+
+
+def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
+    """python.exe AND (A OR B) — the parentheses are load-bearing: without
+    them `-and` binds to the first alternative only."""
+    from scripts.medusa_start import build_process_filter
+
+    predicate = build_process_filter(SERVICES["api"]["marker"])
+    assert predicate.startswith("$_.Name -eq 'python.exe' -and (")
+    assert predicate.endswith(")")
+    assert " -or " in predicate
+    assert predicate.count("$_.CommandLine -like") == 2
+    assert _MODULE_SIGNATURE in predicate and _LEGACY_SIGNATURE in predicate
+
+
+def test_single_string_marker_behaviour_is_unchanged(monkeypatch) -> None:
+    """Engine, watchdog and geometry keep their plain-string markers and the
+    original one-alternative predicate."""
+    import scripts.medusa_start as ms
+
+    assert (
+        ms.build_process_filter("watchdog.py")
+        == "$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*watchdog.py*')"
+    )
+    assert (
+        ms.build_process_filter("run_v070_engine")
+        == "$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*run_v070_engine*')"
+    )
+
+    class _Result:
+        stdout = "ProcessId : 77\n"
+
+    monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: _Result())
+    assert ms.find_process("watchdog.py") == [77]
+
+
+def test_find_process_returns_no_duplicate_pids(monkeypatch) -> None:
+    """One process can satisfy more than one signature; it is reported once."""
+    import scripts.medusa_start as ms
+
+    class _Result:
+        stdout = "ProcessId : 111\nProcessId : 111\nProcessId : 222\nProcessId : 111\n"
+
+    monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: _Result())
+    assert ms.find_process(SERVICES["api"]["marker"]) == [111, 222]
 
 
 def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
@@ -192,8 +275,7 @@ def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
     import scripts.medusa_start as ms
 
     def _detect(marker):
-        # Only the API marker resolves, and only to a mocked legacy PID.
-        return [4321] if marker == "medusa_api" else []
+        return [4321] if marker == SERVICES["api"]["marker"] else []
 
     def _never_popen(*args, **kwargs):
         raise AssertionError("Popen must not run while a process is already detected")
@@ -206,14 +288,15 @@ def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
     assert "Already running" in capsys.readouterr().out
 
 
-def test_status_and_stop_pass_the_common_marker_to_detection(monkeypatch, capsys) -> None:
-    """status() and stop_service() both look the API up by the same common
-    marker, so a legacy process is visible to them too."""
+def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys) -> None:
+    """status() and stop_service() hand process detection the exact two-signature
+    collection, so both launch forms are visible to them."""
     import urllib.request
+    from pathlib import Path
 
     import scripts.medusa_start as ms
 
-    seen: list[str] = []
+    seen: list = []
 
     def _record(marker):
         seen.append(marker)
@@ -224,15 +307,17 @@ def test_status_and_stop_pass_the_common_marker_to_detection(monkeypatch, capsys
 
     monkeypatch.setattr(ms, "find_process", _record)
     monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+    # Test isolation: never read the real snapshot directory.
+    monkeypatch.setattr(Path, "glob", lambda self, pattern: [])
 
     ms.status()
     capsys.readouterr()
-    assert "medusa_api" in seen
+    assert (_MODULE_SIGNATURE, _LEGACY_SIGNATURE) in seen
 
     seen.clear()
     ms.stop_service("api", ms.SERVICES["api"])
     capsys.readouterr()
-    assert seen == ["medusa_api"]
+    assert seen == [(_MODULE_SIGNATURE, _LEGACY_SIGNATURE)]
 
 
 def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys) -> None:
@@ -250,10 +335,12 @@ def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys
 
 
 def test_watchdog_and_geometry_markers_are_unchanged() -> None:
-    """Only the API marker widens; the others keep their exact file names."""
+    """Only the API marker becomes a signature tuple; the others are untouched
+    plain strings matching their own launch commands."""
     assert SERVICES["watchdog"]["marker"] == "watchdog.py"
     assert SERVICES["geometry"]["marker"] == "geometry_daemon.py"
     for name in ("watchdog", "geometry"):
         config = SERVICES[name]
+        assert isinstance(config["marker"], str)
         assert config["marker"] in " ".join(build_command(config))
         assert "medusa_api" not in config["marker"]

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -145,22 +145,33 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 # ---------------------------------------------------------------------------
 # Process selection during the launch migration.
 #
-# Two launch forms exist while the migration completes:
-#   new    : python -u -m scripts.medusa_api --port 8080
-#   legacy : python -u <root>\scripts\medusa_api.py --port 8080
+# Three launch forms may be running while the migration completes:
+#   new             : python -u -m scripts.medusa_api --port 8080
+#   legacy (win)    : python -u C:\UtilityFog\scripts\medusa_api.py --port 8080
+#   legacy (posix)  : python -u C:/UtilityFog/scripts/medusa_api.py --port 8080
 #
-# A module-form-only marker misses the legacy process entirely (status says
-# DOWN, stop never kills it, and a SECOND API is started beside it). A broad
-# substring like "medusa_api" has the opposite fault: it also selects
-# unrelated commands that merely mention the module — notably
+# The orchestrator itself built the backslash form (pathlib renders Windows
+# separators); the forward-slash form is the same launch hand-typed, which
+# Windows accepts. Missing either legacy form starts a SECOND API beside the
+# first, so both separators are covered.
+#
+# A module-form-only marker misses every legacy process. A broad substring
+# like "medusa_api" has the opposite fault: it also selects unrelated
+# commands that merely mention the module — notably
 # `python -m pytest tests/test_medusa_api.py` — which `--stop` would kill.
 #
-# Detection therefore uses a BOUNDED TUPLE of actual launch signatures, and
-# one PowerShell predicate of the shape:
-#     python.exe AND (matches A OR matches B)
+# Detection therefore uses a BOUNDED TUPLE of launch signatures, each legacy
+# entry carrying its LEADING separator so the signature is the
+# "/scripts/medusa_api.py" path segment rather than a bare filename. One
+# PowerShell predicate is built, of the shape:
+#     python.exe AND (matches A OR matches B OR matches C)
 #
 # `-like '*X*'` is plain substring containment for wildcard-free X, which is
 # what every signature here is, so these tests model it with `in`.
+#
+# Command strings below are explicit synthetic literals, NOT built from the
+# host filesystem: the signatures are Windows path forms, and the CI runner
+# is not Windows.
 #
 # No test inspects, starts, stops or kills a real process, binds port 8080,
 # deploys the API, queries live telemetry, or reads the live data directory:
@@ -170,28 +181,33 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 _MODULE_SIGNATURE = "-m scripts.medusa_api"
-_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py"
+_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py"
+_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py"
+
+_EXPECTED_SIGNATURES = (
+    _MODULE_SIGNATURE,
+    _WIN_LEGACY_SIGNATURE,
+    _POSIX_LEGACY_SIGNATURE,
+)
+
+#: Synthetic legacy command lines — deliberately literal, host-independent.
+_WIN_LEGACY_COMMAND = "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port 8080"
+_POSIX_LEGACY_COMMAND = "python.exe -u C:/UtilityFog/scripts/medusa_api.py --port 8080"
+
+#: Commands that merely MENTION the module and must never be selected.
+_UNRELATED_COMMANDS = (
+    "python.exe -m pytest tests/test_medusa_api.py",
+    "python.exe -m pytest tests\\test_medusa_api.py",
+    "python.exe -m pytest -k medusa_api",
+    'python.exe -c "import scripts.medusa_api"',
+    # A relative path has no leading separator, so it is not a launch
+    # signature either.
+    "python.exe -m pytest scripts/medusa_api.py",
+)
 
 
 def _module_command() -> str:
     return " ".join(build_command(SERVICES["api"]))
-
-
-def _legacy_command() -> str:
-    """A representative pre-migration command line (Windows separators)."""
-    return " ".join(
-        [PYTHON, "-u", str(PROJECT_ROOT / "scripts" / "medusa_api.py"), "--port", "8080"]
-    )
-
-
-def _unrelated_pytest_commands() -> list[str]:
-    """Commands that merely MENTION the module and must never be selected."""
-    return [
-        f"{PYTHON} -m pytest tests/test_medusa_api.py",
-        f"{PYTHON} -m pytest tests{os.sep}test_medusa_api.py",
-        f"{PYTHON} -m pytest -k medusa_api",
-        f"{PYTHON} -c \"import scripts.medusa_api\"",
-    ]
 
 
 def _matching(command: str, marker) -> list[str]:
@@ -203,38 +219,49 @@ def _matching(command: str, marker) -> list[str]:
 def test_api_marker_is_a_bounded_tuple_of_launch_signatures() -> None:
     marker = SERVICES["api"]["marker"]
     assert isinstance(marker, tuple)
-    assert marker == (_MODULE_SIGNATURE, _LEGACY_SIGNATURE)
+    assert marker == _EXPECTED_SIGNATURES
 
 
 def test_module_command_matches_only_the_module_signature() -> None:
     assert _matching(_module_command(), SERVICES["api"]["marker"]) == [_MODULE_SIGNATURE]
 
 
-def test_legacy_command_matches_only_the_legacy_signature() -> None:
-    assert _matching(_legacy_command(), SERVICES["api"]["marker"]) == [_LEGACY_SIGNATURE]
+def test_windows_legacy_command_matches_only_the_backslash_signature() -> None:
+    assert _matching(_WIN_LEGACY_COMMAND, SERVICES["api"]["marker"]) == [
+        _WIN_LEGACY_SIGNATURE
+    ]
 
 
-def test_unrelated_pytest_command_matches_no_signature() -> None:
+def test_forward_slash_legacy_command_matches_only_that_signature() -> None:
+    """A hand-typed forward-slash launch on Windows is still the service."""
+    assert _matching(_POSIX_LEGACY_COMMAND, SERVICES["api"]["marker"]) == [
+        _POSIX_LEGACY_SIGNATURE
+    ]
+
+
+def test_unrelated_commands_match_no_signature() -> None:
     """The false positive that made the broad marker dangerous: `--stop`
     would have killed an ordinary test run."""
     marker = SERVICES["api"]["marker"]
-    for command in _unrelated_pytest_commands():
+    for command in _UNRELATED_COMMANDS:
         assert _matching(command, marker) == [], command
         assert "medusa_api" in command  # it DOES mention the module...
         # ...but mentioning it is not a launch signature.
 
 
 def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
-    """python.exe AND (A OR B) — the parentheses are load-bearing: without
-    them `-and` binds to the first alternative only."""
+    """python.exe AND (A OR B OR C) — the parentheses are load-bearing:
+    without them `-and` binds to the first alternative only."""
     from scripts.medusa_start import build_process_filter
 
     predicate = build_process_filter(SERVICES["api"]["marker"])
     assert predicate.startswith("$_.Name -eq 'python.exe' -and (")
     assert predicate.endswith(")")
-    assert " -or " in predicate
-    assert predicate.count("$_.CommandLine -like") == 2
-    assert _MODULE_SIGNATURE in predicate and _LEGACY_SIGNATURE in predicate
+    assert predicate.count("$_.CommandLine -like") == 3
+    assert predicate.count(" -or ") == 2
+    assert predicate.count("(") == 1 and predicate.count(")") == 1
+    for signature in _EXPECTED_SIGNATURES:
+        assert signature in predicate
 
 
 def test_single_string_marker_behaviour_is_unchanged(monkeypatch) -> None:
@@ -289,8 +316,8 @@ def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
 
 
 def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys) -> None:
-    """status() and stop_service() hand process detection the exact two-signature
-    collection, so both launch forms are visible to them."""
+    """status() and stop_service() hand process detection the exact
+    three-signature collection, so every launch form is visible to them."""
     import urllib.request
     from pathlib import Path
 
@@ -312,12 +339,12 @@ def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys
 
     ms.status()
     capsys.readouterr()
-    assert (_MODULE_SIGNATURE, _LEGACY_SIGNATURE) in seen
+    assert _EXPECTED_SIGNATURES in seen
 
     seen.clear()
     ms.stop_service("api", ms.SERVICES["api"])
     capsys.readouterr()
-    assert seen == [(_MODULE_SIGNATURE, _LEGACY_SIGNATURE)]
+    assert seen == [_EXPECTED_SIGNATURES]
 
 
 def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## API process selection: bounded launch signatures

Two files. **Merged** with Kev's authorization after Jack's completed audit as squash `d1d68b9c349ad894900c45d9f49f9e4f91017fc4` on 2026-07-20. No review-thread actions were taken. Reconciled with `main` by ordinary merge commit; histories file-disjoint. Independent of the Nextness lane.

### Problem 1 — a legacy process was invisible

[#397](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/397) moved the API from a file-path launch to a package-module launch and set the marker to `"scripts.medusa_api"`. That string does not occur in the legacy command line, whose path segment is `scripts\medusa_api.py`:

```
marker                    : 'scripts.medusa_api'
marker in NEW command     : True
marker in LEGACY command  : False
```

So a pre-migration API still running would be reported `DOWN` by `--status`, never killed by `--stop`, and missed by duplicate-start detection — `start_service` would launch a **second API** beside it.

### Problem 2 — the first fix over-corrected (found in review)

The first revision of this branch widened the marker to the bare substring `"medusa_api"`. That closed the miss but opened a **worse** fault in the other direction — it selects anything that merely *mentions* the module:

```
marker: 'medusa_api'
MODULE service      -> SELECTED
LEGACY service      -> SELECTED
pytest (posix sep)  -> SELECTED    python -m pytest tests/test_medusa_api.py
pytest (win sep)    -> SELECTED
```

An ordinary test run is not the API service, yet it would be reported `RUNNING` by `--status` and **killed by `--stop`**. A destructive false positive is strictly worse than the detection gap it was meant to fix.

### The design — three bounded launch signatures

| signature | matches |
|---|---|
| `-m scripts.medusa_api` | the new module command |
| `\scripts\medusa_api.py` | a legacy path command **as the orchestrator itself built it** (pathlib renders Windows separators) |
| `/scripts/medusa_api.py` | the same legacy launch **hand-typed with forward slashes**, which Windows accepts |

**Why both legacy separators.** The orchestrator-built and hand-typed forms are equally likely to still be running, and missing *either* one starts a second API beside the first.

**Why it stays safe.** Each legacy signature keeps its **leading separator**, so the bound is the `/scripts/medusa_api.py` *path segment* rather than a bare filename. `pytest tests/test_medusa_api.py` and even `pytest scripts/medusa_api.py` (relative, no leading separator) still match nothing.

- `find_process()` accepts **either a single signature string or a tuple**, normalizing a string to a one-element tuple. Engine, watchdog and geometry keep their plain-string markers and their **original one-alternative predicate exactly**.
- `build_process_filter()` builds **one** PowerShell query:

```
$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*-m scripts.medusa_api*' -or $_.CommandLine -like '*\scripts\medusa_api.py*' -or $_.CommandLine -like '*/scripts/medusa_api.py*')
```

The alternatives are **parenthesized deliberately**: without the parentheses `-and` binds to the first alternative only, and every later signature would match a process of *any* name. Single-signature markers render unchanged:

```
$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*watchdog.py*')
```

- Results are **de-duplicated in order**, so a process satisfying more than one signature is reported once.

### Post-repair

| command | selected? | via |
|---|---|---|
| module service | ✅ | `-m scripts.medusa_api` only |
| legacy service, Windows separators | ✅ | `\scripts\medusa_api.py` only |
| legacy service, forward slashes | ✅ | `/scripts/medusa_api.py` only |
| `python -m pytest tests/test_medusa_api.py` | ❌ | — |
| same, Windows separator | ❌ | — |
| `python -m pytest -k medusa_api` | ❌ | — |
| `python -c "import scripts.medusa_api"` | ❌ | — |
| `python -m pytest scripts/medusa_api.py` (relative) | ❌ | — |

### Portability correction

CI initially failed one test — and it was the **test**, not the production code. The legacy command was synthesized with `pathlib`, which renders **forward slashes on the Linux runner**, so the Windows-form signature matched nothing (`assert [] == ['\scripts\medusa_api.py']`). The signatures are deliberately Windows path forms, and this launcher is Windows-only in practice: `find_process` shells out to PowerShell `Get-CimInstance`, `stop_service` uses `taskkill`.

Command strings are now **explicit synthetic literals, independent of the runner**:

```
python.exe -u C:\UtilityFog\scripts\medusa_api.py --port 8080
python.exe -u C:/UtilityFog/scripts/medusa_api.py --port 8080
```

### Tests (+12, launcher 11 → 23)

The marker is a bounded three-tuple; each launch form matches **only its own** signature; five unrelated commands match **no** signature; the predicate is name-scoped with exactly **one parenthesized OR group and three `-like` clauses**; single-string markers keep their exact predicate and behaviour; duplicate PIDs are collapsed; a **mocked legacy PID** prevents `Popen`; `status()` and `stop_service()` pass the **exact three-signature collection**; `stop_service()` issues no kill when nothing is detected; watchdog and geometry markers remain plain strings.

**Test isolation.** The `status()` test mocks `Path.glob`, so it never reads the real snapshot directory. No test inspects, starts, stops or kills a real process, binds port 8080, deploys the API, queries live telemetry, or reads the live data directory — `find_process`, `Popen`, `subprocess.run`, `urlopen` and `Path.glob` are all replaced.

### Totals and numstat

Focused launcher **23 passed** · full suite **1583 passed / 48 skipped** · `compileall` OK.

**Exact per-file numstat vs `main` — 2 files, cumulative +304/−12:**

| file | added | removed |
|---|---|---|
| `scripts/medusa_start.py` | +64 | −7 |
| `tests/test_medusa_start.py` | +240 | −5 |
| **cumulative** | **+304** | **−12** |

### Boundary

Only the two files above. **Untouched:** `scripts/medusa_api.py`, the Nextness family, `params_schema`, `orchestrator`, `experiments/swarm_hunter_lab/**`, Ian's lane, and every preserved review thread on #397/#399. No merge, deployment, API start/restart, reviewer request, comment, reaction, label or thread action.

### Not included

This PR does **not** restart or deploy the API. Deployment remains a separate authorization after Jack's audit.

