### PR TITLE
fix(s1-lab): stable bounded snapshot of the caller list before ceiling/iteration (concurrent-mutation P2)

### DIFF
--- a/docs/SWARM_HUNTER_V1_PREFLIGHT.md
+++ b/docs/SWARM_HUNTER_V1_PREFLIGHT.md
@@ -372,6 +372,15 @@ immutable inputs to a findings artifact.
   instead of re-emitting duplicates.
 - **No-write guarantees:** inputs are never mutated (hash-before == hash-after test);
   the only artifact is the findings object returned to the caller.
+- **Bounded concurrency contract (honest, not full thread-safety):** for an exact
+  `list` top-level container, membership/order are **defensively shallow-snapshotted**
+  — a private slice of at most `MAX_SNAPSHOTS + 1` references taken *before* the
+  ceiling check and iteration — so a concurrent thread's appends/removals/replacements
+  to the caller's *original* list cannot make this invocation validate, discover,
+  account or serialize more than `MAX_SNAPSHOTS`. An exact `tuple` is already immutable.
+  This defends **only** the top-level list; snapshot dicts, arrays and their contents
+  are **not** copied, so concurrent nested mutation by the caller during a call is
+  **outside the S1 contract** and no thread-safety of nested objects is claimed.
 - **Error behavior:** malformed input → structured refusal finding (`evidence_class:
   SRC`, reason `invalid_input`), never a partial silent result. **Empty result** is a
   first-class artifact: a run that finds nothing emits a header record saying so.

--- a/experiments/swarm_hunter_lab/README.md
+++ b/experiments/swarm_hunter_lab/README.md
@@ -51,6 +51,17 @@ asserted by tests **in both directions**.
   truncated artifact; malformed input → fatal structured refusal.
 - Config: `DetectorConfig(min_component_size=2, component_cap=4096,
   op_budget_multiplier=16)` — closed, immutable, validated first.
+- Concurrency (bounded, honest — **not** a full thread-safety claim): for an
+  exact `list`, the top-level **membership and order are defensively
+  shallow-snapshotted** (a private slice of at most `MAX_SNAPSHOTS + 1`
+  references) **before** the ceiling check and iteration, so appends, removals
+  or replacements a concurrent thread makes to the caller's *original* list
+  after that point **cannot affect this invocation** (they can never push it
+  past 64). An exact `tuple` is already immutable. This defends only the
+  top-level list — the snapshot dicts, their arrays, and their contents are
+  **not** copied, so the caller **must not mutate those nested objects
+  concurrently** during a call; nested concurrent mutation remains **outside
+  the S1 contract**. The detector never mutates the caller's list or inputs.
 
 ## Running the tests
 

--- a/experiments/swarm_hunter_lab/detector.py
+++ b/experiments/swarm_hunter_lab/detector.py
@@ -434,6 +434,31 @@ def _refusal_artifact(refusal, config_valid, config, ids, gens) -> FindingsArtif
     return _finalize([header, record])
 
 
+def _stable_snapshot_sequence(snapshots):
+    """Bounded, private, iterate-safe view of an already-proven exact
+    ``list``/``tuple`` top-level container.
+
+    An exact ``list`` is MUTABLE — a plain ``for item in snapshots`` iterator
+    observes elements a concurrent thread appends *after* the ``len`` ceiling
+    check, so more than ``MAX_SNAPSHOTS`` could be validated, discovered,
+    accounted and serialized. We take a shallow slice of at most
+    ``MAX_SNAPSHOTS + 1`` references (never the full list; the stop bound is a
+    constant) into a private list the caller has no handle on, so later
+    appends/removals/replacements to the caller's original list cannot affect
+    this invocation. Exact-``list`` type is proven by the caller *before* this
+    runs, so slicing can invoke no subclass ``__getitem__`` hook.
+
+    An exact ``tuple`` is already an immutable top-level container, so it is
+    returned directly (no copy needed). NOTE: this defends only the top-level
+    list's membership/order — snapshot dicts, arrays and their contents are NOT
+    copied, and concurrent mutation of those nested objects by the caller
+    remains outside the S1 contract (see README / preflight §5).
+    """
+    if type(snapshots) is list:
+        return snapshots[:MAX_SNAPSHOTS + 1]
+    return snapshots
+
+
 def detect_structures(snapshots, config: DetectorConfig = DetectorConfig()) -> FindingsArtifact:
     """Analyze an ordered sequence of synthetic snapshots. Pure and
     deterministic: identical inputs yield byte-identical ``jsonl``."""
@@ -452,11 +477,18 @@ def detect_structures(snapshots, config: DetectorConfig = DetectorConfig()) -> F
         # truncation and never partial processing.
         if type(snapshots) is not list and type(snapshots) is not tuple:
             raise _Refusal("invalid_input")                        # stage 2a
