### PR TITLE
fix(tuning): request-shape totality for propose/commit/rollback envelopes

### DIFF
--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -36,41 +36,74 @@ outcomes, rate limits, rollback, and ledger/event schemas — is preserved:
   commit `proposal_id` or rollback `to_proposal_id` that is a JSON array/object
   previously reached the registry `dict.get` and raised `unhashable type` (HTTP
   500); a non-string id is now `400 bad_request` (exact-`str` gate before the
-  lookup). `source` / `justification` remain string-coerced metadata, and a
-  container-valued parameter is still recorded as a `wrong_type` validation
-  rejection (422) — both unchanged.
+  lookup). A SUPPLIED `source` / `justification` must be an exact JSON string —
+  the former `str(...)` coercion (which accepted a JSON list/number/object and
+  stored its Python repr) is removed; a missing field keeps its documented
+  default (`unspecified` / empty string) and a valid string is stored
+  byte-for-byte. A finite container-valued parameter is still recorded as a
+  `wrong_type` validation rejection (422) — unchanged.
 - **DIRECT (arbitrary Python objects).** `TuningState.propose/commit/rollback`
   and `validate_proposal` prove exact builtin shapes before any supplied value
   is hashed, looked up, compared, stringified, validated, serialised, or
-  emitted: `params` must be an exact `dict` with exact-`str` keys and exact JSON
-  tree values; `source`/`justification`/`mode`/`approver`/`proposal_id`/
-  `to_proposal_id` must be exact `str` (a `str` subclass is refused). A
-  malformed call terminates through a fixed `TuningError(400, bad_request)`
-  rather than leaking an `AttributeError`/`TypeError`. Parameter keys are
-  refused by exact type before registry hashing/lookup, so a hostile `__hash__`
-  never runs.
+  emitted: `params` must be an exact `dict` with exact-`str` keys and exact
+  standard-JSON tree values — finite floats only, exact ints within the
+  2048-bit width ceiling; `source`/`justification`/`mode`/`approver`/
+  `proposal_id`/`to_proposal_id` must be exact `str` (a `str` subclass is
+  refused). A malformed call terminates through a fixed
+  `TuningError(400, bad_request)` rather than leaking an
+  `AttributeError`/`TypeError`/`ValueError`. Parameter keys are refused by
+  exact type before registry hashing/lookup, so a hostile `__hash__` never
+  runs.
 - **LEDGER/EVENT.** Because the envelope is proven serialisable up front, a
   refused request appends no ledger line, writes no pending file, records no
   proposal, commits/rolls back nothing, and emits no event (including no
-  `tuning.rejected` event carrying a supplied object). Valid requests still
-  append their canonical JSON ledger entries and events unchanged.
+  `tuning.rejected` event carrying a supplied object). The ledger line is also
+  serialized before the ledger file is opened, so a serialization failure can
+  no longer leave a zero-byte ledger file behind. Startup replay skips any
+  unparseable legacy line — including a pre-ceiling line whose oversized int
+  literal raises the plain-`ValueError` digit guard from `json.loads`, which
+  previously escaped the `JSONDecodeError`-only guard and crashed
+  `TuningState` construction. Valid requests still append their canonical JSON
+  ledger entries and events unchanged.
 
 The refusal message is a fixed generic string (`BAD_REQUEST_MESSAGE`) that names
 neither the supplied value nor its type. The normalized `policy:auto` refusal
 (every whitespace/case spelling) and byte-for-byte storage of valid human
 approver strings in the ledger are preserved.
 
-Two totality bounds are recorded as residuals (neither restricts a valid
-request; parsed JSON cannot express either pathology, so both are DIRECT-lane
-only): a container-nesting depth (`_MAX_REQUEST_VALUE_DEPTH`) that keeps the
-JSON-tree proof total against a **cyclic** DIRECT value, and a per-value
-node-visit budget (`_MAX_REQUEST_VALUE_NODES`, far above any realistic value)
-that keeps it total against a **shared-reference DAG** whose repeated
-references would otherwise be traversed — and `json.dumps`-expanded —
-exponentially. A separate, pre-existing residual: a non-finite float
-(`NaN`/`Infinity`) proposed for a float parameter is rejected by validation
-(`wrong_type`) but still recorded in the ledger as a Python-reparseable
-non-standard-JSON token, exactly as before this change.
+**Integer width ceiling.** An exact builtin int anywhere in a tuning request or
+proposal is bounded to `MAX_TUNING_INT_BITS` = 2048 bits
+(`scripts/params_schema.py`, aligned with the repository's
+`MAX_TOOL_RESULT_INT_BITS` tool-result ceiling), decided by `int.bit_length()`
+only after `type(value) is int` — bool keeps its separate behaviour. A
+2048-bit value reaches ordinary parameter validation (and its existing range
+messages, unchanged); a 2049-bit value is the fixed envelope refusal, for both
+signs, independent of the mutable process-wide `sys.get_int_max_str_digits()`
+setting (an accepted int renders to at most 617 decimal digits, below the
+smallest settable limit of 640). Direct `validate_proposal` stays total on
+oversized ints — including for registered int parameters — with a fixed
+refusal that never formats or copies the supplied integer. This closes the
+previously reproduced trio: `ValueError` leaking from direct `propose` under a
+digit limit, a zero-byte ledger file from an unknown-parameter proposal, and
+thousands-of-digits ledger lines with the limit disabled. Non-finite floats
+(`NaN`/`Infinity`) are likewise no longer a recorded validation rejection: the
+JSON-tree proof requires exact finite floats, so they are the fixed
+`400 bad_request` before validation or any ledger write (the former
+non-standard-token-in-ledger residual is closed).
+
+Totality bounds recorded as residuals (none restricts a valid request; parsed
+JSON cannot express the container pathologies, which are DIRECT-lane only): a
+container-nesting depth (`_MAX_REQUEST_VALUE_DEPTH`) that keeps the JSON-tree
+proof total against a **cyclic** DIRECT value, and a proposal-wide node-visit
+budget (`_MAX_REQUEST_NODES`, far above any realistic request) charged once
+across ALL parameter values of one proposal — not restarted per value — that
+keeps it total against a **shared-reference DAG** whose repeated references
+would otherwise be traversed — and `json.dumps`-expanded — exponentially.
+These bounds limit node count, nesting depth, and integer width only: the
+request has **no scalar-string or total-byte ceiling**, so the serialized size
+of an accepted proposal (and hence of a ledger line) is NOT bounded — a single
+long JSON string value passes the proof at any length. Recorded as a residual
+rather than bounded here.
 
 **S — observe-by-default capability model** (`scripts/orchestrator.py`,
 `scripts/orchestrator_config.py`). The LLM-facing surface is capability-gated:

--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -24,6 +24,45 @@ requires a reviewed code change. Human commits (`approver="human:<name>"`),
 reads, dry-run/propose, LOCKED-at-propose rejection, and the per-parameter rate
 limit are unchanged.
 
+Request-shape totality (`scripts/tuning_api.py`, `scripts/params_schema.py`).
+The propose / commit / rollback envelopes are deterministic for malformed value
+shapes across three reachability lanes, while every valid request's behaviour —
+defaults, response bytes, status codes, proposal identifiers, validation
+outcomes, rate limits, rollback, and ledger/event schemas — is preserved:
+
+- **PUBLIC (parsed-JSON reachable).** A non-object top-level body (a JSON array,
+  number, string, or `true`) previously reached `body.get(...)` and returned
+  HTTP 500; it is now a stable `400 bad_request` (exact-`dict` body gate). A
+  commit `proposal_id` or rollback `to_proposal_id` that is a JSON array/object
+  previously reached the registry `dict.get` and raised `unhashable type` (HTTP
+  500); a non-string id is now `400 bad_request` (exact-`str` gate before the
+  lookup). `source` / `justification` remain string-coerced metadata, and a
+  container-valued parameter is still recorded as a `wrong_type` validation
+  rejection (422) — both unchanged.
+- **DIRECT (arbitrary Python objects).** `TuningState.propose/commit/rollback`
+  and `validate_proposal` prove exact builtin shapes before any supplied value
+  is hashed, looked up, compared, stringified, validated, serialised, or
+  emitted: `params` must be an exact `dict` with exact-`str` keys and exact JSON
+  tree values; `source`/`justification`/`mode`/`approver`/`proposal_id`/
+  `to_proposal_id` must be exact `str` (a `str` subclass is refused). A
+  malformed call terminates through a fixed `TuningError(400, bad_request)`
+  rather than leaking an `AttributeError`/`TypeError`. Parameter keys are
+  refused by exact type before registry hashing/lookup, so a hostile `__hash__`
+  never runs.
+- **LEDGER/EVENT.** Because the envelope is proven serialisable up front, a
+  refused request appends no ledger line, writes no pending file, records no
+  proposal, commits/rolls back nothing, and emits no event (including no
+  `tuning.rejected` event carrying a supplied object). Valid requests still
+  append their canonical JSON ledger entries and events unchanged.
+
+The refusal message is a fixed generic string (`BAD_REQUEST_MESSAGE`) that names
+neither the supplied value nor its type. The normalized `policy:auto` refusal
+(every whitespace/case spelling) and byte-for-byte storage of valid human
+approver strings in the ledger are preserved. No new content-size ceiling is
+introduced; the only bound is a container-nesting depth
+(`_MAX_REQUEST_VALUE_DEPTH`) that keeps the JSON-tree proof total against a
+cyclic DIRECT value (recorded as a residual, not a content limit).
+
 **S — observe-by-default capability model** (`scripts/orchestrator.py`,
 `scripts/orchestrator_config.py`). The LLM-facing surface is capability-gated:
 

--- a/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
+++ b/docs/LEGACY_ORCHESTRATOR_QUARANTINE.md
@@ -58,10 +58,19 @@ outcomes, rate limits, rollback, and ledger/event schemas — is preserved:
 The refusal message is a fixed generic string (`BAD_REQUEST_MESSAGE`) that names
 neither the supplied value nor its type. The normalized `policy:auto` refusal
 (every whitespace/case spelling) and byte-for-byte storage of valid human
-approver strings in the ledger are preserved. No new content-size ceiling is
-introduced; the only bound is a container-nesting depth
-(`_MAX_REQUEST_VALUE_DEPTH`) that keeps the JSON-tree proof total against a
-cyclic DIRECT value (recorded as a residual, not a content limit).
+approver strings in the ledger are preserved.
+
+Two totality bounds are recorded as residuals (neither restricts a valid
+request; parsed JSON cannot express either pathology, so both are DIRECT-lane
+only): a container-nesting depth (`_MAX_REQUEST_VALUE_DEPTH`) that keeps the
+JSON-tree proof total against a **cyclic** DIRECT value, and a per-value
+node-visit budget (`_MAX_REQUEST_VALUE_NODES`, far above any realistic value)
+that keeps it total against a **shared-reference DAG** whose repeated
+references would otherwise be traversed — and `json.dumps`-expanded —
+exponentially. A separate, pre-existing residual: a non-finite float
+(`NaN`/`Infinity`) proposed for a float parameter is rejected by validation
+(`wrong_type`) but still recorded in the ledger as a Python-reparseable
+non-standard-JSON token, exactly as before this change.
 
 **S — observe-by-default capability model** (`scripts/orchestrator.py`,
 `scripts/orchestrator_config.py`). The LLM-facing surface is capability-gated:

--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -406,17 +406,34 @@ class ProposalValidation:
     unknown_params: list[str]            # names that don't
 
 
