### PR TITLE
fix(medusa): select the API by launch shape so absolute-path test runs are refused

### DIFF
--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import sys
+import json
 import time
 import subprocess
 import argparse
@@ -27,6 +28,147 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PYTHON = sys.executable
 CREATE_NO_WINDOW = 0x08000000
+
+# ---------------------------------------------------------------------------
+# API launch recognition: COMPLETE ACCEPTED COMMAND FORMS.
+#
+# Detection must select the SERVICE, and only the service. Earlier revisions
+# matched substring signatures, and a substring recognizes a FRAGMENT: it can
+# stop mid-word ("--port" inside "--portability"), start mid-word ("scripts"
+# inside "my_scripts"), or ignore what follows ("--help", trailing arguments,
+# a nested path handed to another tool). The recognizer below accepts a
+# complete command form instead, end to end:
+#
+#   <interpreter> [-u] -m scripts.medusa_api            <accepted arguments>
+#   <interpreter> [-u] <path to scripts\medusa_api.py>  <accepted arguments>
+#
+# <accepted arguments> is the service's own option grammar — "--port" with a
+# value naming a real port (1..65535) and "--host" with a value, each at most
+# once, in either order, both optional — and nothing may follow: the grammar
+# must consume the command to its END. The end boundary is what a substring
+# can never assert, and it is what distinguishes the bare launch (recognized;
+# the port defaults) from "--help" (refused: not the service's grammar).
+#
+# The launch target must sit in LAUNCH POSITION, immediately after the
+# interpreter and its optional -u. A command that merely NAMES the file or
+# module elsewhere — a nested path argument to another tool, a quoted textual
+# mention, a runner invocation — is refused structurally, whatever options it
+# carries. That closes the substring design's stated residual:
+# "tool.py C:\...\scripts\medusa_api.py --port 8080" is refused because
+# "tool.py" occupies the launch position.
+#
+# The path form accepts absolute and relative paths, both separator styles,
+# quoted or unquoted (Windows quotes a path containing spaces; element
+# splitting honors double quotes as grouping characters, and an empty
+# quoted group still yields an element — a real, empty argument the
+# grammar then refuses). Path and module elements compare
+# case-insensitively — Windows filesystem semantics, matching the old query's
+# behavior — but must be COMPLETE: the final path elements must be exactly
+# "scripts\medusa_api.py" and the module exactly "scripts.medusa_api", so a
+# longer word ("my_scripts", "medusa_api_tests", "medusa_api.pyc") never
+# matches. Option names stay exact: argparse itself is case-sensitive.
+#
+# Stated boundaries of the accepted grammar, honestly: only the separate
+# value form is a launch shape ("--port 8080" — the only form any launcher
+# here has ever produced); joined forms ("--port=8080", the fused
+# "-mscripts.medusa_api") and interpreter options other than -u are not
+# accepted commands. Quote handling is a deliberate simplification of the
+# full CommandLineToArgvW rules — backslash-escaped quotes are not
+# modeled, so an adversarially quote-crafted command line can parse
+# differently here than in the OS; every launcher and shell in this
+# system produces conventionally quoted commands. And recognition is by
+# command SHAPE: an identically shaped launch of another checkout's copy
+# of the script is indistinguishable — as in every prior design, the
+# shape is the contract.
+# ---------------------------------------------------------------------------
+
+_API_MODULE = "scripts.medusa_api"
+_API_SCRIPT = "scripts\\medusa_api.py"
+
+
+def _split_command_elements(command: str) -> list:
+    """Split a command line into its elements.
+
+    Whitespace separates elements; double quotes group — they bound an
+    element (or part of one) and are not characters of it. A quoted group
+    with nothing in it still yields an element: ``""`` (and a dangling
+    ``"``) is a real, empty argument to the process, so it must survive
+    splitting for the grammar to refuse it as a trailing element.
+    """
+    elements, current, quoted, grouped = [], [], False, False
+    for character in command:
+        if character == '"':
+            quoted = not quoted
+            grouped = True
+        elif character in " \t" and not quoted:
+            if current or grouped:
+                elements.append("".join(current))
+                current = []
+            grouped = False
+        else:
+            current.append(character)
+    if current or grouped:
+        elements.append("".join(current))
+    return elements
+
+
+def _is_valid_port_value(value: str) -> bool:
+    """A port value is decimal digits naming a real port: 1..65535."""
+    return value.isascii() and value.isdigit() and 0 < int(value) <= 65535
+
+
+def _is_accepted_argument_list(arguments: list) -> bool:
+    """Accept exactly the service's own option grammar, through to the end.
+
+    ``--port <valid value>`` and ``--host <value>``, each at most once, in
+    either order, both optional. Anything else — an unknown option, a
+    missing or invalid value, a duplicate, a trailing element — refuses the
+    whole command. Consuming every element IS the end-of-command boundary.
+    """
+    seen = set()
+    index = 0
+    while index < len(arguments):
+        option = arguments[index]
+        if option not in ("--port", "--host") or option in seen:
+            return False
+        if index + 1 >= len(arguments):
+            return False  # the option's value is missing
+        value = arguments[index + 1]
+        if option == "--port":
+            if not _is_valid_port_value(value):
+                return False
+        elif not value or value.startswith("-"):
+            return False
+        seen.add(option)
+        index += 2
+    return True
+
+
+def _is_api_launch_command(command: str) -> bool:
+    """True only for a complete accepted API launch command.
+
+    The launch target — the module element or the script path — must sit in
+    launch position, immediately after the interpreter and its optional
+    ``-u``, and everything after it must satisfy the accepted argument
+    grammar to the end of the command.
+    """
+    elements = _split_command_elements(command)
+    rest = elements[1:]  # elements[0] is the interpreter, whatever its path
+    if rest and rest[0] == "-u":
+        rest = rest[1:]
+    if not rest:
+        return False
+    if rest[0] == "-m":
+        return (
+            len(rest) >= 2
+            and rest[1].lower() == _API_MODULE
+            and _is_accepted_argument_list(rest[2:])
+        )
+    target = rest[0].replace("/", "\\").lower()
+    if target == _API_SCRIPT or target.endswith("\\" + _API_SCRIPT):
+        return _is_accepted_argument_list(rest[1:])
+    return False
+
 
 # Service definitions
 SERVICES = {
@@ -40,70 +182,15 @@ SERVICES = {
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
     # and the service exits immediately.
     #
-    # Detection must select the SERVICE, and only the service. Each signature
-    # therefore describes a LAUNCH SHAPE whose every element is COMPLETE: it
-    # begins at an argument boundary — a space or a path separator — and ends
-    # with the service's own ``--port`` argument plus the separator that
-    # follows it:
-    #
-    #   " -m scripts.medusa_api --port "     the new module command
-    #   "\\scripts\\medusa_api.py --port "   legacy launch, Windows separators
-    #   "/scripts/medusa_api.py --port "     legacy launch, forward slashes
-    #   "\\scripts\\medusa_api.py\" --port " the same, path quoted for spaces
-    #   "/scripts/medusa_api.py\" --port "   the same, quoted, forward slashes
-    #   " scripts\\medusa_api.py --port "    explicit relative launch, Windows
-    #   " scripts/medusa_api.py --port "     explicit relative launch, POSIX
-    #
-    # Bounding BOTH sides is what stops a prefix from posing as a word.
-    # ``-m scripts.medusa_api_tests`` embeds the module name but not the
-    # module ELEMENT; ``-m scripts.medusa_api --help`` names the module
-    # without the service's argument list; ``--portability`` embeds
-    # ``--port`` but is a different argument, so a nested unrelated path
-    # handed to another tool (``tool.py C:\\...\\scripts\\medusa_api.py
-    # --portability``) is refused too. The trailing space also asserts the
-    # separate-value form ``--port <value>`` — the only form any launcher
-    # here has ever produced. Absolute-path test runs
-    # (``python -m pytest C:\\UtilityFog\\scripts\\medusa_api.py``),
-    # ``tests/test_medusa_api.py``, ``-k medusa_api`` and
-    # ``-c "import scripts.medusa_api"`` all remain refused: this is a
-    # positive test for the launch shape, NOT an exclusion of the word
-    # "pytest"; nothing here enumerates test runners.
-    #
-    # Both separators are covered because the orchestrator built the Windows
-    # form while a hand-typed launch may use forward slashes, and missing
-    # either one starts a SECOND API beside the first. The quoted variants
-    # cover an install path containing spaces, where Windows wraps the script
-    # path in double quotes so the closing quote sits between the path and
-    # the arguments. The relative variants are EXPLICIT complete forms
-    # anchored by the argument boundary before ``scripts`` — relative support
-    # is NOT obtained by removing the leading separator from the absolute
-    # forms, which would let any longer word ending in ``scripts``
-    # (``my_scripts\\medusa_api.py --port 8080``) match as the service.
-    #
-    # Residual, stated honestly: a command that names the file as a complete
-    # ``scripts`` element AND carries ``--port <value>`` in launch position
-    # is indistinguishable from a launch by command-line substring alone. No
-    # real test runner does that (pytest rejects ``--port``), and narrowing
-    # further would need adjacency matching that PowerShell ``-like`` cannot
-    # express without wildcards the portable tests could not faithfully
-    # model. The boundary also cuts the other way: a hand launch that omits
-    # ``--port`` (relying on the argparse default) or reorders it behind
-    # ``--host`` shows no recognized shape and goes undetected. The bare
-    # miss is forced, not chosen — the bare command line is a strict prefix
-    # of the ``--help`` command line, so any substring matching one matches
-    # both — and the orchestrator itself always passes ``--port``.
+    # The marker is the RECOGNIZER of complete accepted launch commands
+    # defined above — not a substring collection. Selection requires the
+    # WHOLE command to be an accepted launch form: module or legacy script,
+    # bare or carrying the service's own options in either order, quoted or
+    # unquoted path, either separator style, and nothing trailing.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
-        "marker": (
-            " -m scripts.medusa_api --port ",
-            "\\scripts\\medusa_api.py --port ",
-            "/scripts/medusa_api.py --port ",
-            "\\scripts\\medusa_api.py\" --port ",
-            "/scripts/medusa_api.py\" --port ",
-            " scripts\\medusa_api.py --port ",
-            " scripts/medusa_api.py --port ",
-        ),
+        "marker": _is_api_launch_command,
         "description": "REST API (Phase 16a)",
     },
     "geometry": {
@@ -114,38 +201,76 @@ SERVICES = {
 }
 
 
-def _signatures(marker) -> tuple:
-    """Normalize a marker to a tuple of launch signatures.
+def build_process_filter(marker: str) -> str:
+    """PowerShell ``Where-Object`` predicate for a plain-string marker.
 
-    A plain string is a single signature (engine, watchdog and geometry all
-    use that form and are unaffected); a tuple is used verbatim.
+    ``python.exe AND (CommandLine contains marker)`` — the engine, watchdog
+    and geometry selectors keep this exact substring form, unchanged.
     """
-    return (marker,) if isinstance(marker, str) else tuple(marker)
+    return f"$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*{marker}*')"
 
 
-def build_process_filter(marker) -> str:
-    """PowerShell ``Where-Object`` predicate for a service's launch signatures.
+#: Host-shell query for the recognizer path: enumerate every python.exe
+#: process with its PID and full command line, as JSON. Recognition happens
+#: in Python — the shell filters by PROCESS NAME only, so the emitted query
+#: carries no knowledge of any launch form.
+_PYTHON_PROCESS_QUERY = (
+    "Where-Object {$_.Name -eq 'python.exe'} | "
+    "Select-Object ProcessId, CommandLine | ConvertTo-Json -Compress"
+)
 
-    Shape: ``python.exe AND (matches A OR matches B OR ...)`` — one query
-    however many signatures a service declares. The alternatives are
-    PARENTHESIZED so the process-name test applies to all of them — without
-    the parentheses, ``-and`` would bind to the first alternative only and
-    every later signature would match any process of any name.
+
+def _parse_process_rows(stdout: str) -> list:
+    """Rows from the JSON query: nothing, one bare object, or an array.
+
+    PowerShell emits a bare object (not a one-element array) when the
+    pipeline yields a single row, and nothing at all when it yields none.
     """
-    alternatives = " -or ".join(
-        f"$_.CommandLine -like '*{signature}*'" for signature in _signatures(marker)
-    )
-    return f"$_.Name -eq 'python.exe' -and ({alternatives})"
+    text = stdout.strip()
+    if not text:
+        return []
+    rows = json.loads(text)
+    return [rows] if isinstance(rows, dict) else rows
+
+
+def _select_recognized_pids(rows, recognizer) -> list:
+    """Ordered, de-duplicated PIDs of rows whose command is recognized.
+
+    A row without a PID is skipped; a row without a command line
+    (``CommandLine`` can be null) is refused. Order follows the query; a
+    PID appearing more than once is reported once.
+    """
+    pids = []
+    for row in rows:
+        pid = row.get("ProcessId")
+        if pid is None:
+            continue
+        pid = int(pid)
+        if recognizer(row.get("CommandLine") or "") and pid not in pids:
+            pids.append(pid)
+    return pids
 
 
 def find_process(marker) -> list:
-    """Find running python.exe processes matching any of the launch signatures.
+    """Find running python.exe processes selected by ``marker``.
 
-    ``marker`` is a single signature string or a tuple of them. All
-    signatures are combined into ONE query, so a process matching more than
-    one is still reported once; the result is de-duplicated in order anyway.
+    A plain-string marker keeps the original substring query, emitted and
+    parsed exactly as before (engine, watchdog, geometry). A callable
+    marker is a full-command recognizer: the shell enumerates python.exe
+    processes and Python classifies each command line, so the shell query
+    itself never encodes a launch form.
     """
     try:
+        if callable(marker):
+            # -NoProfile -NonInteractive keep stdout pure JSON: the strict
+            # parser is all-or-nothing, so a profile banner would otherwise
+            # read as "nothing running" (fail-safe, but a double-start risk).
+            result = subprocess.run(
+                ["powershell", "-NoProfile", "-NonInteractive", "-Command",
+                 "Get-CimInstance Win32_Process | " + _PYTHON_PROCESS_QUERY],
+                capture_output=True, text=True, timeout=10,
+            )
+            return _select_recognized_pids(_parse_process_rows(result.stdout), marker)
         result = subprocess.run(
             ["powershell", "-Command",
              f"Get-CimInstance Win32_Process | Where-Object {{{build_process_filter(marker)}}} | Select-Object ProcessId | Format-List"],

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -30,53 +30,71 @@ PYTHON = sys.executable
 CREATE_NO_WINDOW = 0x08000000
 
 # ---------------------------------------------------------------------------
-# API launch recognition: COMPLETE ACCEPTED COMMAND FORMS.
+# API launch recognition: LAUNCH ENVELOPE + PUBLIC-CLI ARGUMENT MIRROR.
 #
 # Detection must select the SERVICE, and only the service. Earlier revisions
 # matched substring signatures, and a substring recognizes a FRAGMENT: it can
 # stop mid-word ("--port" inside "--portability"), start mid-word ("scripts"
 # inside "my_scripts"), or ignore what follows ("--help", trailing arguments,
-# a nested path handed to another tool). The recognizer below accepts a
-# complete command form instead, end to end:
+# a nested path handed to another tool). The recognizer below has two parts,
+# and the claims for each are deliberately different.
 #
-#   <interpreter> [-u] -m scripts.medusa_api            <accepted arguments>
-#   <interpreter> [-u] <path to scripts\medusa_api.py>  <accepted arguments>
+# Part one, the SUPPORTED PYTHON LAUNCH ENVELOPE:
 #
-# <accepted arguments> is the service's own option grammar — "--port" with a
-# value naming a real port (1..65535) and "--host" with a value, each at most
-# once, in either order, both optional — and nothing may follow: the grammar
-# must consume the command to its END. The end boundary is what a substring
-# can never assert, and it is what distinguishes the bare launch (recognized;
-# the port defaults) from "--help" (refused: not the service's grammar).
+#   <interpreter> [-u] -m scripts.medusa_api            <arguments>
+#   <interpreter> [-u] <path to scripts\medusa_api.py>  <arguments>
 #
 # The launch target must sit in LAUNCH POSITION, immediately after the
-# interpreter and its optional -u. A command that merely NAMES the file or
-# module elsewhere — a nested path argument to another tool, a quoted textual
-# mention, a runner invocation — is refused structurally, whatever options it
-# carries. That closes the substring design's stated residual:
-# "tool.py C:\...\scripts\medusa_api.py --port 8080" is refused because
-# "tool.py" occupies the launch position.
+# interpreter and its optional -u. This envelope is NARROW BY DESIGN: -u is
+# the only interpreter option modeled, because it is the only one any
+# launcher in this system uses. No claim of complete Python-interpreter
+# -option coverage is made — an exotic launch such as ``python -X utf8 -m
+# scripts.medusa_api`` is outside the envelope and goes unrecognized. What
+# the launch position buys is structural: a command that merely NAMES the
+# file or module elsewhere — a nested path argument to another tool, a
+# quoted textual mention, a runner invocation — is refused whatever
+# arguments it carries ("tool.py C:\...\scripts\medusa_api.py --port 8080"
+# is refused because "tool.py" occupies the launch position).
+#
+# Part two, the API ARGUMENT GRAMMAR, is not an independent grammar at all:
+# it is a silent, non-exiting MIRROR of the public CLI that
+# scripts/medusa_api.py actually exposes (argparse with --port type=int,
+# --host type=str, and the auto-added --help, abbreviations allowed). The
+# real parser is the authority on what launches: it accepts "--port=8080",
+# unique abbreviations like "--po 8080" and "--ho localhost", repeated
+# options with the last value winning, empty host values ("--host """ and
+# "--host="), and ANY int()-parsable port spelling ("+8080", "8_080", "0",
+# even negative numbers) — argparse-valid, not socket-valid, because a
+# process launched that way exists and must be visible to status, stop and
+# duplicate prevention. The mirror accepts exactly those. It refuses, all
+# silently: help in any spelling (that process prints usage and exits, so
+# it is never the running service), ambiguous options ("--h": help/host),
+# unknown options ("--portability"), invalid integers, missing values, and
+# extra positional arguments. parse_args consumes the ENTIRE trailing
+# list, which is the end-of-command boundary — and it is what a substring
+# could never assert.
 #
 # The path form accepts absolute and relative paths, both separator styles,
 # quoted or unquoted (Windows quotes a path containing spaces; element
 # splitting honors double quotes as grouping characters, and an empty
-# quoted group still yields an element — a real, empty argument the
-# grammar then refuses). Path and module elements compare
-# case-insensitively — Windows filesystem semantics, matching the old query's
-# behavior — but must be COMPLETE: the final path elements must be exactly
-# "scripts\medusa_api.py" and the module exactly "scripts.medusa_api", so a
-# longer word ("my_scripts", "medusa_api_tests", "medusa_api.pyc") never
-# matches. Option names stay exact: argparse itself is case-sensitive.
+# quoted group still yields an element — a real, empty argument the mirror
+# then refuses as positional). Path and module elements compare
+# case-insensitively — Windows filesystem semantics, matching the old
+# query's behavior — but must be COMPLETE: the final path elements must be
+# exactly "scripts\medusa_api.py" and the module exactly
+# "scripts.medusa_api", so a longer word ("my_scripts", "medusa_api_tests",
+# "medusa_api.pyc") never matches. Long-option names and abbreviations
+# stay case-sensitive, exactly as argparse treats them.
 #
-# Stated boundaries of the accepted grammar, honestly: only the separate
-# value form is a launch shape ("--port 8080" — the only form any launcher
-# here has ever produced); joined forms ("--port=8080", the fused
-# "-mscripts.medusa_api") and interpreter options other than -u are not
-# accepted commands. Quote handling is a deliberate simplification of the
-# full CommandLineToArgvW rules — backslash-escaped quotes are not
-# modeled, so an adversarially quote-crafted command line can parse
-# differently here than in the OS; every launcher and shell in this
-# system produces conventionally quoted commands. And recognition is by
+# Honest boundaries that remain: quote handling is a deliberate
+# simplification of the full CommandLineToArgvW rules — backslash-escaped
+# quotes are not modeled, so an adversarially quote-crafted command line
+# can parse differently here than in the OS; every launcher and shell in
+# this system produces conventionally quoted commands. The mirror parses
+# with the ORCHESTRATOR's own argparse — a service launched by a
+# different Python whose argparse semantics differ could in principle be
+# classified differently than its own parser classified it; every
+# launcher here uses the one seat interpreter. And recognition is by
 # command SHAPE: an identically shaped launch of another checkout's copy
 # of the script is indistinguishable — as in every prior design, the
 # shape is the contract.
@@ -112,45 +130,70 @@ def _split_command_elements(command: str) -> list:
     return elements
 
 
-def _is_valid_port_value(value: str) -> bool:
-    """A port value is decimal digits naming a real port: 1..65535."""
-    return value.isascii() and value.isdigit() and 0 < int(value) <= 65535
+class _ArgumentRefusal(Exception):
+    """Raised inside the mirror parser instead of printing or exiting."""
 
 
-def _is_accepted_argument_list(arguments: list) -> bool:
-    """Accept exactly the service's own option grammar, through to the end.
+class _SilentArgumentMirror(argparse.ArgumentParser):
+    """An ArgumentParser that can neither write output nor exit.
 
-    ``--port <valid value>`` and ``--host <value>``, each at most once, in
-    either order, both optional. Anything else — an unknown option, a
-    missing or invalid value, a duplicate, a trailing element — refuses the
-    whole command. Consuming every element IS the end-of-command boundary.
+    Every argparse refusal path funnels through ``error`` (which normally
+    prints usage to stderr and exits) or ``exit``; overriding both means
+    process scanning can never emit a byte or terminate the orchestrator.
     """
-    seen = set()
-    index = 0
-    while index < len(arguments):
-        option = arguments[index]
-        if option not in ("--port", "--host") or option in seen:
-            return False
-        if index + 1 >= len(arguments):
-            return False  # the option's value is missing
-        value = arguments[index + 1]
-        if option == "--port":
-            if not _is_valid_port_value(value):
-                return False
-        elif not value or value.startswith("-"):
-            return False
-        seen.add(option)
-        index += 2
-    return True
+
+    def error(self, message):
+        raise _ArgumentRefusal(message)
+
+    def exit(self, status=0, message=None):
+        raise _ArgumentRefusal(message or str(status))
+
+
+def _build_api_argument_mirror() -> argparse.ArgumentParser:
+    """The PUBLIC CLI of scripts/medusa_api.py, mirrored silently.
+
+    The same long-option table the real entry point exposes — ``--help``
+    (argparse auto-adds it there; declared here as a plain flag so it can
+    never print), ``--port`` ``type=int``, ``--host`` ``type=str`` — so
+    abbreviation and ambiguity resolve exactly as the real parser resolves
+    them. The short ``-h`` is deliberately absent: it refuses as unknown,
+    and the real ``-h`` process prints usage and exits, so the outcome is
+    the same refusal.
+    """
+    mirror = _SilentArgumentMirror(add_help=False)
+    mirror.add_argument("--help", action="store_true")
+    mirror.add_argument("--port", type=int, default=8080)
+    mirror.add_argument("--host", type=str, default="0.0.0.0")
+    return mirror
+
+
+_API_ARGUMENT_MIRROR = _build_api_argument_mirror()
+
+
+def _accepts_api_arguments(arguments: list) -> bool:
+    """True when the public CLI would accept ``arguments`` AND keep serving.
+
+    ``parse_args`` consumes the ENTIRE trailing list — ambiguous options,
+    unknown options, invalid integers, missing values and extra positional
+    arguments all refuse, silently. A parse that succeeds only to request
+    help is refused too: that process prints usage and exits, so it is
+    never the running service.
+    """
+    try:
+        namespace = _API_ARGUMENT_MIRROR.parse_args(list(arguments))
+    except _ArgumentRefusal:
+        return False
+    return not namespace.help
 
 
 def _is_api_launch_command(command: str) -> bool:
-    """True only for a complete accepted API launch command.
+    """True only for a supported API launch command.
 
     The launch target — the module element or the script path — must sit in
     launch position, immediately after the interpreter and its optional
-    ``-u``, and everything after it must satisfy the accepted argument
-    grammar to the end of the command.
+    ``-u`` (the supported launch envelope), and everything after it must be
+    an argument list the public CLI accepts, consumed to the end of the
+    command.
     """
     elements = _split_command_elements(command)
     rest = elements[1:]  # elements[0] is the interpreter, whatever its path
@@ -162,11 +205,11 @@ def _is_api_launch_command(command: str) -> bool:
         return (
             len(rest) >= 2
             and rest[1].lower() == _API_MODULE
-            and _is_accepted_argument_list(rest[2:])
+            and _accepts_api_arguments(rest[2:])
         )
     target = rest[0].replace("/", "\\").lower()
     if target == _API_SCRIPT or target.endswith("\\" + _API_SCRIPT):
-        return _is_accepted_argument_list(rest[1:])
+        return _accepts_api_arguments(rest[1:])
     return False
 
 
@@ -182,11 +225,12 @@ SERVICES = {
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
     # and the service exits immediately.
     #
-    # The marker is the RECOGNIZER of complete accepted launch commands
-    # defined above — not a substring collection. Selection requires the
-    # WHOLE command to be an accepted launch form: module or legacy script,
-    # bare or carrying the service's own options in either order, quoted or
-    # unquoted path, either separator style, and nothing trailing.
+    # The marker is the RECOGNIZER defined above — not a substring
+    # collection. Selection requires the WHOLE command to be a supported
+    # launch: module or legacy script in launch position, quoted or
+    # unquoted path, either separator style, followed by any argument list
+    # the PUBLIC CLI accepts (mirrored argparse semantics, nothing
+    # trailing).
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -40,36 +40,48 @@ SERVICES = {
     # ``from scripts.tuning_api import ...`` fails with ModuleNotFoundError
     # and the service exits immediately.
     #
-    # Detection must select the SERVICE, and only the service. Several launch
-    # forms exist during the migration, so the marker is a BOUNDED TUPLE of
-    # actual launch signatures rather than a single broad substring:
+    # Detection must select the SERVICE, and only the service. Each signature
+    # therefore describes a LAUNCH SHAPE — a path segment together with the
+    # service's own argument list — not merely a path that happens to name
+    # the module:
     #
-    #   "-m scripts.medusa_api"     the new module command
-    #   "\\scripts\\medusa_api.py"  a legacy path command as the orchestrator
-    #                               itself built it (pathlib renders Windows
-    #                               separators)
-    #   "/scripts/medusa_api.py"    the same legacy launch hand-typed with
-    #                               forward slashes, which Windows accepts
+    #   "-m scripts.medusa_api"             the new module command
+    #   "\\scripts\\medusa_api.py --port"   legacy launch, Windows separators
+    #   "/scripts/medusa_api.py --port"     legacy launch, forward slashes
+    #   "\\scripts\\medusa_api.py\" --port" the same, path quoted for spaces
+    #   "/scripts/medusa_api.py\" --port"   the same, quoted, forward slashes
     #
-    # Both legacy separators are covered because the orchestrator-built and
-    # hand-typed forms are equally likely to still be running, and missing
-    # either one starts a SECOND API beside the first.
+    # Both separators are covered because the orchestrator built the Windows
+    # form while a hand-typed launch may use forward slashes, and missing
+    # either one starts a SECOND API beside the first. The quoted variants
+    # cover an install path containing spaces, where Windows wraps the script
+    # path in double quotes so the closing quote sits between the path and
+    # the arguments.
     #
-    # Every signature stays bounded to a real launch fragment. Each legacy
-    # form carries its LEADING separator, so the signature is the
-    # "/scripts/medusa_api.py" path segment rather than a bare filename:
-    # ``python -m pytest tests/test_medusa_api.py`` and
-    # ``pytest scripts/medusa_api.py`` both fail to match. A bare substring
-    # such as "medusa_api" would select those, and ``--stop`` would kill an
-    # ordinary test run; a module-form-only marker has the opposite fault of
-    # missing every legacy process.
+    # Requiring the trailing " --port" is what makes a path segment alone
+    # insufficient. A test invocation names the same file but never passes
+    # the service's arguments, so absolute-path runs like
+    # ``python -m pytest C:\\UtilityFog\\scripts\\medusa_api.py`` are refused
+    # — as are the relative form, ``tests/test_medusa_api.py``, ``-k
+    # medusa_api`` and ``-c "import scripts.medusa_api"``. This is a positive
+    # test for the launch shape, NOT an exclusion of the word "pytest";
+    # nothing here enumerates test runners.
+    #
+    # Residual, stated honestly: a command that both targets the file AND
+    # passes ``--port`` is indistinguishable from a launch by command-line
+    # substring alone. No real test runner does that (pytest rejects
+    # ``--port``), and narrowing further would need adjacency matching that
+    # PowerShell ``-like`` cannot express without wildcards the portable
+    # tests could not faithfully model.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
         "marker": (
             "-m scripts.medusa_api",
-            "\\scripts\\medusa_api.py",
-            "/scripts/medusa_api.py",
+            "\\scripts\\medusa_api.py --port",
+            "/scripts/medusa_api.py --port",
+            "\\scripts\\medusa_api.py\" --port",
+            "/scripts/medusa_api.py\" --port",
         ),
         "description": "REST API (Phase 16a)",
     },

--- a/scripts/medusa_start.py
+++ b/scripts/medusa_start.py
@@ -41,47 +41,68 @@ SERVICES = {
     # and the service exits immediately.
     #
     # Detection must select the SERVICE, and only the service. Each signature
-    # therefore describes a LAUNCH SHAPE — a path segment together with the
-    # service's own argument list — not merely a path that happens to name
-    # the module:
+    # therefore describes a LAUNCH SHAPE whose every element is COMPLETE: it
+    # begins at an argument boundary — a space or a path separator — and ends
+    # with the service's own ``--port`` argument plus the separator that
+    # follows it:
     #
-    #   "-m scripts.medusa_api"             the new module command
-    #   "\\scripts\\medusa_api.py --port"   legacy launch, Windows separators
-    #   "/scripts/medusa_api.py --port"     legacy launch, forward slashes
-    #   "\\scripts\\medusa_api.py\" --port" the same, path quoted for spaces
-    #   "/scripts/medusa_api.py\" --port"   the same, quoted, forward slashes
+    #   " -m scripts.medusa_api --port "     the new module command
+    #   "\\scripts\\medusa_api.py --port "   legacy launch, Windows separators
+    #   "/scripts/medusa_api.py --port "     legacy launch, forward slashes
+    #   "\\scripts\\medusa_api.py\" --port " the same, path quoted for spaces
+    #   "/scripts/medusa_api.py\" --port "   the same, quoted, forward slashes
+    #   " scripts\\medusa_api.py --port "    explicit relative launch, Windows
+    #   " scripts/medusa_api.py --port "     explicit relative launch, POSIX
+    #
+    # Bounding BOTH sides is what stops a prefix from posing as a word.
+    # ``-m scripts.medusa_api_tests`` embeds the module name but not the
+    # module ELEMENT; ``-m scripts.medusa_api --help`` names the module
+    # without the service's argument list; ``--portability`` embeds
+    # ``--port`` but is a different argument, so a nested unrelated path
+    # handed to another tool (``tool.py C:\\...\\scripts\\medusa_api.py
+    # --portability``) is refused too. The trailing space also asserts the
+    # separate-value form ``--port <value>`` — the only form any launcher
+    # here has ever produced. Absolute-path test runs
+    # (``python -m pytest C:\\UtilityFog\\scripts\\medusa_api.py``),
+    # ``tests/test_medusa_api.py``, ``-k medusa_api`` and
+    # ``-c "import scripts.medusa_api"`` all remain refused: this is a
+    # positive test for the launch shape, NOT an exclusion of the word
+    # "pytest"; nothing here enumerates test runners.
     #
     # Both separators are covered because the orchestrator built the Windows
     # form while a hand-typed launch may use forward slashes, and missing
     # either one starts a SECOND API beside the first. The quoted variants
     # cover an install path containing spaces, where Windows wraps the script
     # path in double quotes so the closing quote sits between the path and
-    # the arguments.
+    # the arguments. The relative variants are EXPLICIT complete forms
+    # anchored by the argument boundary before ``scripts`` — relative support
+    # is NOT obtained by removing the leading separator from the absolute
+    # forms, which would let any longer word ending in ``scripts``
+    # (``my_scripts\\medusa_api.py --port 8080``) match as the service.
     #
-    # Requiring the trailing " --port" is what makes a path segment alone
-    # insufficient. A test invocation names the same file but never passes
-    # the service's arguments, so absolute-path runs like
-    # ``python -m pytest C:\\UtilityFog\\scripts\\medusa_api.py`` are refused
-    # — as are the relative form, ``tests/test_medusa_api.py``, ``-k
-    # medusa_api`` and ``-c "import scripts.medusa_api"``. This is a positive
-    # test for the launch shape, NOT an exclusion of the word "pytest";
-    # nothing here enumerates test runners.
-    #
-    # Residual, stated honestly: a command that both targets the file AND
-    # passes ``--port`` is indistinguishable from a launch by command-line
-    # substring alone. No real test runner does that (pytest rejects
-    # ``--port``), and narrowing further would need adjacency matching that
-    # PowerShell ``-like`` cannot express without wildcards the portable
-    # tests could not faithfully model.
+    # Residual, stated honestly: a command that names the file as a complete
+    # ``scripts`` element AND carries ``--port <value>`` in launch position
+    # is indistinguishable from a launch by command-line substring alone. No
+    # real test runner does that (pytest rejects ``--port``), and narrowing
+    # further would need adjacency matching that PowerShell ``-like`` cannot
+    # express without wildcards the portable tests could not faithfully
+    # model. The boundary also cuts the other way: a hand launch that omits
+    # ``--port`` (relying on the argparse default) or reorders it behind
+    # ``--host`` shows no recognized shape and goes undetected. The bare
+    # miss is forced, not chosen — the bare command line is a strict prefix
+    # of the ``--help`` command line, so any substring matching one matches
+    # both — and the orchestrator itself always passes ``--port``.
     "api": {
         "module": "scripts.medusa_api",
         "args": ["--port", "8080"],
         "marker": (
-            "-m scripts.medusa_api",
-            "\\scripts\\medusa_api.py --port",
-            "/scripts/medusa_api.py --port",
-            "\\scripts\\medusa_api.py\" --port",
-            "/scripts/medusa_api.py\" --port",
+            " -m scripts.medusa_api --port ",
+            "\\scripts\\medusa_api.py --port ",
+            "/scripts/medusa_api.py --port ",
+            "\\scripts\\medusa_api.py\" --port ",
+            "/scripts/medusa_api.py\" --port ",
+            " scripts\\medusa_api.py --port ",
+            " scripts/medusa_api.py --port ",
         ),
         "description": "REST API (Phase 16a)",
     },

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -143,23 +143,32 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Process selection: LAUNCH SHAPES, not paths.
+# Process selection: LAUNCH SHAPES built from COMPLETE elements.
 #
 # Detection must select the API service and nothing else. A signature that is
 # only a path segment is insufficient, because a test invocation names the
-# same file:
+# same file — and a signature whose elements can end MID-WORD is insufficient
+# too, because a prefix then poses as the element:
 #
-#   service : python.exe -u C:\UtilityFog\scripts\medusa_api.py --port 8080
-#   pytest  : python.exe -m pytest C:\UtilityFog\scripts\medusa_api.py
+#   service : python.exe -u -m scripts.medusa_api --port 8080
+#   tests   : python.exe -m scripts.medusa_api_tests
+#   help    : python.exe -m scripts.medusa_api --help
+#   nested  : python.exe tool.py C:\UtilityFog\scripts\medusa_api.py --portability
 #
-# Both contain "\scripts\medusa_api.py". What distinguishes them is that the
-# service carries its own ARGUMENT LIST, so every legacy signature requires
-# the trailing " --port". That is a positive test for the launch shape, NOT
-# an exclusion of the word "pytest" — nothing here enumerates test runners.
+# Only the first is the service: it names the complete module element AND the
+# service's own argument list. The others embed the module name or ``--port``
+# as a prefix of a longer word, or without the argument list. Every signature
+# therefore begins at an argument boundary (a space or a path separator) and
+# ends with " --port " — the complete argument plus its trailing separator.
+# That is a positive test for the launch shape, NOT an exclusion of the word
+# "pytest" — nothing here enumerates test runners.
 #
 # Quoted variants cover an install path containing spaces, where Windows
 # wraps the script path in double quotes and the closing quote lands between
-# the path and the arguments.
+# the path and the arguments. Relative launches are supported ONLY through
+# explicit complete forms anchored by the space before ``scripts`` — not by
+# removing the leading separator from the absolute forms, which would let
+# ``my_scripts\medusa_api.py --port`` match as the service.
 #
 # Signatures are deliberately WILDCARD-FREE, so `-like '*sig*'` is plain
 # substring containment and these portable tests model it faithfully with
@@ -173,11 +182,13 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 # ---------------------------------------------------------------------------
 
 
-_MODULE_SIGNATURE = "-m scripts.medusa_api"
-_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py --port"
-_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py --port"
-_WIN_QUOTED_SIGNATURE = "\\scripts\\medusa_api.py\" --port"
-_POSIX_QUOTED_SIGNATURE = "/scripts/medusa_api.py\" --port"
+_MODULE_SIGNATURE = " -m scripts.medusa_api --port "
+_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py --port "
+_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py --port "
+_WIN_QUOTED_SIGNATURE = "\\scripts\\medusa_api.py\" --port "
+_POSIX_QUOTED_SIGNATURE = "/scripts/medusa_api.py\" --port "
+_WIN_RELATIVE_SIGNATURE = " scripts\\medusa_api.py --port "
+_POSIX_RELATIVE_SIGNATURE = " scripts/medusa_api.py --port "
 
 _EXPECTED_SIGNATURES = (
     _MODULE_SIGNATURE,
@@ -185,6 +196,8 @@ _EXPECTED_SIGNATURES = (
     _POSIX_LEGACY_SIGNATURE,
     _WIN_QUOTED_SIGNATURE,
     _POSIX_QUOTED_SIGNATURE,
+    _WIN_RELATIVE_SIGNATURE,
+    _POSIX_RELATIVE_SIGNATURE,
 )
 
 #: Real service command lines — literal, host-independent.
@@ -196,6 +209,8 @@ _WIN_QUOTED_COMMAND = (
 _POSIX_QUOTED_COMMAND = (
     'python.exe -u "C:/Program Files/UtilityFog/scripts/medusa_api.py" --port 8080'
 )
+_WIN_RELATIVE_COMMAND = "python.exe -u scripts\\medusa_api.py --port 8080"
+_POSIX_RELATIVE_COMMAND = "python.exe -u scripts/medusa_api.py --port 8080"
 
 #: Commands that name or mention the module but are NOT the service.
 _UNRELATED_COMMANDS = (
@@ -212,6 +227,15 @@ _UNRELATED_COMMANDS = (
     # Mentions rather than launches.
     "python.exe -m pytest -k medusa_api",
     'python.exe -c "import scripts.medusa_api"',
+    # Partial words: the module name or ``--port`` appears only as a PREFIX
+    # of a longer element, or without the service's argument list.
+    "python.exe -m scripts.medusa_api_tests",
+    "python.exe -m scripts.medusa_api --help",
+    "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability",
+    # A longer module name carrying the service's own option.
+    "python.exe -m scripts.medusa_api_tests --port 9000",
+    # A ``scripts`` path element that is itself the suffix of a longer word.
+    "python.exe -u C:\\Backup\\my_scripts\\medusa_api.py --port 8080",
 )
 
 
@@ -264,6 +288,86 @@ def test_quoted_install_path_with_spaces_is_detected() -> None:
     assert _matching(_POSIX_QUOTED_COMMAND, marker) == [_POSIX_QUOTED_SIGNATURE]
 
 
+def test_explicit_relative_launches_match_only_their_own_signature() -> None:
+    """Relative-launch support comes from EXPLICIT complete forms anchored at
+    the argument boundary before ``scripts`` — not from removing the leading
+    separator from the absolute signatures."""
+    marker = SERVICES["api"]["marker"]
+    for command, expected in (
+        (_WIN_RELATIVE_COMMAND, _WIN_RELATIVE_SIGNATURE),
+        (_POSIX_RELATIVE_COMMAND, _POSIX_RELATIVE_SIGNATURE),
+    ):
+        assert _matching(command, marker) == [expected], command
+
+
+def test_module_name_is_a_complete_element_not_a_prefix() -> None:
+    """``scripts.medusa_api_tests`` embeds the module name as a prefix; the
+    boundary after the complete module element refuses it — even when the
+    longer module carries the service's own option."""
+    marker = SERVICES["api"]["marker"]
+    for command in (
+        "python.exe -m scripts.medusa_api_tests",
+        "python.exe -m scripts.medusa_api_tests --port 9000",
+    ):
+        assert "-m scripts.medusa_api" in command  # the old signature IS inside
+        assert _matching(command, marker) == [], command
+
+
+def test_module_help_invocation_is_refused() -> None:
+    """This suite itself runs ``-m scripts.medusa_api --help`` as a
+    subprocess; ``--stop`` during a test run must not select it. The
+    discriminator is the service's own argument list, and --help is not
+    it."""
+    command = "python.exe -m scripts.medusa_api --help"
+    assert "-m scripts.medusa_api" in command  # the old signature IS inside
+    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+
+
+def test_option_prefix_on_a_nested_unrelated_path_is_refused() -> None:
+    """``--portability`` embeds ``--port`` as a prefix. The trailing boundary
+    makes ``--port`` a complete argument, so a nested unrelated path handed
+    to another tool is refused."""
+    command = "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability"
+    assert "\\scripts\\medusa_api.py --port" in command  # the old signature IS inside
+    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+
+
+def test_scripts_element_is_complete_not_a_word_suffix() -> None:
+    """De-anchoring the absolute signatures (dropping the leading separator)
+    would let a longer word ending in ``scripts`` match. The retained left
+    boundary refuses it."""
+    command = "python.exe -u C:\\Backup\\my_scripts\\medusa_api.py --port 8080"
+    assert "scripts\\medusa_api.py --port " in command  # the de-anchored form IS inside
+    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+
+
+def test_undetected_hand_launches_are_a_stated_residual() -> None:
+    """The false-NEGATIVE side of the boundary, pinned deliberately: a hand
+    launch relying on the argparse default port, or reordering ``--host``
+    before ``--port``, shows no recognized shape. The bare miss is forced,
+    not chosen — the bare command line is a strict prefix of the refused
+    ``--help`` command line, so under substring matching any signature
+    catching one catches both. The orchestrator itself always passes
+    ``--port``, so no orchestrator-built launch is ever missed."""
+    marker = SERVICES["api"]["marker"]
+    bare = "python.exe -u -m scripts.medusa_api"
+    assert (bare + " --help").startswith(bare)  # the forcing prefix relation
+    for command in (
+        bare,
+        "python.exe -u -m scripts.medusa_api --host 0.0.0.0 --port 8080",
+    ):
+        assert _matching(command, marker) == [], command
+
+
+def test_every_signature_is_bounded_on_both_sides() -> None:
+    """Each signature begins at an argument boundary — a space or a path
+    separator — and ends with the complete ``--port`` argument plus its
+    trailing separator, so no element can extend into a longer word."""
+    for signature in _EXPECTED_SIGNATURES:
+        assert signature[0] in (" ", "\\", "/"), signature
+        assert signature.endswith(" --port "), signature
+
+
 def test_absolute_path_pytest_invocations_are_refused() -> None:
     """The surviving false positive: an absolute-path test run contains the
     whole path segment, leading separator included, yet is not the service."""
@@ -291,8 +395,7 @@ def test_selection_does_not_depend_on_excluding_test_runners() -> None:
     for signature in _EXPECTED_SIGNATURES:
         assert "pytest" not in signature
         assert "test" not in signature
-    for signature in _EXPECTED_SIGNATURES[1:]:
-        assert signature.endswith(" --port")
+        assert signature.endswith(" --port ")
 
 
 def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
@@ -303,8 +406,8 @@ def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
     predicate = build_process_filter(SERVICES["api"]["marker"])
     assert predicate.startswith("$_.Name -eq 'python.exe' -and (")
     assert predicate.endswith(")")
-    assert predicate.count("$_.CommandLine -like") == 5
-    assert predicate.count(" -or ") == 4
+    assert predicate.count("$_.CommandLine -like") == 7
+    assert predicate.count(" -or ") == 6
     assert predicate.count("(") == 1 and predicate.count(")") == 1
     for signature in _EXPECTED_SIGNATURES:
         assert signature in predicate

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -150,27 +150,34 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Process selection: COMPLETE ACCEPTED COMMAND FORMS, not substrings.
+# Process selection: LAUNCH ENVELOPE + PUBLIC-CLI ARGUMENT MIRROR.
 #
 # A substring signature recognizes a fragment, and a fragment can stop
 # mid-word ("--port" inside "--portability"), start mid-word ("scripts"
 # inside "my_scripts"), or ignore what follows ("--help", trailing
-# arguments, a nested path handed to another tool). The recognizer accepts
-# a complete command instead:
+# arguments, a nested path handed to another tool). The recognizer has two
+# parts with deliberately different claims:
 #
-#   <interpreter> [-u] -m scripts.medusa_api            <accepted arguments>
-#   <interpreter> [-u] <path to scripts\medusa_api.py>  <accepted arguments>
+#   <interpreter> [-u] -m scripts.medusa_api            <arguments>
+#   <interpreter> [-u] <path to scripts\medusa_api.py>  <arguments>
 #
-# where the accepted arguments are the service's own option grammar —
-# "--port <1..65535>" and "--host <value>", each at most once, either
-# order, both optional — consumed to the END of the command. The end
-# boundary is what a substring can never assert: it recognizes the bare
-# launch (the port defaults) while refusing "--help", two commands one of
-# which is a strict prefix of the other. And because the launch target
-# must sit in launch position, a command that merely NAMES the file or
-# module — a nested path, a quoted mention, a runner invocation — is
-# refused structurally, even when the service's own options follow. That
-# closes the substring design's stated residual.
+# The SUPPORTED LAUNCH ENVELOPE is narrow by design — -u is the only
+# interpreter option modeled, and no claim of complete Python-interpreter
+# -option coverage is made. The ARGUMENT list is not an independent
+# grammar: it is a silent, non-exiting mirror of the public CLI that
+# scripts/medusa_api.py exposes (argparse: --port type=int, --host
+# type=str, auto --help, abbreviations allowed). The real parser is the
+# authority: "--port=8080", unique abbreviations, repeats (last wins),
+# empty host values and any int()-parsable port are ACCEPTED because a
+# process launched that way exists and must be visible to status, stop
+# and duplicate prevention; help in any spelling, ambiguous or unknown
+# options, invalid integers, missing values and extra positionals are
+# REFUSED, silently. parse_args consumes the ENTIRE trailing list — the
+# end-of-command boundary a substring could never assert; it recognizes
+# the bare launch while refusing "--help", a strict prefix pair. And the
+# launch position refuses a command that merely NAMES the file or module,
+# even when valid service arguments follow — the substring design's
+# stated residual, closed.
 #
 # The portable model is the recognizer itself: pure Python over fixed
 # command strings, identical on every host. The emitted host-shell side is
@@ -212,6 +219,23 @@ _ACCEPTED_COMMANDS = (
     'python.exe "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --host 0.0.0.0 --port 8080',
     # A quoted interpreter path containing spaces.
     '"C:\\Program Files\\Python\\python.exe" -u -m scripts.medusa_api --port 8080',
+    # The public CLI's own acceptances (Jack's audit matrix): = forms,
+    # unique abbreviations, repeats (last value wins), empty host values,
+    # and any int()-parsable port spelling — argparse-valid, not
+    # socket-valid, because a process launched that way exists and must be
+    # visible to status, stop and duplicate prevention.
+    "python.exe -m scripts.medusa_api --port=8080",
+    "python.exe -m scripts.medusa_api --host=localhost",
+    "python.exe -m scripts.medusa_api --po 8080",
+    "python.exe -m scripts.medusa_api --ho localhost",
+    "python.exe -m scripts.medusa_api --port 8080 --port 9090",
+    'python.exe -m scripts.medusa_api --host ""',
+    "python.exe -m scripts.medusa_api --host=",
+    "python.exe -m scripts.medusa_api --port +8080",
+    "python.exe -m scripts.medusa_api --port 8_080",
+    "python.exe -m scripts.medusa_api --port 0",
+    "python.exe -m scripts.medusa_api --port 65536",
+    "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port=8080",
 )
 
 #: Refused commands — fixed literals. Most name the module or the file;
@@ -221,18 +245,21 @@ _REFUSED_COMMANDS = (
     "python.exe -m scripts.medusa_api_tests",
     "python.exe -m scripts.medusa_api_tests --port 9000",
     "python.exe -m scripts.medusa_api2 --port 8080",
-    # --help and other unknown, invalid or incomplete options.
+    # Help in every spelling (that process prints usage and exits, so it
+    # is never the running service), ambiguous, unknown, invalid or
+    # incomplete options — exactly what the public CLI itself refuses.
     "python.exe -m scripts.medusa_api --help",
     "python.exe -u -m scripts.medusa_api --help",
+    "python.exe -m scripts.medusa_api -h",
+    "python.exe -m scripts.medusa_api --he",
+    "python.exe -m scripts.medusa_api --h 0.0.0.0",
     "python.exe -m scripts.medusa_api --port",
     "python.exe -m scripts.medusa_api --port 8o8o",
-    "python.exe -m scripts.medusa_api --port 0",
-    "python.exe -m scripts.medusa_api --port 65536",
-    "python.exe -m scripts.medusa_api --port=8080",
-    "python.exe -m scripts.medusa_api --port 8080 --port 9090",
+    "python.exe -m scripts.medusa_api --port 8080.0",
     "python.exe -m scripts.medusa_api --host",
     "python.exe -m scripts.medusa_api --host --port 8080",
     "python.exe -m scripts.medusa_api --portability",
+    "python.exe -m scripts.medusa_api --ports 8080",
     "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --portability",
     # Extra trailing arguments beyond the accepted grammar.
     "python.exe -m scripts.medusa_api --port 8080 extra",
@@ -378,13 +405,60 @@ def test_element_splitting_honors_double_quotes() -> None:
     assert _split_command_elements('a "') == ["a", ""]
 
 
-def test_port_values_must_name_a_real_port() -> None:
-    from scripts.medusa_start import _is_valid_port_value
+def test_public_cli_argument_semantics_are_mirrored() -> None:
+    """Jack's audit matrix: recognition must match what the PUBLIC CLI
+    (scripts/medusa_api.py argparse) accepts — not a stricter private
+    grammar. A genuine running API launched with any of the accepted
+    forms must be visible to status, stop and duplicate prevention."""
+    recognize = SERVICES["api"]["marker"]
+    prefix = "python.exe -u -m scripts.medusa_api "
+    for tail in (
+        "--port=8080", "--host=localhost",
+        "--po 8080", "--ho localhost", "--po=8080", "--hos 127.0.0.1",
+        "--port 8080 --port 9090",
+        '--host ""', "--host=",
+        "--port +8080", "--port 8_080", "--port 0", "--port 65536",
+        "--port -1",  # argparse's negative-number rule: the real CLI parses it
+    ):
+        assert recognize(prefix + tail), tail
+    for tail in (
+        "--help", "-h", "--he", "--h 0.0.0.0", "--help=x",
+        "--port", "--port 8o8o", "--port 8080.0",
+        "--host", "--host --port 8080",
+        "--portability", "--ports 8080", "--port8080",
+        "extra", "--port 8080 extra", "-- --port 8080",
+    ):
+        assert not recognize(prefix + tail), tail
 
-    for value in ("1", "80", "8080", "65535"):
-        assert _is_valid_port_value(value), value
-    for value in ("", "0", "65536", "8o8o", "-1", "8080 ", "８０８０"):
-        assert not _is_valid_port_value(value), value
+
+def test_refusal_and_recognition_are_silent(capsys) -> None:
+    """Process scanning must never write a byte to stdout or stderr:
+    argparse's print-and-exit paths are overridden into silent refusals."""
+    recognize = SERVICES["api"]["marker"]
+    for command in _ACCEPTED_COMMANDS + _REFUSED_COMMANDS:
+        recognize(command)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+
+
+def test_recognizer_mirror_matches_the_public_cli_source() -> None:
+    """The mirror must track the PUBLIC CLI, never the other way around.
+
+    Pin the real argparse configuration (scripts/medusa_api.py entry
+    point) at source level — exactly these two options and no others — so
+    a CLI change breaks this pin loudly instead of silently diverging
+    from the mirror. The public CLI file itself is never edited here."""
+    src = (PROJECT_ROOT / "scripts" / "medusa_api.py").read_text(encoding="utf-8")
+    assert 'parser.add_argument("--port", type=int, default=8080)' in src
+    assert 'parser.add_argument("--host", type=str, default="0.0.0.0")' in src
+    assert src.count("parser.add_argument(") == 2
+    # The constructor too: kwargs like allow_abbrev=False would change
+    # abbreviation semantics without touching any add_argument line.
+    assert (
+        'parser = argparse.ArgumentParser(description="Medusa REST API (Phase 16a)")'
+        in src
+    )
 
 
 def test_recognition_is_a_positive_grammar_not_a_runner_blacklist() -> None:
@@ -395,9 +469,10 @@ def test_recognition_is_a_positive_grammar_not_a_runner_blacklist() -> None:
 
     source = (
         inspect.getsource(ms._is_api_launch_command)
-        + inspect.getsource(ms._is_accepted_argument_list)
+        + inspect.getsource(ms._accepts_api_arguments)
         + inspect.getsource(ms._split_command_elements)
-        + inspect.getsource(ms._is_valid_port_value)
+        + inspect.getsource(ms._build_api_argument_mirror)
+        + inspect.getsource(ms._SilentArgumentMirror)
     )
     assert "pytest" not in source
     assert "unittest" not in source

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -143,35 +143,28 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Process selection during the launch migration.
+# Process selection: LAUNCH SHAPES, not paths.
 #
-# Three launch forms may be running while the migration completes:
-#   new             : python -u -m scripts.medusa_api --port 8080
-#   legacy (win)    : python -u C:\UtilityFog\scripts\medusa_api.py --port 8080
-#   legacy (posix)  : python -u C:/UtilityFog/scripts/medusa_api.py --port 8080
+# Detection must select the API service and nothing else. A signature that is
+# only a path segment is insufficient, because a test invocation names the
+# same file:
 #
-# The orchestrator itself built the backslash form (pathlib renders Windows
-# separators); the forward-slash form is the same launch hand-typed, which
-# Windows accepts. Missing either legacy form starts a SECOND API beside the
-# first, so both separators are covered.
+#   service : python.exe -u C:\UtilityFog\scripts\medusa_api.py --port 8080
+#   pytest  : python.exe -m pytest C:\UtilityFog\scripts\medusa_api.py
 #
-# A module-form-only marker misses every legacy process. A broad substring
-# like "medusa_api" has the opposite fault: it also selects unrelated
-# commands that merely mention the module — notably
-# `python -m pytest tests/test_medusa_api.py` — which `--stop` would kill.
+# Both contain "\scripts\medusa_api.py". What distinguishes them is that the
+# service carries its own ARGUMENT LIST, so every legacy signature requires
+# the trailing " --port". That is a positive test for the launch shape, NOT
+# an exclusion of the word "pytest" — nothing here enumerates test runners.
 #
-# Detection therefore uses a BOUNDED TUPLE of launch signatures, each legacy
-# entry carrying its LEADING separator so the signature is the
-# "/scripts/medusa_api.py" path segment rather than a bare filename. One
-# PowerShell predicate is built, of the shape:
-#     python.exe AND (matches A OR matches B OR matches C)
+# Quoted variants cover an install path containing spaces, where Windows
+# wraps the script path in double quotes and the closing quote lands between
+# the path and the arguments.
 #
-# `-like '*X*'` is plain substring containment for wildcard-free X, which is
-# what every signature here is, so these tests model it with `in`.
-#
-# Command strings below are explicit synthetic literals, NOT built from the
-# host filesystem: the signatures are Windows path forms, and the CI runner
-# is not Windows.
+# Signatures are deliberately WILDCARD-FREE, so `-like '*sig*'` is plain
+# substring containment and these portable tests model it faithfully with
+# `in`. Command strings are explicit synthetic literals, independent of the
+# CI runner: the signatures are Windows path forms and the runner is Linux.
 #
 # No test inspects, starts, stops or kills a real process, binds port 8080,
 # deploys the API, queries live telemetry, or reads the live data directory:
@@ -181,28 +174,44 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 _MODULE_SIGNATURE = "-m scripts.medusa_api"
-_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py"
-_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py"
+_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py --port"
+_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py --port"
+_WIN_QUOTED_SIGNATURE = "\\scripts\\medusa_api.py\" --port"
+_POSIX_QUOTED_SIGNATURE = "/scripts/medusa_api.py\" --port"
 
 _EXPECTED_SIGNATURES = (
     _MODULE_SIGNATURE,
     _WIN_LEGACY_SIGNATURE,
     _POSIX_LEGACY_SIGNATURE,
+    _WIN_QUOTED_SIGNATURE,
+    _POSIX_QUOTED_SIGNATURE,
 )
 
-#: Synthetic legacy command lines — deliberately literal, host-independent.
+#: Real service command lines — literal, host-independent.
 _WIN_LEGACY_COMMAND = "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port 8080"
 _POSIX_LEGACY_COMMAND = "python.exe -u C:/UtilityFog/scripts/medusa_api.py --port 8080"
+_WIN_QUOTED_COMMAND = (
+    'python.exe -u "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --port 8080'
+)
+_POSIX_QUOTED_COMMAND = (
+    'python.exe -u "C:/Program Files/UtilityFog/scripts/medusa_api.py" --port 8080'
+)
 
-#: Commands that merely MENTION the module and must never be selected.
+#: Commands that name or mention the module but are NOT the service.
 _UNRELATED_COMMANDS = (
+    # Absolute-path test invocations: these contain the full path segment,
+    # leading separator included, and were the surviving false positives.
+    "python.exe -m pytest C:\\UtilityFog\\scripts\\medusa_api.py",
+    "python.exe -m pytest C:/UtilityFog/scripts/medusa_api.py",
+    'python.exe -m pytest "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py"',
+    # Relative form.
+    "python.exe -m pytest scripts/medusa_api.py",
+    # The module's own test file, both separators.
     "python.exe -m pytest tests/test_medusa_api.py",
     "python.exe -m pytest tests\\test_medusa_api.py",
+    # Mentions rather than launches.
     "python.exe -m pytest -k medusa_api",
     'python.exe -c "import scripts.medusa_api"',
-    # A relative path has no leading separator, so it is not a launch
-    # signature either.
-    "python.exe -m pytest scripts/medusa_api.py",
 )
 
 
@@ -222,43 +231,80 @@ def test_api_marker_is_a_bounded_tuple_of_launch_signatures() -> None:
     assert marker == _EXPECTED_SIGNATURES
 
 
+def test_signatures_are_wildcard_free() -> None:
+    """`-like '*sig*'` is substring containment only while signatures carry no
+    wildcards — which is what lets these portable tests model it with `in`."""
+    for signature in _EXPECTED_SIGNATURES:
+        assert "*" not in signature and "?" not in signature and "[" not in signature
+
+
 def test_module_command_matches_only_the_module_signature() -> None:
     assert _matching(_module_command(), SERVICES["api"]["marker"]) == [_MODULE_SIGNATURE]
 
 
-def test_windows_legacy_command_matches_only_the_backslash_signature() -> None:
-    assert _matching(_WIN_LEGACY_COMMAND, SERVICES["api"]["marker"]) == [
-        _WIN_LEGACY_SIGNATURE
-    ]
+def test_real_legacy_launches_match_only_their_own_signature() -> None:
+    """Every real orchestrator launch form is still detected: both separators,
+    quoted and unquoted."""
+    marker = SERVICES["api"]["marker"]
+    for command, expected in (
+        (_WIN_LEGACY_COMMAND, _WIN_LEGACY_SIGNATURE),
+        (_POSIX_LEGACY_COMMAND, _POSIX_LEGACY_SIGNATURE),
+        (_WIN_QUOTED_COMMAND, _WIN_QUOTED_SIGNATURE),
+        (_POSIX_QUOTED_COMMAND, _POSIX_QUOTED_SIGNATURE),
+    ):
+        assert _matching(command, marker) == [expected], command
 
 
-def test_forward_slash_legacy_command_matches_only_that_signature() -> None:
-    """A hand-typed forward-slash launch on Windows is still the service."""
-    assert _matching(_POSIX_LEGACY_COMMAND, SERVICES["api"]["marker"]) == [
-        _POSIX_LEGACY_SIGNATURE
-    ]
+def test_quoted_install_path_with_spaces_is_detected() -> None:
+    """A path containing spaces is quoted by Windows, so the closing quote
+    sits between the path and the arguments."""
+    marker = SERVICES["api"]["marker"]
+    assert "Program Files" in _WIN_QUOTED_COMMAND
+    assert _matching(_WIN_QUOTED_COMMAND, marker) == [_WIN_QUOTED_SIGNATURE]
+    assert _matching(_POSIX_QUOTED_COMMAND, marker) == [_POSIX_QUOTED_SIGNATURE]
+
+
+def test_absolute_path_pytest_invocations_are_refused() -> None:
+    """The surviving false positive: an absolute-path test run contains the
+    whole path segment, leading separator included, yet is not the service."""
+    marker = SERVICES["api"]["marker"]
+    for command in (
+        "python.exe -m pytest C:\\UtilityFog\\scripts\\medusa_api.py",
+        "python.exe -m pytest C:/UtilityFog/scripts/medusa_api.py",
+    ):
+        assert "\\scripts\\medusa_api.py" in command or "/scripts/medusa_api.py" in command
+        assert _matching(command, marker) == [], command
 
 
 def test_unrelated_commands_match_no_signature() -> None:
-    """The false positive that made the broad marker dangerous: `--stop`
-    would have killed an ordinary test run."""
+    """`--stop` must never select a command that merely names the module."""
     marker = SERVICES["api"]["marker"]
     for command in _UNRELATED_COMMANDS:
         assert _matching(command, marker) == [], command
-        assert "medusa_api" in command  # it DOES mention the module...
-        # ...but mentioning it is not a launch signature.
+        assert "medusa_api" in command  # it DOES name the module...
+        # ...but naming it is not a launch shape.
+
+
+def test_selection_does_not_depend_on_excluding_test_runners() -> None:
+    """No signature mentions pytest or any other runner: the discriminator is
+    the presence of the service's own argument list."""
+    for signature in _EXPECTED_SIGNATURES:
+        assert "pytest" not in signature
+        assert "test" not in signature
+    for signature in _EXPECTED_SIGNATURES[1:]:
+        assert signature.endswith(" --port")
 
 
 def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
-    """python.exe AND (A OR B OR C) — the parentheses are load-bearing:
+    """python.exe AND (A OR B OR ...) — the parentheses are load-bearing:
     without them `-and` binds to the first alternative only."""
     from scripts.medusa_start import build_process_filter
 
     predicate = build_process_filter(SERVICES["api"]["marker"])
     assert predicate.startswith("$_.Name -eq 'python.exe' -and (")
     assert predicate.endswith(")")
-    assert predicate.count("$_.CommandLine -like") == 3
-    assert predicate.count(" -or ") == 2
+    assert predicate.count("$_.CommandLine -like") == 5
+    assert predicate.count(" -or ") == 4
     assert predicate.count("(") == 1 and predicate.count(")") == 1
     for signature in _EXPECTED_SIGNATURES:
         assert signature in predicate
@@ -316,8 +362,8 @@ def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
 
 
 def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys) -> None:
-    """status() and stop_service() hand process detection the exact
-    three-signature collection, so every launch form is visible to them."""
+    """status() and stop_service() hand process detection the exact signature
+    collection, so every launch form is visible to them."""
     import urllib.request
     from pathlib import Path
 
@@ -362,7 +408,7 @@ def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys
 
 
 def test_watchdog_and_geometry_markers_are_unchanged() -> None:
-    """Only the API marker becomes a signature tuple; the others are untouched
+    """Only the API marker is a signature tuple; the others are untouched
     plain strings matching their own launch commands."""
     assert SERVICES["watchdog"]["marker"] == "watchdog.py"
     assert SERVICES["geometry"]["marker"] == "geometry_daemon.py"

--- a/tests/test_medusa_start.py
+++ b/tests/test_medusa_start.py
@@ -4,16 +4,19 @@ Launching ``scripts/medusa_api.py`` by absolute file path leaves the repository
 root off ``sys.path``, so the module's import-time ``from scripts.tuning_api
 import ...`` fails with ``ModuleNotFoundError: No module named 'scripts'`` and
 the API exits before serving anything. These tests pin the module form, the
-process marker that matches that command line, and the unchanged watchdog /
-geometry launch shape.
+full-command recognizer that selects the service's process, and the unchanged
+watchdog / geometry launch shape.
 
 Nothing here binds a port, starts a server, restarts or stops any process, or
-touches live data. The only subprocess is ``--help``, which parses arguments
-and exits.
+touches live data. The only subprocesses are ``--help`` (parses arguments and
+exits) and — on Windows only — PowerShell pipelines over SYNTHETIC objects
+that never touch the live process table.
 """
 
 from __future__ import annotations
 
+import base64
+import inspect
 import os
 import subprocess
 import sys
@@ -39,12 +42,13 @@ def test_api_command_carries_no_file_path_form() -> None:
     assert "script" not in SERVICES["api"]
 
 
-def test_api_marker_matches_the_module_command() -> None:
-    """Process detection/status must be able to find the module-form process."""
-    from scripts.medusa_start import _signatures
+def test_api_marker_is_the_full_command_recognizer() -> None:
+    """The marker is the recognizer function itself — not a substring, not a
+    collection of substrings."""
+    from scripts.medusa_start import _is_api_launch_command
 
-    module_command = " ".join(build_command(SERVICES["api"]))
-    assert any(s in module_command for s in _signatures(SERVICES["api"]["marker"]))
+    assert SERVICES["api"]["marker"] is _is_api_launch_command
+    assert callable(SERVICES["api"]["marker"])
 
 
 def test_watchdog_and_geometry_launch_behaviour_unchanged() -> None:
@@ -63,13 +67,16 @@ def test_watchdog_and_geometry_launch_behaviour_unchanged() -> None:
         assert config["marker"] in cmd[2]
 
 
-def test_every_service_marker_appears_in_its_own_command() -> None:
-    """Status/stop rely on at least one signature matching the launch command."""
-    from scripts.medusa_start import _signatures
-
+def test_every_service_marker_selects_its_own_command() -> None:
+    """Status/stop rely on the marker selecting the service's own launch,
+    rendered exactly as the OS renders it (subprocess.list2cmdline)."""
     for name, config in SERVICES.items():
-        command = " ".join(build_command(config))
-        assert any(s in command for s in _signatures(config["marker"])), name
+        command = subprocess.list2cmdline(build_command(config))
+        marker = config["marker"]
+        if callable(marker):
+            assert marker(command), name
+        else:
+            assert marker in command, name
 
 
 def test_api_module_help_resolves_imports() -> None:
@@ -143,274 +150,440 @@ def test_every_real_service_declares_exactly_one_launch_form() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Process selection: LAUNCH SHAPES built from COMPLETE elements.
+# Process selection: COMPLETE ACCEPTED COMMAND FORMS, not substrings.
 #
-# Detection must select the API service and nothing else. A signature that is
-# only a path segment is insufficient, because a test invocation names the
-# same file — and a signature whose elements can end MID-WORD is insufficient
-# too, because a prefix then poses as the element:
+# A substring signature recognizes a fragment, and a fragment can stop
+# mid-word ("--port" inside "--portability"), start mid-word ("scripts"
+# inside "my_scripts"), or ignore what follows ("--help", trailing
+# arguments, a nested path handed to another tool). The recognizer accepts
+# a complete command instead:
 #
-#   service : python.exe -u -m scripts.medusa_api --port 8080
-#   tests   : python.exe -m scripts.medusa_api_tests
-#   help    : python.exe -m scripts.medusa_api --help
-#   nested  : python.exe tool.py C:\UtilityFog\scripts\medusa_api.py --portability
+#   <interpreter> [-u] -m scripts.medusa_api            <accepted arguments>
+#   <interpreter> [-u] <path to scripts\medusa_api.py>  <accepted arguments>
 #
-# Only the first is the service: it names the complete module element AND the
-# service's own argument list. The others embed the module name or ``--port``
-# as a prefix of a longer word, or without the argument list. Every signature
-# therefore begins at an argument boundary (a space or a path separator) and
-# ends with " --port " — the complete argument plus its trailing separator.
-# That is a positive test for the launch shape, NOT an exclusion of the word
-# "pytest" — nothing here enumerates test runners.
+# where the accepted arguments are the service's own option grammar —
+# "--port <1..65535>" and "--host <value>", each at most once, either
+# order, both optional — consumed to the END of the command. The end
+# boundary is what a substring can never assert: it recognizes the bare
+# launch (the port defaults) while refusing "--help", two commands one of
+# which is a strict prefix of the other. And because the launch target
+# must sit in launch position, a command that merely NAMES the file or
+# module — a nested path, a quoted mention, a runner invocation — is
+# refused structurally, even when the service's own options follow. That
+# closes the substring design's stated residual.
 #
-# Quoted variants cover an install path containing spaces, where Windows
-# wraps the script path in double quotes and the closing quote lands between
-# the path and the arguments. Relative launches are supported ONLY through
-# explicit complete forms anchored by the space before ``scripts`` — not by
-# removing the leading separator from the absolute forms, which would let
-# ``my_scripts\medusa_api.py --port`` match as the service.
+# The portable model is the recognizer itself: pure Python over fixed
+# command strings, identical on every host. The emitted host-shell side is
+# validated twice — its exact emission is pinned without execution, and,
+# on Windows only, the production pipeline fragment runs through REAL
+# PowerShell over SYNTHETIC objects (never the live process table); those
+# tests skip on the Linux CI runner and run on the Windows seat.
 #
-# Signatures are deliberately WILDCARD-FREE, so `-like '*sig*'` is plain
-# substring containment and these portable tests model it faithfully with
-# `in`. Command strings are explicit synthetic literals, independent of the
-# CI runner: the signatures are Windows path forms and the runner is Linux.
-#
-# No test inspects, starts, stops or kills a real process, binds port 8080,
-# deploys the API, queries live telemetry, or reads the live data directory:
-# process detection, Popen, subprocess.run, urlopen and Path.glob are all
-# replaced.
+# No test inspects, starts, stops or kills a real process, binds port
+# 8080, deploys the API, queries live telemetry, or reads the live data
+# directory: process detection, Popen, subprocess.run, urlopen and
+# Path.glob are replaced or handed synthetic input everywhere else.
 # ---------------------------------------------------------------------------
 
 
-_MODULE_SIGNATURE = " -m scripts.medusa_api --port "
-_WIN_LEGACY_SIGNATURE = "\\scripts\\medusa_api.py --port "
-_POSIX_LEGACY_SIGNATURE = "/scripts/medusa_api.py --port "
-_WIN_QUOTED_SIGNATURE = "\\scripts\\medusa_api.py\" --port "
-_POSIX_QUOTED_SIGNATURE = "/scripts/medusa_api.py\" --port "
-_WIN_RELATIVE_SIGNATURE = " scripts\\medusa_api.py --port "
-_POSIX_RELATIVE_SIGNATURE = " scripts/medusa_api.py --port "
-
-_EXPECTED_SIGNATURES = (
-    _MODULE_SIGNATURE,
-    _WIN_LEGACY_SIGNATURE,
-    _POSIX_LEGACY_SIGNATURE,
-    _WIN_QUOTED_SIGNATURE,
-    _POSIX_QUOTED_SIGNATURE,
-    _WIN_RELATIVE_SIGNATURE,
-    _POSIX_RELATIVE_SIGNATURE,
+#: Accepted launch commands — fixed literals, host-independent.
+_ACCEPTED_COMMANDS = (
+    # Module form: the orchestrator's own shape, then bare and single-option
+    # hand launches, both option orders, with and without -u.
+    "python.exe -u -m scripts.medusa_api --port 8080",
+    "python.exe -m scripts.medusa_api",
+    "python.exe -u -m scripts.medusa_api",
+    "python.exe -m scripts.medusa_api --port 8080",
+    "python.exe -m scripts.medusa_api --host 0.0.0.0",
+    "python.exe -m scripts.medusa_api --port 8080 --host 0.0.0.0",
+    "python.exe -m scripts.medusa_api --host 192.168.86.29 --port 8080",
+    # Legacy absolute paths, both separator styles, unquoted.
+    "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port 8080",
+    "python.exe -u C:/UtilityFog/scripts/medusa_api.py --port 8080",
+    # Quoted install path containing spaces, both separator styles.
+    'python.exe -u "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --port 8080',
+    'python.exe -u "C:/Program Files/UtilityFog/scripts/medusa_api.py" --port 8080',
+    # Relative launches, both separator styles.
+    "python.exe -u scripts\\medusa_api.py --port 8080",
+    "python.exe -u scripts/medusa_api.py --port 8080",
+    # Legacy bare and host-carrying forms.
+    "python.exe C:\\UtilityFog\\scripts\\medusa_api.py",
+    "python.exe scripts/medusa_api.py --host localhost",
+    'python.exe "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --host 0.0.0.0 --port 8080',
+    # A quoted interpreter path containing spaces.
+    '"C:\\Program Files\\Python\\python.exe" -u -m scripts.medusa_api --port 8080',
 )
 
-#: Real service command lines — literal, host-independent.
-_WIN_LEGACY_COMMAND = "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port 8080"
-_POSIX_LEGACY_COMMAND = "python.exe -u C:/UtilityFog/scripts/medusa_api.py --port 8080"
-_WIN_QUOTED_COMMAND = (
-    'python.exe -u "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --port 8080'
-)
-_POSIX_QUOTED_COMMAND = (
-    'python.exe -u "C:/Program Files/UtilityFog/scripts/medusa_api.py" --port 8080'
-)
-_WIN_RELATIVE_COMMAND = "python.exe -u scripts\\medusa_api.py --port 8080"
-_POSIX_RELATIVE_COMMAND = "python.exe -u scripts/medusa_api.py --port 8080"
-
-#: Commands that name or mention the module but are NOT the service.
-_UNRELATED_COMMANDS = (
-    # Absolute-path test invocations: these contain the full path segment,
-    # leading separator included, and were the surviving false positives.
+#: Refused commands — fixed literals. Most name the module or the file;
+#: none is an accepted launch form.
+_REFUSED_COMMANDS = (
+    # Module names with suffixes — with and without the service's options.
+    "python.exe -m scripts.medusa_api_tests",
+    "python.exe -m scripts.medusa_api_tests --port 9000",
+    "python.exe -m scripts.medusa_api2 --port 8080",
+    # --help and other unknown, invalid or incomplete options.
+    "python.exe -m scripts.medusa_api --help",
+    "python.exe -u -m scripts.medusa_api --help",
+    "python.exe -m scripts.medusa_api --port",
+    "python.exe -m scripts.medusa_api --port 8o8o",
+    "python.exe -m scripts.medusa_api --port 0",
+    "python.exe -m scripts.medusa_api --port 65536",
+    "python.exe -m scripts.medusa_api --port=8080",
+    "python.exe -m scripts.medusa_api --port 8080 --port 9090",
+    "python.exe -m scripts.medusa_api --host",
+    "python.exe -m scripts.medusa_api --host --port 8080",
+    "python.exe -m scripts.medusa_api --portability",
+    "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --portability",
+    # Extra trailing arguments beyond the accepted grammar.
+    "python.exe -m scripts.medusa_api --port 8080 extra",
+    "python.exe -m scripts.medusa_api --port 8080 --help",
+    "python.exe -u scripts/medusa_api.py --port 8080 --reload",
+    # Nested unrelated paths: the file is an ARGUMENT, not the launch
+    # target — refused even when the service's own options follow.
+    "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability",
+    "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --port 8080",
     "python.exe -m pytest C:\\UtilityFog\\scripts\\medusa_api.py",
     "python.exe -m pytest C:/UtilityFog/scripts/medusa_api.py",
     'python.exe -m pytest "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py"',
-    # Relative form.
     "python.exe -m pytest scripts/medusa_api.py",
-    # The module's own test file, both separators.
+    "python.exe -m pytest scripts/medusa_api.py --port 8080",
     "python.exe -m pytest tests/test_medusa_api.py",
     "python.exe -m pytest tests\\test_medusa_api.py",
-    # Mentions rather than launches.
     "python.exe -m pytest -k medusa_api",
+    # Textual mentions inside another command.
     'python.exe -c "import scripts.medusa_api"',
-    # Partial words: the module name or ``--port`` appears only as a PREFIX
-    # of a longer element, or without the service's argument list.
-    "python.exe -m scripts.medusa_api_tests",
-    "python.exe -m scripts.medusa_api --help",
-    "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability",
-    # A longer module name carrying the service's own option.
-    "python.exe -m scripts.medusa_api_tests --port 9000",
-    # A ``scripts`` path element that is itself the suffix of a longer word.
+    'python.exe analyze.py --grep " -m scripts.medusa_api --port "',
+    # Longer words around the path elements.
     "python.exe -u C:\\Backup\\my_scripts\\medusa_api.py --port 8080",
+    "python.exe -u C:\\UtilityFog\\scripts\\medusa_api_extra.py --port 8080",
+    "python.exe -u C:\\UtilityFog\\scripts\\premedusa_api.py --port 8080",
+    "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.pyc --port 8080",
+    # No launch target at all.
+    "python.exe",
+    "python.exe -u",
+    "python.exe --port 8080",
+    "",
+    # Empty quoted groups are REAL empty arguments to the process — an
+    # extra trailing argument the grammar refuses, and an empty launch
+    # target when they sit in launch position.
+    'python.exe -m scripts.medusa_api ""',
+    'python.exe -m scripts.medusa_api "',
+    'python.exe -m scripts.medusa_api --host ok "',
+    'python.exe "" -m scripts.medusa_api --port 8080',
 )
 
 
-def _module_command() -> str:
-    return " ".join(build_command(SERVICES["api"]))
+def test_accepted_commands_are_recognized() -> None:
+    """Every accepted launch form — module and legacy script, bare, each
+    option, both orders, quoted and unquoted, both separator styles."""
+    recognize = SERVICES["api"]["marker"]
+    for command in _ACCEPTED_COMMANDS:
+        assert recognize(command), command
 
 
-def _matching(command: str, marker) -> list[str]:
-    from scripts.medusa_start import _signatures
-
-    return [s for s in _signatures(marker) if s in command]
-
-
-def test_api_marker_is_a_bounded_tuple_of_launch_signatures() -> None:
-    marker = SERVICES["api"]["marker"]
-    assert isinstance(marker, tuple)
-    assert marker == _EXPECTED_SIGNATURES
+def test_refused_commands_are_refused() -> None:
+    """Suffixed modules, --help, invalid/incomplete/unknown options, extra
+    trailing arguments, nested unrelated paths, textual mentions."""
+    recognize = SERVICES["api"]["marker"]
+    for command in _REFUSED_COMMANDS:
+        assert not recognize(command), command
 
 
-def test_signatures_are_wildcard_free() -> None:
-    """`-like '*sig*'` is substring containment only while signatures carry no
-    wildcards — which is what lets these portable tests model it with `in`."""
-    for signature in _EXPECTED_SIGNATURES:
-        assert "*" not in signature and "?" not in signature and "[" not in signature
+def test_build_command_output_is_recognized_as_rendered() -> None:
+    """The exact command build_command() produces — as the OS renders it,
+    including a quoted interpreter path when it contains spaces."""
+    recognize = SERVICES["api"]["marker"]
+    assert recognize(subprocess.list2cmdline(build_command(SERVICES["api"])))
+    spaced = subprocess.list2cmdline(
+        ["C:\\Program Files\\Python\\python.exe", "-u", "-m",
+         "scripts.medusa_api", "--port", "8080"]
+    )
+    assert recognize(spaced)
 
 
-def test_module_command_matches_only_the_module_signature() -> None:
-    assert _matching(_module_command(), SERVICES["api"]["marker"]) == [_MODULE_SIGNATURE]
+def test_end_of_command_boundary_separates_bare_launch_from_help() -> None:
+    """The substring design could not hold both of these at once: the bare
+    launch is a strict PREFIX of the --help invocation, so any fragment
+    matching one matched both. Recognizing the complete command with an
+    end boundary holds both."""
+    recognize = SERVICES["api"]["marker"]
+    bare = "python.exe -u -m scripts.medusa_api"
+    assert recognize(bare)
+    assert recognize(bare + " --port 8080")
+    assert not recognize(bare + " --help")
+    assert not recognize(bare + " --port 8080 --help")
+    assert not recognize(bare + " --port 8080 extra")
 
 
-def test_real_legacy_launches_match_only_their_own_signature() -> None:
-    """Every real orchestrator launch form is still detected: both separators,
-    quoted and unquoted."""
-    marker = SERVICES["api"]["marker"]
-    for command, expected in (
-        (_WIN_LEGACY_COMMAND, _WIN_LEGACY_SIGNATURE),
-        (_POSIX_LEGACY_COMMAND, _POSIX_LEGACY_SIGNATURE),
-        (_WIN_QUOTED_COMMAND, _WIN_QUOTED_SIGNATURE),
-        (_POSIX_QUOTED_COMMAND, _POSIX_QUOTED_SIGNATURE),
-    ):
-        assert _matching(command, marker) == [expected], command
+def test_option_order_no_longer_matters() -> None:
+    """--host before --port was a stated false negative of the substring
+    design; the parsed grammar accepts either order."""
+    recognize = SERVICES["api"]["marker"]
+    assert recognize("python.exe -u -m scripts.medusa_api --host 192.168.86.29 --port 8080")
+    assert recognize("python.exe -u -m scripts.medusa_api --port 8080 --host 192.168.86.29")
 
 
-def test_quoted_install_path_with_spaces_is_detected() -> None:
-    """A path containing spaces is quoted by Windows, so the closing quote
-    sits between the path and the arguments."""
-    marker = SERVICES["api"]["marker"]
-    assert "Program Files" in _WIN_QUOTED_COMMAND
-    assert _matching(_WIN_QUOTED_COMMAND, marker) == [_WIN_QUOTED_SIGNATURE]
-    assert _matching(_POSIX_QUOTED_COMMAND, marker) == [_POSIX_QUOTED_SIGNATURE]
+def test_nested_path_is_refused_even_with_service_options() -> None:
+    """The substring design's stated residual, now closed: a command whose
+    launch position holds another tool is refused even when the medusa
+    path AND valid service options follow as arguments."""
+    recognize = SERVICES["api"]["marker"]
+    nested = "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --port 8080"
+    launch = "python.exe -u C:\\UtilityFog\\scripts\\medusa_api.py --port 8080"
+    assert not recognize(nested)
+    assert recognize(launch)
 
 
-def test_explicit_relative_launches_match_only_their_own_signature() -> None:
-    """Relative-launch support comes from EXPLICIT complete forms anchored at
-    the argument boundary before ``scripts`` — not from removing the leading
-    separator from the absolute signatures."""
-    marker = SERVICES["api"]["marker"]
-    for command, expected in (
-        (_WIN_RELATIVE_COMMAND, _WIN_RELATIVE_SIGNATURE),
-        (_POSIX_RELATIVE_COMMAND, _POSIX_RELATIVE_SIGNATURE),
-    ):
-        assert _matching(command, marker) == [expected], command
-
-
-def test_module_name_is_a_complete_element_not_a_prefix() -> None:
-    """``scripts.medusa_api_tests`` embeds the module name as a prefix; the
-    boundary after the complete module element refuses it — even when the
-    longer module carries the service's own option."""
-    marker = SERVICES["api"]["marker"]
+def test_partial_word_forms_remain_refused() -> None:
+    """The three exhibits that defeated prefix substrings stay refused."""
+    recognize = SERVICES["api"]["marker"]
     for command in (
         "python.exe -m scripts.medusa_api_tests",
-        "python.exe -m scripts.medusa_api_tests --port 9000",
+        "python.exe -m scripts.medusa_api --help",
+        "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability",
     ):
-        assert "-m scripts.medusa_api" in command  # the old signature IS inside
-        assert _matching(command, marker) == [], command
+        assert not recognize(command), command
 
 
-def test_module_help_invocation_is_refused() -> None:
-    """This suite itself runs ``-m scripts.medusa_api --help`` as a
-    subprocess; ``--stop`` during a test run must not select it. The
-    discriminator is the service's own argument list, and --help is not
-    it."""
-    command = "python.exe -m scripts.medusa_api --help"
-    assert "-m scripts.medusa_api" in command  # the old signature IS inside
-    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+def test_windows_path_case_is_insensitive_and_options_are_exact() -> None:
+    """Path and module elements compare case-insensitively (Windows
+    filesystem semantics, matching the old query's behavior); option names
+    stay exact, as argparse itself is case-sensitive."""
+    recognize = SERVICES["api"]["marker"]
+    assert recognize("PYTHON.EXE -u C:\\UTILITYFOG\\SCRIPTS\\MEDUSA_API.PY --port 8080")
+    assert recognize("python.exe -m SCRIPTS.MEDUSA_API --port 8080")
+    assert not recognize("python.exe -m scripts.medusa_api --PORT 8080")
 
 
-def test_option_prefix_on_a_nested_unrelated_path_is_refused() -> None:
-    """``--portability`` embeds ``--port`` as a prefix. The trailing boundary
-    makes ``--port`` a complete argument, so a nested unrelated path handed
-    to another tool is refused."""
-    command = "python.exe tool.py C:\\UtilityFog\\scripts\\medusa_api.py --portability"
-    assert "\\scripts\\medusa_api.py --port" in command  # the old signature IS inside
-    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+def test_element_splitting_honors_double_quotes() -> None:
+    """Quotes group; they bound elements and are not characters of them."""
+    from scripts.medusa_start import _split_command_elements
+
+    assert _split_command_elements(
+        'python.exe -u "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py" --port 8080'
+    ) == [
+        "python.exe", "-u",
+        "C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py",
+        "--port", "8080",
+    ]
+    assert _split_command_elements("  python.exe   -m   scripts.medusa_api  ") == [
+        "python.exe", "-m", "scripts.medusa_api",
+    ]
+    assert _split_command_elements('a "b c" d') == ["a", "b c", "d"]
+    assert _split_command_elements("") == []
+    # An empty quoted group is a REAL empty argument and must survive
+    # splitting, so the grammar can refuse it as a trailing element.
+    assert _split_command_elements('a "" b') == ["a", "", "b"]
+    assert _split_command_elements('a ""') == ["a", ""]
+    assert _split_command_elements('a "') == ["a", ""]
 
 
-def test_scripts_element_is_complete_not_a_word_suffix() -> None:
-    """De-anchoring the absolute signatures (dropping the leading separator)
-    would let a longer word ending in ``scripts`` match. The retained left
-    boundary refuses it."""
-    command = "python.exe -u C:\\Backup\\my_scripts\\medusa_api.py --port 8080"
-    assert "scripts\\medusa_api.py --port " in command  # the de-anchored form IS inside
-    assert _matching(command, SERVICES["api"]["marker"]) == [], command
+def test_port_values_must_name_a_real_port() -> None:
+    from scripts.medusa_start import _is_valid_port_value
+
+    for value in ("1", "80", "8080", "65535"):
+        assert _is_valid_port_value(value), value
+    for value in ("", "0", "65536", "8o8o", "-1", "8080 ", "８０８０"):
+        assert not _is_valid_port_value(value), value
 
 
-def test_undetected_hand_launches_are_a_stated_residual() -> None:
-    """The false-NEGATIVE side of the boundary, pinned deliberately: a hand
-    launch relying on the argparse default port, or reordering ``--host``
-    before ``--port``, shows no recognized shape. The bare miss is forced,
-    not chosen — the bare command line is a strict prefix of the refused
-    ``--help`` command line, so under substring matching any signature
-    catching one catches both. The orchestrator itself always passes
-    ``--port``, so no orchestrator-built launch is ever missed."""
-    marker = SERVICES["api"]["marker"]
-    bare = "python.exe -u -m scripts.medusa_api"
-    assert (bare + " --help").startswith(bare)  # the forcing prefix relation
-    for command in (
-        bare,
-        "python.exe -u -m scripts.medusa_api --host 0.0.0.0 --port 8080",
-    ):
-        assert _matching(command, marker) == [], command
+def test_recognition_is_a_positive_grammar_not_a_runner_blacklist() -> None:
+    """No runner is enumerated anywhere in the recognizer: refusal falls out
+    of the accepted grammar, so an unknown future runner is refused for the
+    same reason pytest is."""
+    import scripts.medusa_start as ms
+
+    source = (
+        inspect.getsource(ms._is_api_launch_command)
+        + inspect.getsource(ms._is_accepted_argument_list)
+        + inspect.getsource(ms._split_command_elements)
+        + inspect.getsource(ms._is_valid_port_value)
+    )
+    assert "pytest" not in source
+    assert "unittest" not in source
 
 
-def test_every_signature_is_bounded_on_both_sides() -> None:
-    """Each signature begins at an argument boundary — a space or a path
-    separator — and ends with the complete ``--port`` argument plus its
-    trailing separator, so no element can extend into a longer word."""
-    for signature in _EXPECTED_SIGNATURES:
-        assert signature[0] in (" ", "\\", "/"), signature
-        assert signature.endswith(" --port "), signature
-
-
-def test_absolute_path_pytest_invocations_are_refused() -> None:
-    """The surviving false positive: an absolute-path test run contains the
-    whole path segment, leading separator included, yet is not the service."""
-    marker = SERVICES["api"]["marker"]
-    for command in (
-        "python.exe -m pytest C:\\UtilityFog\\scripts\\medusa_api.py",
-        "python.exe -m pytest C:/UtilityFog/scripts/medusa_api.py",
-    ):
-        assert "\\scripts\\medusa_api.py" in command or "/scripts/medusa_api.py" in command
-        assert _matching(command, marker) == [], command
-
-
-def test_unrelated_commands_match_no_signature() -> None:
-    """`--stop` must never select a command that merely names the module."""
-    marker = SERVICES["api"]["marker"]
-    for command in _UNRELATED_COMMANDS:
-        assert _matching(command, marker) == [], command
-        assert "medusa_api" in command  # it DOES name the module...
-        # ...but naming it is not a launch shape.
-
-
-def test_selection_does_not_depend_on_excluding_test_runners() -> None:
-    """No signature mentions pytest or any other runner: the discriminator is
-    the presence of the service's own argument list."""
-    for signature in _EXPECTED_SIGNATURES:
-        assert "pytest" not in signature
-        assert "test" not in signature
-        assert signature.endswith(" --port ")
-
-
-def test_process_filter_is_name_and_parenthesized_alternatives() -> None:
-    """python.exe AND (A OR B OR ...) — the parentheses are load-bearing:
-    without them `-and` binds to the first alternative only."""
+def test_string_marker_predicate_is_unchanged() -> None:
+    """Engine, watchdog and geometry keep the exact substring predicate."""
     from scripts.medusa_start import build_process_filter
 
-    predicate = build_process_filter(SERVICES["api"]["marker"])
-    assert predicate.startswith("$_.Name -eq 'python.exe' -and (")
-    assert predicate.endswith(")")
-    assert predicate.count("$_.CommandLine -like") == 7
-    assert predicate.count(" -or ") == 6
-    assert predicate.count("(") == 1 and predicate.count(")") == 1
-    for signature in _EXPECTED_SIGNATURES:
-        assert signature in predicate
+    assert (
+        build_process_filter("watchdog.py")
+        == "$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*watchdog.py*')"
+    )
+    assert (
+        build_process_filter("run_v070_engine")
+        == "$_.Name -eq 'python.exe' -and ($_.CommandLine -like '*run_v070_engine*')"
+    )
+
+
+def test_api_query_is_name_only_and_launch_form_free() -> None:
+    """The recognizer path's shell query filters by process NAME and selects
+    PID + CommandLine as JSON — it encodes nothing about any launch form."""
+    from scripts.medusa_start import _PYTHON_PROCESS_QUERY
+
+    assert _PYTHON_PROCESS_QUERY == (
+        "Where-Object {$_.Name -eq 'python.exe'} | "
+        "Select-Object ProcessId, CommandLine | ConvertTo-Json -Compress"
+    )
+    assert "medusa" not in _PYTHON_PROCESS_QUERY
+    assert "-like" not in _PYTHON_PROCESS_QUERY
+
+
+def test_find_process_emits_the_name_only_query_for_the_api(monkeypatch) -> None:
+    """Emission pin, no execution: the API path sends exactly the
+    enumeration query; nothing about the service leaks into the shell."""
+    import scripts.medusa_start as ms
+
+    captured: list = []
+
+    class _Result:
+        stdout = ""
+
+    def _capture(args, **kwargs):
+        captured.append(args)
+        return _Result()
+
+    monkeypatch.setattr(ms.subprocess, "run", _capture)
+    assert ms.find_process(ms.SERVICES["api"]["marker"]) == []
+    assert captured == [[
+        "powershell", "-NoProfile", "-NonInteractive", "-Command",
+        "Get-CimInstance Win32_Process | " + ms._PYTHON_PROCESS_QUERY,
+    ]]
+
+
+def test_find_process_emits_the_unchanged_query_for_string_markers(monkeypatch) -> None:
+    """Emission pin, no execution: plain-string markers keep the original
+    substring query byte for byte."""
+    import scripts.medusa_start as ms
+
+    captured: list = []
+
+    class _Result:
+        stdout = ""
+
+    def _capture(args, **kwargs):
+        captured.append(args)
+        return _Result()
+
+    monkeypatch.setattr(ms.subprocess, "run", _capture)
+    assert ms.find_process("watchdog.py") == []
+    assert captured == [[
+        "powershell", "-Command",
+        "Get-CimInstance Win32_Process | Where-Object {$_.Name -eq 'python.exe'"
+        " -and ($_.CommandLine -like '*watchdog.py*')} | Select-Object ProcessId"
+        " | Format-List",
+    ]]
+
+
+def test_parse_process_rows_handles_every_query_shape() -> None:
+    """Fixed strings for the three JSON shapes the query can emit."""
+    from scripts.medusa_start import _parse_process_rows
+
+    assert _parse_process_rows("") == []
+    assert _parse_process_rows("   \n") == []
+    single = '{"ProcessId":7,"CommandLine":"python.exe -m scripts.medusa_api"}'
+    assert _parse_process_rows(single) == [
+        {"ProcessId": 7, "CommandLine": "python.exe -m scripts.medusa_api"}
+    ]
+    many = (
+        '[{"ProcessId":1,"CommandLine":null},'
+        '{"ProcessId":2,"CommandLine":"python.exe -m scripts.medusa_api"}]'
+    )
+    assert _parse_process_rows(many) == [
+        {"ProcessId": 1, "CommandLine": None},
+        {"ProcessId": 2, "CommandLine": "python.exe -m scripts.medusa_api"},
+    ]
+
+
+def test_select_recognized_pids_orders_dedupes_and_refuses_null() -> None:
+    """Ordered de-duplicated PIDs; null command lines and missing PIDs are
+    never selected."""
+    from scripts.medusa_start import _select_recognized_pids
+
+    marker = SERVICES["api"]["marker"]
+    rows = [
+        {"ProcessId": 11, "CommandLine": "python.exe -u -m scripts.medusa_api --port 8080"},
+        {"ProcessId": 22, "CommandLine": "python.exe -u -m scripts.medusa_api --help"},
+        {"ProcessId": 11, "CommandLine": "python.exe -u -m scripts.medusa_api --port 8080"},
+        {"ProcessId": None, "CommandLine": "python.exe -u -m scripts.medusa_api --port 8080"},
+        {"ProcessId": 44, "CommandLine": None},
+        {"ProcessId": 55, "CommandLine": "python.exe -u scripts\\medusa_api.py --host 0.0.0.0"},
+    ]
+    assert _select_recognized_pids(rows, marker) == [11, 55]
+
+
+def test_noisy_query_output_reads_as_nothing_running(monkeypatch) -> None:
+    """The JSON parser is all-or-nothing by design: non-JSON noise in the
+    query output yields NO pids (fail-safe — never a wrong PID, never a
+    wrong kill). The -NoProfile -NonInteractive invocation keeps the real
+    stream pure JSON."""
+    import scripts.medusa_start as ms
+
+    class _Result:
+        stdout = (
+            'Loading personal profile...\n'
+            '[{"ProcessId":11,"CommandLine":"python.exe -u -m scripts.medusa_api --port 8080"}]'
+        )
+
+    monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: _Result())
+    assert ms.find_process(ms.SERVICES["api"]["marker"]) == []
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="validates the host shell itself")
+def test_host_shell_pipeline_matches_the_portable_model() -> None:
+    """The production query fragment, run through REAL PowerShell over
+    SYNTHETIC objects: the shell keeps every python.exe row whatever its
+    command shape (recognition is Python's job) and drops other process
+    names; the JSON round-trips through the production parser; the
+    recognizer then selects exactly the accepted commands. No live process
+    is touched — Get-CimInstance never runs here."""
+    import scripts.medusa_start as ms
+
+    script = (
+        "@("
+        "[pscustomobject]@{Name='python.exe'; ProcessId=11; CommandLine="
+        "'python.exe -u -m scripts.medusa_api --port 8080'},"
+        "[pscustomobject]@{Name='python.exe'; ProcessId=22; CommandLine="
+        "'python.exe -u -m scripts.medusa_api --help'},"
+        "[pscustomobject]@{Name='node.exe'; ProcessId=33; CommandLine="
+        "'python.exe -u -m scripts.medusa_api --port 8080'},"
+        "[pscustomobject]@{Name='python.exe'; ProcessId=11; CommandLine="
+        "'python.exe -u -m scripts.medusa_api --port 8080'},"
+        "[pscustomobject]@{Name='python.exe'; ProcessId=44; CommandLine="
+        "'python.exe -u \"C:\\Program Files\\UtilityFog\\scripts\\medusa_api.py\" --port 8080'}"
+        ") | " + ms._PYTHON_PROCESS_QUERY
+    )
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-EncodedCommand", encoded],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    rows = ms._parse_process_rows(result.stdout)
+    assert [row["ProcessId"] for row in rows] == [11, 22, 11, 44]
+    assert ms._select_recognized_pids(rows, ms.SERVICES["api"]["marker"]) == [11, 44]
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="validates the host shell itself")
+def test_host_shell_single_row_json_shape_is_handled() -> None:
+    """One pipeline row makes PowerShell emit a bare object, not an array —
+    the shape _parse_process_rows normalizes. Synthetic objects only."""
+    import scripts.medusa_start as ms
+
+    script = (
+        "@([pscustomobject]@{Name='python.exe'; ProcessId=7; CommandLine="
+        "'python.exe -m scripts.medusa_api'}) | " + ms._PYTHON_PROCESS_QUERY
+    )
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-EncodedCommand", encoded],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    rows = ms._parse_process_rows(result.stdout)
+    assert isinstance(rows, list) and len(rows) == 1
+    assert ms._select_recognized_pids(rows, ms.SERVICES["api"]["marker"]) == [7]
 
 
 def test_single_string_marker_behaviour_is_unchanged(monkeypatch) -> None:
@@ -435,14 +608,20 @@ def test_single_string_marker_behaviour_is_unchanged(monkeypatch) -> None:
 
 
 def test_find_process_returns_no_duplicate_pids(monkeypatch) -> None:
-    """One process can satisfy more than one signature; it is reported once."""
+    """One PID can appear more than once in the query rows; it is reported
+    once, in first-seen order."""
     import scripts.medusa_start as ms
 
     class _Result:
-        stdout = "ProcessId : 111\nProcessId : 111\nProcessId : 222\nProcessId : 111\n"
+        stdout = (
+            '[{"ProcessId":111,"CommandLine":"python.exe -u -m scripts.medusa_api --port 8080"},'
+            '{"ProcessId":111,"CommandLine":"python.exe -u -m scripts.medusa_api --port 8080"},'
+            '{"ProcessId":222,"CommandLine":"python.exe -u scripts/medusa_api.py --port 8080"},'
+            '{"ProcessId":111,"CommandLine":"python.exe -u -m scripts.medusa_api --port 8080"}]'
+        )
 
     monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: _Result())
-    assert ms.find_process(SERVICES["api"]["marker"]) == [111, 222]
+    assert ms.find_process(ms.SERVICES["api"]["marker"]) == [111, 222]
 
 
 def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
@@ -464,9 +643,10 @@ def test_legacy_process_prevents_a_duplicate_start(monkeypatch, capsys) -> None:
     assert "Already running" in capsys.readouterr().out
 
 
-def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys) -> None:
-    """status() and stop_service() hand process detection the exact signature
-    collection, so every launch form is visible to them."""
+def test_status_and_stop_pass_the_recognizer_itself(monkeypatch, capsys) -> None:
+    """status() and stop_service() hand process detection the exact marker —
+    the recognizer function — so every accepted launch form is visible to
+    them."""
     import urllib.request
     from pathlib import Path
 
@@ -488,12 +668,12 @@ def test_status_and_stop_pass_the_exact_signature_collection(monkeypatch, capsys
 
     ms.status()
     capsys.readouterr()
-    assert _EXPECTED_SIGNATURES in seen
+    assert any(marker is ms._is_api_launch_command for marker in seen)
 
     seen.clear()
     ms.stop_service("api", ms.SERVICES["api"])
     capsys.readouterr()
-    assert seen == [_EXPECTED_SIGNATURES]
+    assert len(seen) == 1 and seen[0] is ms._is_api_launch_command
 
 
 def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys) -> None:
@@ -511,8 +691,8 @@ def test_stop_service_does_not_kill_when_nothing_is_detected(monkeypatch, capsys
 
 
 def test_watchdog_and_geometry_markers_are_unchanged() -> None:
-    """Only the API marker is a signature tuple; the others are untouched
-    plain strings matching their own launch commands."""
+    """Only the API marker is a recognizer; the others are untouched plain
+    strings matching their own launch commands."""
     assert SERVICES["watchdog"]["marker"] == "watchdog.py"
     assert SERVICES["geometry"]["marker"] == "geometry_daemon.py"
     for name in ("watchdog", "geometry"):


### PR DESCRIPTION
## API process selection: launch envelope + public-CLI argument mirror

Two files. Merged with Kev's authorization after Jack's completed audit as squash 1f33f47f35b8579fd2751b8d459fda14e8dc86c5 on 2026-07-21. No review-thread actions were taken. Base `d1d68b9c349ad894900c45d9f49f9e4f91017fc4` (main). Head `6718bf8bfad22e488dce5ade965bfe63c324fd03` (parent `b7ac26f9`).

Fourth commit of the correction arc after [#400](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/pull/400): `9b665cd0` added the argument-list discriminator, `c5bb9d88` bounded the signatures, `b7ac26f9` retired substrings for a parsed recognizer, and this commit repairs the finding from **Jack's audit of that recognizer**. **Neither #400 thread nor either review note on this PR is touched; both notes remain unresolved.**

### Jack's finding, reproduced

The parsed recognizer used a *private* option grammar (separate-value `--port 1..65535`, `--host <value>`, each once). The **public CLI is the authority**, and `scripts/medusa_api.py`'s actual argparse (`--port type=int`, `--host type=str`, auto `--help`, abbreviations on) accepts more: `--port=8080`, `--host=localhost`, unique abbreviations (`--po 8080`, `--ho localhost`), repeated options with the last value winning, empty host values (`--host ""`, `--host=`), and **any `int()`-parsable port spelling** (`+8080`, `8_080`, `0`, `65536`, even negatives via argparse's negative-number rule). A genuine API launched with any of those was invisible to status, stop, and duplicate prevention — a double-start risk.

### The repair: mirror, don't re-specify

The private grammar is gone. The trailing argument list is now judged by a **silent, non-exiting mirror of the real parser**: the same long-option table — `--help` declared as a plain flag so it can never print, `--port type=int`, `--host type=str` — with `error()` and `exit()` overridden to raise internally. Abbreviation and ambiguity therefore resolve *exactly* as the real parser resolves them, and no refusal ever writes a byte to stdout/stderr or terminates the orchestrator (pinned by a dedicated silence test over the full accepted+refused matrices).

**Accepted** (because the real CLI accepts them and such a process exists): everything in Jack's matrix above — argparse-valid, not socket-valid, deliberately. **Refused, all silently**: help in every spelling (`--help`, `-h`, the `--he` abbreviation — that process prints usage and exits, so it is never the running service), ambiguous options (`--h`: help/host), unknown options (`--portability`, `--ports`), invalid integers (`8o8o`, `8080.0`), missing values (`--port`, `--host --port 8080`), and extra positional arguments (including empty quoted groups and everything after `--`). `parse_args` consumes the **entire trailing list** — the end-of-command boundary is unchanged, and the strict-prefix pair (bare launch recognized / `--help` refused) still holds.

### Contract wording, corrected

The recognizer's claims are now split honestly in both files' comment blocks:

- **Supported Python launch envelope** — `<interpreter> [-u]` then the module element or a complete `scripts\medusa_api.py` path in launch position. Narrow by design: `-u` is the only interpreter option modeled, and **no claim of complete Python-interpreter-option coverage is made**. The launch position is what structurally refuses nested paths, mentions, and runner invocations, whatever arguments follow.
- **API argument grammar** — not an independent grammar at all: a mirror of the public CLI, which remains the single authority. A source-level pin on `scripts/medusa_api.py` (both `add_argument` lines, the `add_argument` count, and the constructor line — so even an `allow_abbrev=False` change would trip it) makes CLI drift break tests loudly instead of silently diverging. `scripts/medusa_api.py` itself is untouched.
- Honest boundaries stated: quote handling simplifies full `CommandLineToArgvW` (backslash-escaped quotes unmodeled); the mirror parses with the orchestrator's own argparse (same-interpreter assumption; every launcher here uses the one seat interpreter); recognition is by command shape.

### Receipts

**Differential verification before commit**: the mirror vs the real parser configuration, ~25,000 argument lists — Jack's full matrix, every abbreviation length of all three options in bare/space/`=` forms, int edge spellings, prefix-char oddities, `--` separators, help interleavings, plus ~19k fuzzed lists and real-subprocess cross-checks against the exact `medusa_api.py` parser construction — **zero disagreements, zero bytes of output**. Envelope decomposition re-verified over ~4k synthesized full commands.

Unchanged and re-pinned: launch-position and end-of-command boundaries; the name-only PowerShell query (`-NoProfile -NonInteractive`, PID+CommandLine as JSON) and its exact emission; string-marker query byte-identical; ordered de-duplicated PID handling on both paths; JSON shapes (empty/bare-object/array); fail-safe noise handling; duplicate-start prevention; status/stop marker identity; the two real-PowerShell synthetic-pipeline tests; and every prior false-positive refusal (partial words, nested paths, mentions, suffixed modules, empty-quote trailing arguments).

### Totals, numstat, checks

Focused launcher **39 passed** on the Windows seat (the two host-shell tests execute here; on the Linux CI runner they skip) · full suite **1599 passed / 48 skipped** · `py_compile` OK on both files.

**Checks on head `6718bf8b` (exact SHA): 7 check-runs, 7 pass** — CodeQL, agent-safety, frontend-quality ×2, verify-python ×2, Analyze Python; 4 workflow runs for this SHA all successful (Agent Safety Suite, CodeQL Python baseline, CI ×2). **No Theory Tripwire run exists for this SHA**, so none is claimed.

**Exact per-file numstat vs `main` — 2 files, cumulative +762/−156:**

| file | added | removed |
|---|---|---|
| `scripts/medusa_start.py` | +250 | −48 |
| `tests/test_medusa_start.py` | +512 | −108 |
| **cumulative** | **+762** | **−156** |

### Boundary and write ledger

Only the two files above; `scripts/medusa_api.py` read but not edited. **Untouched:** the Nextness family, `params_schema`, `orchestrator`, `experiments/swarm_hunter_lab/**`, Ian's lane, every preserved review thread on #397/#399/#400, and **both review notes on this PR (unresolved, unchanged)**. This round's GitHub writes: **one ordinary commit + push, this one description update — nothing else.** No amend, rebase, force, ready transition, merge, review reply, reaction, label change or branch deletion. No process inspected, started, stopped or killed; no port bound; no telemetry or live data read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