-        if len(snapshots) == 0:
+        # Normalize to a bounded, private, iterate-safe sequence BEFORE the
+        # ceiling and iteration. For an exact list this is a shallow slice of at
+        # most MAX_SNAPSHOTS+1 references (never the full list) that a concurrent
+        # caller-thread append cannot grow; a tuple is used directly. Every
+        # subsequent length check and the validation iteration read `stable`
+        # only — the caller's original `snapshots` is not referenced again.
+        stable = _stable_snapshot_sequence(snapshots)
+        if len(stable) == 0:
             raise _Refusal("invalid_input")                        # stage 2b
-        if len(snapshots) > MAX_SNAPSHOTS:
+        if len(stable) > MAX_SNAPSHOTS:
             raise _Refusal("invalid_input")                        # stage 2c
-        validated = [_validate_snapshot(item, ctx) for item in snapshots]  # 3
+        validated = [_validate_snapshot(item, ctx) for item in stable]  # 3
 
         ids = [s["snapshot_id"] for s in validated]                # stage 4
         if len(set(ids)) != len(ids):

--- a/experiments/swarm_hunter_lab/tests/test_properties.py
+++ b/experiments/swarm_hunter_lab/tests/test_properties.py
@@ -1,6 +1,7 @@
 """Property, determinism, refusal-order, and resource tests for the frozen S1 contract."""
 
 import builtins
+import threading
 import time
 import tracemalloc
 import warnings
@@ -12,7 +13,9 @@ from swarm_hunter_lab import (
     DetectorConfig, FindingsArtifact, compute_sha256_triple,
     detect_structures, fixtures, leanctx_summary, lp, schema,
 )
-from swarm_hunter_lab.detector import MAX_SNAPSHOTS, _axis_interval
+from swarm_hunter_lab.detector import (
+    MAX_SNAPSHOTS, _axis_interval, _stable_snapshot_sequence,
+)
 
 
 def refusal_of(snaps, config=DetectorConfig()):
@@ -897,3 +900,92 @@ def test_amd3_valid_string_source_discriminator_preserved():
     _, refusal = refusal_of([s])
     assert refusal["reason"] == "s2_gated"
     assert detect_structures([_amd3_tiny()]).records()[0]["kind"] == "header"
+
+
+# ---------------------------------------------------------------------------
+# S1 stable-snapshot-sequence follow-up (Jack post-merge P2) — an exact list is
+# MUTABLE, so a plain `for item in snapshots` iterator observes elements a
+# concurrent thread appends AFTER the len<=MAX_SNAPSHOTS check. detect_structures
+# now takes a bounded (<= MAX_SNAPSHOTS+1) private shallow slice of an exact list
+# before the ceiling and iterates only that; a tuple is immutable and used
+# directly. Threading tests use events + joins (no sleeps, no flaky timing).
+# ---------------------------------------------------------------------------
+
+
+def test_stable_sequence_bounded_shallow_copy():
+    # a large exact list is sliced to at most MAX_SNAPSHOTS+1 references (never
+    # copied in full) into a distinct private list; a tuple is returned as-is.
+    big = [_tiny_snap(0)] * 1000
+    stable = _stable_snapshot_sequence(big)
+    assert type(stable) is list
+    assert len(stable) == MAX_SNAPSHOTS + 1          # 65, bounded — not 1000
+    assert stable is not big                          # a private copy
+    assert all(stable[i] is big[i] for i in range(MAX_SNAPSHOTS + 1))  # shallow
+    tup = tuple(_tiny_snap(i) for i in range(3))
+    assert _stable_snapshot_sequence(tup) is tup      # tuple: no copy
+
+
+def test_stable_sequence_over_limit_refused_before_item_inspection(monkeypatch):
+    from swarm_hunter_lab import detector as _d
+    calls = {"n": 0}
+    real = _d._validate_snapshot
+
+    def spy(item, ctx):
+        calls["n"] += 1
+        return real(item, ctx)
+
+    monkeypatch.setattr(_d, "_validate_snapshot", spy)
+    _, refusal = refusal_of([_tiny_snap(i) for i in range(MAX_SNAPSHOTS + 1)])  # 65
+    assert refusal["reason"] == "invalid_input"
+    assert calls["n"] == 0                            # refused before any item
+    calls["n"] = 0
+    _, refusal = refusal_of([_tiny_snap(0)] * 1000)   # large -> bounded slice, refused
+    assert refusal["reason"] == "invalid_input"
+    assert calls["n"] == 0
+
+
+def test_stable_sequence_concurrent_append_ignored(monkeypatch):
+    from swarm_hunter_lab import detector as _d
+    snaps = [_tiny_snap(i) for i in range(MAX_SNAPSHOTS)]  # 64
+    extra = _tiny_snap(MAX_SNAPSHOTS)
+    started, appended = threading.Event(), threading.Event()
+    real = _d._validate_snapshot
+    calls = {"n": 0}
+
+    def hooked(item, ctx):
+        calls["n"] += 1
+        if calls["n"] == 1:               # first validated item: signal + wait
+            started.set()
+            assert appended.wait(timeout=10), "worker never appended"
+        return real(item, ctx)
+
+    monkeypatch.setattr(_d, "_validate_snapshot", hooked)
+
+    def worker():
+        assert started.wait(timeout=10), "validation never started"
+        snaps.append(extra)               # append AFTER the slice + ceiling check
+        appended.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    try:
+        records = detect_structures(snaps).records()
+    finally:
+        t.join(timeout=10)
+        assert not t.is_alive()
+    header = records[0]
+    assert header["run"]["snapshot_count"] == MAX_SNAPSHOTS   # exactly 64
+    assert calls["n"] == MAX_SNAPSHOTS                          # 64 validated, not 65
+    assert len(snaps) == MAX_SNAPSHOTS + 1                      # caller's list DID grow
+
+
+def test_stable_sequence_does_not_mutate_caller_list_or_inputs():
+    snaps = [_tiny_snap(i) for i in range(3)]
+    before_len = len(snaps)
+    before_order = [id(s) for s in snaps]
+    before_states = [s["states"].copy() for s in snaps]
+    detect_structures(snaps)
+    assert len(snaps) == before_len                   # not mutated
+    assert [id(s) for s in snaps] == before_order      # same objects, same order
+    for s, b in zip(snaps, before_states):
+        assert np.array_equal(s["states"], b)          # nested arrays unmutated