-def validate_proposal(params: dict[str, Any]) -> ProposalValidation:
+def validate_proposal(params: Any) -> ProposalValidation:
     """Validate a proposed {name: value} dict against the registry.
 
     Runs every parameter; collects ALL errors rather than short-circuiting.
     Returns `ok=True` iff every known parameter validates and no unknown
     names are present. LOCKED parameters always fail validation.
+
+    Total on arbitrary input (this is a DIRECT entry point): a proposal that
+    is not EXACTLY a builtin ``dict`` resolves to a not-ok result rather than
+    leaking an ``.items()`` AttributeError, and a non-``str`` key forces the
+    aggregate result to not-ok WITHOUT being hashed into ``PARAMS.get`` (which
+    would run a hostile ``__hash__``) or copied into any message. Exact-type
+    decisions only — a proposed value's methods still run no code here.
     """
+    if type(params) is not dict:
+        return ProposalValidation(
+            ok=False, errors={}, known_params=[], unknown_params=[])
     errors: dict[str, ValidationResult] = {}
     known: list[str] = []
     unknown: list[str] = []
+    malformed_keys = 0
     for name, value in params.items():
+        # A non-str key cannot name a registered parameter. Refuse it by exact
+        # type BEFORE ``PARAMS.get`` — hashing it (or formatting it into a
+        # message) would execute a supplied object's ``__hash__``/``__repr__``.
+        if type(name) is not str:
+            malformed_keys += 1
+            continue
         param = PARAMS.get(name)
         if param is None:
             unknown.append(name)
@@ -431,7 +448,7 @@ def validate_proposal(params: dict[str, Any]) -> ProposalValidation:
         if not result.ok:
             errors[name] = result
     return ProposalValidation(
-        ok=len(errors) == 0,
+        ok=len(errors) == 0 and malformed_keys == 0,
         errors=errors,
         known_params=known,
         unknown_params=unknown,

--- a/scripts/params_schema.py
+++ b/scripts/params_schema.py
@@ -61,6 +61,19 @@ class ValidationResult:
     message: str = ""
 
 
+MAX_TUNING_INT_BITS: Final[int] = 2048
+"""Code-level magnitude ceiling (bit length) for an exact builtin int anywhere
+in a tuning request or proposal. Aligned with the repository's tool-result
+ceiling (``MAX_TOOL_RESULT_INT_BITS`` in ``scripts/orchestrator.py``). Checked
+via ``int.bit_length()`` only AFTER ``type(value) is int`` proves the exact
+builtin type (bool is excluded by that identity check and keeps its separate
+behaviour), so acceptance is decided without rendering the value and is
+independent of the mutable process-wide ``sys.get_int_max_str_digits()``
+setting. A within-ceiling int renders to at most 617 decimal digits — below
+the smallest settable digit limit (640) — so the existing range-refusal
+messages and ledger serialisation can never raise for an accepted integer."""
+
+
 # --- Hook-free type description ----------------------------------------------
 
 
@@ -169,12 +182,32 @@ class TunableParam:
                     error=ValidationError.WRONG_TYPE,
                     message=f"{self.name} requires int, got {_describe_type(value)}.",
                 )
+            # Width ceiling AFTER the exact-int proof: bit_length here is the
+            # builtin int method, and an oversized value is refused before any
+            # bound comparison or message formatting could render its digits
+            # (str() of a wide int raises under sys.set_int_max_str_digits).
+            # The refusal message never carries the supplied value.
+            if value.bit_length() > MAX_TUNING_INT_BITS:
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires an int within {MAX_TUNING_INT_BITS} bits.",
+                )
         elif self.value_type is float:
             if value_type is not int and value_type is not float:
                 return ValidationResult(
                     ok=False,
                     error=ValidationError.WRONG_TYPE,
                     message=f"{self.name} requires float, got {_describe_type(value)}.",
+                )
+            # Same width ceiling for an int offered to a float parameter: one
+            # uniform rule — no exact int wider than the ceiling proceeds to
+            # conversion, comparison, or formatting.
+            if value_type is int and value.bit_length() > MAX_TUNING_INT_BITS:
+                return ValidationResult(
+                    ok=False,
+                    error=ValidationError.WRONG_TYPE,
+                    message=f"{self.name} requires an int within {MAX_TUNING_INT_BITS} bits.",
                 )
             # Bounded normalization: float() of an exact builtin int can
             # overflow, and NaN would sail through the inclusive bound
@@ -457,6 +490,7 @@ def validate_proposal(params: Any) -> ProposalValidation:
 
 __all__ = [
     "Category",
+    "MAX_TUNING_INT_BITS",
     "ValidationError",
     "ValidationResult",
     "TunableParam",

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -35,6 +35,7 @@ propose/dry-run, reads, and human-approved commits are intentionally unchanged.
 from __future__ import annotations
 
 import json
+import math
 import secrets
 import threading
 from datetime import datetime, timezone
@@ -44,6 +45,7 @@ from typing import Any, Callable, Optional
 from flask import Blueprint, Response, jsonify, request
 
 from scripts.params_schema import (
+    MAX_TUNING_INT_BITS,
     PARAMS,
     Category,
     get_param,
@@ -80,41 +82,54 @@ loop; it is not a limit on scalar content. Values obtainable through parsed
 JSON are far shallower, so no valid public request is affected (recorded as a
 residual — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md)."""
 
-_MAX_REQUEST_VALUE_NODES = 100_000
-"""Per-value cap on nodes VISITED while proving one proposed parameter value is
-a JSON tree. The depth bound alone stops cycles/recursion but not a shared-
-reference DAG (a DIRECT value where a node is referenced repeatedly), which
-would otherwise be traversed — and later ``json.dumps``-expanded — an
-exponential number of times. Counting visits per occurrence mirrors that
-serialisation cost and refuses such a value before the ledger write. Set far
-above any realistic parsed-JSON value (JSON cannot express sharing, so PUBLIC
-bodies are self-limiting), so no valid request is affected; recorded as a
-residual bound — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md."""
+_MAX_REQUEST_NODES = 100_000
+"""Proposal-wide cap on nodes VISITED while proving the parameter values of
+ONE complete proposal are JSON trees — a single budget charged across every
+value, not restarted per parameter entry (multiple entries sharing repeated
+structure would otherwise multiply the cap). The depth bound alone stops
+cycles/recursion but not a shared-reference DAG (a DIRECT value where a node
+is referenced repeatedly), which would otherwise be traversed — and later
+``json.dumps``-expanded — an exponential number of times. Counting visits per
+occurrence mirrors that serialisation cost and refuses such a proposal before
+the ledger write. Set far above any realistic parsed-JSON request (JSON cannot
+express sharing, so PUBLIC bodies are self-limiting), so no valid request is
+affected; recorded as a residual bound — see
+docs/LEGACY_ORCHESTRATOR_QUARANTINE.md."""
 
 
 # -- helpers ----------------------------------------------------------------
 
 
 def _is_exact_json_tree(value: Any, depth: int, budget: list) -> bool:
-    """True when ``value`` is EXACTLY a builtin JSON tree: exact
-    ``str``/``bool``/``int``/``float``/``None``, or an exact ``list`` / exact
-    ``dict`` (with exact-``str`` keys) recursively within ``depth`` and within
-    the ``budget`` node-visit count (``budget`` is ``[remaining]``, mutated in
-    place). Decided by ``type`` identity — a refused value's methods are never
-    invoked, and only confirmed exact builtin containers are traversed. A
-    proposed parameter value that passes this is guaranteed
-    ``json.dumps``-serialisable for the ledger AND bounded in serialised size;
-    anything else (a set, bytes, a custom object, a hostile mapping, a cyclic
-    or exponentially-shared structure) is a malformed value shape. Non-finite
-    floats are permitted here (they serialise without error and are refused
-    later by per-parameter validation); this gate is only about ledger
-    serialisability, not numeric range."""
+    """True when ``value`` is EXACTLY a builtin standard-JSON tree: exact
+    ``str``, exact ``bool``, exact ``int`` within ``MAX_TUNING_INT_BITS``,
+    exact FINITE ``float``, ``None``, or an exact ``list`` / exact ``dict``
+    (with exact-``str`` keys) recursively within ``depth`` and within the
+    ``budget`` node-visit count (``budget`` is ``[remaining]``, mutated in
+    place and shared across every value of one proposal). Decided by ``type``
+    identity — a refused value's methods are never invoked, only confirmed
+    exact builtin containers are traversed, and the int width check runs only
+    after the exact-``int`` proof (bool is accepted separately, never routed
+    through ``bit_length``). A proposed parameter value that passes is
+    guaranteed ``json.dumps``-serialisable to STANDARD JSON tokens for the
+    ledger, independent of ``sys.get_int_max_str_digits()`` (an accepted int
+    renders to at most 617 digits, below the smallest settable limit).
+    Anything else (a set, bytes, a custom object, a hostile mapping, an int
+    wider than the ceiling, a NaN/Infinity float, a cyclic or exponentially-
+    shared structure) is a malformed value shape. NOTE: this proof bounds
+    nodes, depth, and integer width — NOT serialized byte size; scalar
+    strings and the total encoded length are unbounded (recorded residual —
+    see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md)."""
     budget[0] -= 1
     if budget[0] < 0:
         return False
     t = type(value)
-    if t is str or t is bool or t is int or t is float or value is None:
+    if t is str or t is bool or value is None:
         return True
+    if t is int:
+        return value.bit_length() <= MAX_TUNING_INT_BITS
+    if t is float:
+        return math.isfinite(value)
     if t is list:
         if depth <= 0:
             return False
@@ -143,18 +158,21 @@ def _require_valid_proposal_shape(
     """Prove a propose envelope has exact builtin shapes BEFORE any supplied
     value is hashed, looked up, compared, stringified, validated, serialised,
     or emitted. ``params`` must be an exact ``dict`` whose keys are exact
-    ``str`` and whose values are exact JSON trees (ledger-serialisable);
-    ``source`` / ``justification`` / ``mode`` must be exact ``str``. Any
-    deviation is a fixed ``400 bad_request`` — refused requests create no
-    proposal, ledger append, pending file, or event."""
+    ``str`` and whose values are exact standard-JSON trees (ledger-
+    serialisable: finite floats, ints within the width ceiling) proven against
+    ONE shared node-visit budget for the whole proposal; ``source`` /
+    ``justification`` / ``mode`` must be exact ``str``. Any deviation is a
+    fixed ``400 bad_request`` — refused requests create no proposal, ledger
+    append, pending file, or event."""
     _require_exact_str(source)
     _require_exact_str(justification)
     _require_exact_str(mode)
     if type(params) is not dict:
         raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
+    budget = [_MAX_REQUEST_NODES]
     for name, value in params.items():
         if type(name) is not str or not _is_exact_json_tree(
-            value, _MAX_REQUEST_VALUE_DEPTH, [_MAX_REQUEST_VALUE_NODES]
+            value, _MAX_REQUEST_VALUE_DEPTH, budget
         ):
             raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
 
@@ -480,8 +498,17 @@ class TuningState:
                     continue
                 try:
                     entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue  # skip corrupt lines; don't let a bad append poison startup
+                except ValueError:
+                    # Skip corrupt lines; don't let a bad append poison
+                    # startup. ValueError, not its JSONDecodeError subclass:
+                    # a LEGACY line holding an int wider than the runtime
+                    # sys.get_int_max_str_digits() limit (writable before the
+                    # width ceiling existed) raises the plain-ValueError digit
+                    # guard from json.loads, which previously escaped and
+                    # crashed replay. The gated writer no longer produces such
+                    # lines (accepted ints render to <= 617 digits, below the
+                    # smallest settable limit).
+                    continue
                 etype = entry.get("type")
                 if etype == "propose":
                     self._proposals[entry["proposal_id"]] = entry
@@ -503,9 +530,14 @@ class TuningState:
                         self._last_commit_gen[name] = gen
 
     def _append_ledger(self, entry: dict[str, Any]) -> None:
+        # Serialize BEFORE touching the filesystem: opening in append mode
+        # creates the file, so a json.dumps failure after open would leave a
+        # zero-byte ledger behind. With the line built first, a serialization
+        # failure performs no filesystem operation at all.
+        line = json.dumps(entry, sort_keys=True)
         self.data_dir.mkdir(parents=True, exist_ok=True)
         with self.ledger_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, sort_keys=True) + "\n")
