### PR TITLE
fix(agent-backends): total hook-free tool-argument decoding in OpenAI-compat _response_from_wire

### DIFF
--- a/scripts/agent_backends/openai_compat_backend.py
+++ b/scripts/agent_backends/openai_compat_backend.py
@@ -286,11 +286,30 @@ class OpenAICompatBackend(AgentBackend):
                 if fn is None:
                     continue
                 name = _attr_or_key(fn, "name", "") or ""
-                args_raw = _attr_or_key(fn, "arguments", "") or ""
-                try:
-                    args = json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw)
-                except (ValueError, TypeError):
-                    args = {"_raw_arguments": str(args_raw)}
+                # `arguments` is model/server-reachable and can be any value,
+                # so decoding is total and hook-free: the value's truthiness,
+                # iteration, mapping-conversion, and string-conversion hooks
+                # are never invoked. Exact strings are parsed (JSON object →
+                # kept; other valid JSON → {}; undecodable or parser
+                # recursion → the established raw-fallback shape); exact
+                # dicts continue into ToolUseBlock's hardened normalization;
+                # every other value — absent included — becomes a fresh {}.
+                # MemoryError is deliberately not caught.
+                args_raw = _attr_or_key(fn, "arguments", None)
+                if type(args_raw) is str:
+                    if args_raw == "":
+                        args = {}
+                    else:
+                        try:
+                            parsed = json.loads(args_raw)
+                        except (ValueError, RecursionError):
+                            args = {"_raw_arguments": args_raw}
+                        else:
+                            args = parsed if type(parsed) is dict else {}
+                elif type(args_raw) is dict:
+                    args = args_raw
+                else:
+                    args = {}
                 blocks.append(ToolUseBlock(
                     id=_attr_or_key(tc, "id", "") or "",
                     name=name,

--- a/tests/test_openai_compat_backend.py
+++ b/tests/test_openai_compat_backend.py
@@ -44,6 +44,7 @@ from typing import Any, Optional
 
 import pytest
 
+import scripts.agent_backends.openai_compat_backend as openai_compat_backend_module
 from scripts.agent_backends import (
     AgentResponse,
     Message,
@@ -518,6 +519,136 @@ def test_env_var_api_key_does_not_trigger_dummy(monkeypatch):
         model="llama3.1:8b",
     )
     assert backend.name == "openai-compat"
+
+
+# -- argument-decode totality: tool_call.arguments is model/server-reachable
+#    and can be ANY value, so decoding must be total and hook-free. Exact
+#    strings: JSON object kept; other valid JSON → {}; undecodable or parser
+#    recursion → {"_raw_arguments": original}. Empty/absent → {}. Exact dicts
+#    pass through to ToolUseBlock's hardened normalization. Everything else →
+#    a fresh {} with no __bool__/__iter__/keys/__str__ hook ever invoked. ----
+
+
+def _raw_tc(arguments: Any) -> SimpleNamespace:
+    """A tool_call whose `arguments` is an arbitrary raw wire value (not
+    necessarily the JSON string a well-behaved SDK produces)."""
+    return SimpleNamespace(
+        id="tu_raw", type="function",
+        function=SimpleNamespace(name="f", arguments=arguments),
+    )
+
+
+def _complete_with_arguments(arguments: Any) -> AgentResponse:
+    client = _MockClient()
+    client.chat.completions.response = _make_response(
+        content=None, tool_calls=[_raw_tc(arguments)], finish_reason="tool_calls",
+    )
+    backend = OpenAICompatBackend(client=client)
+    return backend.complete(messages=[Message(role="user", content="x")], tools=[])
+
+
+def test_empty_string_arguments_normalize_to_empty_dict():
+    """'' is how several servers encode a no-argument call; it must become
+    {} — not the {"_raw_arguments": ""} shape the old json.loads('')
+    ValueError path produced."""
+    resp = _complete_with_arguments("")
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_absent_arguments_normalize_to_empty_dict():
+    """arguments=None (field absent) must also become {}."""
+    resp = _complete_with_arguments(None)
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_json_array_scalar_and_null_arguments_normalize_to_empty_dict():
+    """Valid JSON that is not an object carries no argument mapping; the
+    backend itself normalizes to {} rather than pushing a non-dict into
+    the ToolUseBlock boundary."""
+    for raw in ("[1, 2]", "5", '"s"', "true", "null"):
+        resp = _complete_with_arguments(raw)
+        assert resp.tool_calls[0].arguments == {}, f"arguments={raw!r}"
+
+
+def test_valid_json_object_arguments_retained():
+    """The ordinary path is untouched: a JSON object keeps its content."""
+    resp = _complete_with_arguments('{"verbose": true, "n": 5}')
+    assert resp.tool_calls[0].arguments == {"verbose": True, "n": 5}
+
+
+def test_pair_list_arguments_are_not_dict_converted():
+    """The old eager dict(...) manufactured {"a": 1} from a pair-list wire
+    value; non-string values must normalize to {} without conversion."""
+    resp = _complete_with_arguments([["a", 1]])
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_exact_dict_arguments_pass_through():
+    """Some local servers return arguments as an already-decoded dict; an
+    exact dict continues through ToolUseBlock's hardened normalization."""
+    resp = _complete_with_arguments({"k": 1})
+    assert resp.tool_calls[0].arguments == {"k": 1}
+
+
+def test_hostile_arguments_value_never_has_hooks_invoked():
+    """A direct wire value whose truthiness / iteration / mapping-conversion /
+    string-conversion hooks raise must decode to {} with no hook executed
+    (the old path invoked __bool__ via `or ""` and str() in the fallback)."""
+
+    class Hostile:
+        def __bool__(self):
+            raise AssertionError("hook invoked: __bool__")
+
+        def __len__(self):
+            raise AssertionError("hook invoked: __len__")
+
+        def __iter__(self):
+            raise AssertionError("hook invoked: __iter__")
+
+        def keys(self):
+            raise AssertionError("hook invoked: keys()")
+
+        def __str__(self):
+            raise AssertionError("hook invoked: __str__")
+
+    resp = _complete_with_arguments(Hostile())
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_str_subclass_arguments_normalize_to_empty_dict():
+    """A str subclass is not an exact string (subclasses can override
+    behavior), so it takes the hook-free {} path, never the parser."""
+
+    class WeirdStr(str):
+        pass
+
+    resp = _complete_with_arguments(WeirdStr('{"a": 1}'))
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_parser_recursion_error_uses_raw_fallback(monkeypatch):
+    """RecursionError raised by the JSON parser on an ordinary exact-string
+    value must land in the same {"_raw_arguments": ...} fallback as invalid
+    JSON, not escape the backend. Deterministic parser substitution — no
+    dependence on a platform-specific nesting depth."""
+    marker = '{"deep": "payload"}'
+    real_loads = json.loads
+
+    def fake_loads(s, *args, **kwargs):
+        if s == marker:
+            raise RecursionError("maximum recursion depth exceeded")
+        return real_loads(s, *args, **kwargs)
+
+    monkeypatch.setattr(openai_compat_backend_module.json, "loads", fake_loads)
+    resp = _complete_with_arguments(marker)
+    assert resp.tool_calls[0].arguments == {"_raw_arguments": marker}
+
+
+def test_malformed_arguments_fallback_shape_exact():
+    """The established fallback keeps the ORIGINAL string under
+    _raw_arguments — exact shape, no str() re-wrapping."""
+    resp = _complete_with_arguments("{not valid")
+    assert resp.tool_calls[0].arguments == {"_raw_arguments": "{not valid"}
 
 
 # -- regression: orchestrator can swap backends seamlessly ------------------


### PR DESCRIPTION
# OpenAI-compat tool-argument decoding totality repair

Bounded implementation package executed on the Ian seat (84) under Kev's personally typed authorization of 2026-07-22, implementing the boundary defect identified by the completed read-only agent-backend boundary audit. **DRAFT — do not merge, do not mark ready.** Awaiting Jack's audit; merge is Kev's word only.

## OIDs

| Ref | OID |
|---|---|
| Base (`main` at branch creation AND at push) | `6b7a01c052903816c66e013e9c5f56f31efb8905` |
| Audited main at package drafting (historical receipt) | `5d90ea35bf8d60387e667559b193178ae7d64b4d` |
| The one commit | `33eceb23da09d3ce16eb3a4f4e7ecd76a9839117` |
| Pushed head (verified via `ls-remote` post-push) | `33eceb23da09d3ce16eb3a4f4e7ecd76a9839117` |

State lock: the sole main advance since the audit receipt (`5d90ea3..6b7a01c`, the #406 merge) touches `docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`, `scripts/orchestrator.py`, `tests/test_orchestrator.py`; the sole open PR (#408, tuning lane) touches `docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`, `scripts/params_schema.py`, `scripts/tuning_api.py`, `tests/test_params_schema.py`, `tests/test_tuning_api.py`. Both proven disjoint from this PR's two files before any edit. #406/#408 untouched.

## Files and diffstat (exact two-file scope)

```
 scripts/agent_backends/openai_compat_backend.py |  29 +++++-
 tests/test_openai_compat_backend.py             | 131 ++++++++++++++++++++++++
 2 files changed, 155 insertions(+), 5 deletions(-)
```

## Defect (proven before editing)

`_response_from_wire` decoded tool-call `arguments` as:

```python
args_raw = _attr_or_key(fn, "arguments", "") or ""
try:
    args = json.loads(args_raw) if isinstance(args_raw, str) else dict(args_raw)
except (ValueError, TypeError):
    args = {"_raw_arguments": str(args_raw)}
```

`arguments` is model/server-reachable wire data, and this shape (a) truthiness-coerces the value (`or ""` → `__bool__`/`__len__` hooks execute), (b) eagerly `dict()`-converts non-strings (iteration/`keys()` hooks execute; a pair-list manufactures argument content), (c) `str()`-wraps the fallback (string-conversion hook executes), (d) lets parser `RecursionError` escape the backend, and (e) turns empty/absent arguments into `{"_raw_arguments": ""}` instead of `{}`.

## Failing-before → passing-after (deterministic reproductions, injected mock client, no network)

| Case | Before (observed at base) | After (observed at head) |
|---|---|---|
| Empty exact string `""` | `{'_raw_arguments': ''}` | `{}` |
| Absent arguments (`None`) | `{'_raw_arguments': ''}` | `{}` |
| Parser `RecursionError` on ordinary exact string (deterministic parser substitution — no platform nesting depth) | **`RecursionError` escapes `complete()`** | `{'_raw_arguments': original_string}` |
| Valid JSON object | retained (correct) | retained — unchanged |
| Valid JSON array / int / string / `true` / `null` | non-dict pushed into `ToolUseBlock`; `{}` only via the #405 boundary | `{}` normalized locally in the backend |
| Pair-list `[["a", 1]]` | `dict()`-converted → `{'a': 1}` manufactured | `{}` — no conversion hook |
| Hostile value (raising `__bool__`/`__len__`/`__iter__`/`keys`/`__str__`) | **`__bool__` hook executed, raised out of backend** | `{}` — no hook invoked |
| Exact dict `{'k': 1}` | retained via `dict()` copy | retained — passes through to hardened `ToolUseBlock` |
| Non-empty invalid exact string `"{not valid"` | `{'_raw_arguments': '{not valid'}` (correct) | unchanged — established fallback preserved |
| `str` subclass carrying valid JSON | isinstance-parsed → content kept | `{}` — not an exact string (disclosed behavior change, consistent with the repo's exact-type hardening lineage: #394/#405/#407) |

## Repair (production, single site)

Argument extraction reads the raw value with no truthiness coercion, then dispatches on exact type: exact `str` → `""` becomes `{}`, otherwise `json.loads`; parsed exact `dict` kept, any other parse result `{}`; undecodable/recursing non-empty string → `{"_raw_arguments": original_string}` (original object, no `str()` wrap); exact `dict` → passed through to `ToolUseBlock`'s hardened normalization (#405); every other value → fresh `{}` with no boolean/iterator/mapping-conversion/string-conversion hook invoked. Accepted-response behavior and all other provider semantics untouched.

## Exact exception policy

- `try` covers **only** `json.loads(args_raw)` on a type-proven exact non-empty `str`.
- Caught: **`(ValueError, RecursionError)`** — `ValueError` covers `json.JSONDecodeError`/`UnicodeDecodeError`; `RecursionError` per the totality contract.
- `TypeError` no longer caught: unreachable for `json.loads` of a type-proven `str` (the old catch existed for the removed `dict(...)` branch).
- **`MemoryError` is not caught. No blanket `except Exception`. No exception text is exposed** — the fallback carries only the original argument string, exactly as before.

## Tests

`tests/test_openai_compat_backend.py`: +11 regressions in a new argument-decode-totality section (plus one import line). **6 fail at the base commit** (empty-string, absent, hostile hooks, pair-list, parser recursion, str-subclass) **and pass at head**; 5 lock established behavior locally (valid object retained, exact-dict pass-through, array/scalar/null → `{}`, exact malformed-fallback shape, plus the pre-existing malformed test retained). The recursion regression uses deterministic parser substitution (monkeypatched `json.loads` for one marker string), per the package spec.

Local verification (this seat has Python 3.13.7, no pytest, and installs are not authorized): all 34 module tests executed via a stdlib driver that emulates the four pytest features the file uses — base: 27 passed / 3 skipped / **6 failed** (the 6 new totality tests); head: **33 passed / 3 skipped / 0 failed** (3 skips = the openai-SDK construction tests, which run in CI where `openai` is installed). `py_compile` clean on both files; `git diff --check` clean. The authoritative full-suite gate for this seat is CI `verify-python` (established lane).

## CI conclusions (observed to completion on head `33eceb2`)

All checks **PASS** — no failures, no cancellations:

| Check | Result |
|---|---|
| `verify-python` (full maintained suite, PR run) | pass, 1m36s — **1926 passed / 12 skipped / 0 failed** (includes the 11 new regressions) |
| `verify-python` (push run) | pass, 1m19s |
| `agent-safety` | pass |
| `frontend-quality` (PR + push runs) | pass ×2 |
| `Analyze Python` / `CodeQL` | pass |
| `tripwire` | pass |

## Model identity

- Opening model: **Claude Fable 5** (`claude-fable-5`), Ian seat 84, single foreground agent, no subagents/background tasks/parallel fan-out.
- Closing model: **Claude Fable 5** — same seat end to end; no routing/fallback/crossover notice observed at any point in the run.

## Fences held

No merge, no ready-marking, no rebase, no force-push, no history rewrite, no merge-from-main after branch creation, no admin bypass, no auto-merge, no protection/settings change, no review-thread replies/resolutions, no reactions, no label changes, no edits to other PRs (#406/#408 untouched), no memory writes, no changes outside the two named files, no work on any other lane, S2+ unbegun.

---

## Correction — test-count receipt (2026-07-23, Kev-authorized body-only amendment)

The Tests section above (and this PR's commit message) states "+11 regressions". That receipt overcounts by one: it counted the retained **pre-existing** malformed-fallback test as a new regression. Verified against the pushed diff at head `33eceb23da09d3ce16eb3a4f4e7ecd76a9839117` (`git diff 6b7a01c..33eceb2` shows exactly ten `+def test_` additions):

- This PR adds **10 new test functions** — **six failing-before regressions** (empty-string, absent, hostile hooks, pair-list, parser recursion via deterministic substitution, str-subclass) and **four pass-already behavior locks** (array/scalar/null → `{}`, valid JSON object retained, exact-dict pass-through, exact malformed-fallback shape).
- **One pre-existing test** (`test_response_with_malformed_tool_arguments_falls_back`) remains green, unchanged.
- Total: **11 relevant argument-decoding tests, but not 11 new regressions.**

The commit message is not rewritten (history is never rewritten here); this body correction is the durable record. All other receipts above — OIDs, diffstat, failing-before/passing-after table, exception policy, CI conclusions (1926 passed / 12 skipped / 0 failed includes the 10 new tests) — are unaffected. Correction applied as a body-only edit under Kev's typed word of 2026-07-23; no code, commit, branch, comment, label, review, thread, ready-state, or merge action taken. Model at correction: Claude Fable 5.

---

## Merge reconciliation — 2026-07-23, Kev-authorized seal lane (Jack re-audit approved)

Pre-seal reconciliation under Kev's typed closure authorization: one ordinary merge-from-main commit (no rebase, no rewritten history) brought the branch up to date with live main for the repository's strict up-to-date protection.

- **Audited head (unchanged, Jack-approved):** `33eceb23da09d3ce16eb3a4f4e7ecd76a9839117`
- **Merged-in main:** `6f035bff6d6800f03f823f21a4c0615e05c846ca` (advances since base `6b7a01c` = #408 tuning lane + #411 medusa_api lane — proven disjoint from this PR's two files)
- **New head (merge commit):** `eae980220d68abbc2880d30e681ba6eccc8ea9c0`, fast-forward pushed after re-verifying the remote head was still exactly `33eceb2`
- **Equivalence proof:** `git diff origin/main..eae9802` is **byte-identical** to the audited delta `git diff 6b7a01c..33eceb2` — SHA-256 `428341B369B16B54D7139017271216E415103D5460966DADAA8C592195248341` over both patch texts; diffstat unchanged (2 files, +155 −5)
- **Fresh CI at `eae9802` (observed to completion):** all checks pass — `verify-python` **2089 passed / 12 skipped / 0 failed** (×2 runs), `agent-safety`, `frontend-quality` ×2, `Analyze Python`, `CodeQL`
- **Review threads at seal time:** zero
- **Model:** Claude Fable 5 end to end; no crossover

Next per authorization: mark ready → ordinary protected squash merge pinned to `eae9802` → branch deletion only via the repository's automatic setting.