### PR DESCRIPTION
## S1 stable-snapshot-sequence — concurrent caller-list mutation repair (Jack post-merge P2)

S1-only, four permitted files. **Draft — do not merge.** Opened for Jack's audit. Follow-up to the merged #394 (`91d3bae`).

### The finding (Jack P2, `detector.py`)
`detect_structures()` proved an exact `list` and checked its length, then iterated the **caller's original mutable list**: `validated = [_validate_snapshot(item, ctx) for item in snapshots]`. A Python list iterator observes elements appended after iteration begins, so a concurrent thread appending **after** the `len ≤ MAX_SNAPSHOTS` check (while validation runs) could make **more than 64** snapshots be validated, discovered, accounted, and serialized.

**Failing-before receipt (deterministic — `threading.Event` + `join`, no sleeps):** a 64-item list; a synchronized worker appends a valid 65th once first-item validation begins → the merged implementation validated **65** and reported `run.snapshot_count == 65`.

### Repair (`detector.py`)
New `_stable_snapshot_sequence(snapshots)` normalizes an already-proven exact container to a **bounded, private, iterate-safe** sequence:
- **exact `list`** → a shallow slice `snapshots[:MAX_SNAPSHOTS + 1]` — at most **65 references**, never the full list; the exact-`list` proof precedes slicing so no subclass `__getitem__` hook can run; the slice is a private list the caller has no handle on.
- **exact `tuple`** → returned directly (already immutable; no copy).

Stage 2 now takes this `stable`, applies the empty/over-limit checks to it, and iterates it only. **Bounded audit:** after normalization, no validation/discovery/accounting/serialization path references the caller's original `snapshots` again (verified — the only remaining mention is inside the helper's own docstring).

**Passing-after receipt (same synchronized append):** only the caller's original list grows to 65; the invocation validates **exactly 64** and reports `run.snapshot_count == 64`.

### Bounded-copy proof
`_stable_snapshot_sequence([_tiny_snap]*1000)` → a **distinct** `list` of length **65** (not 1000), holding the same first-65 references (shallow); a tuple is returned as the same object. A 65-item and a 1000-item list are both refused `invalid_input` with **0 `_validate_snapshot` calls** (spy) — refused before any item inspection, work bounded to ≤65 references. No enormous resource test is manufactured (1000 refs is trivial).

### Honest concurrency contract (no full thread-safety claim)
Documented in README + preflight §5: the top-level exact-`list` **membership/order** is shallow-snapshotted defensively; appends/removals/replacements to the caller's original list after that snapshot **cannot affect** this invocation; snapshot **dicts, arrays and their contents are not copied**, so concurrent nested mutation by the caller remains **outside the S1 contract**. The detector does not mutate the caller's list or nested inputs (test-proven).