+            f.write(line + "\n")
 
 
 def _contains_human_approval_param(params: dict[str, Any]) -> bool:
@@ -565,8 +597,13 @@ def create_blueprint(state: TuningState) -> Blueprint:
                 "error": "bad_request",
                 "message": "'params' (non-empty object) is required",
             }), 400
-        source = str(body.get("source", "unspecified"))
-        justification = str(body.get("justification", ""))
+        # No str() coercion: a SUPPLIED source/justification must already be
+        # an exact builtin str (proven inside state.propose — anything else is
+        # the fixed 400), so a JSON list/number/object can no longer enter the
+        # ledger as its Python repr. A MISSING field keeps its documented
+        # default; a valid string is stored byte-for-byte.
+        source = body.get("source", "unspecified")
+        justification = body.get("justification", "")
         mode = body.get("mode", "dry-run")  # default to safe
         try:
             entry = state.propose(

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -67,8 +67,77 @@ identity are all rejected (``auto_commit_disabled``). Re-enabling autonomous
 commits must be a reviewed code change here — there is deliberately no env flag,
 query param, header, or alternate route that turns it back on."""
 
+BAD_REQUEST_MESSAGE = "request envelope has a malformed value shape."
+"""Fixed generic refusal for a malformed request envelope. It reports neither
+the supplied value nor its type name, so no proposed object's ``__str__`` /
+``__repr__`` is executed and no attacker-chosen text enters a response, the
+ledger, or an event payload."""
+
+_MAX_REQUEST_VALUE_DEPTH = 64
+"""Container-nesting depth accepted while proving a proposed parameter VALUE is
+a builtin JSON tree. This bounds the recursion so a cyclic DIRECT value cannot
+loop; it is not a limit on scalar content. Values obtainable through parsed
+JSON are far shallower, so no valid public request is affected (recorded as a
+residual — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md)."""
+
 
 # -- helpers ----------------------------------------------------------------
+
+
+def _is_exact_json_tree(value: Any, depth: int) -> bool:
+    """True when ``value`` is EXACTLY a builtin JSON tree: exact
+    ``str``/``bool``/``int``/``float``/``None``, or an exact ``list`` / exact
+    ``dict`` (with exact-``str`` keys) recursively within ``depth``. Decided by
+    ``type`` identity — a refused value's methods are never invoked, and only
+    confirmed exact builtin containers are traversed. A proposed parameter
+    value that passes this is guaranteed ``json.dumps``-serialisable for the
+    ledger; anything else (a set, bytes, a custom object, a hostile mapping) is
+    a malformed value shape. Non-finite floats are permitted here (they
+    serialise without error and are refused later by per-parameter validation);
+    this gate is only about ledger serialisability, not numeric range."""
+    t = type(value)
+    if t is str or t is bool or t is int or t is float or value is None:
+        return True
+    if t is list:
+        if depth <= 0:
+            return False
+        return all(_is_exact_json_tree(item, depth - 1) for item in value)
+    if t is dict:
+        if depth <= 0:
+            return False
+        return all(
+            type(k) is str and _is_exact_json_tree(v, depth - 1)
+            for k, v in value.items()
+        )
+    return False
+
+
+def _require_exact_str(value: Any) -> None:
+    """Raise a fixed ``400 bad_request`` unless ``value`` is EXACTLY a builtin
+    ``str`` (str subclasses, whose methods may be overridden, are refused). No
+    method of a refused value is invoked."""
+    if type(value) is not str:
+        raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
+
+
+def _require_valid_proposal_shape(
+    params: Any, source: Any, justification: Any, mode: Any
+) -> None:
+    """Prove a propose envelope has exact builtin shapes BEFORE any supplied
+    value is hashed, looked up, compared, stringified, validated, serialised,
+    or emitted. ``params`` must be an exact ``dict`` whose keys are exact
+    ``str`` and whose values are exact JSON trees (ledger-serialisable);
+    ``source`` / ``justification`` / ``mode`` must be exact ``str``. Any
+    deviation is a fixed ``400 bad_request`` — refused requests create no
+    proposal, ledger append, pending file, or event."""
+    _require_exact_str(source)
+    _require_exact_str(justification)
+    _require_exact_str(mode)
+    if type(params) is not dict:
+        raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
+    for name, value in params.items():
+        if type(name) is not str or not _is_exact_json_tree(value, _MAX_REQUEST_VALUE_DEPTH):
+            raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
 
 
 def _now_iso() -> str:
@@ -161,6 +230,10 @@ class TuningState:
         justification: str,
         mode: str,
     ) -> dict[str, Any]:
+        # Prove exact envelope shapes before any supplied value is validated,
+        # hashed, serialised, or emitted. A malformed shape is a fixed
+        # 400 bad_request that leaves no proposal, ledger line, or event.
+        _require_valid_proposal_shape(params, source, justification, mode)
         if mode not in VALID_MODES:
             raise TuningError(400, "bad_mode", f"mode must be one of {VALID_MODES}")
         with self._lock:
@@ -201,6 +274,12 @@ class TuningState:
     # ---- write: commit ----
 
     def commit(self, proposal_id: str, approver: str) -> dict[str, Any]:
+        # Exact-string shape proof BEFORE the registry lookup (which hashes
+        # proposal_id) and before the try/emit block, so a malformed-shape
+        # commit is a fixed 400 bad_request with no proposal lookup, no state
+        # mutation, and no rejected event carrying a supplied object.
+        _require_exact_str(proposal_id)
+        _require_exact_str(approver)
         try:
             entry = self._commit_locked(proposal_id, approver)
         except TuningError as e:
@@ -223,18 +302,10 @@ class TuningState:
 
     def _commit_locked(self, proposal_id: str, approver: str) -> dict[str, Any]:
         with self._lock:
-            # Type guard: `approver` must be a string before any string
-            # operation (the quarantine comparison and the human-approval
-            # startswith check below both assume str). A bool/number/null/
-            # list/dict is a malformed request → stable 400 bad_request, never
-            # an AttributeError. Checked first so a bad type cannot slip past
-            # on an otherwise-valid proposal.
-            if not isinstance(approver, str):
-                raise TuningError(
-                    400, "bad_request",
-                    "approver must be a string.",
-                )
-
+            # `proposal_id` and `approver` are already proven EXACTLY str by
+            # commit() before this lock is taken, so the registry lookup below
+            # and the quarantine / human-approval string operations run no
+            # supplied object's code.
             proposal = self._proposals.get(proposal_id)
             if proposal is None:
                 raise TuningError(
@@ -322,6 +393,11 @@ class TuningState:
     # ---- write: rollback ----
 
     def rollback(self, to_proposal_id: str) -> dict[str, Any]:
+        # Exact-string shape proof BEFORE the snapshot lookup (which hashes
+        # to_proposal_id) and before the try/emit block, so a malformed-shape
+        # rollback is a fixed 400 bad_request with no lookup, no mutation, and
+        # no rejected event carrying a supplied object.
+        _require_exact_str(to_proposal_id)
         try:
             entry = self._rollback_locked(to_proposal_id)
         except TuningError as e:
@@ -432,6 +508,20 @@ def _first_param_in_category(params: dict[str, Any], category: Category) -> str:
 # -- blueprint --------------------------------------------------------------
 
 
+def _json_object_body() -> dict:
+    """Return the request body only when it is EXACTLY a JSON object.
+
+    ``request.get_json(silent=True) or {}`` swapped in ``{}`` for *falsy*
+    bodies only, so a truthy non-object body (a JSON array, number, string, or
+    ``true``) survived and reached ``body.get(...)`` — an AttributeError /
+    HTTP 500. Guarding for an exact ``dict`` here turns every non-object body
+    into a stable 400 bad_request. Raises TuningError(400) on a non-object."""
+    body = request.get_json(silent=True)
+    if type(body) is not dict:
+        raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
+    return body
+
+
 def create_blueprint(state: TuningState) -> Blueprint:
     bp = Blueprint("tuning", __name__, url_prefix="/api")
 
@@ -446,7 +536,10 @@ def create_blueprint(state: TuningState) -> Blueprint:
 
     @bp.route("/tuning/propose", methods=["POST"])
     def propose() -> Response:
-        body = request.get_json(silent=True) or {}
+        try:
+            body = _json_object_body()
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
         params = body.get("params")
         if not isinstance(params, dict) or not params:
             return jsonify({
@@ -472,7 +565,10 @@ def create_blueprint(state: TuningState) -> Blueprint:
 
     @bp.route("/tuning/commit", methods=["POST"])
     def commit() -> Response:
-        body = request.get_json(silent=True) or {}
+        try:
+            body = _json_object_body()
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
         proposal_id = body.get("proposal_id")
         approver = body.get("approver")
         if not proposal_id or not approver:
@@ -494,7 +590,10 @@ def create_blueprint(state: TuningState) -> Blueprint:
 
     @bp.route("/tuning/rollback", methods=["POST"])
     def rollback() -> Response:
-        body = request.get_json(silent=True) or {}
+        try:
+            body = _json_object_body()
+        except TuningError as e:
+            return jsonify({"error": e.code, "message": e.message}), e.status_code
         to_proposal_id = body.get("to_proposal_id")
         if not to_proposal_id:
             return jsonify({
@@ -519,6 +618,7 @@ __all__ = [
     "MIN_GEN_BETWEEN_COMMITS_PER_PARAM",
     "VALID_MODES",
     "AUTO_COMMIT_APPROVER",
+    "BAD_REQUEST_MESSAGE",
     "TuningError",
     "TuningState",
     "create_blueprint",

--- a/scripts/tuning_api.py
+++ b/scripts/tuning_api.py
@@ -80,33 +80,50 @@ loop; it is not a limit on scalar content. Values obtainable through parsed
 JSON are far shallower, so no valid public request is affected (recorded as a
 residual — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md)."""
 
+_MAX_REQUEST_VALUE_NODES = 100_000
+"""Per-value cap on nodes VISITED while proving one proposed parameter value is
+a JSON tree. The depth bound alone stops cycles/recursion but not a shared-
+reference DAG (a DIRECT value where a node is referenced repeatedly), which
+would otherwise be traversed — and later ``json.dumps``-expanded — an
+exponential number of times. Counting visits per occurrence mirrors that
+serialisation cost and refuses such a value before the ledger write. Set far
+above any realistic parsed-JSON value (JSON cannot express sharing, so PUBLIC
+bodies are self-limiting), so no valid request is affected; recorded as a
+residual bound — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md."""
+
 
 # -- helpers ----------------------------------------------------------------
 
 
-def _is_exact_json_tree(value: Any, depth: int) -> bool:
+def _is_exact_json_tree(value: Any, depth: int, budget: list) -> bool:
     """True when ``value`` is EXACTLY a builtin JSON tree: exact
     ``str``/``bool``/``int``/``float``/``None``, or an exact ``list`` / exact
-    ``dict`` (with exact-``str`` keys) recursively within ``depth``. Decided by
-    ``type`` identity — a refused value's methods are never invoked, and only
-    confirmed exact builtin containers are traversed. A proposed parameter
-    value that passes this is guaranteed ``json.dumps``-serialisable for the
-    ledger; anything else (a set, bytes, a custom object, a hostile mapping) is
-    a malformed value shape. Non-finite floats are permitted here (they
-    serialise without error and are refused later by per-parameter validation);
-    this gate is only about ledger serialisability, not numeric range."""
+    ``dict`` (with exact-``str`` keys) recursively within ``depth`` and within
+    the ``budget`` node-visit count (``budget`` is ``[remaining]``, mutated in
+    place). Decided by ``type`` identity — a refused value's methods are never
+    invoked, and only confirmed exact builtin containers are traversed. A
+    proposed parameter value that passes this is guaranteed
+    ``json.dumps``-serialisable for the ledger AND bounded in serialised size;
+    anything else (a set, bytes, a custom object, a hostile mapping, a cyclic
+    or exponentially-shared structure) is a malformed value shape. Non-finite
+    floats are permitted here (they serialise without error and are refused
+    later by per-parameter validation); this gate is only about ledger
+    serialisability, not numeric range."""
+    budget[0] -= 1
+    if budget[0] < 0:
+        return False
     t = type(value)
     if t is str or t is bool or t is int or t is float or value is None:
         return True
     if t is list:
         if depth <= 0:
             return False
-        return all(_is_exact_json_tree(item, depth - 1) for item in value)
+        return all(_is_exact_json_tree(item, depth - 1, budget) for item in value)
     if t is dict:
         if depth <= 0:
             return False
         return all(
-            type(k) is str and _is_exact_json_tree(v, depth - 1)
+            type(k) is str and _is_exact_json_tree(v, depth - 1, budget)
             for k, v in value.items()
         )
     return False
@@ -136,7 +153,9 @@ def _require_valid_proposal_shape(
     if type(params) is not dict:
         raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
     for name, value in params.items():
-        if type(name) is not str or not _is_exact_json_tree(value, _MAX_REQUEST_VALUE_DEPTH):
+        if type(name) is not str or not _is_exact_json_tree(
+            value, _MAX_REQUEST_VALUE_DEPTH, [_MAX_REQUEST_VALUE_NODES]
+        ):
             raise TuningError(400, "bad_request", BAD_REQUEST_MESSAGE)
 
 

--- a/tests/test_params_schema.py
+++ b/tests/test_params_schema.py
@@ -638,16 +638,18 @@ def test_public_proposal_path_returns_validation_not_server_error():
         assert err["message"] == "magnon_coupling requires a finite float value."
         assert str(_OVERSIZED_INT)[:20] not in resp.get_data(as_text=True)
 
+        # A NaN literal is no longer a recorded 422 rejection: the request
+        # JSON-tree proof requires exact finite floats, so it is refused at
+        # the envelope (fixed 400) before validation or any ledger write.
+        from scripts.tuning_api import BAD_REQUEST_MESSAGE
+
         nan_body = ('{"params": {"magnon_coupling": NaN}, '
                     '"source": "human:kevin", "justification": "pin"}')
         resp = client.post("/api/tuning/propose", data=nan_body,
                            content_type="application/json")
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.get_json()
-        assert body["status"] == "rejected"
-        err = body["validation"]["errors"]["magnon_coupling"]
-        assert err["error"] == "wrong_type"
-        assert err["message"] == "magnon_coupling requires a finite float value."
+        assert body == {"error": "bad_request", "message": BAD_REQUEST_MESSAGE}
 
 
 # -- request-shape totality: validate_proposal on arbitrary Python objects ----
@@ -727,3 +729,111 @@ def test_validate_proposal_str_key_paths_unchanged():
     unknown = validate_proposal({"nope": 1})
     assert unknown.unknown_params == ["nope"]
     assert unknown.errors["nope"].error is ValidationError.UNKNOWN_PARAM
+
+
+# -- follow-up: integer width ceiling (bit-length gate) ------------------------
+#
+# An exact builtin int wider than MAX_TUNING_INT_BITS (2048 bits) is refused by
+# a bit-length check BEFORE any conversion, comparison, or formatting, so
+# validation is total on oversized ints independently of the mutable
+# process-wide sys.get_int_max_str_digits() setting, and no refusal message
+# ever copies the supplied digits. Ints within the ceiling keep the existing
+# range messages byte-for-byte: a 2048-bit int renders to at most 617 decimal
+# digits, below the smallest settable digit limit (640).
+
+import contextlib
+import sys as _sys
+
+_WIDE_OK = 2 ** 2048 - 1     # bit_length 2048 — widest accepted magnitude
+_WIDE_OVER = 2 ** 2048       # bit_length 2049 — narrowest refused magnitude
+_HUGE_5K = 10 ** 5000        # Jack's reproduction value (16 610 bits)
+_WIDTH_REFUSAL_N = "n requires an int within 2048 bits."
+_WIDTH_REFUSAL_X = "x requires an int within 2048 bits."
+
+
+@contextlib.contextmanager
+def _digit_limit(n):
+    saved = _sys.get_int_max_str_digits()
+    _sys.set_int_max_str_digits(n)
+    try:
+        yield
+    finally:
+        _sys.set_int_max_str_digits(saved)
+
+
+def test_int_bits_ceiling_constant_and_repo_alignment():
+    from scripts.params_schema import MAX_TUNING_INT_BITS
+    assert MAX_TUNING_INT_BITS == 2048
+    from scripts.orchestrator import MAX_TOOL_RESULT_INT_BITS
+    assert MAX_TUNING_INT_BITS == MAX_TOOL_RESULT_INT_BITS
+    # Runtime-independence arithmetic: the widest accepted int renders to 617
+    # decimal digits, strictly below the smallest settable digit limit (640).
+    assert len(str(_WIDE_OK)) == 617 < 640
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_int_param_oversized_int_total_and_value_free(limit):
+    p = _int_param()
+    with _digit_limit(limit):
+        for value in (_HUGE_5K, -_HUGE_5K, _WIDE_OVER, -_WIDE_OVER):
+            result = p.validate(value)  # must not raise ValueError
+            assert not result.ok
+            assert result.error is ValidationError.WRONG_TYPE
+            assert result.message == _WIDTH_REFUSAL_N
+            assert len(result.message) < 80
+            assert "0" * 20 not in result.message
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_int_param_2048_bit_boundary_keeps_range_messages(limit):
+    p = _int_param()  # bounds [0, 10]
+    over_msg = f"n={_WIDE_OK} above max 10."      # rendered at default limit
+    under_msg = f"n={-_WIDE_OK} below min 0."
+    with _digit_limit(limit):
+        result = p.validate(_WIDE_OK)
+        assert result.error is ValidationError.ABOVE_MAX
+        assert result.message == over_msg
+        result = p.validate(-_WIDE_OK)
+        assert result.error is ValidationError.BELOW_MIN
+        assert result.message == under_msg
+
+
+def test_bool_behavior_unaffected_by_width_gate():
+    # bool has a bit_length method but must never be routed through the int
+    # width gate: exact-type identity keeps its separate refusal and its
+    # acceptance for bool params byte-identical.
+    assert _int_param().validate(True).message == "n requires int, got bool."
+    assert _bool_param().validate(True).ok
+    assert _bool_param().validate(False).ok
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_float_param_oversized_int_width_refusal(limit):
+    p = _float_param()
+    with _digit_limit(limit):
+        for value in (_WIDE_OVER, -_WIDE_OVER, _HUGE_5K, -_HUGE_5K):
+            result = p.validate(value)
+            assert not result.ok
+            assert result.error is ValidationError.WRONG_TYPE
+            assert result.message == _WIDTH_REFUSAL_X
+    # Within the ceiling the existing finite-normalization refusal is
+    # preserved byte-for-byte (10**400 is 1329 bits — inside 2048).
+    assert _float_param().validate(10 ** 400).message == _FINITE_REFUSAL
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_validate_proposal_oversized_int_total_and_value_free(limit):
+    with _digit_limit(limit):
+        result = validate_proposal({
+            "magnon_radius": _HUGE_5K,        # int param, oversized
+            "magnon_coupling": -_HUGE_5K,     # float param, oversized
+            "not_a_real_param": _WIDE_OVER,   # unknown name, oversized value
+            "signal_interval": 12,            # valid alongside
+        })
+        assert result.ok is False
+        assert result.errors["magnon_radius"].error is ValidationError.WRONG_TYPE
+        assert result.errors["magnon_coupling"].error is ValidationError.WRONG_TYPE
+        assert result.errors["not_a_real_param"].error is ValidationError.UNKNOWN_PARAM
+        for r in result.errors.values():
+            assert len(r.message) < 120
+            assert "0" * 20 not in r.message

--- a/tests/test_params_schema.py
+++ b/tests/test_params_schema.py
@@ -648,3 +648,82 @@ def test_public_proposal_path_returns_validation_not_server_error():
         err = body["validation"]["errors"]["magnon_coupling"]
         assert err["error"] == "wrong_type"
         assert err["message"] == "magnon_coupling requires a finite float value."
+
+
+# -- request-shape totality: validate_proposal on arbitrary Python objects ----
+#
+# validate_proposal is a DIRECT entry point (the tuning API and direct callers
+# both reach it). It must be total on any object: a non-dict proposal and a
+# proposal carrying non-str keys must resolve to a not-ok result without a
+# leaked AttributeError/TypeError and without hashing a hostile key into the
+# registry lookup.
+
+
+class _RecordingKey:
+    """A non-str dict key whose hooks record. __hash__ records (dict insertion
+    needs it) so a test measures only NEW invocations after construction."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __hash__(self):
+        self.calls.append("__hash__")
+        return 0
+
+    def __eq__(self, other):
+        self.calls.append("__eq__")
+        return self is other
+
+    def __str__(self):
+        self.calls.append("__str__")
+        return "k"
+
+    def __repr__(self):
+        self.calls.append("__repr__")
+        return "k"
+
+
+@pytest.mark.parametrize("bad", [
+    [1, 2], "params", 42, 3.14, True, None, ("k", "v"),
+], ids=["list", "str", "int", "float", "bool", "none", "tuple"])
+def test_validate_proposal_non_dict_is_not_ok_without_raising(bad):
+    result = validate_proposal(bad)  # must not raise .items() AttributeError
+    assert isinstance(result, ProposalValidation)
+    assert result.ok is False
+    assert result.errors == {}
+    assert result.known_params == []
+    assert result.unknown_params == []
+
+
+def test_validate_proposal_non_str_key_is_not_ok_without_lookup():
+    key = _RecordingKey()
+    params = {key: 1}
+    key.calls.clear()  # forget the hash from dict construction
+    result = validate_proposal(params)
+    assert result.ok is False
+    # No registry lookup / equality / stringify of the hostile key.
+    assert key.calls == []
+
+
+def test_validate_proposal_mixed_str_and_non_str_keys():
+    """Valid str keys still validate; a non-str key alongside them forces the
+    aggregate result to not-ok while the valid keys are still processed."""
+    key = _RecordingKey()
+    params = {"signal_interval": 12, key: 1}
+    key.calls.clear()
+    result = validate_proposal(params)
+    assert result.ok is False
+    assert "signal_interval" in result.known_params
+    assert key.calls == []
+
+
+def test_validate_proposal_str_key_paths_unchanged():
+    """Positive control: an all-str-key proposal behaves exactly as before."""
+    ok = validate_proposal({"signal_interval": 12, "magnon_sage_age_min": 7.5})
+    assert ok.ok is True
+    bad = validate_proposal({"signal_interval": 0})
+    assert bad.ok is False
+    assert bad.errors["signal_interval"].error is ValidationError.BELOW_MIN
+    unknown = validate_proposal({"nope": 1})
+    assert unknown.unknown_params == ["nope"]
+    assert unknown.errors["nope"].error is ValidationError.UNKNOWN_PARAM

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -858,8 +858,9 @@ def test_valid_direct_propose_still_writes_serialisable_ledger(tmp_path):
 # The gates are exact-type (type(x) is ...), never isinstance — so a well-behaved
 # str/dict/list subclass is refused everywhere, not just at the commit-approver
 # gate. The container-nesting depth bound keeps the JSON-tree proof total against
-# a cyclic DIRECT value. Non-finite floats remain a recorded validation rejection
-# whose ledger line is Python-reparseable (unchanged from before this batch).
+# a cyclic DIRECT value. Non-finite floats are refused at the envelope (fixed
+# 400) — the tree proof requires exact finite floats, closing the former
+# recorded-NaN/Infinity-ledger-token residual.
 
 
 class _DictSub(dict):
@@ -983,21 +984,19 @@ def test_direct_propose_shared_dag_value_is_bounded_not_hang(tmp_path):
 
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")],
                          ids=["nan", "inf", "-inf"])
