### PR TITLE
fix(s1-lab): hook-free exact-int guards — drop pre-type-proof isinstance(x, bool) (totality)

### DIFF
--- a/experiments/swarm_hunter_lab/detector.py
+++ b/experiments/swarm_hunter_lab/detector.py
@@ -127,7 +127,12 @@ def _validate_config(config) -> None:
         raise _Refusal("invalid_config")
     for name, (lo, hi) in _CONFIG_BOUNDS.items():
         value = getattr(config, name)
-        if isinstance(value, bool) or type(value) is not int:
+        # Exact builtin int by type() identity ONLY — hook-free. `type(x)`
+        # reads the real type slot and never consults a hostile `__class__`
+        # property, whereas `isinstance(x, bool)` would. bool is still rejected:
+        # `type(True) is bool`, not `int`, so the exact check catches it without
+        # the (now-removed) isinstance(..., bool) prefix.
+        if type(value) is not int:
             raise _Refusal("invalid_config")
         if not lo <= value <= hi:
             raise _Refusal("invalid_config")
@@ -212,16 +217,21 @@ def _validate_snapshot(item, ctx):
     states = item["states"]
     n = _validate_states(states, sid)
 
+    # Exact builtin int by type() identity ONLY — hook-free (see _validate_config):
+    # `type(x)` never consults a hostile `__class__` property; bool is still
+    # rejected because `type(True) is bool`, not `int`. The `!= n` / range / `!= 5`
+    # comparisons run only after the exact-int proof (short-circuit `or`), on a
+    # proven builtin int, so no scalar `__eq__`/`__le__` hook can execute either.
     lattice_size = prov["lattice_size"]
-    if isinstance(lattice_size, bool) or type(lattice_size) is not int or lattice_size != n:
+    if type(lattice_size) is not int or lattice_size != n:
         raise _Refusal("invalid_provenance", sid)
     num_states = prov["num_states"]
-    if isinstance(num_states, bool) or type(num_states) is not int:
+    if type(num_states) is not int:
         raise _Refusal("invalid_provenance", sid)
     if num_states != 5:
         raise _Refusal("unsupported_num_states", sid)
     generation = prov["generation"]
-    if isinstance(generation, bool) or type(generation) is not int \
+    if type(generation) is not int \
             or not 0 <= generation <= MAX_GENERATION:
         raise _Refusal("invalid_provenance", sid)
     ctx["gens_seen"].append(generation)

--- a/experiments/swarm_hunter_lab/tests/test_properties.py
+++ b/experiments/swarm_hunter_lab/tests/test_properties.py
@@ -989,3 +989,72 @@ def test_stable_sequence_does_not_mutate_caller_list_or_inputs():
     assert [id(s) for s in snaps] == before_order      # same objects, same order
     for s, b in zip(snaps, before_states):
         assert np.array_equal(s["states"], b)          # nested arrays unmutated