### Equivalence, tests, scope
- **Accepted-byte equivalence:** byte-identical to base `0552af6` — **22 cases (11 fixture artifacts + 11 LeanCTX), 0 mismatches**. Unchanged: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, cap/budget arithmetic, `components_emitted`, hashing, LeanCTX; empty-list, exact-tuple, hostile-container, invalid-config precedence and all prior regressions retained.
- **Regressions: +4 (76 → 80 lab-local)** — bounded shallow-copy proof, over-limit refused before item inspection (spy), the deterministic concurrent-append test (events + join, exactly 64 validated), and caller-list / nested-input non-mutation.
- **Diffstat (exactly 4 files):** `detector.py +35/−3` · `tests/test_properties.py +93/−1` · `README.md +11/−0` · `docs/SWARM_HUNTER_V1_PREFLIGHT.md +9/−0` (total **+148/−4**).
- CI: full lab-local suite green (80); `swarm-hunter-lab` workflow gates it. Maintained `verify-python` scopes to `tests/` (lab excluded by design).

### Authority & fences
Kev (repo owner) personally authorized this exact package (four permitted S1 files, the stable-shallow-snapshot repair, deterministic regressions + honest concurrency docs, one focused commit, one branch, one draft PR, `swarm-hunter` label, CI observation). **No merge, no thread actions.** #394's four review threads untouched; #394 not amended/reopened; #397, #398, Nextness, Medusa and every other lane untouched; **S2 and all later Swarm Hunter stages remain hard-gated and unbegun.** Branched from freshly verified main `0552af65df88dbeef08e69a067a16acc9313ae5d`; no main-update after branching.

### Model identity
Authored by seat 84 = **Claude Opus 4.8** (`claude-opus-4-8`). (A mid-session `/model` toggle to `claude-fable-5` and back to `claude-opus-4-8` occurred during a host-availability pause, before any write; recorded, seat closed as Opus 4.8.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Merge reconciliation — 2026-07-22 (Jack final verdict + Kev's closure authorization)

**This section supersedes the "Draft — do not merge / opened for Jack's audit" gate above.** Jack completed the read-only audit of this PR and found **no remaining defect** — approved for protected closure. Kev personally authorized the update-and-merge closure (execution-time main permitted only while all disjointness/state gates hold, which they did).

- **Audited head:** `09f1e621a07352d53aeda42830ae8a70a4f3314e` · **branch point:** `0552af65df88dbeef08e69a067a16acc9313ae5d`.
- **Updated head:** `276bccfa175b41fa53282035c1da3d98f6091e34` — one ordinary merge of current main `08687304d1f6fc0822738589620eaea39552b741` into the branch. No rebase, no amend, no rewrite, no force-push, no conflicts.
- **Equivalence receipt:** `git diff 0868730..276bccf` is **byte-identical** to the audited `git diff 0552af6..09f1e62` — exactly the same four S1 files, **+148/−4**: `docs/SWARM_HUNTER_V1_PREFLIGHT.md +9/−0` · `experiments/swarm_hunter_lab/README.md +11/−0` · `experiments/swarm_hunter_lab/detector.py +35/−3` · `experiments/swarm_hunter_lab/tests/test_properties.py +93/−1`.
- **Disjointness gate:** the six main commits since the branch point (Medusa/Nextness/params, 11 files) have **zero overlap** with the four S1 files; the only other open draft (#403) is likewise disjoint — verified freshly before merging.
- **Fresh CI at `276bccf` (all conclusive, none pending/neutral):** `swarm-hunter-lab` **80 passed** · `verify-python` success · `frontend-quality` success · `agent-safety` success. (Theory Tripwire already ran conclusively when the `swarm-hunter` label was applied; it triggers on `opened`/`reopened`/`labeled`, not `synchronize`, so it correctly does not re-fire on a branch update.)
- **What this PR lands:** the caller-list concurrent-mutation repair — `detect_structures()` now takes a bounded (≤ `MAX_SNAPSHOTS + 1` references) private shallow snapshot of an exact list before the ceiling check and iteration (a tuple is used directly), so a concurrent append after the length check can never make the invocation validate more than 64. Accepted detector + LeanCTX bytes stayed byte-identical; `SCHEMA_ID`, `DETECTOR_VERSION`, output schema, `DetectorConfig`, cap/budget arithmetic, `components_emitted`, hashing and LeanCTX all unchanged.
- **Merge:** marked ready + ordinary **protected head-pinned squash merge** pinned to `276bccf` — no admin bypass, no auto-merge, no protection/settings change; source-branch deletion only via the repository's ordinary automatic setting.
- **Threads/comments/label:** #404 has **zero** review threads (none created); the `swarm-hunter` label, the automatic tripwire comment, and the Gemini sunset notice are unchanged. **#394's four review threads (two current, two outdated, all unresolved) are left entirely untouched.**
- **Fences:** #403 and every other lane untouched; **S2 and all later Swarm Hunter stages remain hard-gated and unbegun.**
- **Model:** Claude Opus 4.8 (`claude-opus-4-8`).
