### PR TITLE
fix(orchestrator): message totality in ToolRouter.execute — exact-dict acceptance, fixed failure messages

### DIFF
--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -293,6 +293,17 @@ justification or a forbidden `commit-pending` mode. Distinct from
 `http_rejection` (server said no) because no request left the process; still a
 genuine tool error (is_error=True) that never creates a proposal."""
 
+HANDLER_FAILURE_MESSAGE = "tool handler failed"
+"""Fixed message for every handler failure — a raised exception or a refused
+non-dict return. The offending exception/object is never stringified,
+represented, formatted, measured, or sliced, so its class name and arguments
+cannot enter any result."""
+
+TRANSPORT_FAILURE_MESSAGE = "URLError"
+"""Fixed message for transport failures — byte-identical to the message an
+ordinary ``urllib.error.URLError`` produced here before, but emitted without
+inspecting the caught exception at all."""
+
 DEFAULT_MAX_TOTAL_TOOL_CALLS = 24
 """Total tool calls permitted across an entire iteration, independent of the
 per-turn `max_tool_depth`. Bounds a model that emits many tool calls per turn."""
@@ -360,7 +371,13 @@ class ToolRouter:
 
         Error kinds are distinguished by a stable ``category`` field:
         unknown_tool, transport_failure, handler_exception, and http_rejection
-        (HTTP status >= 400 is a genuine tool error, not a silent success)."""
+        (HTTP status >= 400 is a genuine tool error, not a silent success).
+        Failure messages are the fixed strings ``HANDLER_FAILURE_MESSAGE`` /
+        ``TRANSPORT_FAILURE_MESSAGE``: the caught exception, its class, and its
+        arguments are never stringified, represented, formatted, measured, or
+        sliced. A handler result is accepted only when it is EXACTLY a builtin
+        dict — any subclass or other object is refused without reading its
+        ``__class__``, its type name, or calling any of its methods."""
         handler = self._handlers.get(name)
         if handler is None:
             return (
@@ -368,29 +385,32 @@ class ToolRouter:
                  "message": f"tool {name} not registered"},
                 True,
             )
-        # Handler invocation, return-shape validation, and the _status /
+        # Handler invocation, return-shape refusal, and the _status /
         # local-rejection inspection all live inside the defensive try, so a
-        # handler that returns a non-dict (None, list, scalar, …) or that
-        # raises becomes a bounded handler_exception error — it can never crash
-        # the iteration loop.
+        # handler that raises becomes a bounded error result — it can never
+        # crash the iteration loop. Refusals decide by exact builtin type
+        # identity alone, before any method of the returned object could run.
         try:
             payload = handler(arguments)
-            if not isinstance(payload, dict):
-                raise TypeError(
-                    f"handler returned {type(payload).__name__}, expected dict"
+            if type(payload) is not dict:
+                return (
+                    {"error": "tool_handler_exception",
+                     "category": CATEGORY_HANDLER_EXCEPTION,
+                     "tool": name, "message": HANDLER_FAILURE_MESSAGE},
+                    True,
                 )
             is_local_rejection = bool(payload.get("_local_rejection"))
             status = payload.get("_status")
-        except urllib.error.URLError as e:  # network/transport-level failure
+        except urllib.error.URLError:  # network/transport-level failure
             return (
                 {"error": "transport_failure", "category": CATEGORY_TRANSPORT_FAILURE,
-                 "tool": name, "message": type(e).__name__},
+                 "tool": name, "message": TRANSPORT_FAILURE_MESSAGE},
                 True,
             )
-        except Exception as e:  # defensive: any handler bug → LLM-visible error
+        except Exception:  # defensive: any handler bug → LLM-visible error
             return (
                 {"error": "tool_handler_exception", "category": CATEGORY_HANDLER_EXCEPTION,
-                 "tool": name, "message": f"{type(e).__name__}: {e}"},
+                 "tool": name, "message": HANDLER_FAILURE_MESSAGE},
                 True,
             )
         if is_local_rejection:
@@ -402,10 +422,12 @@ class ToolRouter:
             clean = {k: v for k, v in payload.items() if k != "_local_rejection"}
             clean.setdefault("category", CATEGORY_LOCAL_REJECTION)
             return (clean, True)
-        if isinstance(status, int) and status >= 400:
+        if type(status) is int and status >= 400:
             # An HTTP rejection is a genuine tool error. Keep bounded metadata
             # (status + any error code/message) but flag it so callers do not
-            # count a rejected proposal/commit as applied.
+            # count a rejected proposal/commit as applied. Only an EXACT
+            # builtin int classifies: bool and int subclasses are not HTTP
+            # statuses and are never queried for their class.
             return ({**payload, "category": CATEGORY_HTTP_REJECTION}, True)
         return payload, False
 
@@ -865,6 +887,8 @@ __all__ = [
     "MAX_LIMIT_CEILING",
     "MAX_RECEIPT_BYTES",
     "OUTCOME_OK",
+    "HANDLER_FAILURE_MESSAGE",
+    "TRANSPORT_FAILURE_MESSAGE",
     "CATEGORY_UNKNOWN_TOOL",
     "CATEGORY_HANDLER_EXCEPTION",
     "CATEGORY_TRANSPORT_FAILURE",

--- a/scripts/orchestrator.py
+++ b/scripts/orchestrator.py
@@ -377,7 +377,11 @@ class ToolRouter:
         arguments are never stringified, represented, formatted, measured, or
         sliced. A handler result is accepted only when it is EXACTLY a builtin
         dict — any subclass or other object is refused without reading its
-        ``__class__``, its type name, or calling any of its methods."""
+        ``__class__``, its type name, or calling any of its methods. The
+        complete post-processing of an accepted result (local-rejection
+        cleanup, HTTP classification, successful return) also runs inside the
+        protected block, so a raising hook on payload contents degrades to the
+        bounded fixed-message failure instead of escaping."""
         handler = self._handlers.get(name)
         if handler is None:
             return (
@@ -385,11 +389,14 @@ class ToolRouter:
                  "message": f"tool {name} not registered"},
                 True,
             )
-        # Handler invocation, return-shape refusal, and the _status /
-        # local-rejection inspection all live inside the defensive try, so a
-        # handler that raises becomes a bounded error result — it can never
-        # crash the iteration loop. Refusals decide by exact builtin type
-        # identity alone, before any method of the returned object could run.
+        # Handler invocation and the COMPLETE post-processing of its result —
+        # exact-shape refusal, local-rejection cleanup, HTTP classification,
+        # and the successful return — live inside the defensive try, so a
+        # handler that raises, or hostile payload CONTENTS whose hooks raise
+        # inside dict machinery during post-processing, become a bounded error
+        # result — execute() can never crash the iteration loop. Refusals
+        # decide by exact builtin type identity alone, before any method of
+        # the returned object could run.
         try:
             payload = handler(arguments)
             if type(payload) is not dict:
@@ -399,8 +406,31 @@ class ToolRouter:
                      "tool": name, "message": HANDLER_FAILURE_MESSAGE},
                     True,
                 )
+            # Both marker lookups run eagerly, BEFORE the local-rejection
+            # branch, preserving the pre-relocation operation order: a raising
+            # hash-collision on either lookup is bounded right here instead of
+            # surviving inside a returned payload (review-caught regression).
             is_local_rejection = bool(payload.get("_local_rejection"))
             status = payload.get("_status")
+            if is_local_rejection:
+                # A refusal the router enforced locally (blank justification,
+                # commit-pending). A genuine error: flagged is_error,
+                # categorized local_rejection, and — because no request was
+                # sent — it cannot have created a proposal. The internal
+                # marker is stripped so it never reaches the model.
+                clean = {k: v for k, v in payload.items()
+                         if k != "_local_rejection"}
+                clean.setdefault("category", CATEGORY_LOCAL_REJECTION)
+                return (clean, True)
+            if type(status) is int and status >= 400:
+                # An HTTP rejection is a genuine tool error. Keep bounded
+                # metadata (status + any error code/message) but flag it so
+                # callers do not count a rejected proposal/commit as applied.
+                # Only an EXACT builtin int classifies: bool and int
+                # subclasses are not HTTP statuses and are never queried for
+                # their class.
+                return ({**payload, "category": CATEGORY_HTTP_REJECTION}, True)
+            return payload, False
         except urllib.error.URLError:  # network/transport-level failure
             return (
                 {"error": "transport_failure", "category": CATEGORY_TRANSPORT_FAILURE,
@@ -413,23 +443,6 @@ class ToolRouter:
                  "tool": name, "message": HANDLER_FAILURE_MESSAGE},
                 True,
             )
-        if is_local_rejection:
-            # A refusal the router enforced locally (blank justification,
-            # commit-pending). A genuine error: flagged is_error, categorized
-            # local_rejection, and — because no request was sent — it cannot
-            # have created a proposal. The internal marker is stripped so it
-            # never reaches the model.
-            clean = {k: v for k, v in payload.items() if k != "_local_rejection"}
-            clean.setdefault("category", CATEGORY_LOCAL_REJECTION)
-            return (clean, True)
-        if type(status) is int and status >= 400:
-            # An HTTP rejection is a genuine tool error. Keep bounded metadata
-            # (status + any error code/message) but flag it so callers do not
-            # count a rejected proposal/commit as applied. Only an EXACT
-            # builtin int classifies: bool and int subclasses are not HTTP
-            # statuses and are never queried for their class.
-            return ({**payload, "category": CATEGORY_HTTP_REJECTION}, True)
-        return payload, False
 
     # handlers ---
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1559,6 +1559,266 @@ def test_local_rejection_flag_bool_is_bounded():
     assert "hostile __bool__" not in json.dumps(payload, sort_keys=True)
 
 
+def test_local_rejection_cleanup_raising_key_comparison_is_bounded():
+    """The remaining gap (thread-independent reproduction): an exact builtin
+    dict marked as a local rejection carries a custom key whose comparison
+    raises during the cleanup comprehension's ``k != "_local_rejection"``.
+    The raise comes from ``__ne__`` — which only the cleanup's ``!=`` uses;
+    dict lookups use ``__eq__``, so the in-try ``.get`` cannot trigger it —
+    making the reproduction deterministic. Post-processing must be inside the
+    defensive try: the result is the bounded fixed handler failure, never a
+    crash of execute()."""
+    calls: list[str] = []
+
+    class _NeBombKey:
+        def __hash__(self):
+            calls.append("hash")
+            return 12345
+        def __eq__(self, other):
+            calls.append("eq")
+            return False
+        def __ne__(self, other):
+            calls.append("ne")
+            raise RuntimeError("hostile __ne__ during cleanup")
+        def __str__(self):  # pragma: no cover - must not be called
+            calls.append("str")
+            return "k"
+        def __repr__(self):  # pragma: no cover - must not be called
+            calls.append("repr")
+            return "k"
+
+    def handler(_args):
+        return {_NeBombKey(): "x", "_local_rejection": True}
+
+    payload, is_error = _census_router(handler).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload == {
+        "error": "tool_handler_exception",
+        "category": CATEGORY_HANDLER_EXCEPTION,
+        "tool": "get_medusa_census",
+        "message": _FIXED_HANDLER_MESSAGE,
+    }
+    # Exactly one comparison attempt raised; text hooks never ran. (__eq__ may
+    # run 0..n times from bucket-dependent dict probes; it is benign here.)
+    assert calls.count("ne") == 1
+    assert "str" not in calls and "repr" not in calls
+    assert "hostile __ne__" not in json.dumps(payload, sort_keys=True)
+
+
+def test_local_rejection_category_insertion_with_colliding_key():
+    """Local-rejection cleanup with a custom key hash-colliding with
+    "category" (recording ``__eq__`` honestly returning False): the category
+    default is still inserted, the colliding key and its value survive, and no
+    text hook was consulted. The recorded ``__eq__`` calls include both the
+    cleanup's ``!=`` (default ``__ne__`` falls back to ``__eq__``) and the
+    ``setdefault`` probe — the latter is guaranteed to run by the forced
+    full-hash collision, though the count alone does not isolate it."""
+    calls: list[str] = []
+
+    class _CollidingKey:
+        def __hash__(self):
+            calls.append("hash")
+            return hash("category")
+        def __eq__(self, other):
+            calls.append("eq")
+            return False
+        def __str__(self):  # pragma: no cover - must not be called
+            calls.append("str")
+            return "k"
+        def __repr__(self):  # pragma: no cover - must not be called
+            calls.append("repr")
+            return "k"
+
+    colliding = _CollidingKey()
+
+    def handler(_args):
+        return {"_local_rejection": True, "error": "bad_request",
+                colliding: "kept-value"}
+
+    payload, is_error = _census_router(handler).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_LOCAL_REJECTION
+    assert payload["error"] == "bad_request"
+    assert payload[colliding] == "kept-value"
+    assert "_local_rejection" not in payload
+    assert calls.count("eq") >= 1  # the collision comparison genuinely ran
+    assert "str" not in calls and "repr" not in calls
+
+
+def test_http_rejection_construction_with_nonstandard_contents():
+    """HTTP-rejection rebuild with a custom key hash-colliding with
+    "category" (recording, honestly-False ``__eq__``): the category is still
+    added, all contents survive, and no text hook runs. A second variant whose
+    ``__eq__`` raises during the rebuild is bounded to the fixed handler
+    failure — it can no longer escape execute()."""
+    calls: list[str] = []
+
+    class _CollidingKey:
+        def __hash__(self):
+            calls.append("hash")
+            return hash("category")
+        def __eq__(self, other):
+            calls.append("eq")
+            return False
+        def __str__(self):  # pragma: no cover - must not be called
+            calls.append("str")
+            return "k"
+        def __repr__(self):  # pragma: no cover - must not be called
+            calls.append("repr")
+            return "k"
+
+    colliding = _CollidingKey()
+
+    def handler(_args):
+        return {"_status": 502, "error": "bad_gateway", colliding: "kept"}
+
+    payload, is_error = _census_router(handler).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == "http_rejection"
+    assert payload["_status"] == 502
+    assert payload["error"] == "bad_gateway"
+    assert payload[colliding] == "kept"
+    assert calls.count("eq") >= 1
+    assert "str" not in calls and "repr" not in calls
+
+    raising_calls: list[str] = []
+
+    class _EqBombKey:
+        def __hash__(self):
+            raising_calls.append("hash")
+            return hash("category")
+        def __eq__(self, other):
+            raising_calls.append("eq")
+            raise RuntimeError("hostile __eq__ during rebuild")
+
+    def raising_handler(_args):
+        return {"_status": 502, _EqBombKey(): "x"}
+
+    payload, is_error = _census_router(raising_handler).execute(
+        "get_medusa_census", {})
+    assert is_error is True
+    assert payload == {
+        "error": "tool_handler_exception",
+        "category": CATEGORY_HANDLER_EXCEPTION,
+        "tool": "get_medusa_census",
+        "message": _FIXED_HANDLER_MESSAGE,
+    }
+    assert raising_calls.count("eq") == 1
+    assert "hostile __eq__" not in json.dumps(payload, sort_keys=True)
+
+
+def test_status_collision_on_local_rejection_stays_bounded():
+    """Review-caught regression pin: a local-rejection exact dict carrying a
+    key that hash-collides with "_status" and raises from ``__eq__`` (benign
+    ``__ne__``). The eager ``_status`` lookup — preserved in its
+    pre-relocation position before the local-rejection branch — hits the
+    collision inside the try, so the result is the bounded fixed handler
+    failure; the live hostile key can never survive into a returned payload.
+    The equal-full-hash probe makes the single ``__eq__`` call deterministic."""
+    calls: list[str] = []
+
+    class _StatusCollideBomb:
+        def __hash__(self):
+            calls.append("hash")
+            return hash("_status")
+        def __eq__(self, other):
+            calls.append("eq")
+            raise RuntimeError("hostile __eq__ vs _status")
+        def __ne__(self, other):
+            calls.append("ne")
+            return True
+
+    def handler(_args):
+        return {_StatusCollideBomb(): "v", "_local_rejection": True,
+                "error": "x"}
+
+    payload, is_error = _census_router(handler).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload == {
+        "error": "tool_handler_exception",
+        "category": CATEGORY_HANDLER_EXCEPTION,
+        "tool": "get_medusa_census",
+        "message": _FIXED_HANDLER_MESSAGE,
+    }
+    assert calls.count("eq") == 1
+    assert calls.count("ne") == 0
+    assert "hostile __eq__" not in json.dumps(payload, sort_keys=True)
+
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_sc", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    orch, _http = _make_orchestrator(backend)
+    orch.router._handlers["get_medusa_census"] = handler
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "end_turn"
+    assert result.outcome_counts.get(CATEGORY_HANDLER_EXCEPTION) == 1
+
+
+def test_ordinary_postprocessing_results_byte_identical():
+    """Ordinary local rejection, HTTP rejection, and success flows through the
+    relocated post-processing, pinned by exact dict equality against fully
+    literal expected dicts (and by object identity for the success flow —
+    stronger than byte equality: the payload is passed through unmodified)."""
+    payload, is_error = _census_router(
+        lambda _a: {"_local_rejection": True, "error": "bad_request",
+                    "message": "justification is required"}).execute(
+        "get_medusa_census", {})
+    assert is_error is True
+    assert payload == {"error": "bad_request", "category": "local_rejection",
+                       "message": "justification is required"}
+
+    payload, is_error = _census_router(
+        lambda _a: {"_status": 500, "error": "server_broke"}).execute(
+        "get_medusa_census", {})
+    assert is_error is True
+    assert payload == {"_status": 500, "error": "server_broke",
+                       "category": "http_rejection"}
+
+    success = {"generation": 41, "counts": {"VOID": 9}}
+    payload, is_error = _census_router(lambda _a: success).execute(
+        "get_medusa_census", {})
+    assert is_error is False
+    assert payload is success
+    assert payload == {"generation": 41, "counts": {"VOID": 9}}
+
+
+def test_iteration_completes_on_hostile_local_rejection_cleanup():
+    """run_one_iteration for the newly covered path: a hostile local-rejection
+    payload whose cleanup comparison raises completes the iteration, records
+    handler_exception (the bounded conversion), keeps the fixed message in the
+    LLM-visible result, and yields a valid bounded receipt."""
+    calls: list[str] = []
+
+    class _NeBombKey:
+        def __hash__(self):
+            return 12345
+        def __eq__(self, other):
+            return False
+        def __ne__(self, other):
+            calls.append("ne")
+            raise RuntimeError("hostile __ne__ during cleanup")
+
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_lr", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    orch, _http = _make_orchestrator(backend)
+    orch.router._handlers["get_medusa_census"] = (
+        lambda _a: {_NeBombKey(): "x", "_local_rejection": True})
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "end_turn"
+    assert result.outcome_counts.get(CATEGORY_HANDLER_EXCEPTION) == 1
+    assert result.outcome_counts.get(CATEGORY_LOCAL_REJECTION, 0) == 0
+    block = backend.calls[1].messages[-1].content[0]
+    assert block.is_error is True
+    assert json.loads(block.content)["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls.count("ne") == 1
+    receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
+    assert len(receipt_json.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    assert "hostile __ne__" not in receipt_json
+
+
 def test_execute_source_fence_no_exception_formatting():
     """Source fence: execute() contains no isinstance and no exception or
     type-name formatting — refusals decide by exact type identity alone.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -23,6 +23,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import urllib.error
 from typing import Optional
 
 import pytest