+
+
+# ---------------------------------------------------------------------------
+# S1 exact-integer-guard totality (Jack) — the config and provenance integer
+# guards previously ran isinstance(x, bool) BEFORE the exact-type proof, and
+# isinstance() consults a hostile x.__class__ property. They now use type()
+# identity only (hook-free): bool is still rejected (type(True) is bool, not
+# int), valid exact ints are retained, int subclasses are rejected, and a
+# hostile __class__ never executes.
+# ---------------------------------------------------------------------------
+
+
+class _ClassHook:
+    """An object whose __class__ property spoofs int and records every access.
+    A hook-free guard (type() only) must never touch it; isinstance() would."""
+    hits = 0
+
+    @property
+    def __class__(self):
+        _ClassHook.hits += 1
+        return int
+
+
+def _valid_snap_with(field, value):
+    snap = fixtures.fx_single()[0]
+    snap["provenance"][field] = value
+    snap["provenance"]["sha256_triple"] = compute_sha256_triple(snap["states"])
+    return snap
+
+
+def test_config_int_guard_hostile_class_hook_not_executed():
+    for field in ("min_component_size", "component_cap", "op_budget_multiplier"):
+        _ClassHook.hits = 0
+        cfg = DetectorConfig(**{field: _ClassHook()})
+        _, refusal = refusal_of(fixtures.fx_single(), cfg)
+        assert refusal["reason"] == "invalid_config"
+        assert _ClassHook.hits == 0     # type()-only guard never read __class__
+
+
+def test_provenance_int_guard_hostile_class_hook_not_executed():
+    for field in ("lattice_size", "num_states", "generation"):
+        _ClassHook.hits = 0
+        _, refusal = refusal_of([_valid_snap_with(field, _ClassHook())])
+        assert refusal["reason"] == "invalid_provenance"
+        assert _ClassHook.hits == 0
+
+
+def test_int_guards_reject_bools_structurally():
+    _, refusal = refusal_of(fixtures.fx_single(), DetectorConfig(component_cap=True))
+    assert refusal["reason"] == "invalid_config"
+    for field in ("lattice_size", "num_states", "generation"):
+        _, refusal = refusal_of([_valid_snap_with(field, True)])
+        assert refusal["reason"] == "invalid_provenance"
+
+
+def test_int_guards_retain_valid_exact_ints_reject_subclasses():
+    # a fully valid exact-int config + provenance still validates normally
+    header = detect_structures(fixtures.fx_single(),
+                               DetectorConfig(min_component_size=1)).records()[0]
+    assert header["kind"] == "header" and header["counts"]["refusals"] == 0
+
+    class _MyInt(int):
+        pass
+
+    _, refusal = refusal_of(fixtures.fx_single(),
+                            DetectorConfig(component_cap=_MyInt(100)))
+    assert refusal["reason"] == "invalid_config"       # int subclass rejected
+    _, refusal = refusal_of([_valid_snap_with("num_states", _MyInt(5))])
+    assert refusal["reason"] == "invalid_provenance"


### PR DESCRIPTION
## S1 exact-integer-guard totality — hook-free int checks (Jack)

S1-only, **two** permitted files (`detector.py`, `tests/test_properties.py`). **Draft — do not merge.** Opened for Jack's audit.

### The finding
Four integer guards ran `isinstance(value, bool)` **before** the exact-type proof, in the `or` chain:
- `_validate_config` — each config field (`min_component_size`, `component_cap`, `op_budget_multiplier`);
- `_validate_snapshot` — provenance `lattice_size`, `num_states`, `generation`.

`isinstance(x, cls)` consults `x.__class__`, so a hostile value whose `__class__` is a property could **execute an arbitrary hook** (or spoof `int`) during validation, before any exact-type proof ran.

**Failing-before receipt:** an object with a hits-counting `@property __class__` returning `int` fired the hook **exactly once** for each of the four guards (config field + provenance `lattice_size`/`num_states`/`generation`).

### Repair (`detector.py`, four guards)
Drop the `isinstance(..., bool) or` prefix, leaving `type(x) is not int`:
- `type()` reads the real type slot and **never** consults `__class__` → hook-free;
- **bool is still rejected** because `type(True) is bool`, not `int` — so behavior is unchanged (bool → structured refusal, exact int accepted, **int subclass rejected**);
- the `!= n` / range / `!= 5` comparisons run only **after** the exact-int proof via `or` short-circuit, on a proven builtin int, so no scalar `__eq__`/`__le__` hook can execute either.

**Scope note:** the remaining `isinstance` uses in `detector.py` (`lp` L62, `_hex16` L380) operate on already-validated internal strings/bytes, not caller-controlled hostile input, so they are out of scope.

**Passing-after receipt:** all four guards refuse (`invalid_config` / `invalid_provenance`) with the hostile `__class__` executing **zero times** (flag-asserted).

