### PR TITLE
fix(params): exact-value totality in TunableParam.validate — hook-free refusals (Batch 5)

### DIFF
--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -18,6 +18,8 @@ later PRs as we gain confidence about their tuning semantics.
 
 from __future__ import annotations
 
+import math
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Final
@@ -174,7 +176,25 @@ class TunableParam:
                     error=ValidationError.WRONG_TYPE,
                     message=f"{self.name} requires float, got {_describe_type(value)}.",
                 )
-            value = float(value)
+            # Bounded normalization: float() of an exact builtin int can
+            # overflow, and NaN would sail through the inclusive bound
+            # comparisons below. The refusal message never carries the
+            # supplied value — an oversized int would copy hundreds of
+            # digits into results and proposal output.
+            try:
+                value = float(value)
+            except (OverflowError, ValueError):
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires a finite float value.",
+                )
+            if not math.isfinite(value):
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires a finite float value.",
+                )
         if self.min_value is not None and value < self.min_value:
             return ValidationResult(
                 ok=False,

--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Final
 
 
 class Category(str, Enum):
@@ -57,6 +57,40 @@ class ValidationResult:
     ok: bool
     error: ValidationError | None = None
     message: str = ""
+
+
+# --- Hook-free type description ----------------------------------------------
+
+
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description for rejection messages.
+
+    ``type(value).__name__`` consults the metaclass — a hostile class can
+    override ``__name__`` so that reading it raises from inside error
+    formatting. Identity comparison against builtin types runs no user code
+    (a dict keyed by type would hash the class through its metaclass), and
+    anything that is not one of these builtins is described generically
+    instead of executing a hook merely to improve a message.
+    """
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
 
 
 @dataclass(frozen=True)
@@ -112,28 +146,33 @@ class TunableParam:
                 error=ValidationError.LOCKED,
                 message=f"{self.name} is LOCKED — critical invariant, not tunable.",
             )
-        # bool is a subclass of int; be strict about type distinctions.
+        # Exact builtin types only, decided by identity on type(value) BEFORE
+        # any conversion or comparison: isinstance() reads a proposed value's
+        # __class__ property, and a subclass that reached float()/bounds would
+        # run its own __float__/__lt__ — a proposed value must execute no code
+        # here. bool is an int subclass; identity keeps the strict distinction.
+        value_type = type(value)
         if self.value_type is bool:
-            if not isinstance(value, bool):
+            if value_type is not bool:
                 return ValidationResult(
                     ok=False,
                     error=ValidationError.WRONG_TYPE,
-                    message=f"{self.name} requires bool, got {type(value).__name__}.",
+                    message=f"{self.name} requires bool, got {_describe_type(value)}.",
                 )
             return ValidationResult(ok=True)
         if self.value_type is int:
-            if isinstance(value, bool) or not isinstance(value, int):
+            if value_type is not int:
                 return ValidationResult(
                     ok=False,
                     error=ValidationError.WRONG_TYPE,
-                    message=f"{self.name} requires int, got {type(value).__name__}.",
+                    message=f"{self.name} requires int, got {_describe_type(value)}.",
                 )
         elif self.value_type is float:
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if value_type is not int and value_type is not float:
                 return ValidationResult(
                     ok=False,
                     error=ValidationError.WRONG_TYPE,
-                    message=f"{self.name} requires float, got {type(value).__name__}.",
+                    message=f"{self.name} requires float, got {_describe_type(value)}.",
                 )
             value = float(value)
         if self.min_value is not None and value < self.min_value:

--- a/tests/test_params_schema.py
+++ b/tests/test_params_schema.py
@@ -11,6 +11,8 @@ Verifies the schema framework and the initial parameter registry:
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from scripts.params_schema import (
@@ -271,3 +273,270 @@ def test_schema_dict_param_entries_have_required_keys():
                 "min_value", "max_value"}
     for name, entry in schema["params"].items():
         assert required <= set(entry), f"{name} missing keys: {required - set(entry)}"
+
+
+# -- Batch 5 — exact-value totality: hostile proposed values ------------------
+#
+# validate() must decide a proposed value by exact type(value) identity alone.
+# A rejected value's methods, properties and metaclass must never run: not
+# isinstance() (reads __class__), not type(value).__name__ (reads the
+# metaclass), not bounds/float() on a subclass (runs __lt__/__float__).
+# Each hostile below records every hook invocation; a passing test asserts
+# the typed WRONG_TYPE result AND an empty call log.
+
+
+def _int_param(**kwargs) -> TunableParam:
+    defaults = dict(
+        name="n",
+        value_type=int,
+        default=1,
+        category=Category.AUTO,
+        group="test",
+        description="n",
+        min_value=0,
+        max_value=10,
+    )
+    defaults.update(kwargs)
+    return TunableParam(**defaults)
+
+
+def _bool_param(**kwargs) -> TunableParam:
+    defaults = dict(
+        name="enabled",
+        value_type=bool,
+        default=True,
+        category=Category.AUTO,
+        group="test",
+        description="enabled",
+    )
+    defaults.update(kwargs)
+    return TunableParam(**defaults)
+
+
+def _hostile_name_value():
+    """Value whose class-name lookup raises: type(v).__name__ consults the
+    metaclass, so a hostile metaclass turns message formatting into a hook."""
+
+    class Meta(type):
+        calls: list[str] = []
+
+        @property
+        def __name__(cls):
+            Meta.calls.append("__name__")
+            raise RuntimeError("metaclass __name__ hook executed")
+
+    bomb_cls = Meta("NameBomb", (), {})
+    return bomb_cls(), Meta.calls
+
+
+def _hostile_class_value():
+    """Value whose __class__ property raises — isinstance() reads it whenever
+    the exact-type fast path misses."""
+
+    class ClassBomb:
+        calls: list[str] = []
+
+        @property
+        def __class__(self):
+            ClassBomb.calls.append("__class__")
+            raise RuntimeError("__class__ hook executed")
+
+    return ClassBomb(), ClassBomb.calls
+
+
+def _hostile_int_subclass():
+    """int subclass whose comparison and float-conversion hooks raise — the
+    value the old isinstance() gate admitted to bounds/conversion."""
+
+    class EvilInt(int):
+        calls: list[str] = []
+
+        def __lt__(self, other):
+            EvilInt.calls.append("__lt__")
+            raise RuntimeError("__lt__ hook executed")
+
+        def __gt__(self, other):
+            EvilInt.calls.append("__gt__")
+            raise RuntimeError("__gt__ hook executed")
+
+        def __le__(self, other):
+            EvilInt.calls.append("__le__")
+            raise RuntimeError("__le__ hook executed")
+
+        def __ge__(self, other):
+            EvilInt.calls.append("__ge__")
+            raise RuntimeError("__ge__ hook executed")
+
+        def __float__(self):
+            EvilInt.calls.append("__float__")
+            raise RuntimeError("__float__ hook executed")
+
+        def __index__(self):
+            EvilInt.calls.append("__index__")
+            raise RuntimeError("__index__ hook executed")
+
+    return EvilInt(5), EvilInt.calls
+
+
+class _PlainIntSubclass(int):
+    """Benign int subclass — exact-type totality refuses even quiet ones."""
+
+
+class _PlainFloatSubclass(float):
+    """Benign float subclass."""
+
+
+def test_hostile_name_value_gets_typed_refusal_not_escape():
+    for param, expected in [
+        (_bool_param(), "enabled requires bool, got non-builtin value."),
+        (_int_param(), "n requires int, got non-builtin value."),
+        (_float_param(), "x requires float, got non-builtin value."),
+    ]:
+        value, calls = _hostile_name_value()
+        result = param.validate(value)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+        assert result.message == expected
+        assert calls == []
+
+
+def test_hostile_class_value_gets_typed_refusal_not_escape():
+    for param, expected in [
+        (_bool_param(), "enabled requires bool, got non-builtin value."),
+        (_int_param(), "n requires int, got non-builtin value."),
+        (_float_param(), "x requires float, got non-builtin value."),
+    ]:
+        value, calls = _hostile_class_value()
+        result = param.validate(value)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+        assert result.message == expected
+        assert calls == []
+
+
+def test_int_param_refuses_int_subclass_before_bounds():
+    value, calls = _hostile_int_subclass()
+    result = _int_param().validate(value)  # 5 is inside [0, 10] — type-only refusal
+    assert not result.ok
+    assert result.error is ValidationError.WRONG_TYPE
+    assert result.message == "n requires int, got non-builtin value."
+    assert calls == []
+
+
+def test_float_param_refuses_int_subclass_before_conversion():
+    value, calls = _hostile_int_subclass()
+    result = _float_param().validate(value)
+    assert not result.ok
+    assert result.error is ValidationError.WRONG_TYPE
+    assert result.message == "x requires float, got non-builtin value."
+    assert calls == []
+
+
+def test_benign_subclasses_are_refused_too():
+    assert _int_param().validate(_PlainIntSubclass(5)).error is ValidationError.WRONG_TYPE
+    assert _float_param().validate(_PlainIntSubclass(0)).error is ValidationError.WRONG_TYPE
+    assert _float_param().validate(_PlainFloatSubclass(0.5)).error is ValidationError.WRONG_TYPE
+
+
+def test_locked_param_refuses_before_inspecting_value():
+    p = _float_param(category=Category.LOCKED)
+    for factory in (_hostile_name_value, _hostile_class_value, _hostile_int_subclass):
+        value, calls = factory()
+        result = p.validate(value)
+        assert not result.ok
+        assert result.error is ValidationError.LOCKED
+        assert calls == []
+
+
+def test_bool_param_accepts_only_exact_bool():
+    p = _bool_param()
+    assert p.validate(True).ok
+    assert p.validate(False).ok
+    for bad in (1, 0, 1.0, "true", None, [], {}):
+        result = p.validate(bad)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_int_param_accepts_only_exact_int():
+    p = _int_param()
+    assert p.validate(5).ok
+    for bad in (True, False, 5.0, "5", None):
+        result = p.validate(bad)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_float_param_accepts_exact_int_and_exact_float_only():
+    p = _float_param()
+    assert p.validate(0.25).ok
+    assert p.validate(1).ok  # exact builtin int still converts
+    for bad in (True, "0.5", None, [0.5], {"v": 0.5}):
+        result = p.validate(bad)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+
+
+def test_builtin_json_value_messages_unchanged():
+    assert _int_param().validate("x").message == "n requires int, got str."
+    assert _int_param().validate(1.5).message == "n requires int, got float."
+    assert _int_param().validate(True).message == "n requires int, got bool."
+    assert _int_param().validate(None).message == "n requires int, got NoneType."
+    assert _int_param().validate([1]).message == "n requires int, got list."
+    assert _int_param().validate({}).message == "n requires int, got dict."
+    assert _float_param().validate("x").message == "x requires float, got str."
+    assert _bool_param().validate(1).message == "enabled requires bool, got int."
+
+
+def test_float_param_int_conversion_and_bounds_retained():
+    p = _float_param(min_value=0.0, max_value=1.0)
+    result = p.validate(2)  # exact int converts, then trips the max bound
+    assert not result.ok
+    assert result.error is ValidationError.ABOVE_MAX
+    assert result.message == "x=2.0 above max 1.0."
+
+
+def test_validate_proposal_propagates_hostile_refusals():
+    name_bomb, name_calls = _hostile_name_value()
+    evil_int, evil_calls = _hostile_int_subclass()
+    result = validate_proposal({
+        "magnon_radius": evil_int,       # int param in the live registry
+        "magnon_coupling": name_bomb,    # float param in the live registry
+        "signal_interval": 12,           # valid alongside the hostiles
+    })
+    assert not result.ok
+    assert set(result.errors) == {"magnon_radius", "magnon_coupling"}
+    assert result.errors["magnon_radius"].error is ValidationError.WRONG_TYPE
+    assert result.errors["magnon_coupling"].error is ValidationError.WRONG_TYPE
+    assert set(result.known_params) == {
+        "magnon_radius", "magnon_coupling", "signal_interval",
+    }
+    assert result.unknown_params == []
+    assert name_calls == []
+    assert evil_calls == []
+
+
+def test_describe_type_is_hook_free_and_fixed():
+    from scripts.params_schema import _describe_type
+
+    assert _describe_type(True) == "bool"
+    assert _describe_type(3) == "int"
+    assert _describe_type(3.0) == "float"
+    assert _describe_type("s") == "str"
+    assert _describe_type(None) == "NoneType"
+    assert _describe_type([]) == "list"
+    assert _describe_type({}) == "dict"
+    assert _describe_type(_PlainIntSubclass(3)) == "non-builtin value"
+    for factory in (_hostile_name_value, _hostile_class_value):
+        value, calls = factory()
+        assert _describe_type(value) == "non-builtin value"
+        assert calls == []
+
+
+def test_validate_source_has_no_value_type_name_lookup():
+    """The three former ``type(value).__name__`` sites must be gone, and no
+    isinstance() may touch a proposed value."""
+    src = inspect.getsource(TunableParam.validate)
+    code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    assert "type(value).__name__" not in code
+    assert "isinstance" not in code

--- a/tests/test_params_schema.py
+++ b/tests/test_params_schema.py
@@ -540,3 +540,111 @@ def test_validate_source_has_no_value_type_name_lookup():
     code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
     assert "type(value).__name__" not in code
     assert "isinstance" not in code
+
+
+# -- follow-up: bounded float normalization (finite-value totality) -----------
+#
+# The exact-type gate proves a proposed float-param value is builtin int or
+# float — but float() of an oversized int raises OverflowError, and NaN
+# passes both inclusive bound comparisons. Normalization is now bounded:
+# conversion failures and non-finite results get WRONG_TYPE with the
+# supplied-value-free message "<name> requires a finite float value.";
+# only finite normalized values reach the bound comparisons.
+
+_OVERSIZED_INT = 10 ** 400
+_FINITE_REFUSAL = "x requires a finite float value."
+
+
+def test_float_param_refuses_oversized_int_without_raising():
+    p = _float_param()
+    for value in (_OVERSIZED_INT, -_OVERSIZED_INT):
+        result = p.validate(value)  # must not raise OverflowError
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+        assert result.message == _FINITE_REFUSAL
+
+
+def test_float_param_refuses_nan_and_infinities():
+    p = _float_param()
+    for value in (float("nan"), float("inf"), float("-inf")):
+        result = p.validate(value)
+        assert not result.ok
+        assert result.error is ValidationError.WRONG_TYPE
+        assert result.message == _FINITE_REFUSAL
+
+
+def test_finite_refusal_message_carries_no_supplied_value():
+    digits = str(_OVERSIZED_INT)
+    for value in (_OVERSIZED_INT, float("inf"), float("nan")):
+        result = _float_param().validate(value)
+        assert len(result.message) < 80
+        assert digits[:20] not in result.message
+        assert "inf" not in result.message
+        assert "nan" not in result.message
+
+
+def test_finite_int_conversion_and_bound_messages_unchanged():
+    p = _float_param(min_value=0.0, max_value=1.0)
+    assert p.validate(0.25).ok
+    assert p.validate(1).ok
+    assert p.validate(2).message == "x=2.0 above max 1.0."
+    assert p.validate(-1).message == "x=-1.0 below min 0.0."
+
+
+def test_validate_proposal_propagates_finite_refusals():
+    result = validate_proposal({
+        "magnon_coupling": _OVERSIZED_INT,       # float param, oversized int
+        "magnon_sage_age_min": float("nan"),     # float param, NaN
+        "signal_interval": 12,                   # valid alongside
+    })
+    assert not result.ok
+    assert set(result.errors) == {"magnon_coupling", "magnon_sage_age_min"}
+    for name in ("magnon_coupling", "magnon_sage_age_min"):
+        assert result.errors[name].error is ValidationError.WRONG_TYPE
+        assert result.errors[name].message == f"{name} requires a finite float value."
+    assert result.unknown_params == []
+    assert all(len(r.message) < 80 for r in result.errors.values())
+
+
+def test_public_proposal_path_returns_validation_not_server_error():
+    """POST /api/tuning/propose with an oversized int previously escaped as
+    HTTP 500, and a NaN literal was ACCEPTED (200). Both must now be ordinary
+    422 rejections whose bodies never carry the supplied value."""
+    pytest.importorskip("flask")
+    from flask import Flask
+
+    from scripts.tuning_api import TuningState, create_blueprint
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        state = TuningState(data_dir=Path(td), gen_getter=lambda: 1_000_000)
+        app = Flask(__name__)
+        app.register_blueprint(create_blueprint(state))
+        client = app.test_client()
+
+        oversized_body = (
+            '{"params": {"magnon_coupling": ' + str(_OVERSIZED_INT)
+            + '}, "source": "human:kevin", "justification": "pin"}'
+        )
+        resp = client.post("/api/tuning/propose", data=oversized_body,
+                           content_type="application/json")
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["status"] == "rejected"
+        err = body["validation"]["errors"]["magnon_coupling"]
+        assert err["error"] == "wrong_type"
+        assert err["message"] == "magnon_coupling requires a finite float value."
+        assert str(_OVERSIZED_INT)[:20] not in resp.get_data(as_text=True)
+
+        nan_body = ('{"params": {"magnon_coupling": NaN}, '
+                    '"source": "human:kevin", "justification": "pin"}')
+        resp = client.post("/api/tuning/propose", data=nan_body,
+                           content_type="application/json")
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["status"] == "rejected"
+        err = body["validation"]["errors"]["magnon_coupling"]
+        assert err["error"] == "wrong_type"
+        assert err["message"] == "magnon_coupling requires a finite float value."


### PR DESCRIPTION
Batch 5 of the parked `type(value).__name__` inventory — the `params_schema` batch, sites 121/129/136 of the 22 raw hook-bearing sites. Two files. Merged with Kev's authorization after Jack's completed audit as squash 08687304d1f6fc0822738589620eaea39552b741 on 2026-07-21. No review-thread actions were taken. (The orchestrator sites 380/387/393 are outside this PR, held for their mandated re-audit.)

Base `1f33f47f35b8579fd2751b8d459fda14e8dc86c5` (main). Head `d4a3fc5398021f054983bb6e49664a9c93047771` (two ordinary commits on the base: `5b1af698` exact-type totality, `d4a3fc53` bounded float normalization). Numstat: `scripts/params_schema.py` +68/−9 · `tests/test_params_schema.py` +377/−0.

### Defects, reproduced by direct call before the edit

A proposed value could execute its own code inside `TunableParam.validate` three ways, each demonstrated against live registry params on the unedited module:

1. **Metaclass `__name__` read** — a class whose metaclass defines `__name__` as a raising property escaped from message formatting at sites 129 and 136 (site 121 is the same shape on the bool path).
2. **`__class__` property read** — `isinstance()` falls back to the instance's `__class__` when the exact-type fast path misses, so a raising `__class__` property escaped from the gate itself at lines 125/132, before any message site.
3. **Subclass admitted to comparison/conversion** — an `int` subclass passed the `isinstance` gate; its `__lt__` then raised from the bounds comparison (line 139, int param) and its `__float__` from `float(value)` (line 138, float param). This is the value-substitution shape: a subclass could also *lie* from those hooks, not just raise.

### The repair

`validate()` now decides by exact `type(value)` identity before any conversion or comparison:

- bool params accept exact builtin `bool` only; int params exact builtin `int` only; float params exact builtin `int` or `float` only — subclasses refused with `WRONG_TYPE` before any of their methods can run;
- no `isinstance` on the proposed value anywhere in `validate` (the remaining `isinstance` calls in the module are construction-time `__post_init__` on `self.default`, explicitly unchanged);
- rejection messages come from a new local `_describe_type` — tuple identity scan over fixed builtin names (a dict keyed by type would hash the class through its metaclass — Jack's #398 catch), `"non-builtin value"` for everything else. A rejected value is never inspected beyond exact `type(value)` identity;
- messages for builtin JSON values are byte-identical to before (`"n requires int, got str."` etc.); only non-builtin rejects change wording, and the tuning API passes `message` through opaquely;
- the LOCKED refusal stays ahead of any inspection of the proposed value; bounds, validation codes, proposal aggregation, registry data and serialization are untouched.

### Receipts (first commit `5b1af698`)

- **Post-edit proof**: the same three hostile families (call-recording variants) now return `WRONG_TYPE` with **empty hook-call logs** across bool/int/float params, and `LOCKED` with empty logs on locked params — the hooks are proven uncalled, not merely non-fatal.
- **14 new tests**: hostile trio × param kinds, LOCKED ordering, benign-subclass refusal, exact-type acceptance (bool/int/float), byte-exact builtin messages, int→float conversion + bounds retention (`"x=2.0 above max 1.0."`), proposal-level propagation with a valid param alongside two hostiles, hook-free `_describe_type`, and a source fence asserting `validate()` contains no `isinstance` and no `type(value).__name__` (comments stripped).
- **Suites**: `test_params_schema.py` + `test_tuning_api.py` 73 passed; full suite **1613 passed / 48 skipped** = main baseline 1599 + exactly the 14 new tests. `py_compile` clean on both files.
- **Boundary**: `git diff --name-only main` shows exactly the two authorized files. Sole textual remnant of `type(value).__name__` is `_describe_type`'s docstring naming the hazard.
- **Checks**: 8 check runs at commit `5b1af698` (incl. tripwire) all pass. At the current head `d4a3fc53`: **7 check runs — verify-python ×2, frontend-quality ×2, CodeQL, Analyze Python, agent-safety — all pass; no Theory Tripwire run exists for this SHA, so none is claimed.** The rollup was CLEAN/MERGEABLE at merge.

### Follow-up commit `d4a3fc53` — bounded float normalization (finite-value totality)

Kev-authorized follow-up answering both Gemini threads (left unresolved and untouched; any outdated marking is GitHub's automatic status, not a thread action). The exact-type gate proved a float-param value was builtin int/float, but normalization itself was unbounded — reproduced by direct call at head `5b1af698` before editing:

- `float(10**400)` and `float(-10**400)` raised `OverflowError` from `params_schema.py:177`, propagated through `validate_proposal`, and surfaced as **HTTP 500** on `POST /api/tuning/propose`;
- exact builtin **NaN validated successfully** — the public path returned **200 accepted** for a NaN literal (Python's JSON parser admits `NaN`);
- infinities were rejected, but as bound errors interpolating `inf` into the message (`1e999` → 422 `above_max` "…=inf above max 10.0.").

Neither `validate_proposal` nor the route carries a failure of its own — every traceback bottoms out in `TunableParam.validate`, so this one bounded repair closes all lanes.

**Contract:** after the exact-type proof, `float(value)` runs inside a bounded conversion catching `OverflowError`/`ValueError`; non-finite results are refused via `math.isfinite`. Both refusals use the existing `WRONG_TYPE` code (no new public code) with the supplied-value-free message `<name> requires a finite float value.` — the oversized/non-finite value is never interpolated, stringified, or represented. Only finite normalized values reach the inclusive bound comparisons. Exact-type gate and every rejected-object guarantee unchanged; finite int→float conversion and bound messages byte-identical (`"x=2.0 above max 1.0."` pinned). **Behavior change to flag:** ±inf moves from `ABOVE_MAX`/`BELOW_MIN` (value-interpolating) to the generic `WRONG_TYPE` finite refusal.

**Receipts:** 6 new pins — ±oversized ints (no raise, exact code+message), NaN/±inf, supplied-value-free message (length-bounded, no digits/`inf`/`nan`), finite conversion + bound messages byte-identical, proposal-level propagation with a valid param alongside, and the public path returning **422 rejected** for both the oversized int (was 500) and the NaN literal (was 200 accepted) with the oversized digits absent from the whole response body. Focused suites 79 passed; full suite **1619 passed / 48 skipped** = prior 1613 + exactly 6. `py_compile` clean; diff boundary still exactly the two authorized files.

**Observation for the audit (no repair, outside this PR's file boundary):** `TuningState.propose` records the raw proposed params into the ledger entry (`"params": dict(params)`), so an oversized proposed int is still written to the ledger by `tuning_api.py` even though validation now refuses it and the HTTP response carries no trace of it.

### Remaining boundaries

No review-thread actions or deployment occurred. Behavior change to flag for audit: values that previously *passed* as int/float subclasses (e.g. `IntEnum` members) are now refused by design — exact-value totality is the point of the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

