### PR TITLE
fix(agent-backends): ToolUseBlock value-shape normalization — exact-str id/name bounded 256/128, exact-dict input

### DIFF
--- a/scripts/agent_backends/base.py
+++ b/scripts/agent_backends/base.py
@@ -28,6 +28,22 @@ from typing import Any, ClassVar, Literal, Optional, Union
 # -- content blocks ---------------------------------------------------------
 
 
+_TOOL_NAME_MAX_LEN = 128
+_TOOL_ID_MAX_LEN = 256
+
+
+def _bounded_exact_str(value: Any, limit: int) -> str:
+    """Keep `value` (sliced to `limit`) only when it is exactly `str`.
+
+    Every other exact type — including str subclasses, whose methods may be
+    overridden — becomes "" without any conversion, length, or representation
+    method being requested on the value.
+    """
+    if type(value) is str:
+        return value[:limit]
+    return ""
+
+
 @dataclass(frozen=True)
 class TextBlock:
     """Plain-text assistant or user content."""
@@ -38,12 +54,27 @@ class TextBlock:
 
 @dataclass(frozen=True)
 class ToolUseBlock:
-    """Model is requesting a tool call. Matches Anthropic's block shape."""
+    """Model is requesting a tool call. Matches Anthropic's block shape.
+
+    Field values are model-reachable (backends build these straight from
+    wire/SDK responses, e.g. `json.loads` of an arguments string can yield
+    any JSON type), so construction normalizes to a bounded shape:
+    `id`/`name` are kept only when exactly `str` (sliced to 256/128 chars,
+    else ""), and `input` is kept only when exactly `dict` (else replaced
+    by a fresh empty dict — never derived from other shapes). This keeps
+    `AgentResponse.from_content` total over every constructed block.
+    """
 
     id: str
     name: str
     input: dict[str, Any] = field(default_factory=dict)
     type: Literal["tool_use"] = "tool_use"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _bounded_exact_str(self.id, _TOOL_ID_MAX_LEN))
+        object.__setattr__(self, "name", _bounded_exact_str(self.name, _TOOL_NAME_MAX_LEN))
+        if type(self.input) is not dict:
+            object.__setattr__(self, "input", {})
 
 
 @dataclass(frozen=True)

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -9,6 +9,9 @@ Covers:
     recorded calls capture all inputs.
   - MockBackend callable-mode: invoked per call with correct args.
   - Frozen dataclasses reject mutation (immutability fence).