-def test_direct_propose_non_finite_float_is_recorded_wrong_type(tmp_path, bad):
-    """Residual characterisation (behaviour unchanged from before this batch):
-    a non-finite float passes the ledger-serialisability gate, is REJECTED by
-    per-parameter validation as wrong_type/finite, and is recorded — its ledger
-    line is Python-reparseable (json.loads accepts NaN/Infinity tokens)."""
-    state, _, _ = _fresh_state(tmp_path)
-    entry = state.propose(params={"magnon_coupling": bad},
-                          source="human:kevin", justification="j", mode="dry-run")
-    assert entry["validation"]["ok"] is False
-    assert entry["validation"]["errors"]["magnon_coupling"]["error"] == "wrong_type"
-    line = (tmp_path / "tuning_ledger.jsonl").read_text(encoding="utf-8").strip()
-    reparsed = json.loads(line)          # non-strict JSON tokens still reparse
-    assert reparsed["type"] == "propose"
-    assert _math.isnan(reparsed["params"]["magnon_coupling"]) or \
-        _math.isinf(reparsed["params"]["magnon_coupling"])
+def test_direct_propose_non_finite_float_is_bad_request_no_ledger(tmp_path, bad):
+    """The former residual is closed: the request JSON-tree proof requires
+    exact FINITE floats, so a NaN/±Infinity parameter value is refused at the
+    envelope (fixed 400) before validation — no ledger line (previously a
+    non-standard ``NaN``/``Infinity`` token was recorded), no event."""
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"magnon_coupling": bad},
+                      source="human:kevin", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
 
 
 def test_direct_commit_and_rollback_refusal_messages_carry_no_leak(tmp_path):