### Equivalence, tests, scope
- **Accepted-byte equivalence:** byte-identical to base `37c7caf` — **22 cases (11 fixture artifacts + 11 LeanCTX), 0 mismatches**. Unchanged: `SCHEMA_ID`, `DETECTOR_VERSION`, output keys/schema, `DetectorConfig`, cap/budget arithmetic, `components_emitted`, hashing, LeanCTX, refusal vocabulary.
- **Regressions: +4 (80 → 84 lab-local)** — hostile `__class__` hook not executed for config and provenance guards (flag asserts 0 hits), structured bool rejection (config + provenance), valid exact-int retention, int-subclass rejection by exact-type identity.
- **Diffstat (exactly 2 files):** `detector.py +14/−4` · `tests/test_properties.py +69/−0` (total **+83/−4**).
- CI: full lab-local suite green (84); `swarm-hunter-lab` workflow gates it. Maintained `verify-python` scopes to `tests/` (lab excluded by design).

### Authority & fences
Kev (repo owner) personally authorized this exact package in his own words (two S1 files, the four hook-free exact-int guards, deterministic failing-before regressions, one commit, one branch, one draft PR, `swarm-hunter` label, CI observation). **No merge, no ready, no thread actions.** Branched from freshly verified main `37c7caf7fb710065a4782694a0ec24837ead43ae` (disjoint from open lanes); no main-update after branching; #406 and every other lane untouched; **S2 and all later Swarm Hunter stages remain hard-gated and unbegun.**

### Model identity
Authored by seat 84 = **Claude Opus 4.8** (`claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Reconciliation — 2026-07-22 (Jack approved; ready for merge)

**Jack's audit: approved.** The four hook-free exact-int guards are verified — `type(x) is not int` reads the real type slot without consulting `__class__`, so bool and int-subclasses stay rejected by identity and the four hostile-`__class__` regressions confirm zero hook execution. Accepted-byte equivalence (22 cases, 0 mismatches) and the +4 lab-local regressions (80 → 84) reproduce; `SCHEMA_ID` / `DETECTOR_VERSION` / output schema / refusal vocabulary unchanged. Cleared to mark ready and merge.

**Scope-sentence correction (non-blocking).** The original scope note grouped `lp` (L62) with `_hex16` (L380) as "already-validated internal … not caller-controlled." That conflation is corrected: `_hex16` **is** internal (private, `_`-prefixed, operating on already-validated bytes), whereas `lp` is **publicly exported** — a caller *can* invoke it directly — but malformed direct `lp` calls have **no structured-refusal contract** (`lp` assumes validated input and is not part of the S1 structured-refusal surface), so it remains outside this amendment either way. The guard repair and its out-of-scope conclusion are unchanged; only the stated justification for `lp` is corrected.

**Staging record.** Under Kev's own-words authorization (repo owner), seat 84 on **Claude Opus 4.8** (`claude-opus-4-8`) staged the ordinary closure — fresh re-verify (main `37c7caf` unchanged → no branch update; head `49ed60e`; 0 review threads; #406 disjoint), body reconciliation, and mark-ready. The first two ordinary protected head-pinned squash-merge attempts were **stopped by Claude Code's local permission classifier — not by GitHub or branch protection** (the second a transient stage-2 classifier error); between attempts the PR was held OPEN/MERGEABLE at the pinned head `49ed60e`, its body kept accurate as OPEN/unmerged, pending each re-authorization.

**Merged — 2026-07-22.** On the third Kev-authorized retry the classifier cleared and the identical pinned squash merge succeeded. **Squash OID `5d90ea35bf8d60387e667559b193178ae7d64b4d`**, merged by `Goldislops` at **2026-07-22T09:08:02Z**, head-pinned to `49ed60e`. **Post-merge CI on main `5d90ea3`: rollup SUCCESS** — `verify-python`, `frontend-quality`, `swarm-hunter-lab` all pass. Source branch `fix/s1-exact-int-guard-totality` auto-deleted via the repository's normal setting. #394's four review threads and #406 left untouched throughout; S2 and all later Swarm Hunter stages remain hard-gated and unbegun.