+  - ToolUseBlock value-shape normalization: exact-str id/name bounded to
+    256/128 chars, exact-dict input, hostile shapes replaced without
+    invoking any conversion/length/representation hook.
 """
 
 from __future__ import annotations
@@ -162,6 +165,275 @@ def test_from_content_preserves_empty_text_filtered():
     content = [TextBlock(text=""), TextBlock(text="actual")]
     resp = AgentResponse.from_content(content)
     assert resp.text == "actual"
+
+
+# -- ToolUseBlock value-shape normalization ----------------------------------
+#
+# ToolUseBlock.__post_init__ must produce a consistent bounded shape before
+# AgentResponse.from_content derives tool calls:
+#   - id/name kept only when type(value) is str, sliced to 256/128 chars;
+#     every other exact type becomes "" with no conversion and no
+#     type-name reporting.
+#   - input kept only when type(input) is dict; every other exact type
+#     (including dict subclasses) is replaced by a fresh empty dict.
+# The hostile instruments below raise _HookCalled from every conversion,
+# length, and representation hook, so a passing test is proof the
+# normalization never requested any of those methods.
+
+
+class _HookCalled(Exception):
+    """Raised by hostile instruments when any forbidden hook is requested."""
+
+
+class _HostileValue:
+    """Non-str/non-dict object whose hooks all raise."""
+
+    def __str__(self):
+        raise _HookCalled("__str__")
+
+    def __repr__(self):
+        raise _HookCalled("__repr__")
+
+    def __format__(self, spec):
+        raise _HookCalled("__format__")
+
+    def __bytes__(self):
+        raise _HookCalled("__bytes__")
+
+    def __len__(self):
+        raise _HookCalled("__len__")
+
+    def __bool__(self):
+        raise _HookCalled("__bool__")
+
+    def __int__(self):
+        raise _HookCalled("__int__")
+
+    def __index__(self):
+        raise _HookCalled("__index__")
+
+    def __iter__(self):
+        raise _HookCalled("__iter__")
+
+    def keys(self):
+        raise _HookCalled("keys")
+
+
+class _HostileStr(str):
+    """str subclass whose hooks raise — the exact-type gate must refuse it
+    without requesting any of these methods."""
+
+    def __str__(self):
+        raise _HookCalled("__str__")
+
+    def __repr__(self):
+        raise _HookCalled("__repr__")
+
+    def __len__(self):
+        raise _HookCalled("__len__")
+
+    def __getitem__(self, item):
+        raise _HookCalled("__getitem__")
+
+    def __bool__(self):
+        raise _HookCalled("__bool__")
+
+
+class _PlainStrSub(str):
+    """Well-behaved str subclass — still refused, proving the gate is
+    exact-type, not isinstance."""
+
+
+class _PlainDictSub(dict):
+    """Well-behaved dict subclass — still replaced, proving the gate is
+    exact-type, not isinstance."""
+
+
+class _HostileDict(dict):
+    """dict subclass whose view/iteration hooks raise — must be replaced
+    without requesting any of these methods."""
+
+    def keys(self):
+        raise _HookCalled("keys")
+
+    def items(self):
+        raise _HookCalled("items")
+
+    def values(self):
+        raise _HookCalled("values")
+
+    def __iter__(self):
+        raise _HookCalled("__iter__")
+
+    def __len__(self):
+        raise _HookCalled("__len__")
+
+    def __bool__(self):
+        raise _HookCalled("__bool__")
+
+    def __getitem__(self, key):
+        raise _HookCalled("__getitem__")
+
+    def copy(self):
+        raise _HookCalled("copy")
+
+
+_NON_STR_VALUES = [123, 1.5, True, False, None, b"bytes", ["list"], {"d": 1}, ("t",)]
+_NON_STR_IDS = ["int", "float", "true", "false", "none", "bytes", "list", "dict", "tuple"]
+
+_NON_DICT_INPUTS = [["array"], "string", b"bytes", 42, 3.14, True, False, None, ("k", "v")]
+_NON_DICT_IDS = ["array", "string", "bytes", "int", "float", "true", "false", "none", "tuple"]
+
+
+def test_normalization_preserves_wellformed_name_id_and_input():
+    d = {"x": 1, "nested": {"y": 2}}
+    b = ToolUseBlock(id="tu_wellformed", name="get_params", input=d)
+    assert b.id == "tu_wellformed"
+    assert b.name == "get_params"
+    assert b.input is d  # preserved, not copied — current behavior retained
+    assert b.type == "tool_use"
+
+
+def test_normalization_preserves_exact_boundary_lengths():
+    name_128 = "a" * 127 + "b"
+    id_256 = "c" * 255 + "d"
+    b = ToolUseBlock(id=id_256, name=name_128)
+    assert b.name == name_128
+    assert len(b.name) == 128
+    assert b.id == id_256
+    assert len(b.id) == 256
+
+
+def test_normalization_truncates_above_boundary_deterministically():
+    long_name = "n" * 127 + "XY"  # 129 chars
+    long_id = "i" * 255 + "XY"  # 257 chars
+    b1 = ToolUseBlock(id=long_id, name=long_name)
+    b2 = ToolUseBlock(id=long_id, name=long_name)
+    assert b1.name == long_name[:128]
+    assert len(b1.name) == 128
+    assert b1.id == long_id[:256]
+    assert len(b1.id) == 256
+    # deterministic: identical inputs → identical normalized values
+    assert b1.name == b2.name
+    assert b1.id == b2.id
+
+
+@pytest.mark.parametrize("value", _NON_STR_VALUES, ids=_NON_STR_IDS)
+def test_normalization_replaces_non_str_name(value):
+    b = ToolUseBlock(id="tu_1", name=value)
+    assert type(b.name) is str
+    assert b.name == ""  # no conversion, no type-name reporting
+    assert b.id == "tu_1"
+
+
+@pytest.mark.parametrize("value", _NON_STR_VALUES, ids=_NON_STR_IDS)
+def test_normalization_replaces_non_str_id(value):
+    b = ToolUseBlock(id=value, name="get_params")
+    assert type(b.id) is str
+    assert b.id == ""
+    assert b.name == "get_params"
+
+
+def test_normalization_replaces_str_subclass_name_and_id():
+    b = ToolUseBlock(id=_PlainStrSub("tu_sub"), name=_PlainStrSub("sub_name"))
+    assert type(b.id) is str
+    assert b.id == ""
+    assert type(b.name) is str
+    assert b.name == ""
+
+
+def test_normalization_refuses_hostile_str_subclass_without_hooks():
+    # Constructing must not raise _HookCalled: no len/slice/str on the value.
+    b = ToolUseBlock(id=_HostileStr("evil-id"), name=_HostileStr("evil-name"))
+    assert b.id == ""
+    assert b.name == ""
+
+
+def test_normalization_refuses_hostile_object_name_id_without_hooks():
+    b = ToolUseBlock(id=_HostileValue(), name=_HostileValue())
+    assert b.id == ""
+    assert b.name == ""
+
+
+@pytest.mark.parametrize("bad_input", _NON_DICT_INPUTS, ids=_NON_DICT_IDS)
+def test_normalization_replaces_non_dict_input(bad_input):
+    b = ToolUseBlock(id="tu_1", name="get_params", input=bad_input)
+    assert type(b.input) is dict
+    assert b.input == {}
+
+
+def test_normalization_replaces_dict_subclass_input_without_deriving():
+    b = ToolUseBlock(id="tu_1", name="get_params", input=_PlainDictSub({"a": 1}))
+    assert type(b.input) is dict
+    assert b.input == {}  # replaced, not derived — contents dropped
+
+
+def test_normalization_replaces_hostile_dict_subclass_without_hooks():
+    b = ToolUseBlock(id="tu_1", name="get_params", input=_HostileDict())
+    assert type(b.input) is dict
+    assert b.input == {}
+
+
+def test_normalization_replaces_hostile_object_input_without_hooks():
+    b = ToolUseBlock(id="tu_1", name="get_params", input=_HostileValue())
+    assert type(b.input) is dict
+    assert b.input == {}
+
+
+def test_normalization_replacement_dicts_are_independent():
+    b1 = ToolUseBlock(id="tu_1", name="n", input=["not-a-dict"])
+    b2 = ToolUseBlock(id="tu_2", name="n", input="also-not")
+    assert b1.input is not b2.input
+    b1.input["k"] = "v"
+    assert b2.input == {}
+
+
+def test_normalized_block_remains_frozen():
+    b = ToolUseBlock(id="tu_1", name="get_params")
+    with pytest.raises(Exception):
+        b.name = "other"  # frozen dataclass → FrozenInstanceError
+
+
+def test_from_content_returns_normally_for_every_normalized_shape():
+    blocks = [
+        ToolUseBlock(id=123, name=None, input=["array"]),
+        ToolUseBlock(id=_HostileValue(), name=_HostileStr("x"), input=_HostileDict()),
+        ToolUseBlock(id=_PlainStrSub("s"), name=b"bytes", input="string"),
+        ToolUseBlock(id=None, name=True, input=42),
+        ToolUseBlock(id="tu_ok", name="fine", input={"k": 1}),
+    ]
+    resp = AgentResponse.from_content(blocks)
+    assert len(resp.tool_calls) == len(blocks)
+    for tc in resp.tool_calls[:4]:
+        assert tc.id == ""
+        assert tc.name == ""
+        assert tc.arguments == {}
+    assert resp.tool_calls[4].id == "tu_ok"
+    assert resp.tool_calls[4].arguments == {"k": 1}
+
+
+def test_from_content_tool_call_reflects_normalized_block():
+    long_name = "m" * 200
+    b = ToolUseBlock(id="tu_long", name=long_name, input={"a": 1})
+    resp = AgentResponse.from_content([b])
+    tc = resp.tool_calls[0]
+    assert tc.name == long_name[:128]
+    assert tc.name == b.name  # ToolCall mirrors the normalized block
+    assert tc.arguments == b.input
+    assert tc.arguments is not b.input  # copy semantics retained
+
+
+def test_from_content_raw_content_carries_normalized_blocks():
+    b = ToolUseBlock(id="x" * 300, name=_HostileValue(), input=("not", "dict"))
+    resp = AgentResponse.from_content([b])
+    assert resp.raw_content[0] is b  # same object, already normalized
+    assert resp.raw_content[0].id == "x" * 256
+    assert resp.raw_content[0].name == ""
+    assert resp.raw_content[0].input == {}
+    # derived ToolCall and raw_content reflect the SAME normalized shape
+    assert resp.tool_calls[0].id == resp.raw_content[0].id
+    assert resp.tool_calls[0].name == resp.raw_content[0].name
+    assert resp.tool_calls[0].arguments == resp.raw_content[0].input
 
 
 # -- AgentBackend ABC --------------------------------------------------------

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -355,6 +355,17 @@ def test_normalization_refuses_hostile_object_name_id_without_hooks():
     assert b.name == ""
 
 
+def test_normalization_refuses_hostile_name_and_id_separately():
+    # Each field is gated on its own: a hostile value in one never
+    # disturbs a well-formed value in the other, and no hook runs.
+    b1 = ToolUseBlock(id="tu_ok", name=_HostileValue())
+    assert b1.id == "tu_ok"
+    assert b1.name == ""
+    b2 = ToolUseBlock(id=_HostileValue(), name="get_params")
+    assert b2.id == ""
+    assert b2.name == "get_params"
+
+
 @pytest.mark.parametrize("bad_input", _NON_DICT_INPUTS, ids=_NON_DICT_IDS)
 def test_normalization_replaces_non_dict_input(bad_input):
     b = ToolUseBlock(id="tu_1", name="get_params", input=bad_input)
@@ -383,6 +394,14 @@ def test_normalization_replaces_hostile_object_input_without_hooks():
 def test_normalization_replacement_dicts_are_independent():
     b1 = ToolUseBlock(id="tu_1", name="n", input=["not-a-dict"])
     b2 = ToolUseBlock(id="tu_2", name="n", input="also-not")
+    assert b1.input is not b2.input
+    b1.input["k"] = "v"
+    assert b2.input == {}
+
+
+def test_default_input_dicts_are_independent_instances():
+    b1 = ToolUseBlock(id="tu_1", name="n")
+    b2 = ToolUseBlock(id="tu_2", name="n")
     assert b1.input is not b2.input
     b1.input["k"] = "v"
     assert b2.input == {}


### PR DESCRIPTION
# fix(agent-backends): ToolUseBlock value-shape normalization — exact-str id/name bounded 256/128, exact-dict input

## Problem

`ToolUseBlock` fields are model-reachable. `openai_compat_backend.py` builds `input` from `json.loads` of the model's `arguments` string, and `json.loads` can return **any** JSON type — array, string, number, boolean, or null — not just an object. Today that non-dict value flows unchanged into `ToolUseBlock.input` and crashes on the unprotected transport path when `AgentResponse.from_content` runs `dict(block.input)` (`dict(["array"])` → `TypeError`, `dict("x")` → `ValueError`). The exception escapes `complete()` and takes down the orchestrator iteration loop before the router's defensive try is ever reached. The same raw value would also reach the wire re-encoders on echo-back (`dict(b.input)` in the Anthropic encoder, `json.dumps(b.input or {})` in the OpenAI encoder).

## Change

`ToolUseBlock.__post_init__` (frozen-dataclass pattern via `object.__setattr__`) now normalizes every constructed block to a consistent bounded shape **before** `AgentResponse.from_content` derives tool calls:

- `id` is kept only when `type(id) is str`, sliced to **256** chars; every other exact type becomes `""`.
- `name` is kept only when `type(name) is str`, sliced to **128** chars; every other exact type becomes `""`.
- Refused id/name values are replaced **without conversion and without type-name reporting** — no conversion, length, or representation method is ever requested on them.
- `input` is kept only when `type(input) is dict` (exact); arrays, strings, numbers, booleans, null values, and **dict subclasses** are replaced by a fresh empty dict — never derived.

`from_content` is now total over every constructed block, and `raw_content` and the derived `ToolCall` reflect the same normalized values. No public signature changes; `__all__` unchanged; no orchestrator edits.

## Compatibility

- **Well-formed blocks are byte-identical in behavior**: exact `str` id/name within bounds pass through unchanged; an exact `dict` input is preserved **by reference** (current identity semantics retained). All 26 pre-existing tests in the file pass unmodified, as do the Anthropic/OpenAI backend, provider-parity, and orchestrator suites (no edits to any of them).
- Both production construction sites were traced. The Anthropic backend already coerces `input` through `dict(... or {})`, so it always constructs exact dicts — no behavior change. The OpenAI-compat backend is the one site that changes: a well-formed-JSON-but-non-object `arguments` (list/scalar/bool/null) previously passed through raw (and later crashed `from_content`); it now becomes `{}`. This deliberately trades the raw non-object payload for totality; the backend's existing malformed-JSON fallback (`{"_raw_arguments": ...}`) is an exact dict and is preserved untouched.
- A read-only consumer sweep found **no identity (`is`) reliance** on `input`/`name`/`id` anywhere in `scripts/` or `tests/` — all consumers copy or compare by value — so the fresh-`{}` replacement breaks no consumer.
- Bonus hardening: `json.dumps(b.input or {})` in the OpenAI wire encoder previously evaluated `__bool__` on an arbitrary `input` object (a hostile-hook path); post-normalization it always sees a genuine dict.
- Truncation caveat: a legitimately >256-char id or >128-char name would now truncate (which would break `tool_use`↔`tool_result` id linkage if it ever occurred). Real wire ids are well under 40 chars; no legitimate path hits the bound.

## Known residuals (flagged, deliberately out of scope)

1. The `type` field (`Literal["tool_use"]`) is not normalized. Adversarial review confirmed its blast radius is bounded: every consumer dispatches via `isinstance`, none reads or routes on `block.type`, and the wire encoders emit hardcoded type strings.
2. An exact dict `input` may still carry hostile keys/values. At construction and in `from_content`'s `dict()` copy nothing runs on them (C-level table copy); the residual surface is the wire encoders and the orchestrator result lane — the separate, already-scoped orchestrator/result-shaping batch. Not reachable from the model path (`json.loads` objects always have str keys and JSON-native values).

## Evidence

- Failing-first: the 38 regression tests of commit 1 were run before the implementation and failed exactly as predicted (38 failed / 29 passed, the 3 pass-already tests being pins of current well-formed behavior); after the change: 67/67. Commit 2 adds 2 review-driven pins (per-field hostile gating, default-input dict independence, both passing against the unchanged implementation): **69/69** in `tests/test_agent_backend.py`.
- Neighbors: `test_anthropic_backend.py` + `test_openai_compat_backend.py` + `test_provider_parity.py` + `test_orchestrator.py` = **146 passed** (run at commit 1; commit 2 touches only the backend test file).
- Full suite: **1685 passed, 48 skipped**.
- `python -m py_compile` clean on both files.
- Coverage: valid names/ids/dicts; exact boundary lengths (128/256) and deterministic truncation above each; every non-dict input shape incl. plain and hostile dict subclasses; non-str and str-subclass name/id; hostile instruments raising from every conversion/length/representation hook proving none is requested (jointly and per-field); derived `ToolCall.arguments`; normalized `raw_content`; defaults; frozen fence.
- Post-implementation review waves (read-only): an adversarial substitution-lens review found no confirmed defect — `type()` gates are escape-proof (ignores `__class__` lies), slicing on confirmed exact `str` dispatches only to C-level `str.__getitem__`, `__post_init__` is total, and no `copy`/`replace` path resurrects un-normalized state; a test-matrix review judged the required coverage complete with mutant-killing assertions (exact-type vs isinstance, wrong-bound 127/128, subclass-derive vs replace, shared-`{}`) and no pytest collection hazards.

### Boundary

`git diff main` touches exactly the two authorized files:

- `scripts/agent_backends/base.py` +32/−1
- `tests/test_agent_backend.py` +291/−0

### Status

Merged with Kev's authorization after Jack's completed audit as squash 37c7caf7fb710065a4782694a0ec24837ead43ae on 2026-07-22. No review-thread actions or deployment occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