@@ -1010,3 +1009,284 @@ def test_direct_commit_and_rollback_refusal_messages_carry_no_leak(tmp_path):
         assert len(msg) < 120
         for leak in ("[1", "{'a'", "list", "dict"):
             assert leak not in msg
+
+
+# -- follow-up: integer width ceiling, finite floats, exact-str metadata, ------
+#    proposal-wide node budget
+#
+# The request JSON-tree proof now enforces a 2048-bit width ceiling on exact
+# ints (MAX_TUNING_INT_BITS, aligned with the repository's tool-result
+# ceiling) and exact FINITE floats, decided by bit_length / math.isfinite —
+# never by rendering the value — so envelope behaviour is independent of the
+# mutable process-wide sys.get_int_max_str_digits() setting. PUBLIC metadata
+# (`source` / `justification`) is no longer str()-coerced: a supplied field
+# must be an exact builtin str; missing fields keep their documented defaults.
+# The node-visit budget is charged once across the complete proposal, not
+# restarted per parameter value. The tree proof does NOT bound serialized byte
+# size: scalar strings and the total encoded length are unbounded (recorded
+# residual — see docs/LEGACY_ORCHESTRATOR_QUARANTINE.md).
+
+import contextlib
+import sys as _sys
+
+from scripts.tuning_api import BAD_REQUEST_MESSAGE, _is_exact_json_tree
+
+_INT_WIDE_OK = 2 ** 2048 - 1     # bit_length 2048 — widest accepted magnitude
+_INT_WIDE_OVER = 2 ** 2048       # bit_length 2049 — narrowest refused magnitude
+_HUGE_INT = 10 ** 5000           # Jack's reproduction value (16 610 bits)
+_HUGE_LITERAL = "1" + "0" * 5000  # decimal literal of 10**5000, built str-free
+
+
+@contextlib.contextmanager
+def _digit_limit(n):
+    saved = _sys.get_int_max_str_digits()
+    _sys.set_int_max_str_digits(n)
+    try:
+        yield
+    finally:
+        _sys.set_int_max_str_digits(saved)
+
+
+def test_tree_proof_int_width_boundary_both_signs():
+    for v in (_INT_WIDE_OK, -_INT_WIDE_OK, 0, 1, -1):
+        assert _is_exact_json_tree(v, 64, [100]) is True
+    for v in (_INT_WIDE_OVER, -_INT_WIDE_OVER, _HUGE_INT, -_HUGE_INT):
+        assert _is_exact_json_tree(v, 64, [100]) is False
+
+
+def test_tree_proof_requires_finite_floats():
+    for v in (0.0, 1.5, -2.75):
+        assert _is_exact_json_tree(v, 64, [100]) is True
+    for v in (float("nan"), float("inf"), float("-inf")):
+        assert _is_exact_json_tree(v, 64, [100]) is False
+
+
+def test_request_node_budget_constant_is_proposal_wide():
+    from scripts.tuning_api import _MAX_REQUEST_NODES
+    assert _MAX_REQUEST_NODES == 100_000
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+@pytest.mark.parametrize("pname", ["magnon_radius", "definitely_unknown"],
+                         ids=["known-int", "unknown"])
+@pytest.mark.parametrize("sign", [1, -1], ids=["pos", "neg"])
+def test_direct_propose_oversized_int_bad_request_all_limits(
+        tmp_path, limit, pname, sign):
+    """Closes the reproduced leak trio: no ValueError under a digit limit, no
+    zero-byte ledger file for an unknown parameter, no thousands-of-digits
+    ledger line with the limit disabled — one fixed envelope refusal."""
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with _digit_limit(limit):
+        with pytest.raises(TuningError) as ei:
+            state.propose(params={pname: sign * _HUGE_INT}, source="s",
+                          justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert ei.value.message == BAD_REQUEST_MESSAGE
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_direct_propose_2048_bit_validates_2049_refused(tmp_path, limit):
+    """Exact boundary, both signs, independent of the runtime digit limit:
+    a 2048-bit int reaches ordinary parameter validation (recorded range
+    rejection, ledger line written); a 2049-bit int is the fixed envelope
+    refusal (no ledger)."""
+    state_ok, _, _ = _fresh_state(tmp_path / "ok")
+    with _digit_limit(limit):
+        entry = state_ok.propose(params={"magnon_radius": _INT_WIDE_OK},
+                                 source="s", justification="j", mode="dry-run")
+        assert entry["validation"]["errors"]["magnon_radius"]["error"] == "above_max"
+        entry = state_ok.propose(params={"magnon_radius": -_INT_WIDE_OK},
+                                 source="s", justification="j", mode="dry-run")
+        assert entry["validation"]["errors"]["magnon_radius"]["error"] == "below_min"
+    ledger = (tmp_path / "ok" / "tuning_ledger.jsonl").read_text(encoding="utf-8")
+    assert len(ledger.splitlines()) == 2
+
+    state_over, _, _ = _fresh_state(tmp_path / "over")
+    with _digit_limit(limit):
+        for v in (_INT_WIDE_OVER, -_INT_WIDE_OVER):
+            with pytest.raises(TuningError) as ei:
+                state_over.propose(params={"magnon_radius": v}, source="s",
+                                   justification="j", mode="dry-run")
+            assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path / "over", state_over)
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+@pytest.mark.parametrize("pname", ["magnon_radius", "definitely_unknown"],
+                         ids=["known-int", "unknown"])
+@pytest.mark.parametrize("sign", ["", "-"], ids=["pos", "neg"])
+def test_public_propose_oversized_int_bad_request(tmp_path, limit, pname, sign):
+    state, client, _ = _fresh_state(tmp_path)
+    body = '{"params": {"%s": %s%s}}' % (pname, sign, _HUGE_LITERAL)
+    with _digit_limit(limit):
+        resp = _post_raw(client, "/api/tuning/propose", body)
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "bad_request",
+                               "message": BAD_REQUEST_MESSAGE}
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("limit", [640, 0], ids=["digits-640", "digits-0"])
+def test_public_propose_2048_bit_boundary_independent_of_digit_limit(
+        tmp_path, limit):
+    state, client, _ = _fresh_state(tmp_path)
+    lit_ok = str(_INT_WIDE_OK)      # 617 digits — safe at the default limit
+    lit_over = str(_INT_WIDE_OVER)  # 617 digits as well
+    with _digit_limit(limit):
+        resp = _post_raw(client, "/api/tuning/propose",
+                         '{"params": {"magnon_radius": %s}}' % lit_ok)
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["validation"]["errors"]["magnon_radius"]["error"] == "above_max"
+        resp = _post_raw(client, "/api/tuning/propose",
+                         '{"params": {"magnon_radius": %s}}' % lit_over)
+        assert resp.status_code == 400
+        assert resp.get_json() == {"error": "bad_request",
+                                   "message": BAD_REQUEST_MESSAGE}
+
+
+@pytest.mark.parametrize("value_factory", [
+    lambda: [1, _INT_WIDE_OVER],            # wide int inside a list
+    lambda: {"k": [_HUGE_INT]},             # wide int nested list-in-dict
+    lambda: [[-_INT_WIDE_OVER]],            # negative wide int, double-nested
+    lambda: [float("nan")],                 # NaN inside a list
+    lambda: {"k": float("inf")},            # +inf inside a dict
+    lambda: [[float("-inf")]],              # -inf double-nested
+], ids=["list-wide", "dict-list-wide", "nested-neg-wide",
+        "list-nan", "dict-inf", "nested-neg-inf"])
+def test_direct_nested_wide_int_and_non_finite_refused(tmp_path, value_factory):
+    """Composition pin: the width and finite gates apply through container
+    recursion, not only to top-level scalar values — a refactor hoisting them
+    into a top-level fast path must fail here."""
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"magnon_radius": value_factory()}, source="s",
+                      justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("inner", ["[1, %s]" % _HUGE_LITERAL, "[NaN]",
+                                   '{"k": [-Infinity]}'],
+                         ids=["nested-wide", "nested-nan", "nested-neg-inf"])
+def test_public_nested_wide_int_and_non_finite_refused(tmp_path, inner):
+    state, client, _ = _fresh_state(tmp_path)
+    body = '{"params": {"definitely_unknown": %s}}' % inner
+    with _digit_limit(0):
+        resp = _post_raw(client, "/api/tuning/propose", body)
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "bad_request",
+                               "message": BAD_REQUEST_MESSAGE}
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("field", ["source", "justification"])
+@pytest.mark.parametrize("raw", ["[1, 2]", "42", "7.5", '{"a": 1}', "true", "null"],
+                         ids=["list", "int", "float", "object", "bool", "null"])
+def test_public_non_str_metadata_bad_request_not_coerced(tmp_path, field, raw):
+    """PUBLIC str() coercion removed: a supplied non-string source or
+    justification (previously accepted as e.g. \"[1, 2]\" / \"{'a': 1}\") is
+    the fixed 400 — no proposal, ledger line, pending file, or event."""
+    bus = _RecordingBus()
+    state, client, _ = _fresh_state(tmp_path, bus=bus)
+    body = '{"params": {"signal_interval": 12}, "%s": %s}' % (field, raw)
+    resp = _post_raw(client, "/api/tuning/propose", body)
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "bad_request",
+                               "message": BAD_REQUEST_MESSAGE}
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
+
+
+def test_public_metadata_defaults_and_exact_strings_preserved(tmp_path):
+    """Missing source still defaults to 'unspecified', missing justification
+    to ''; supplied exact strings are stored byte-for-byte."""
+    state, client, _ = _fresh_state(tmp_path)
+    resp = client.post("/api/tuning/propose",
+                       json={"params": {"signal_interval": 12}})
+    assert resp.status_code == 200
+    raw_src = "human:Kévin "        # unicode + trailing space, kept verbatim
+    raw_just = "why\tnot\n"
+    resp = client.post("/api/tuning/propose",
+                       json={"params": {"joy_beta": 0.5}, "source": raw_src,
+                             "justification": raw_just})
+    assert resp.status_code == 200
+    lines = (tmp_path / "tuning_ledger.jsonl").read_text(encoding="utf-8").splitlines()
+    first, second = (json.loads(ln) for ln in lines)
+    assert first["source"] == "unspecified" and first["justification"] == ""
+    assert second["source"] == raw_src and second["justification"] == raw_just
+
+
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_public_non_finite_param_value_bad_request_no_ledger(tmp_path, token):
+    """A non-standard JSON numeric token can no longer reach the ledger:
+    the envelope refuses non-finite floats before validation."""
+    bus = _RecordingBus()
+    state, client, _ = _fresh_state(tmp_path, bus=bus)
+    body = '{"params": {"magnon_coupling": %s}}' % token
+    resp = _post_raw(client, "/api/tuning/propose", body)
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "bad_request",
+                               "message": BAD_REQUEST_MESSAGE}
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
+
+
+def test_node_budget_spans_whole_proposal(tmp_path):
+    """Regression for the budget-restart hole: parameter entries sharing
+    repeated structure are charged against ONE proposal-wide budget. Each
+    value below costs 60_001 visits — alone it passes; two entries together
+    (120_002 > 100_000) are refused at the envelope."""
+    inner = [0] * 999            # 1_000 visits per traversal
+    outer = [inner] * 60         # 60_001 visits per traversal
+    state_multi, _, _ = _fresh_state(tmp_path / "multi")
+    with pytest.raises(TuningError) as ei:
+        state_multi.propose(params={"a": outer, "b": outer}, source="s",
+                            justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path / "multi", state_multi)
+
+    state_single, _, _ = _fresh_state(tmp_path / "single")
+    entry = state_single.propose(params={"a": outer}, source="s",
+                                 justification="j", mode="dry-run")
+    assert entry["validation"]["ok"] is False    # unknown param — but envelope passed
+    assert (tmp_path / "single" / "tuning_ledger.jsonl").exists()
+
+
+def test_failed_ledger_serialization_leaves_no_file(tmp_path):
+    """The ledger line is serialized BEFORE the file is opened, so a dumps
+    failure can no longer create or truncate anything (the reproduced
+    zero-byte-ledger mechanism, exercised here directly)."""
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TypeError):
+        state._append_ledger({"type": "probe", "value": object()})
+    assert not (tmp_path / "tuning_ledger.jsonl").exists()
+
+
+@pytest.mark.parametrize("limit", [640, 4300], ids=["digits-640", "digits-default"])
+def test_replay_skips_legacy_wide_int_line_not_crash(tmp_path, limit):
+    """Startup totality for poisoned LEGACY ledgers: the pre-ceiling code could
+    write thousands-of-digits int lines; parsing one under a runtime digit
+    limit raises plain ValueError (not its JSONDecodeError subclass), which
+    previously escaped the corrupt-line guard and crashed TuningState.__init__.
+    Such a line must be skipped like any other corrupt line, and the valid
+    lines around it still replayed."""
+    wide_digits = "1" * 5001            # wider than any settable digit limit
+    legacy = ('{"type": "propose", "proposal_id": "prop-legacy", '
+              '"params": {"x": %s}}' % wide_digits)
+    valid = json.dumps({
+        "type": "propose", "proposal_id": "prop-ok",
+        "params": {"signal_interval": 12},
+        "validation": {"ok": True, "errors": {}},
+    })
+    (tmp_path / "tuning_ledger.jsonl").write_text(
+        legacy + "\n" + valid + "\n", encoding="utf-8")
+    with _digit_limit(limit):
+        state = TuningState(data_dir=tmp_path, gen_getter=lambda: 0)
+    assert "prop-ok" in state._proposals
+    assert "prop-legacy" not in state._proposals

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -851,3 +851,162 @@ def test_valid_direct_propose_still_writes_serialisable_ledger(tmp_path):
     reparsed = json.loads(lines[0])
     assert reparsed["type"] == "propose"
     assert reparsed["params"] == {"signal_interval": 12}