@@ -38,6 +39,7 @@ from scripts.agent_backends import (
 from scripts.orchestrator import (
     CATEGORY_HANDLER_EXCEPTION,
     CATEGORY_LOCAL_REJECTION,
+    CATEGORY_TRANSPORT_FAILURE,
     DEFAULT_MAX_TOTAL_TOOL_CALLS,
     IterationResult,
     MAX_LIMIT_CEILING,
@@ -1143,3 +1145,406 @@ def test_orchestrator_has_no_reverse_dependency_on_observer_or_engine():
     for banned in ("continuous_evolution_ca", "nextness_observer",
                    "nextness_calibration", "swarm_hunter"):
         assert banned not in src
+
+
+# -- ToolRouter.execute() message totality (sites 380/387/393) ----------------
+#
+# The result-message sites inside execute()'s defensive try must never run
+# code belonging to a hostile handler return or exception. Contract:
+#   * a handler result is accepted only when it is EXACTLY a builtin dict —
+#     any subclass or other object is refused without reading its __class__,
+#     its type name, or calling any of its methods;
+#   * both failure messages are fixed strings — the caught exception, its
+#     class, and its arguments are never stringified, represented, formatted,
+#     measured, or sliced;
+#   * ``_status`` is honored only as an EXACT builtin int, so a non-standard
+#     value is never queried for its class.
+# Every hostile hook below RECORDS instead of raising, so "not consulted" is
+# proven by an empty call log rather than inferred from the absence of a crash.
+
+_FIXED_HANDLER_MESSAGE = "tool handler failed"
+_FIXED_TRANSPORT_MESSAGE = "URLError"
+
+
+def _census_router(handler) -> ToolRouter:
+    """A router whose get_medusa_census handler is replaced by `handler`."""
+    client, _ = _client_with_fake()
+    router = ToolRouter(client)
+    router._handlers["get_medusa_census"] = handler
+    return router
+
+
+def test_handler_failure_fields_and_fixed_message():
+    """Ordinary handler failure: the payload shape is pinned exactly — stable
+    error/category/tool fields plus the fixed message, nothing else."""
+    def boom(_args):
+        raise ValueError("boom")
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload == {
+        "error": "tool_handler_exception",
+        "category": CATEGORY_HANDLER_EXCEPTION,
+        "tool": "get_medusa_census",
+        "message": _FIXED_HANDLER_MESSAGE,
+    }
+
+
+def test_transport_failure_fields_and_fixed_message():
+    """Ordinary transport failure: pinned payload with the fixed ``URLError``
+    message — byte-identical to what a plain URLError produced here before."""
+    def boom(_args):
+        raise urllib.error.URLError("network down")
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload == {
+        "error": "transport_failure",
+        "category": CATEGORY_TRANSPORT_FAILURE,
+        "tool": "get_medusa_census",
+        "message": _FIXED_TRANSPORT_MESSAGE,
+    }
+
+
+def test_exception_with_hostile_text_conversion_is_never_stringified():
+    """An exception whose __str__/__repr__/__format__ record their invocation
+    returns normally with the fixed message and an empty call log."""
+    calls: list[str] = []
+
+    class _TextTrapError(Exception):
+        def __str__(self):
+            calls.append("__str__")
+            return "trap"
+        def __repr__(self):
+            calls.append("__repr__")
+            return "trap"
+        def __format__(self, spec):
+            calls.append("__format__")
+            return "trap"
+
+    def boom(_args):
+        raise _TextTrapError("x")
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls == []
+
+
+def test_exception_argument_is_never_inspected():
+    """An exception carrying an argument with recording text/representation/
+    measurement hooks: none of the argument's methods run."""
+    calls: list[str] = []
+
+    class _HostileArg:
+        def __str__(self):
+            calls.append("arg.__str__")
+            return "a"
+        def __repr__(self):
+            calls.append("arg.__repr__")
+            return "a"
+        def __format__(self, spec):
+            calls.append("arg.__format__")
+            return "a"
+        def __len__(self):
+            calls.append("arg.__len__")
+            return 0
+
+    def boom(_args):
+        raise ValueError(_HostileArg())
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls == []
+
+
+def test_exception_class_name_is_never_queried():
+    """A custom exception class whose metaclass __name__ records access: the
+    name is never read and never appears in the result."""
+    calls: list[str] = []
+
+    class _NameTrapMeta(type):
+        @property
+        def __name__(cls):
+            calls.append("cls.__name__")
+            return "TrappedName"
+
+    class _NameTrapError(Exception, metaclass=_NameTrapMeta):
+        pass
+
+    def boom(_args):
+        raise _NameTrapError("x")
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert "TrappedName" not in json.dumps(payload, sort_keys=True)
+    assert calls == []
+
+
+def test_url_error_subclass_gets_fixed_transport_result():
+    """A URLError subclass with recording class-name and text hooks is matched
+    by real MRO only: fixed transport result, empty call log."""
+    calls: list[str] = []
+
+    class _URLNameTrapMeta(type):
+        @property
+        def __name__(cls):
+            calls.append("cls.__name__")
+            return "NotURLError"
+
+    class _TrapURLError(urllib.error.URLError, metaclass=_URLNameTrapMeta):
+        def __str__(self):
+            calls.append("__str__")
+            return "trap"
+        def __repr__(self):
+            calls.append("__repr__")
+            return "trap"
+
+    def boom(_args):
+        raise _TrapURLError("no route")
+    payload, is_error = _census_router(boom).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_TRANSPORT_FAILURE
+    assert payload["message"] == _FIXED_TRANSPORT_MESSAGE
+    assert "NotURLError" not in json.dumps(payload, sort_keys=True)
+    assert calls == []
+
+
+def test_non_dict_return_with_hostile_class_is_refused_unconsulted():
+    """A non-dict return whose __class__ property records access (and lies,
+    claiming dict) is refused by exact type identity — the property never runs."""
+    calls: list[str] = []
+
+    class _ClassTrapReturn:
+        @property
+        def __class__(self):
+            calls.append("__class__")
+            return dict
+
+    payload, is_error = _census_router(
+        lambda _a: _ClassTrapReturn()).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_HANDLER_EXCEPTION
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls == []
+
+
+def test_non_dict_return_type_name_is_never_read():
+    """A non-dict return whose metaclass __name__ records access and yields an
+    oversized name: refused with the fixed message, name never read."""
+    calls: list[str] = []
+
+    class _NameTrapReturnMeta(type):
+        @property
+        def __name__(cls):
+            calls.append("type.__name__")
+            return "N" * 4096
+
+    class _NameTrapReturn(metaclass=_NameTrapReturnMeta):
+        pass
+
+    payload, is_error = _census_router(
+        lambda _a: _NameTrapReturn()).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert "N" * 64 not in json.dumps(payload, sort_keys=True)
+    assert calls == []
+
+
+def test_dict_subclass_return_is_refused_before_its_methods_run():
+    """A dict subclass with recording get/items/keys/__iter__ hooks is refused
+    by exact type before any of those methods is called."""
+    calls: list[str] = []
+
+    class _HookedDict(dict):
+        def get(self, key, default=None):
+            calls.append("get")
+            return dict.get(self, key, default)
+        def items(self):
+            calls.append("items")
+            return dict.items(self)
+        def keys(self):
+            calls.append("keys")
+            return dict.keys(self)
+        def __iter__(self):
+            calls.append("__iter__")
+            return dict.__iter__(self)
+
+    payload, is_error = _census_router(
+        lambda _a: _HookedDict(generation=1)).execute("get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_HANDLER_EXCEPTION
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls == []
+
+
+def test_huge_exception_payloads_never_enlarge_the_fixed_results():
+    """Very large exception arguments (handler and transport lanes) neither
+    appear in the result nor enlarge its fixed message."""
+    big = "Z" * 1_000_000
+
+    def boom_handler(_args):
+        raise ValueError(big)
+    payload, is_error = _census_router(boom_handler).execute("get_medusa_census", {})
+    encoded = json.dumps(payload, sort_keys=True)
+    assert is_error is True
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert big[:64] not in encoded
+    assert len(encoded.encode("utf-8")) < 512
+
+    def boom_transport(_args):
+        raise urllib.error.URLError(big)
+    payload, is_error = _census_router(boom_transport).execute("get_medusa_census", {})
+    encoded = json.dumps(payload, sort_keys=True)
+    assert is_error is True
+    assert payload["message"] == _FIXED_TRANSPORT_MESSAGE
+    assert big[:64] not in encoded
+    assert len(encoded.encode("utf-8")) < 512
+
+
+def test_exact_dict_nonstandard_status_value_class_never_accessed():
+    """An exact dict whose _status value records __class__/comparison access
+    passes through as an ordinary success with an empty call log."""
+    calls: list[str] = []
+
+    class _StatusTrap:
+        @property
+        def __class__(self):
+            calls.append("__class__")
+            return int
+        def __ge__(self, other):
+            calls.append("__ge__")
+            return True
+        def __gt__(self, other):
+            calls.append("__gt__")
+            return True
+
+    trap_payload = {"_status": _StatusTrap(), "generation": 7}
+    payload, is_error = _census_router(
+        lambda _a: trap_payload).execute("get_medusa_census", {})
+    assert is_error is False
+    assert payload is trap_payload
+    assert calls == []
+
+
+def test_status_exactness_pins():
+    """Exact-int statuses keep their existing classification; bool stays a
+    non-rejection; an int SUBCLASS 500 is now an ordinary success BY DESIGN
+    (the intentional compatibility change: non-standard values are never
+    queried for their class, so they cannot classify as HTTP rejections)."""
+    payload, is_error = _census_router(
+        lambda _a: {"_status": 500, "error": "server_broke"}).execute(
+        "get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == "http_rejection"
+
+    payload, is_error = _census_router(
+        lambda _a: {"_status": True}).execute("get_medusa_census", {})
+    assert is_error is False
+
+    class _Code(int):
+        pass
+    payload, is_error = _census_router(
+        lambda _a: {"_status": _Code(500)}).execute("get_medusa_census", {})
+    assert is_error is False
+
+
+def test_iteration_completes_on_hostile_handler_exception():
+    """run_one_iteration completes when the transport raises a text-trapping
+    exception: correct category, fixed LLM-visible message, bounded valid
+    receipt, empty call log."""
+    calls: list[str] = []
+
+    class _TextTrapError(Exception):
+        def __str__(self):
+            calls.append("__str__")
+            return "trap-text"
+        def __repr__(self):
+            calls.append("__repr__")
+            return "trap-text"
+
+    def boom_http(method, url, *, json=None, timeout=5.0):
+        raise _TextTrapError("x")
+
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_h", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    client = OrchestratorClient("http://test:8080", http_do=boom_http)
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        max_tool_depth=4)
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "end_turn"
+    assert result.outcome_counts.get(CATEGORY_HANDLER_EXCEPTION) == 1
+    block = backend.calls[1].messages[-1].content[0]
+    assert isinstance(block, ToolResultBlock)
+    assert block.is_error is True
+    assert json.loads(block.content)["message"] == _FIXED_HANDLER_MESSAGE
+    assert calls == []
+    receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
+    assert len(receipt_json.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    assert "trap-text" not in receipt_json
+
+
+def test_iteration_completes_on_hostile_transport_exception():
+    """run_one_iteration completes when the transport raises a hostile URLError
+    subclass: transport_failure category, fixed message, bounded valid receipt."""
+    calls: list[str] = []
+
+    class _TrapURLError(urllib.error.URLError):
+        def __str__(self):
+            calls.append("__str__")
+            return "trap-url"
+        def __repr__(self):
+            calls.append("__repr__")
+            return "trap-url"
+
+    def boom_http(method, url, *, json=None, timeout=5.0):
+        raise _TrapURLError("no route")
+
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_t", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    client = OrchestratorClient("http://test:8080", http_do=boom_http)
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        max_tool_depth=4)
+    result = orch.run_one_iteration("go")
+    assert result.stopped_because == "end_turn"
+    assert result.outcome_counts.get(CATEGORY_TRANSPORT_FAILURE) == 1
+    block = backend.calls[1].messages[-1].content[0]
+    assert json.loads(block.content)["message"] == _FIXED_TRANSPORT_MESSAGE
+    assert calls == []
+    receipt_json = json.dumps(build_audit_receipt(result), sort_keys=True)
+    assert len(receipt_json.encode("utf-8")) <= MAX_RECEIPT_BYTES
+    assert "trap-url" not in receipt_json
+
+
+def test_handler_exception_text_never_reaches_the_model():
+    """Sensitive exception text stays out of the LLM-visible tool result, not
+    just out of the audit receipt: the message is the fixed string."""
+    secret = "SECRET_API_KEY_sk-abc123"
+
+    def boom_http(method, url, *, json=None, timeout=5.0):
+        raise ValueError(secret)
+
+    backend = MockBackend(responses=[
+        _tool_use_response("tu_s", "get_medusa_census", {}),
+        _text_response("done"),
+    ])
+    client = OrchestratorClient("http://test:8080", http_do=boom_http)
+    orch = Orchestrator(backend=backend, client=client, system_prompt="s",
+                        max_tool_depth=4)
+    result = orch.run_one_iteration("go")
+    assert result.outcome_counts.get(CATEGORY_HANDLER_EXCEPTION) == 1
+    block = backend.calls[1].messages[-1].content[0]
+    assert secret not in block.content
+    assert json.loads(block.content)["message"] == _FIXED_HANDLER_MESSAGE
+
+
+def test_execute_source_fence_no_exception_formatting():
+    """Source fence: execute() contains no isinstance and no exception or
+    type-name formatting — refusals decide by exact type identity alone."""
+    import inspect
+    src = inspect.getsource(ToolRouter.execute)
+    body = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    for banned in ("type(e).__name__", "type(payload).__name__", "{e}",
+                   "str(e", "repr(", "isinstance("):
+        assert banned not in body

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1279,8 +1279,11 @@ def test_exception_class_name_is_never_queried():
 
 
 def test_url_error_subclass_gets_fixed_transport_result():
-    """A URLError subclass with recording class-name and text hooks is matched
-    by real MRO only: fixed transport result, empty call log."""
+    """A URLError subclass with recording class-name and text hooks yields the
+    fixed transport result with an empty call log: its class name and text
+    hooks are never consulted. (Except-clause matching may consult a metaclass
+    ``__subclasscheck__``, but its result cannot change the classification and
+    a raise inside it stays bounded — see the review notes in the PR.)"""
     calls: list[str] = []
 
     class _URLNameTrapMeta(type):
@@ -1539,12 +1542,39 @@ def test_handler_exception_text_never_reaches_the_model():
     assert json.loads(block.content)["message"] == _FIXED_HANDLER_MESSAGE
 
 
+def test_local_rejection_flag_bool_is_bounded():
+    """The one unavoidable in-try method execution: bool() on an exact dict's
+    _local_rejection value. A raising __bool__ stays bounded to the fixed
+    handler-failure result — it can never crash the iteration loop."""
+    class _BoolBomb:
+        def __bool__(self):
+            raise RuntimeError("hostile __bool__")
+
+    payload, is_error = _census_router(
+        lambda _a: {"_local_rejection": _BoolBomb()}).execute(
+        "get_medusa_census", {})
+    assert is_error is True
+    assert payload["category"] == CATEGORY_HANDLER_EXCEPTION
+    assert payload["message"] == _FIXED_HANDLER_MESSAGE
+    assert "hostile __bool__" not in json.dumps(payload, sort_keys=True)
+
+
 def test_execute_source_fence_no_exception_formatting():
     """Source fence: execute() contains no isinstance and no exception or
-    type-name formatting — refusals decide by exact type identity alone."""
+    type-name formatting — refusals decide by exact type identity alone.
+    The scan runs over an ast round-trip with the docstring dropped, so only
+    executable code (no comments, no docstring) is fenced."""
+    import ast
     import inspect
-    src = inspect.getsource(ToolRouter.execute)
-    body = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    import textwrap
+    src = textwrap.dedent(inspect.getsource(ToolRouter.execute))
+    fn = ast.parse(src).body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    if (fn.body and isinstance(fn.body[0], ast.Expr)
+            and isinstance(fn.body[0].value, ast.Constant)
+            and isinstance(fn.body[0].value.value, str)):
+        fn.body = fn.body[1:]
+    body = ast.unparse(fn)
     for banned in ("type(e).__name__", "type(payload).__name__", "{e}",
                    "str(e", "repr(", "isinstance("):
         assert banned not in body


### PR DESCRIPTION
Orchestrator batch of the parked `type(value).__name__` inventory — the three result-message sites 380/387/393 inside `ToolRouter.execute()`, under Jack's mandated re-audit of the C1 finding (the defensive try was not escape-proof). Two files.

Base: live `main` `41e0a049ffd39b77abd023ba7e2eb96df9ea2564` (#404's squash). Head `1675601b25efcf957e90b88129d7b604b214c5e8` — an ordinary two-parent synchronization merge (first parent `c91b1ba45a58481d5d7a5691d8c3c5d7d34bb083`, the three-commit audited chain `12a1d9ed` → `da6e76f4` → `c91b1ba4`; second parent `41e0a049`), no conflict, no conflict-resolution edits, no amend/rebase/force. Ian's four #404 files (`docs/SWARM_HUNTER_V1_PREFLIGHT.md`, `experiments/swarm_hunter_lab/README.md`, `experiments/swarm_hunter_lab/detector.py`, `experiments/swarm_hunter_lab/tests/test_properties.py`) are carried **byte-identically** (0-byte diff vs new main). Diff vs new main: exactly `scripts/orchestrator.py` +65/−28 · `tests/test_orchestrator.py` +695/−0, and the two-file patch is **byte-identical** to the audited pre-synchronization patch (`cmp` clean).

### Defects, reproduced before the edit

The regression battery was written first and run against the unmodified module: **15 failed / 1 passed** of the initial 16 (the passing one pins the ordinary transport message `URLError`, byte-identical before and after — by design it cannot distinguish the repair; the transport-lane demonstrations that do distinguish it failed on unfixed code). Each hostile test proves invocation with a recording hook, so the pre-edit failures are positive reproductions, not absence-of-crash inferences:

1. **Site 380** — `isinstance(payload, dict)` consulted a hostile `__class__` property (which could lie, claiming `dict`), and the `TypeError` message read `type(payload).__name__` through a metaclass `__name__` property; dict *subclasses* were accepted and their `get()` ran inside the router.
2. **Site 387** — the transport message was `type(e).__name__`: a `URLError` subclass's metaclass `__name__` property executed and its value entered the LLM-visible result.
3. **Site 393** — `f"{type(e).__name__}: {e}"` executed both the metaclass name property and the exception's `__str__`/`__format__` (and its arguments' text hooks), and copied unbounded exception text into the result — including sensitive-looking strings, which reached the model-visible tool result (the receipt was already clean; the conversation lane was not).
4. **`_status`** — `isinstance(status, int)` consulted a hostile value's `__class__` property, and a value lying `int` then reached `status >= 400` *outside* the defensive try: its `__ge__` ran and could crash the iteration loop or forge an HTTP rejection.

### Reachability: normal application vs direct Python

These are separate lanes and this PR does not conflate them. In the **normal application lane**, handler payloads come from `json.loads` (exact builtin dicts, plain-str keys) and `_status` comes from `resp.status`/`e.code` (exact builtin ints) — the hostile *objects* above are not constructible from model input or HTTP responses; triggering them requires **direct Python access** (injecting a handler or `http_do` in-process). This is therefore **not an ordinary model-input defect**. The normal-lane defect that *was* live: site 393 copied arbitrary exception text (e.g. an exception argument carrying a sensitive string) into the LLM-visible tool result on any ordinary handler bug.

### The repair (fixed-message contract)

- A handler result is accepted only when `type(payload) is dict` — every subclass or other value is refused with the bounded `handler_exception` shape, without reading its `__class__`, its type name, or calling any of its methods.
- Exceptions are never stringified, represented, formatted, measured, or sliced. No `type(e).__name__`, no `{e}`; the except clauses no longer even bind the exception.
- Handler failures (raised exception or refused non-dict return) carry the fixed message **`tool handler failed`** (`HANDLER_FAILURE_MESSAGE`).
- Transport failures carry the fixed message **`URLError`** (`TRANSPORT_FAILURE_MESSAGE`) — byte-identical to what the previous code produced for an ordinary `URLError`; the caught exception itself is never inspected.
- `_status` classifies as an HTTP rejection only when `type(status) is int` — bool and int subclasses are not HTTP statuses and are never queried for their class.
- Preserved exactly: `error` / `category` / `tool` / `is_error` fields, exact-dictionary success, local-rejection, HTTP-rejection, outcome-count, and receipt behavior. No `_safe_exc_message` helper — the messages are fixed strings, not sanitized reconstructions.

**Intentional compatibility changes (flag for audit; stable fields and categories unchanged; item 1 can occur on an ordinary handler failure, while items 2–4 require a custom or direct integration):**
1. Handler-error text becomes generic — the model no longer sees exception class names or text (previously e.g. `ValueError: <text>`).
2. Every `URLError` subclass now reports the fixed `URLError` message — an injected transport raising `HTTPError`/`ContentTooShortError` previously produced those class names (category `transport_failure` unchanged; `_default_http_do` converts `HTTPError` to `(code, body)` itself, so only injected `HttpDo` implementations are affected).
3. Dict-subclass returns (`OrderedDict`, `defaultdict`, …), previously accepted as success, are refused BY DESIGN as `handler_exception`. No in-repo producer exists.
4. An int-subclass `_status` ≥ 400 (e.g. `http.HTTPStatus` from a custom transport) previously classified `http_rejection`/`is_error=True`; it now flows as an ordinary success with `_status` passed through, counted `ok`. The default transport always yields exact ints, so real 4xx/5xx classification is unchanged.

### Receipts

- **17 new tests**, every hostile hook a recorder asserted empty: ordinary handler/transport pinned payload shapes; hostile `__str__`/`__repr__`/`__format__` exceptions; hostile exception *arguments* (text/representation/measurement hooks); metaclass `__name__` traps on exception classes and returned objects; hostile `URLError` subclass → fixed transport result; `__class__`-lying non-dict returns; dict subclasses with hooked `get`/`items`/`keys`/`__iter__` refused before any hook runs; 1 MB exception text absent from results with the serialized error < 512 B; exact-dict `_status` trap (`__class__`/`__ge__`/`__gt__` recorders) passing through untouched; `_status` exactness pins (500 → `http_rejection` unchanged, `True` → non-rejection unchanged, int-subclass 500 → ordinary success BY DESIGN); a raising `__bool__` on a `_local_rejection` value bounded to the fixed result (the one unavoidable in-try method execution); `run_one_iteration()` completing on both hostile lanes with correct categories, fixed LLM-visible messages, valid plain-`json.dumps` receipts ≤ `MAX_RECEIPT_BYTES`, and no exception text anywhere; a sensitive-string leak pin on the conversation lane; and an ast-based source fence (docstring dropped, executable code only: no `isinstance`, no `type(e).__name__`, no `{e}`, no `repr(`/`str(e`).
- **Suites** (current head `c91b1ba4`): `tests/test_orchestrator.py` 98 passed; adjacent modules (`test_medusa_start`, `test_nextness_calibration`, `test_nextness_metrics`, `test_openai_compat_backend`, `test_provider_parity`, `test_tuning_api`) 461 passed / 4 skipped; **full suite 1642 passed / 48 skipped** = main baseline 1619 + exactly the 23 new tests (17 from the first two commits + 6 from `c91b1ba4`). `py_compile` clean on both files. **Post-synchronization at head `1675601b`**: `tests/` 1642 passed / 48 skipped (unchanged); Ian's `experiments/swarm_hunter_lab/tests/` 80 passed (1 deliberate observation `UserWarning` from `test_max_lattice_64_cubed_measured`, by design); combined **1722 passed / 48 skipped**; `py_compile` clean on the two authorized files plus Ian's `detector.py`/`test_properties.py`.
- **Boundary**: `git diff --name-only main` shows exactly the two authorized files.
- **Independent worker reviews** (three read-only lenses — dispatch semantics, compatibility, test adequacy — run post-implementation; zero blocking/important findings): the dispatch lens CONFIRMED all 7 contract points by adversarial probes against the edited module, including that a hostile hook raising during except-matching stays bounded. Refinement adopted into the test wording: CPython's except-clause matching may consult a metaclass `__subclasscheck__`, but its result cannot change the classification (the C-level MRO decides) and it is not a text/name/measurement hook — `__name__` and `__instancecheck__` are never consulted. The compat lens sourced compatibility items 2–4 above (reproduced live). The test lens confirmed all required demonstrations are covered and that non-invocation is proven by recording hooks, and prompted the `__bool__` pin and the ast-based fence in `da6e76f4`.
- **Recorded, not implemented (outside the two-file boundary):** `docs/LEGACY_ORCHESTRATOR_QUARANTINE.md` "Error-shape guarantees" (lines ~57–62) now under-describes the refusal set (dict subclasses) and omits the fixed-message guarantee — needs a one-line doc amendment in a later authorized change. Pre-existing sites outside the three repaired ones, unchanged by this PR: `run_one_iteration` serializes *successful* payloads with `json.dumps(..., default=str)` (so the totality guarantee is scoped to `execute()`'s failure lanes), and the `unknown_tool` message interpolates the model-chosen tool name.
- **Checks**: at prior head `da6e76f4`, 8 check runs all completed success (CodeQL, frontend-quality ×2, verify-python ×2, agent-safety, tripwire, Analyze Python). At the current head `c91b1ba4`: **7 check runs, all completed success — CodeQL, Analyze Python, frontend-quality ×2, verify-python ×2, agent-safety; no Theory Tripwire run exists for this SHA, so none is claimed.** At the synchronized head `1675601b`: **7 check runs, all completed success — CodeQL, Analyze Python, agent-safety, frontend-quality ×2, verify-python ×2; no Theory Tripwire run exists for this SHA, so none is claimed.** Rollup MERGEABLE, still draft.

### Follow-up commit `c91b1ba4` — complete post-processing inside the protected block

Kev-authorized follow-up. Reproduced failing-first at head `da6e76f4` by direct call: the local-rejection cleanup (`{k: v for k, v in payload.items() if k != "_local_rejection"}` + `setdefault("category", …)`), the HTTP-rejection `{**payload, …}` rebuild, and the successful return ran **outside** the defensive try — an exact builtin dict marked `_local_rejection` carrying a custom key whose comparison raises during cleanup escaped `execute()` raw (deterministic via a raising `__ne__`, which only the cleanup's `!=` uses; dict lookups use `__eq__`).

**Now**: the complete handler-result post-processing — exact-dict refusal, eager `_local_rejection`/`_status` lookups, local-rejection cleanup and category default, exact-built-in-int classification, HTTP-rejection construction, and the ordinary successful return — resides **inside** the existing try. Except branches and both fixed messages unchanged. The marker lookups stay eager, before the local-rejection branch, preserving the pre-relocation operation order: an independent review reproduced (end-to-end, differentially against `da6e76f4`) that deferring the `_status` lookup would have un-bounded a raising hash-collision on `"_status"` inside a local-rejection payload; that input class is now pinned bounded at both `execute()` and iteration level.

**6 new tests** (recording objects asserting exactly which methods ran): raising-`__ne__` cleanup escape (failing-first, `ne` count == 1, text hooks unconsulted); colliding-key category insertion (category default still inserted, colliding key + value survive); HTTP rebuild with non-standard contents (benign collision preserved + raising collision bounded to the fixed handler result, `eq` count == 1); ordinary local-rejection/HTTP-rejection/success pinned by exact dict equality with literal expected dicts and success-object identity; iteration-level completion + receipt accounting for the newly covered path; and the `_status`-collision regression pin (`eq` == 1, `ne` == 0, bounded at both levels).

**Worker reviews (round 2, three read-only lenses)**: one important finding — the `_status`-lookup deferral described above — reproduced by the compatibility lens and repaired in this same commit with the eager-lookup restoration; the behavior lens probe-proved all six raising-hook lanes bounded (five previously escaped raw) and eight ordinary flows byte-identical with success-object identity preserved, and confirmed no new inspection lanes (AST fingerprint identical); the test lens confirmed all six required pins genuine, with two docstring-precision notes adopted. Recorded observations: a post-processing hook raising `URLError` classifies as the fixed `transport_failure` result (previously that raise escaped raw; fixed messages both ways; telemetry-category skew only), and `BaseException`-derived raises still propagate per the deliberate `except Exception` contract (residual 1).

**Compatibility**: no ordinary flow changes — the only behavioral delta vs `da6e76f4` is that payload-content hooks raising during post-processing now produce the bounded fixed-message failure instead of escaping `execute()` raw. The four compatibility disclosures above stand unchanged.

### Parked residual questions (outside this PR)

1. A handler directly raising `KeyboardInterrupt` or `SystemExit` remains outside the `except Exception` contract.
2. Arbitrary contents of otherwise successful direct-handler payloads and of surviving local-rejection/HTTP-rejection payloads — **narrowed, not solved**: hooks that *raise* during `execute()` post-processing are now bounded, but contents that *survive* `execute()` are not normalized. Reproduced by the round-2 reviews (pre-existing on both old and new code): a surviving non-str key crashes `run_one_iteration` at the caller's `json.dumps(payload, sort_keys=True, default=str)` serialization, and a non-JSON-serializable value has its `__str__` executed there with the text entering the LLM-visible tool result. Together with non-string direct-call tool names, this caller-side lane requires a separate later review.

### Status

Merged with Kev's authorization after Jack's completed audit as squash 5ce0be175e4b5a937498c2f8484a59b65aca00d9 on 2026-07-22. No review-thread actions or deployment occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