+
+
+# -- review-wave pins: exact-type discrimination, depth bound, nan/inf ---------
+#
+# The gates are exact-type (type(x) is ...), never isinstance — so a well-behaved
+# str/dict/list subclass is refused everywhere, not just at the commit-approver
+# gate. The container-nesting depth bound keeps the JSON-tree proof total against
+# a cyclic DIRECT value. Non-finite floats remain a recorded validation rejection
+# whose ledger line is Python-reparseable (unchanged from before this batch).
+
+
+class _DictSub(dict):
+    """Well-behaved dict subclass whose views record if consulted."""
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.calls = []
+
+    def items(self):
+        self.calls.append("items")
+        return super().items()
+
+    def keys(self):
+        self.calls.append("keys")
+        return super().keys()
+
+
+class _ListSub(list):
+    pass
+
+
+class _StrSub(str):
+    pass
+
+
+def test_direct_propose_dict_subclass_params_refused_without_items(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    params = _DictSub({"signal_interval": 12})
+    params.calls.clear()
+    with pytest.raises(TuningError) as ei:
+        state.propose(params=params, source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert params.calls == []          # views never consulted — exact-type gate
+    _no_side_effects(tmp_path, state)
+
+
+def test_direct_propose_str_subclass_key_refused(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={_StrSub("signal_interval"): 12},
+                      source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("value_factory", [
+    lambda: _StrSub("x"), lambda: _ListSub([1, 2]), lambda: _DictSub({"a": 1}),
+], ids=["str-sub", "list-sub", "dict-sub"])
+def test_direct_propose_subclass_value_refused_before_ledger(tmp_path, value_factory):
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"signal_interval": value_factory()},
+                      source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+def test_validate_proposal_dict_subclass_is_not_ok_without_items():
+    from scripts.params_schema import validate_proposal, ProposalValidation
+    sub = _DictSub({"signal_interval": 12})
+    sub.calls.clear()
+    result = validate_proposal(sub)
+    assert isinstance(result, ProposalValidation)
+    assert result.ok is False
+    assert sub.calls == []             # exact-dict gate, no items()/keys()
+
+
+def test_direct_propose_cyclic_value_is_bad_request_not_recursion_error(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    cyclic = []
+    cyclic.append(cyclic)             # self-referential exact list
+    with pytest.raises(TuningError) as ei:   # must NOT be RecursionError
+        state.propose(params={"signal_interval": cyclic},
+                      source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+def _nest_lists(n):
+    v = 0
+    for _ in range(n):
+        v = [v]
+    return v
+
+
+def test_direct_propose_depth_bound_64_in_65_out(tmp_path):
+    from scripts.tuning_api import _MAX_REQUEST_VALUE_DEPTH
+    assert _MAX_REQUEST_VALUE_DEPTH == 64
+    # At the bound: the tree passes the envelope gate and reaches validation,
+    # where a nested list is an ordinary wrong_type rejection (recorded 422).
+    state_a, _, _ = _fresh_state(tmp_path / "in")
+    entry = state_a.propose(params={"signal_interval": _nest_lists(64)},
+                            source="s", justification="j", mode="dry-run")
+    assert entry["validation"]["ok"] is False
+    assert entry["validation"]["errors"]["signal_interval"]["error"] == "wrong_type"
+    # One past the bound: refused at the envelope, no ledger.
+    state_b, _, _ = _fresh_state(tmp_path / "out")
+    with pytest.raises(TuningError) as ei:
+        state_b.propose(params={"signal_interval": _nest_lists(65)},
+                        source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert not (tmp_path / "out" / "tuning_ledger.jsonl").exists()
+
+
+def test_direct_propose_shared_dag_value_is_bounded_not_hang(tmp_path):
+    """A shared-reference DAG (each level references one child twice) is within
+    the depth bound but expands exponentially; the per-value node budget must
+    refuse it quickly (400) rather than traverse ~2**40 nodes. This test would
+    time out against a depth-only gate."""
+    node = 0
+    for _ in range(40):
+        node = [node, node]          # shares the same child twice per level
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"signal_interval": node},
+                      source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")],
+                         ids=["nan", "inf", "-inf"])
+def test_direct_propose_non_finite_float_is_recorded_wrong_type(tmp_path, bad):
+    """Residual characterisation (behaviour unchanged from before this batch):
+    a non-finite float passes the ledger-serialisability gate, is REJECTED by
+    per-parameter validation as wrong_type/finite, and is recorded — its ledger
+    line is Python-reparseable (json.loads accepts NaN/Infinity tokens)."""
+    state, _, _ = _fresh_state(tmp_path)
+    entry = state.propose(params={"magnon_coupling": bad},
+                          source="human:kevin", justification="j", mode="dry-run")
+    assert entry["validation"]["ok"] is False
+    assert entry["validation"]["errors"]["magnon_coupling"]["error"] == "wrong_type"
+    line = (tmp_path / "tuning_ledger.jsonl").read_text(encoding="utf-8").strip()
+    reparsed = json.loads(line)          # non-strict JSON tokens still reparse
+    assert reparsed["type"] == "propose"
+    assert _math.isnan(reparsed["params"]["magnon_coupling"]) or \
+        _math.isinf(reparsed["params"]["magnon_coupling"])
+
+
+def test_direct_commit_and_rollback_refusal_messages_carry_no_leak(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    for call in (lambda: state.commit(proposal_id=[1, 2], approver="human:kevin"),
+                 lambda: state.rollback(to_proposal_id={"a": 1})):
+        with pytest.raises(TuningError) as ei:
+            call()
+        msg = ei.value.message
+        assert len(msg) < 120
+        for leak in ("[1", "{'a'", "list", "dict"):
+            assert leak not in msg

--- a/tests/test_tuning_api.py
+++ b/tests/test_tuning_api.py
@@ -496,3 +496,358 @@ def test_ledger_survives_corrupt_line(tuning):
     fresh = TuningState(data_dir=tmp_path, gen_getter=gen)
     # State from the valid lines is still restored.
     assert fresh.effective_params()["signal_interval"] == 14
+
+
+# -- request-shape totality (PUBLIC / DIRECT / LEDGER lanes) ------------------
+#
+# The proposal/commit/rollback envelopes must be deterministic for malformed
+# value shapes across three reachability lanes:
+#   PUBLIC   — values obtainable through parsed JSON (str/int/float/bool/None/
+#              list/dict only); a malformed envelope returns a stable
+#              400 bad_request, never a 500.
+#   DIRECT   — TuningState / validate_proposal called with arbitrary Python
+#              objects; a malformed call terminates through a fixed typed
+#              TuningError(400) rather than leaking AttributeError/TypeError.
+#   LEDGER   — no refused request appends to the ledger, writes the pending
+#              file, records a proposal, commits, rolls back, or emits an event.
+# Refusals carry a fixed generic message that names neither the supplied value
+# nor its type. Hostile instruments RECORD their hook invocations so "not
+# consulted" is proven by an empty call log, not inferred from the absence of
+# a crash.
+
+import math as _math
+
+from scripts.tuning_api import TuningError, TuningState, create_blueprint
+
+
+def _fresh_state(tmp_path, bus=None):
+    gen = FakeGen()
+    state = TuningState(data_dir=tmp_path, gen_getter=gen, event_publisher=bus)
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint(state))
+    return state, app.test_client(), gen
+
+
+def _post_raw(client, path, raw_body):
+    return client.post(path, data=raw_body, content_type="application/json")
+
+
+def _no_side_effects(tmp_path, state):
+    """No ledger file, no pending file, no recorded proposal."""
+    assert not (tmp_path / "tuning_ledger.jsonl").exists()
+    assert not (tmp_path / "tuning_pending.json").exists()
+    assert state._proposals == {}
+
+
+# -- PUBLIC lane: non-object top-level body reaching .get --------------------
+
+
+_NON_OBJECT_BODIES = ["[1, 2, 3]", "42", "3.14", "true", '"hello"']
+
+
+@pytest.mark.parametrize("raw", _NON_OBJECT_BODIES)
+@pytest.mark.parametrize("path", [
+    "/api/tuning/propose", "/api/tuning/commit", "/api/tuning/rollback",
+])
+def test_public_non_object_body_is_bad_request_not_500(tmp_path, raw, path):
+    state, client, _ = _fresh_state(tmp_path)
+    resp = _post_raw(client, path, raw)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("path", [
+    "/api/tuning/propose", "/api/tuning/commit", "/api/tuning/rollback",
+])
+def test_public_empty_and_null_body_still_bad_request(tmp_path, path):
+    state, client, _ = _fresh_state(tmp_path)
+    for raw in ("null", ""):
+        resp = _post_raw(client, path, raw)
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "bad_request"
+
+
+# -- PUBLIC lane: unhashable / non-string ids reaching registry .get ---------
+
+
+@pytest.mark.parametrize("raw_id", ["[1, 2]", '{"a": 1}', "123", "true"])
+def test_public_commit_non_string_proposal_id_is_bad_request(tmp_path, raw_id):
+    state, client, _ = _fresh_state(tmp_path)
+    body = '{"proposal_id": ' + raw_id + ', "approver": "human:kevin"}'
+    resp = _post_raw(client, "/api/tuning/commit", body)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "bad_request"
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+@pytest.mark.parametrize("raw_id", ["[1, 2]", '{"a": 1}', "123", "true"])
+def test_public_rollback_non_string_to_proposal_id_is_bad_request(tmp_path, raw_id):
+    state, client, _ = _fresh_state(tmp_path)
+    body = '{"to_proposal_id": ' + raw_id + "}"
+    resp = _post_raw(client, "/api/tuning/rollback", body)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "bad_request"
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+# -- PUBLIC lane: preserved behaviour for valid & recorded-rejection paths ----
+
+
+def test_public_valid_propose_commit_rollback_unchanged(tmp_path):
+    """Golden-path smoke: the whole valid envelope still behaves exactly."""
+    state, client, gen = _fresh_state(tmp_path)
+    pid = client.post("/api/tuning/propose", json={
+        "params": {"signal_interval": 15}, "source": "human:kevin",
+        "justification": "t", "mode": "commit-pending",
+    }).get_json()["proposal_id"]
+    assert pid.startswith("prop-")
+    r = client.post("/api/tuning/commit",
+                    json={"proposal_id": pid, "approver": "human:kevin"})
+    assert r.status_code == 200 and r.get_json()["status"] == "committed"
+    assert state.effective_params()["signal_interval"] == 15
+    r = client.post("/api/tuning/rollback", json={"to_proposal_id": pid})
+    assert r.status_code == 200 and r.get_json()["status"] == "rolled_back"
+
+
+def test_public_container_param_value_still_records_wrong_type(tmp_path):
+    """A JSON container as a param value is not a scalar, but it IS a JSON
+    tree — it still reaches validation and is recorded as a wrong_type
+    rejection (422), exactly as before; not refused at the envelope."""
+    state, client, _ = _fresh_state(tmp_path)
+    resp = _post_raw(client, "/api/tuning/propose",
+                     '{"params": {"signal_interval": [1, 2]}}')
+    assert resp.status_code == 422
+    body = resp.get_json()
+    assert body["status"] == "rejected"
+    assert body["validation"]["errors"]["signal_interval"]["error"] == "wrong_type"
+
+
+# -- DIRECT lane: TuningState.propose malformed envelope shapes ---------------
+
+
+class _Recorder:
+    """Base for hostile instruments: every hook appends its name to `calls`."""
+
+    def __init__(self):
+        self.calls = []
+
+
+class _HostileKey(_Recorder):
+    """A non-str dict key whose equality/str hooks record. __hash__ records too
+    (dict insertion needs it) so the test measures only NEW calls after build."""
+
+    def __hash__(self):
+        self.calls.append("__hash__")
+        return 0
+
+    def __eq__(self, other):
+        self.calls.append("__eq__")
+        return self is other
+
+    def __str__(self):
+        self.calls.append("__str__")
+        return "k"
+
+    def __repr__(self):
+        self.calls.append("__repr__")
+        return "k"
+
+
+class _HostileScalar(_Recorder):
+    """A non-JSON, non-str value whose conversion hooks all record."""
+
+    def __str__(self):
+        self.calls.append("__str__")
+        return "v"
+
+    def __repr__(self):
+        self.calls.append("__repr__")
+        return "v"
+
+    def __eq__(self, other):
+        self.calls.append("__eq__")
+        return False
+
+    def __hash__(self):
+        self.calls.append("__hash__")
+        return 0
+
+    def __bool__(self):
+        self.calls.append("__bool__")
+        return True
+
+    def __iter__(self):
+        self.calls.append("__iter__")
+        return iter(())
+
+
+@pytest.mark.parametrize("bad_params", [
+    [1, 2], "params", 42, 3.14, True, None, ("k", "v"),
+], ids=["list", "str", "int", "float", "bool", "none", "tuple"])
+def test_direct_propose_non_dict_params_is_typed_bad_request(tmp_path, bad_params):
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params=bad_params, source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400
+    assert ei.value.code == "bad_request"
+    _no_side_effects(tmp_path, state)
+
+
+def test_direct_propose_non_str_key_refused_without_registry_lookup(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    key = _HostileKey()
+    params = {key: 1}
+    key.calls.clear()  # forget the hash from dict construction
+    with pytest.raises(TuningError) as ei:
+        state.propose(params=params, source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    # No registry lookup / equality / stringify of the hostile key.
+    assert key.calls == []
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("field", ["source", "justification"])
+def test_direct_propose_non_str_metadata_is_bad_request_no_ledger(tmp_path, field):
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    val = _HostileScalar()
+    kw = dict(params={"signal_interval": 12}, source="s", justification="j", mode="dry-run")
+    kw[field] = val
+    with pytest.raises(TuningError) as ei:
+        state.propose(**kw)
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert val.calls == []            # never stringified/serialized
+    assert bus.published == []        # no event emitted
+    _no_side_effects(tmp_path, state)
+
+
+def test_direct_propose_non_str_mode_refused_without_equality(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    mode = _HostileScalar()
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"signal_interval": 12}, source="s",
+                      justification="j", mode=mode)
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert mode.calls == []           # `mode not in VALID_MODES` never ran __eq__
+    _no_side_effects(tmp_path, state)
+
+
+@pytest.mark.parametrize("value_factory", [
+    lambda: {1, 2, 3},           # set — not JSON serializable
+    lambda: object(),            # bare object
+    lambda: b"bytes",            # bytes
+], ids=["set", "object", "bytes"])
+def test_direct_propose_non_json_value_refused_before_ledger(tmp_path, value_factory):
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"signal_interval": value_factory()},
+                      source="s", justification="j", mode="dry-run")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert bus.published == []
+    _no_side_effects(tmp_path, state)
+
+
+def test_direct_propose_refusal_message_carries_no_value_or_type(tmp_path):
+    state, _, _ = _fresh_state(tmp_path)
+    with pytest.raises(TuningError) as ei:
+        state.propose(params={"signal_interval": {1, 2, 3}},
+                      source="s", justification="j", mode="dry-run")
+    msg = ei.value.message
+    assert len(msg) < 120
+    for leak in ("set", "{1", "signal_interval", "object", "bytes"):
+        assert leak not in msg
+
+
+# -- DIRECT lane: commit / rollback id shapes --------------------------------
+
+
+@pytest.mark.parametrize("bad_id", [
+    [1, 2], {"a": 1}, 123, 1.5, True, None, _HostileScalar,
+], ids=["list", "dict", "int", "float", "bool", "none", "hostile"])
+def test_direct_commit_non_str_proposal_id_is_bad_request(tmp_path, bad_id):
+    state, _, _ = _fresh_state(tmp_path)
+    pid = bad_id() if bad_id is _HostileScalar else bad_id
+    with pytest.raises(TuningError) as ei:
+        state.commit(proposal_id=pid, approver="human:kevin")
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    if isinstance(pid, _HostileScalar):
+        assert pid.calls == []        # never hashed for the registry lookup
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+@pytest.mark.parametrize("bad_id_factory", [
+    lambda: [1, 2],            # unhashable: currently a raw TypeError (no emit)
+    lambda: _HostileScalar(),  # hostile-hashable: currently emits a rejected event
+], ids=["unhashable", "hostile-hash"])
+def test_direct_commit_non_str_proposal_id_emits_no_event(tmp_path, bad_id_factory):
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with pytest.raises(TuningError):
+        state.commit(proposal_id=bad_id_factory(), approver="human:kevin")
+    assert bus.published == []          # malformed shape → no rejected event at all
+
+
+@pytest.mark.parametrize("bad_id", [
+    [1, 2], {"a": 1}, 123, 1.5, True, None, _HostileScalar,
+], ids=["list", "dict", "int", "float", "bool", "none", "hostile"])
+def test_direct_rollback_non_str_id_is_bad_request(tmp_path, bad_id):
+    state, _, _ = _fresh_state(tmp_path)
+    tid = bad_id() if bad_id is _HostileScalar else bad_id
+    with pytest.raises(TuningError) as ei:
+        state.rollback(to_proposal_id=tid)
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    if isinstance(tid, _HostileScalar):
+        assert tid.calls == []
+    assert not (tmp_path / "tuning_pending.json").exists()
+
+
+def test_direct_rollback_hostile_id_emits_no_event(tmp_path):
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    with pytest.raises(TuningError):
+        state.rollback(to_proposal_id=_HostileScalar())
+    assert bus.published == []
+
+
+def test_direct_commit_str_subclass_approver_is_refused(tmp_path):
+    """Exact-type gate: a str subclass approver is refused (400), not run
+    through the quarantine's strip/casefold subclass methods."""
+    class _SubStr(str):
+        pass
+
+    state, client, _ = _fresh_state(tmp_path)
+    pid = _propose(client, {"signal_interval": 15})
+    with pytest.raises(TuningError) as ei:
+        state.commit(proposal_id=pid, approver=_SubStr("human:kevin"))
+    assert ei.value.status_code == 400 and ei.value.code == "bad_request"
+    assert state.effective_params()["signal_interval"] == PARAMS["signal_interval"].default
+
+
+# -- LEDGER/EVENT lane: refused request is inert ------------------------------
+
+
+def test_refused_direct_propose_writes_no_ledger_line(tmp_path):
+    bus = _RecordingBus()
+    state, _, _ = _fresh_state(tmp_path, bus=bus)
+    for bad in ([1, 2], {"signal_interval": object()}, {object(): 1}):
+        with pytest.raises(TuningError):
+            state.propose(params=bad, source="s", justification="j", mode="dry-run")
+    assert not (tmp_path / "tuning_ledger.jsonl").exists()
+    assert bus.published == []
+    assert state._proposals == {}
+
+
+def test_valid_direct_propose_still_writes_serialisable_ledger(tmp_path):
+    """Positive control: a well-formed proposal still appends exactly one
+    JSON-serialisable ledger line and records the proposal."""
+    state, _, _ = _fresh_state(tmp_path)
+    entry = state.propose(params={"signal_interval": 12}, source="human:kevin",
+                          justification="ok", mode="dry-run")
+    assert entry["proposal_id"].startswith("prop-")
+    lines = (tmp_path / "tuning_ledger.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    reparsed = json.loads(lines[0])
+    assert reparsed["type"] == "propose"
+    assert reparsed["params"] == {"signal_interval": 12}


### PR DESCRIPTION
# fix(tuning): request-shape totality for propose/commit/rollback envelopes

Makes the tuning proposal, commit, and rollback request envelopes deterministic for malformed value shapes across three reachability lanes, while preserving every valid request's behavior. The repair is decided entirely by exact builtin `type()` identity — a refused value's methods are never invoked. Three ordinary commits: the base batch (`ecab1e0`), the shared-DAG bound + review-wave pins (`e752b05`), and the integer-totality follow-up from Jack's re-audit (`b2389c3`).

## Reachability table (all reproduced read-only before each fix)

| Lane | Malformed input | Before | After |
|---|---|---|---|
| **PUBLIC** | Truthy non-object body (`[1,2,3]`, `42`, `"s"`, `true`) → `body.get(...)` on all 3 endpoints | **HTTP 500** `AttributeError` | `400 bad_request` (exact-`dict` body gate) |
| **PUBLIC** | commit `proposal_id` / rollback `to_proposal_id` = JSON array/object → registry `dict.get` | **HTTP 500** `unhashable type` | `400 bad_request` (exact-`str` gate before lookup) |
| **PUBLIC** | non-string-but-hashable id (`123`, `true`) | `404 unknown_proposal` | `400 bad_request` (exact-`str`) |
| **PUBLIC** | container-valued param (`{"signal_interval":[1,2]}`) | `422` recorded wrong_type | **unchanged** (`422`, finite JSON tree reaches validation) |
| **PUBLIC** | `source`/`justification` as JSON list/number/object | `str()`-coerced and stored (`{"a": 1}` → `"{'a': 1}"`), `200`/`422` | `400 bad_request` — supplied metadata must be exact JSON strings; **missing** fields keep their defaults (`unspecified` / `""`); valid strings stored byte-for-byte |
| **PUBLIC/DIRECT** | oversized int param (`±10**5000`), digit limit disabled (`0`) | accepted; **thousands-of-digits ledger lines** (10 KB+) and a `tuning.rejected` event carrying the raw int | `400 bad_request`, no ledger line, no event |
| **DIRECT** | oversized int, `sys.set_int_max_str_digits(640)`, known int param | **`ValueError` leak** from range-message formatting | `400 bad_request` |
| **DIRECT** | oversized int, limit 640, unknown param | **`ValueError` leak** from ledger `json.dumps` + **zero-byte ledger file** left behind | `400 bad_request`, no filesystem touch |
| **PUBLIC/DIRECT** | `NaN` / `±Infinity` param value | `422` recorded; **non-standard `NaN`/`Infinity` tokens written to the ledger** | `400 bad_request` before validation or any ledger write |
| **DIRECT** | multiple param entries sharing repeated structure (per-value budgets each pass; combined 120k node visits) | envelope passed; 360 KB ledger line | `400 bad_request` (one proposal-wide budget) |
| **LEDGER** | legacy pre-ceiling ledger line with an oversized int literal, replayed under a runtime digit limit | plain `ValueError` escaped the `JSONDecodeError`-only guard → **`TuningState` startup crash** | line skipped like any corrupt line; valid lines still replay |
| **DIRECT** | `propose(params=<non-dict>)` → `validate_proposal.items()` | `AttributeError` | `TuningError(400)` |
| **DIRECT** | `propose` with hostile-`__hash__` param key → `PARAMS.get` | hostile `__hash__` runs / `RuntimeError` | `400`, key refused by exact type before any lookup |
| **DIRECT** | `propose(source=<non-JSON object>)` → ledger `json.dumps` | `TypeError` (+ 0-byte ledger file) | `400`, no ledger write |
| **DIRECT** | `propose(mode=<hostile __eq__>)` → `mode not in VALID_MODES` | hostile `__eq__` runs / `RuntimeError` | `400`, membership never reached |
| **DIRECT** | `propose({"signal_interval": <set/object/bytes>})` → ledger `json.dumps` | `TypeError` (+ 0-byte ledger file) | `400`, no ledger write |
| **DIRECT** | `commit`/`rollback` with unhashable/hostile id → registry `dict.get` | raw `TypeError` (unhashable) or `tuning.rejected` event carrying the raw object (hostile-hash) | `400` before the try/emit block, no event |
| **DIRECT** | `str`/`dict`/`list` subclass at any field | accepted (`isinstance`-passthrough) | `400` (exact `type()`) |
| **LEDGER/EVENT** | any refused request | — | no ledger line, no pending file, no proposal, no commit/rollback, no event |

## What changed

- **`scripts/tuning_api.py`** — `_json_object_body()` (exact-`dict` HTTP body gate on all three endpoints); `_require_exact_str()` and `_require_valid_proposal_shape()` (exact-string/exact-dict/exact-JSON-tree envelope proofs) run at the top of `TuningState.propose/commit/rollback` **before** any supplied value is hashed, looked up, compared, stringified, validated, serialised, or emitted — and, for commit/rollback, before the `try` that emits `tuning.rejected`; `_is_exact_json_tree()` proves a param value is an exact builtin **standard-JSON** tree — finite floats only, ints within the 2048-bit width ceiling, within depth 64 and one **proposal-wide** node-visit budget (`_MAX_REQUEST_NODES = 100_000`, charged once across all values of a proposal, not per value) — so the ledger `json.dumps` is total and emits standard tokens, independent of `sys.get_int_max_str_digits()`. Ledger lines are serialized **before** the ledger file is opened (a dumps failure performs no filesystem operation — the zero-byte failure mode is structurally removed), and startup replay skips any unparseable legacy line via an `except ValueError` guard (`JSONDecodeError`'s superclass — a pre-ceiling oversized-int line raises the plain-`ValueError` digit guard). The PUBLIC `str()` coercion of `source`/`justification` is removed. The now-redundant `isinstance(approver)` check inside `_commit_locked` was removed (the exact-string proof moved up to `commit()`).
- **`scripts/params_schema.py`** — `validate_proposal` is total on arbitrary input: a non-`dict` proposal resolves to not-ok instead of leaking `.items()`, and a non-`str` key forces not-ok **without** being hashed into `PARAMS.get` (a hostile `__hash__` never runs). **`MAX_TUNING_INT_BITS = 2048`** — one code-level integer width ceiling, aligned with the repository's `MAX_TOOL_RESULT_INT_BITS` (`scripts/orchestrator.py`), checked via `int.bit_length()` only **after** `type(value) is int` (bool keeps its separate behavior everywhere). `TunableParam.validate` refuses oversized ints for int **and** float parameters with a fixed supplied-value-free message; exact 2048-bit values reach ordinary range validation with the existing messages byte-identical (an accepted int renders to ≤ 617 decimal digits, below the 640-digit settable floor of `sys.set_int_max_str_digits`); exact 2049-bit values get the fixed envelope refusal — both signs, independent of the runtime digit limit.
- **`docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`** — the "Request-shape totality" record updated: metadata exact-string rule, integer width ceiling, finite-float gate, proposal-wide budget, serialize-before-open, replay-skip, and the residuals below.

## Compatibility

- **No production consumer is affected.** Every in-process path into these functions crosses the JSON boundary (`request.get_json`), which yields exact builtins only — a subclass or hostile object cannot cross it. The legacy orchestrator reaches the server only over HTTP; `validate_proposal` has a single production caller (`propose`), which pre-proves the exact-dict shape. `medusa_api.py` merely constructs `TuningState`/registers the blueprint. (Confirmed by read-only compatibility sweeps on both the base batch and the follow-up; the follow-up sweep also verified legacy `NaN`/`Infinity`-token ledger lines and 617-digit lines still replay.)
- **Preserved byte-for-byte / behaviourally:** the normalized `policy:auto` refusal (every whitespace/case spelling), byte-for-byte storage of valid human-approver strings in the ledger, defaults (`source` → `unspecified`, `justification` → `""`), response bytes, status codes, proposal identifiers, validation outcomes, rate limits, rollback, and ledger/event schemas for valid requests and ordinary invalid parameter values. Existing built-in-integer range messages are unchanged for every value within the ceiling (incl. `10**400` on float params: still `requires a finite float value.`).
- **Deliberate deltas (all for always-invalid input, all 4xx):** non-string `mode` → `bad_request` not `bad_mode`; non-string-but-hashable id → `400` not `404`; malformed-shape commit/rollback emits no `tuning.rejected` event; supplied non-string `source`/`justification` → `400` (previously coerced); `NaN`/`±Infinity` param values → `400` at the envelope (previously recorded `422`); ints wider than 2048 bits → `400` at the envelope (previously `ValueError` leak, HTTP 500, or oversized ledger lines depending on lane and runtime digit limit).
- **Fixed generic refusal** (`BAD_REQUEST_MESSAGE`) names neither the supplied value nor its type; the width refusal in `params_schema` names only the parameter and the ceiling constant. `__all__` gains exactly `BAD_REQUEST_MESSAGE` (tuning_api) and `MAX_TUNING_INT_BITS` (params_schema); no public signature changed.

## Bounds and residuals (stated precisely)

The request JSON-tree proof bounds **node count** (`_MAX_REQUEST_NODES = 100_000`, one budget per proposal), **nesting depth** (`_MAX_REQUEST_VALUE_DEPTH = 64`), and **integer width** (`MAX_TUNING_INT_BITS = 2048`). It does **not** bound scalar-string length or total serialized byte size — a single long JSON string value passes the proof at any length, so the size of an accepted proposal's ledger line is unbounded. Recorded as a residual in the quarantine doc rather than claimed away.

1. **Depth 64** — keeps the proof total against a cyclic DIRECT value (cycle → `400`, never `RecursionError`). Unreachable via parsed JSON.
2. **Proposal-wide node budget 100k** — keeps the proof total against shared-reference DAGs, including entries sharing repeated structure across multiple parameters (regression pinned). Unreachable via parsed JSON.
3. **No scalar-string / total-byte ceiling** — see above; PUBLIC reachable.
4. The former non-finite-float-token-in-ledger residual is **closed** (finite-float gate). Legacy lines already containing such tokens still replay; legacy oversized-int lines are skipped at replay instead of crashing startup.

## Evidence

- **Failing-first (base batch):** 66 new cases red on then-current code → 152 focused green; +13 review-wave pins → 165 focused green.
- **Failing-first (follow-up):** all of Jack's findings independently reproduced first (28 probes: both signs, known/unknown params, digit limits 640/0, PUBLIC/DIRECT/LEDGER/EVENT lanes, str()-coercion, NaN/Infinity tokens, per-value budget restart); 47 new cases red on head `e752b05` with only test edits → 216 focused green; the review-wave replay finding red (2 cases) → green; focused final **227 passed**.
- Adjacent (orchestrator + provider-parity + agent-backend + anthropic + openai-compat + event-bus): **336 passed**.
- Full suite: **1941 passed, 48 skipped**. `python -m py_compile` clean on all four Python files.
- **Review waves (follow-up):** four read-only waves — compatibility, test-matrix, numeric-bound, final substitution. Substitution wave clean (instrumented hostile `bit_length`/`__float__`/`__class__`/dunder attacks: no hook fires before refusal). Three waves independently converged on the one confirmed defect (the replay guard, repaired above); matrix wave verified nested wide-int/non-finite values are refused through container recursion (now pinned PUBLIC + DIRECT); numeric wave verified the boundary arithmetic (`2**2048-1` = 2048 bits = 617 digits < 640 floor; both signs; int→str **and** str→int digit limits; float-param overflow band 1025–2048 bits keeps the finite refusal).

### Boundary

`git diff main` touches exactly the five authorized files (+1298/−27):

- `scripts/tuning_api.py`
- `scripts/params_schema.py`
- `tests/test_tuning_api.py`
- `tests/test_params_schema.py`
- `docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`

### Status

**MERGED** 2026-07-23 (Sydney) by ordinary head-pinned squash → main **`c6b0dc77926c6133aa81e38b5eac48a3d15a7079`** (single parent `6b7a01c052903816c66e013e9c5f56f31efb8905`). Kev authorized the merge on-seat; Jack's audit completed. Head `b2389c317ca58db2b5b6fa8cbd5fc22355ef4880` (parent `e752b05f`), three ordinary commits, 7/7 registered checks passing (the label-triggered Theory Tripwire registers only on opened/reopened/labeled events — it ran successfully on the PR-open head and is by design never a blocking check). No review-thread actions and no deployment; the remote branch was removed automatically by the repository's delete-branch-on-merge setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
