### PR TITLE
fix(agent-backends): total hook-free inbound response decoding in Anthropic _response_from_wire

### DIFF
--- a/scripts/agent_backends/anthropic_backend.py
+++ b/scripts/agent_backends/anthropic_backend.py
@@ -189,31 +189,49 @@ class AnthropicBackend(AgentBackend):
         """Convert an `anthropic.types.Message` back into our `AgentResponse`.
 
         Reads via attribute access first, falls back to dict access for
-        robustness across SDK versions.
+        robustness across SDK versions. Every wire value here is model/
+        server-reachable, so decoding is total and hook-free: no value's
+        truthiness, iteration, mapping-conversion, or string-conversion
+        hook is ever invoked. Content is decoded only from an exact list;
+        text is kept only when exactly str; tool_use input is kept only
+        when exactly dict (never derived from other shapes) and continues
+        into ToolUseBlock's hardened normalization; stop_reason is kept
+        only when an exactly-str known value (absent → "end_turn", any
+        other shape → "other" per the model-error philosophy above).
         """
         blocks: list[ContentBlock] = []
-        for raw in getattr(response, "content", []) or []:
+        content = _attr_or_key(response, "content", None)
+        if type(content) is not list:
+            content = []
+        for raw in content:
             btype = _attr_or_key(raw, "type")
+            if type(btype) is not str:
+                continue
             if btype == "text":
-                blocks.append(TextBlock(text=_attr_or_key(raw, "text", "") or ""))
+                text = _attr_or_key(raw, "text", None)
+                blocks.append(TextBlock(text=text if type(text) is str else ""))
             elif btype == "tool_use":
+                raw_input = _attr_or_key(raw, "input", None)
                 blocks.append(
                     ToolUseBlock(
                         id=_attr_or_key(raw, "id", ""),
                         name=_attr_or_key(raw, "name", ""),
-                        input=dict(_attr_or_key(raw, "input", {}) or {}),
+                        input=raw_input if type(raw_input) is dict else {},
                     )
                 )
             # Unknown or "thinking" blocks: skip for now. A later PR can
             # preserve them if we start using extended-thinking mode.
 
-        raw_stop = _attr_or_key(response, "stop_reason", "end_turn") or "end_turn"
-        stop_reason: StopReason = (
-            raw_stop if raw_stop in _KNOWN_STOP_REASONS else "other"
-        )
+        raw_stop = _attr_or_key(response, "stop_reason", None)
+        if raw_stop is None:
+            stop_reason: StopReason = "end_turn"
+        elif type(raw_stop) is str and raw_stop in _KNOWN_STOP_REASONS:
+            stop_reason = raw_stop
+        else:
+            stop_reason = "other"
 
         usage: dict[str, Any] = {}
-        u = getattr(response, "usage", None)
+        u = _attr_or_key(response, "usage", None)
         if u is not None:
             usage = {
                 "input_tokens": _attr_or_key(u, "input_tokens", None),

--- a/scripts/agent_backends/anthropic_backend.py
+++ b/scripts/agent_backends/anthropic_backend.py
@@ -188,16 +188,21 @@ class AnthropicBackend(AgentBackend):
     def _response_from_wire(response: Any) -> AgentResponse:
         """Convert an `anthropic.types.Message` back into our `AgentResponse`.
 
-        Reads via attribute access first, falls back to dict access for
-        robustness across SDK versions. Every wire value here is model/
-        server-reachable, so decoding is total and hook-free: no value's
-        truthiness, iteration, mapping-conversion, or string-conversion
-        hook is ever invoked. Content is decoded only from an exact list;
-        text is kept only when exactly str; tool_use input is kept only
-        when exactly dict (never derived from other shapes) and continues
-        into ToolUseBlock's hardened normalization; stop_reason is kept
-        only when an exactly-str known value (absent → "end_turn", any
-        other shape → "other" per the model-error philosophy above).
+        Supported containers are SDK-style typed objects (ordinary
+        attribute access, which is inherent to supporting them) and exact
+        built-in dicts (built-in lookup); dict SUBCLASSES are refused as
+        unsupported mapping containers without invoking their overridden
+        `.get()` or attribute hooks — see `_attr_or_key`. Within that
+        contract decoding is total and hook-free over extracted field
+        values: no field value's truthiness, iteration, mapping-
+        conversion, string-conversion, or equality hook is ever invoked.
+        Content is decoded only from an exact list; text is kept only
+        when exactly str; tool_use input is kept only when exactly dict
+        (never derived from other shapes) and continues into
+        ToolUseBlock's hardened normalization; stop_reason keeps the
+        established semantics — absent, None, or empty exact string →
+        "end_turn"; known exact string → itself; anything else → "other"
+        per the model-error philosophy above.
         """
         blocks: list[ContentBlock] = []
         content = _attr_or_key(response, "content", None)
@@ -225,13 +230,20 @@ class AnthropicBackend(AgentBackend):
         raw_stop = _attr_or_key(response, "stop_reason", None)
         if raw_stop is None:
             stop_reason: StopReason = "end_turn"
-        elif type(raw_stop) is str and raw_stop in _KNOWN_STOP_REASONS:
-            stop_reason = raw_stop
+        elif type(raw_stop) is str:
+            if raw_stop == "":
+                stop_reason = "end_turn"
+            elif raw_stop in _KNOWN_STOP_REASONS:
+                stop_reason = raw_stop
+            else:
+                stop_reason = "other"
         else:
             stop_reason = "other"
 
         usage: dict[str, Any] = {}
         u = _attr_or_key(response, "usage", None)
+        if isinstance(u, dict) and type(u) is not dict:
+            u = None  # dict-subclass container refused → empty usage, no hooks
         if u is not None:
             usage = {
                 "input_tokens": _attr_or_key(u, "input_tokens", None),
@@ -244,18 +256,30 @@ class AnthropicBackend(AgentBackend):
 
 
 def _attr_or_key(obj: Any, name: str, default: Any = None) -> Any:
-    """Read `name` from an object via attribute access, falling back to
-    dict-key access. Returns `default` if neither is present.
+    """Read `name` from a supported container, else return `default`.
+
+    Supported-container contract:
+      - an exact built-in dict takes the built-in dict lookup path first
+        (its `.get` cannot be overridden);
+      - a dict SUBCLASS is refused as an unsupported mapping container —
+        checked before any attribute access, so neither its overridden
+        `.get()` nor its attribute hooks are ever invoked;
+      - anything else keeps ordinary attribute access, which is inherent
+        to supporting SDK-style typed objects (and SimpleNamespace test
+        fixtures);
+      - missing fields return `default`.
 
     The anthropic SDK historically returned typed objects; very old
-    versions returned dicts. Test fixtures may use SimpleNamespace. This
-    helper lets the translator work against all three shapes.
+    versions returned plain dicts. This helper supports exactly those
+    shapes and refuses lookalike mapping containers.
     """
+    if type(obj) is dict:
+        return obj.get(name, default)
+    if isinstance(obj, dict):
+        return default
     val = getattr(obj, name, None)
     if val is not None:
         return val
-    if isinstance(obj, dict):
-        return obj.get(name, default)
     return default
 
 

--- a/tests/test_anthropic_backend.py
+++ b/tests/test_anthropic_backend.py
@@ -12,6 +12,9 @@ required. Verifies:
   - Transport errors propagate; empty content returns cleanly
   - Model override via constructor kwarg
   - Missing anthropic package raises at construction (sans injected client)
+  - Inbound shape totality: hostile / malformed wire values (non-list
+    content, non-str text, non-dict tool input, unhashable stop_reason,
+    dict-shaped responses) decode totally and hook-free
 """
 
 from __future__ import annotations
@@ -312,6 +315,168 @@ def test_empty_content_returns_clean_response():
     resp = backend.complete(messages=[Message(role="user", content="x")], tools=[])
     assert resp.text is None
     assert resp.tool_calls == []
+    assert resp.raw_content == []
+
+
+# -- inbound shape totality: every wire value in a response is model/server-
+#    reachable and can be ANY shape, so decoding must be total and hook-free.
+#    Content decodes only from an exact list; text kept only when exactly
+#    str; tool_use input kept only when exactly dict (never derived from
+#    pair-lists) and continues into ToolUseBlock's hardened normalization;
+#    stop_reason kept only when an exactly-str known value (absent →
+#    "end_turn", any other shape → "other"); dict-shaped responses keep
+#    their content and usage. No __bool__ / __len__ / __iter__ / keys() /
+#    __str__ / __eq__ hook of a wire value is ever invoked. -------------------
+
+
+class _HostileValue:
+    """Wire value whose truthiness / iteration / mapping-conversion /
+    string-conversion hooks all raise if invoked."""
+
+    def __bool__(self):
+        raise AssertionError("hook invoked: __bool__")
+
+    def __len__(self):
+        raise AssertionError("hook invoked: __len__")
+
+    def __iter__(self):
+        raise AssertionError("hook invoked: __iter__")
+
+    def keys(self):
+        raise AssertionError("hook invoked: keys()")
+
+    def __str__(self):
+        raise AssertionError("hook invoked: __str__")
+
+
+class _RaisingEq:
+    """Wire value whose equality hook raises if invoked."""
+
+    def __eq__(self, other):
+        raise AssertionError("hook invoked: __eq__")
+
+    __hash__ = None
+
+
+def _complete(response) -> AgentResponse:
+    client = _MockClient()
+    client.messages.response = response
+    backend = AnthropicBackend(client=client)
+    return backend.complete(messages=[Message(role="user", content="x")], tools=[])
+
+
+def test_dict_shaped_response_recovers_content_and_usage():
+    """A fully dict-shaped response (very old SDKs / proxies / injected
+    clients) must decode content AND usage — the old bare getattr silently
+    dropped both."""
+    resp = _complete({
+        "content": [{"type": "text", "text": "dict-response"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 2},
+    })
+    assert resp.text == "dict-response"
+    assert resp.usage == {"input_tokens": 1, "output_tokens": 2}
+
+
+def test_pair_list_tool_input_is_not_dict_derived():
+    """The old eager dict(...) manufactured {"a": 1} from a pair-list wire
+    value; ToolUseBlock.input must never be derived from other shapes."""
+    resp = _complete(_make_response(
+        [_tool_use("tu_1", "f", [["a", 1]])], stop_reason="tool_use",
+    ))
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_non_mapping_tool_input_normalizes_to_empty_dict():
+    """dict(5) / dict([1, 2]) raised TypeError out of complete(); any
+    non-exact-dict input must become a fresh {} instead."""
+    for bad in (5, [1, 2]):
+        resp = _complete(_make_response(
+            [_tool_use("tu_1", "f", bad)], stop_reason="tool_use",
+        ))
+        assert resp.tool_calls[0].arguments == {}, f"input={bad!r}"
+
+
+def test_hostile_tool_input_value_never_has_hooks_invoked():
+    """The old `or {}` executed the value's __bool__; hostile hook objects
+    must decode to {} with no hook invoked."""
+    resp = _complete(_make_response(
+        [_tool_use("tu_1", "f", _HostileValue())], stop_reason="tool_use",
+    ))
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_exact_dict_tool_input_passes_through():
+    """An exact dict keeps its content (through ToolUseBlock's hardened
+    normalization) — behavior lock."""
+    resp = _complete(_make_response(
+        [_tool_use("tu_1", "f", {"k": 1})], stop_reason="tool_use",
+    ))
+    assert resp.tool_calls[0].arguments == {"k": 1}
+
+
+def test_non_str_text_value_normalizes_to_empty():
+    """A truthy non-str text (e.g. 123) used to reach the from_content
+    join and raise TypeError; it must decode as an empty text."""
+    resp = _complete(_make_response([SimpleNamespace(type="text", text=123)]))
+    assert resp.text == ""
+
+
+def test_hostile_text_value_never_has_hooks_invoked():
+    """The old `or ""` executed the text value's __bool__; hostile hook
+    objects must decode as empty text with no hook invoked."""
+    resp = _complete(_make_response(
+        [SimpleNamespace(type="text", text=_HostileValue())],
+    ))
+    assert resp.text == ""
+
+
+def test_unhashable_or_hostile_stop_reason_maps_to_other():
+    """An unhashable stop_reason crashed the set-membership test and a
+    hostile one had its __bool__ executed by `or`; both are unexpected
+    model shapes and must map to "other"."""
+    for bad in (["end_turn"], _HostileValue()):
+        resp = _complete(_make_response([], stop_reason=bad))
+        assert resp.stop_reason == "other", f"stop_reason={type(bad).__name__}"
+
+
+def test_empty_string_stop_reason_maps_to_other():
+    """Disclosed behavior change: "" was truthiness-folded into "end_turn";
+    an empty string is an unexpected stop_reason and now maps to "other"
+    per the module's model-error philosophy."""
+    resp = _complete(_make_response([], stop_reason=""))
+    assert resp.stop_reason == "other"
+
+
+def test_absent_stop_reason_defaults_to_end_turn():
+    """Absent (None) stop_reason keeps its established "end_turn" default
+    — behavior lock."""
+    resp = _complete(_make_response([], stop_reason=None))
+    assert resp.stop_reason == "end_turn"
+
+
+def test_non_list_content_yields_no_blocks():
+    """Content is decoded only from an exact list: a hostile object (whose
+    __bool__ the old `or []` executed), a str (whose chars the old code
+    iterated), or any other shape must yield a clean empty response."""
+    for bad in (_HostileValue(), "hi", 42):
+        resp = _complete(_make_response(bad))
+        assert resp.raw_content == [], f"content={type(bad).__name__}"
+        assert resp.text is None
+
+
+def test_raising_eq_block_type_is_skipped():
+    """A block whose `type` raises on equality comparison must be skipped
+    (exact-str proof before dispatch), not crash the decode."""
+    resp = _complete(_make_response(
+        [SimpleNamespace(type=_RaisingEq(), text="x")],
+    ))
+    assert resp.raw_content == []
+
+
+def test_non_str_block_type_is_skipped():
+    """A non-str block type (e.g. 42) is skipped — behavior lock."""
+    resp = _complete(_make_response([SimpleNamespace(type=42, text="x")]))
     assert resp.raw_content == []
 
 

--- a/tests/test_anthropic_backend.py
+++ b/tests/test_anthropic_backend.py
@@ -318,15 +318,20 @@ def test_empty_content_returns_clean_response():
     assert resp.raw_content == []
 
 
-# -- inbound shape totality: every wire value in a response is model/server-
-#    reachable and can be ANY shape, so decoding must be total and hook-free.
-#    Content decodes only from an exact list; text kept only when exactly
-#    str; tool_use input kept only when exactly dict (never derived from
-#    pair-lists) and continues into ToolUseBlock's hardened normalization;
-#    stop_reason kept only when an exactly-str known value (absent →
-#    "end_turn", any other shape → "other"); dict-shaped responses keep
-#    their content and usage. No __bool__ / __len__ / __iter__ / keys() /
-#    __str__ / __eq__ hook of a wire value is ever invoked. -------------------
+# -- inbound shape totality: wire values in a response are model/server-
+#    reachable and can be ANY shape. Supported containers are SDK-style
+#    typed objects (ordinary attribute access — inherent to supporting
+#    them) and exact built-in dicts; dict SUBCLASSES are refused without
+#    invoking their overridden .get() or attribute hooks (Amendment 1).
+#    Within that contract decoding is total and hook-free over extracted
+#    field values: content decodes only from an exact list; text kept only
+#    when exactly str; tool_use input kept only when exactly dict (never
+#    derived from pair-lists) and continues into ToolUseBlock's hardened
+#    normalization; stop_reason keeps established semantics (absent/None/
+#    empty exact string → "end_turn", known exact string → itself, any
+#    other shape → "other" without hashing, truth-testing, or comparison
+#    hooks). No __bool__ / __len__ / __iter__ / keys() / __str__ / __eq__
+#    hook of an extracted field value is ever invoked. ------------------------
 
 
 class _HostileValue:
@@ -440,12 +445,12 @@ def test_unhashable_or_hostile_stop_reason_maps_to_other():
         assert resp.stop_reason == "other", f"stop_reason={type(bad).__name__}"
 
 
-def test_empty_string_stop_reason_maps_to_other():
-    """Disclosed behavior change: "" was truthiness-folded into "end_turn";
-    an empty string is an unexpected stop_reason and now maps to "other"
-    per the module's model-error philosophy."""
+def test_empty_string_stop_reason_stays_end_turn():
+    """Amendment 1 (Jack finding 1): the established pre-PR semantics map
+    an empty exact-string stop_reason to "end_turn" — restored, and pinned
+    without truth-testing unproven values (exact-str proof, then ==)."""
     resp = _complete(_make_response([], stop_reason=""))
-    assert resp.stop_reason == "other"
+    assert resp.stop_reason == "end_turn"
 
 
 def test_absent_stop_reason_defaults_to_end_turn():
@@ -458,8 +463,25 @@ def test_absent_stop_reason_defaults_to_end_turn():
 def test_non_list_content_yields_no_blocks():
     """Content is decoded only from an exact list: a hostile object (whose
     __bool__ the old `or []` executed), a str (whose chars the old code
-    iterated), or any other shape must yield a clean empty response."""
-    for bad in (_HostileValue(), "hi", 42):
+    iterated), a list SUBCLASS (refused before iteration — its __iter__ is
+    never invoked), a bool, a number, an exact dict, a tuple, or any other
+    shape must yield a clean empty response."""
+
+    class _HostileList(list):
+        def __iter__(self):
+            raise AssertionError("hook invoked: __iter__")
+
+    variants = (
+        _HostileValue(),
+        "hi",
+        42,
+        _HostileList([{"type": "text", "text": "x"}]),
+        True,
+        3.5,
+        {"type": "text", "text": "x"},
+        ({"type": "text", "text": "x"},),
+    )
+    for bad in variants:
         resp = _complete(_make_response(bad))
         assert resp.raw_content == [], f"content={type(bad).__name__}"
         assert resp.text is None
@@ -478,6 +500,144 @@ def test_non_str_block_type_is_skipped():
     """A non-str block type (e.g. 42) is skipped — behavior lock."""
     resp = _complete(_make_response([SimpleNamespace(type=42, text="x")]))
     assert resp.raw_content == []
+
+
+# -- Amendment 1 matrix: dict-subclass container refusal + stop_reason pins --
+
+
+class _HostileDict(dict):
+    """dict subclass whose mapping and attribute hooks raise if invoked.
+    Data is seeded through the built-in dict constructor (C-level); only
+    the overridden accessors are hostile."""
+
+    def get(self, *args, **kwargs):
+        raise AssertionError("hook invoked: get()")
+
+    def __getattr__(self, name):
+        raise AssertionError("hook invoked: __getattr__")
+
+    def keys(self):
+        raise AssertionError("hook invoked: keys()")
+
+    def __iter__(self):
+        raise AssertionError("hook invoked: __iter__")
+
+    def __bool__(self):
+        raise AssertionError("hook invoked: __bool__")
+
+    def __len__(self):
+        raise AssertionError("hook invoked: __len__")
+
+    def __str__(self):
+        raise AssertionError("hook invoked: __str__")
+
+
+class _BenignSubDict(dict):
+    """dict subclass with NO overrides — still refused: the supported-
+    container contract is exact built-in dict, not isinstance(dict)."""
+
+
+class _WeirdStr(str):
+    """str subclass — not an exact string."""
+
+
+def test_top_level_dict_subclass_response_refused_without_hooks():
+    """A dict-subclass response container is refused before any attribute
+    or .get() access: clean empty response, absent-field semantics."""
+    resp = _complete(_HostileDict(
+        content=[{"type": "text", "text": "hi"}],
+        stop_reason="end_turn",
+        usage={"input_tokens": 1, "output_tokens": 2},
+    ))
+    assert resp.raw_content == []
+    assert resp.text is None
+    assert resp.stop_reason == "end_turn"
+    assert resp.usage == {}
+
+
+def test_dict_subclass_content_block_skipped_without_hooks():
+    """A dict-subclass content block is refused (type discriminator reads
+    as absent) without invoking its .get() or attribute hooks."""
+    resp = _complete(_make_response([_HostileDict(type="text", text="x")]))
+    assert resp.raw_content == []
+
+
+def test_exact_dict_usage_accepted():
+    """A plain-dict usage container on a typed response keeps its counters
+    — behavior lock for the supported-container contract."""
+    resp = _complete(SimpleNamespace(
+        content=[], stop_reason="end_turn",
+        usage={"input_tokens": 7, "output_tokens": 9},
+    ))
+    assert resp.usage == {"input_tokens": 7, "output_tokens": 9}
+
+
+def test_dict_subclass_usage_refused_to_empty():
+    """A dict-subclass usage container — hostile or benign — is refused to
+    an EMPTY usage dict (not a dict of two None counters), without hooks."""
+    for u in (_HostileDict(input_tokens=1, output_tokens=2),
+              _BenignSubDict(input_tokens=1, output_tokens=2)):
+        resp = _complete(SimpleNamespace(content=[], stop_reason="end_turn", usage=u))
+        assert resp.usage == {}, f"usage container={type(u).__name__}"
+
+
+def test_dict_subclass_tool_input_normalizes_to_empty_dict():
+    """A dict-subclass tool input is not an exact dict: normalized to a
+    fresh {} without invoking its hooks — same rule as pair-lists."""
+    for bad in (_HostileDict(k=1), _BenignSubDict(k=1)):
+        resp = _complete(_make_response(
+            [_tool_use("tu_1", "f", bad)], stop_reason="tool_use",
+        ))
+        assert resp.tool_calls[0].arguments == {}, f"input={type(bad).__name__}"
+
+
+def test_str_subclass_block_type_is_skipped():
+    """A str-subclass block discriminator is not an exact str: the block
+    is skipped — behavior lock."""
+    resp = _complete(_make_response(
+        [SimpleNamespace(type=_WeirdStr("text"), text="x")],
+    ))
+    assert resp.raw_content == []
+
+
+def test_str_subclass_stop_reason_maps_to_other():
+    """A str-subclass stop_reason is not an exact str: maps to "other"
+    without hashing or comparison of the supplied value — behavior lock."""
+    resp = _complete(_make_response([], stop_reason=_WeirdStr("end_turn")))
+    assert resp.stop_reason == "other"
+
+
+def test_known_stop_reasons_pass_through():
+    """Every known non-empty exact-string stop_reason maps to itself —
+    behavior lock."""
+    for known in ("end_turn", "tool_use", "max_tokens", "stop_sequence", "error"):
+        resp = _complete(_make_response([], stop_reason=known))
+        assert resp.stop_reason == known
+
+
+def test_absent_stop_reason_field_defaults_to_end_turn():
+    """A response with NO stop_reason field at all (not just None) keeps
+    the "end_turn" default — behavior lock."""
+    resp = _complete(SimpleNamespace(content=[], usage=None))
+    assert resp.stop_reason == "end_turn"
+
+
+def test_mixed_valid_and_refused_blocks_preserve_order():
+    """Refused blocks (dict-subclass, non-str type) are skipped without
+    disturbing the relative order of accepted blocks."""
+    resp = _complete(_make_response([
+        {"type": "text", "text": "first"},
+        _HostileDict(type="tool_use", id="evil", name="evil", input={}),
+        SimpleNamespace(type="tool_use", id="tu_1", name="f", input={"k": 1}),
+        SimpleNamespace(type=42, text="skip"),
+        {"type": "text", "text": "last"},
+    ], stop_reason="tool_use"))
+    assert [type(b).__name__ for b in resp.raw_content] == [
+        "TextBlock", "ToolUseBlock", "TextBlock",
+    ]
+    assert resp.raw_content[0].text == "first"
+    assert resp.raw_content[1].id == "tu_1"
+    assert resp.raw_content[2].text == "last"
 
 
 # -- error-path / construction ----------------------------------------------


### PR DESCRIPTION
# Anthropic inbound-response shape-totality repair

Bounded implementation executed on the Ian seat (84) under Kev's personally typed authorization of 2026-07-23 (phase 2; phase 1 was the body-only test-count correction on #409). Implements fix candidate 2 of the completed read-only agent-backend boundary audit of 2026-07-22. **DRAFT — do not merge, do not mark ready.** Awaiting Jack's audit; merge is Kev's word only.

## OIDs

| Ref | OID |
|---|---|
| Base (`main` at branch creation AND at push) | `c6b0dc77926c6133aa81e38b5eac48a3d15a7079` |
| Audit baseline (historical receipt) | `5d90ea35bf8d60387e667559b193178ae7d64b4d` |
| The one commit | `f6e3e25506c0e9eb2aec573118854a2ab7ad68c3` |
| Pushed head (verified via `ls-remote` post-push) | `f6e3e25506c0e9eb2aec573118854a2ab7ad68c3` |

State lock: cumulative main advances since the audit baseline (`5d90ea3..c6b0dc7`, the #406 and #408 merges) touch only orchestrator/tuning-lane files (`docs/LEGACY_ORCHESTRATOR_QUARANTINE.md`, `scripts/orchestrator.py`, `scripts/params_schema.py`, `scripts/tuning_api.py`, and their tests) — disjoint from this PR's two files. The sole open PR at drafting time was #409 (OpenAI-compat lane, two different files) — disjoint; this branch was created directly from live main, not from #409.

## Files and diffstat (exact two-file scope)

```
 scripts/agent_backends/anthropic_backend.py |  36 ++++--
 tests/test_anthropic_backend.py             | 165 ++++++++++++++++++++++++++++
 2 files changed, 192 insertions(+), 9 deletions(-)
```

## Defect (proven before editing)

`_response_from_wire` was non-total on the dict/proxy/injected-client path:

- `getattr(response, "content", []) or []` and `getattr(response, "usage", None)` — bare `getattr` with no dict fallback: a fully dict-shaped response **silently lost all content and usage**; the `or` executed the value's `__bool__`.
- `dict(_attr_or_key(raw, "input", {}) or {})` — truthiness-coerced the value, **derived** a populated dict from a pair-list (breaking the #405 "never derived" contract), and **raised TypeError** on non-mapping input.
- `_attr_or_key(raw, "text", "") or ""` — a truthy non-str `text` passed through to `AgentResponse.from_content`'s join and **raised TypeError**; hostile `__bool__` executed.
- `_attr_or_key(response, "stop_reason", "end_turn") or "end_turn"` then `raw_stop in _KNOWN_STOP_REASONS` — hostile `__bool__` executed; an **unhashable stop_reason crashed** the membership test.
- `btype == "text"` — a block `type` with a raising `__eq__` **crashed** dispatch.

## Failing-before → passing-after (deterministic reproductions, injected mock client, no network, no `anthropic` package needed)

| Case | Before (observed at base) | After (observed at head) |
|---|---|---|
| Fully dict-shaped response | text `None`, usage `{}` (silently dropped) | text decoded, usage `{'input_tokens': 1, 'output_tokens': 2}` |
| Pair-list tool input `[["a", 1]]` | `{'a': 1}` derived | `{}` |
| Non-mapping tool input (`5`, `[1, 2]`) | **TypeError escaped `complete()`** | `{}` |
| Hostile tool input (raising hooks) | **`__bool__` executed, raised out** | `{}` — no hook invoked |
| Exact-dict tool input `{'k': 1}` | retained | retained — behavior lock |
| Truthy non-str text `123` | **TypeError in `from_content` join** | `""` |
| Hostile text value | **`__bool__` executed, raised out** | `""` — no hook invoked |
| Unhashable stop_reason `["end_turn"]` | **TypeError (unhashable) escaped** | `"other"` |
| Hostile stop_reason | **`__bool__` executed, raised out** | `"other"` — no hook invoked |
| Empty-string stop_reason `""` | `"end_turn"` (truthiness-folded) | `"other"` — **disclosed behavior change**, per the module's documented model-error philosophy (unexpected stop_reason → `"other"`) |
| Absent stop_reason (`None`) | `"end_turn"` | `"end_turn"` — behavior lock |
| Hostile content value | **`__bool__` executed, raised out** | no blocks, clean response |
| Non-list content (`"hi"`, `42`) | str iterated char-by-char / no blocks | no blocks — exact-list proof, locked |
| Block `type` with raising `__eq__` | **`AssertionError` from hook escaped** | block skipped |
| Non-str block `type` (`42`) | skipped | skipped — behavior lock |

## Repair (production, single method)

Decoding is total and hook-free by construction: `content` and `usage` are read via `_attr_or_key` (dict-shaped responses now decode — the module docstring's "attributes with dict fallback" promise, honored); content iterates only when exactly `list`; block `type` must be exactly `str` before dispatch; `text` kept only when exactly `str` (else `""`, locally — `TextBlock` has no #405-style hardening of its own); `tool_use` `input` kept only when exactly `dict` (never derived) and continues into `ToolUseBlock`'s hardened normalization (#405); `stop_reason` kept only when an exactly-`str` member of `_KNOWN_STOP_REASONS` (absent/`None` → `"end_turn"`, any other shape → `"other"`). No truthiness, iteration, mapping-conversion, string-conversion, or equality hook of any wire value is ever invoked. Outbound translation and all other provider semantics untouched.

## Exact exception policy

**No exception handling added, removed, or widened.** The repair replaces crash-prone eager conversions (`dict(...)`, join of non-str) and hook-executing coercions (`or`, set membership on unproven values) with exact-type proofs, so the decode is total without catching anything. Transport errors continue to propagate per the module's contract. `MemoryError` is never caught; there is no blanket `except`; no exception text is exposed.

## Tests

`tests/test_anthropic_backend.py`: **+13 new test functions** in a new inbound-shape-totality section (plus one docstring bullet) — **10 failing-before regressions** (dict-shaped content+usage recovery, pair-list derivation, non-mapping input ×2, hostile input hooks, non-str text, hostile text hooks, unhashable + hostile stop_reason, empty-string stop_reason, non-list content ×3, raising-`__eq__` block type) and **3 pass-already behavior locks** (exact-dict input pass-through, absent stop_reason → `end_turn`, non-str block type skipped). All **17 pre-existing tests unchanged and green**. Total: 30 tests in the module. These tests need no `anthropic` package (injected mock clients; the SDK import is lazy), so they genuinely run under CI's `verify-python` gate.

Local verification (this seat has Python 3.13.7, no pytest, and installs are not authorized): full module executed via the same stdlib pytest-shim used for #409 — base: 20 passed / **10 failed** (exactly the 10 new regressions); head: **30 passed / 0 skipped / 0 failed**. The OpenAI-compat backend module (base version on this branch) re-run green: 23 passed / 3 skipped / 0 failed. `py_compile` clean on both files; `git diff --check` clean. The authoritative full-suite gate is CI `verify-python`.

## CI conclusions (observed to completion on head `f6e3e25`)

All checks **PASS** — no failures, no cancellations:

| Check | Result |
|---|---|
| `verify-python` (full maintained suite, PR run) | pass, 1m29s — **2077 passed / 12 skipped / 0 failed** (2064 at base + the 13 new tests, all executed — no vacuous skip: this module needs no `anthropic` package) |
| `verify-python` (push run) | pass, 1m32s |
| `agent-safety` | pass |
| `frontend-quality` (PR + push runs) | pass ×2 |
| `Analyze Python` / `CodeQL` | pass |
| `tripwire` | pass |

## Model identity

- Opening model: **Claude Fable 5** (`claude-fable-5`), Ian seat 84, single foreground agent, no subagents/background tasks/parallel fan-out.
- Closing model: **Claude Fable 5** — same seat end to end across both phases (the #409 body correction and this implementation); no routing/fallback/crossover notice observed at any point.

## Fences held

No merge, no ready-marking on either PR, no rebase, no force-push, no history rewrite, no merge-from-main after branch creation, no admin bypass, no auto-merge, no protection/settings change, no review replies/resolutions, no reactions, no labels, no comments, no memory writes, no changes outside the two named Anthropic files, no changes to #408, no code/branch changes to #409 (its body-only test-count correction was phase 1 of the same typed authorization), no work on any other lane, S2+ unbegun.

---

## Amendment 1 — 2026-07-23, Kev-authorized, per Jack's audit findings

**Head OIDs:** old `f6e3e25506c0e9eb2aec573118854a2ab7ad68c3` → new `82e2316bbb1ed70f4b309ceb2232a81dfdf31b89` (one focused follow-up commit; the original commit is not amended or rewritten; normal fast-forward push after re-verifying the remote head was still exactly `f6e3e25`).

**Amendment diffstat** (`f6e3e25..82e2316`, still the same two permitted files):

```
 scripts/agent_backends/anthropic_backend.py |  60 ++++++---
 tests/test_anthropic_backend.py             | 192 +++++++++++++++++++++++++---
 2 files changed, 218 insertions(+), 34 deletions(-)
```

### Jack finding 1 — empty stop_reason semantics restored

This body's earlier "Empty-string stop_reason `""` → `"other"` — disclosed behavior change" row and its test are **superseded**: the established pre-PR semantics are restored. Pinned contract, with no truth-testing of unproven values: absent / `None` / empty exact string → `"end_turn"`; known non-empty exact string → itself; unknown non-empty exact string → `"other"`; every non-string shape → `"other"` without hashing, truth-testing, or supplied comparison hooks. Failing-at-`f6e3e25`: `""` decoded to `"other"`; now `"end_turn"`.

### Jack finding 2 — exact-dictionary container routing

`_attr_or_key` performed attribute access first and then accepted `isinstance(obj, dict)`, so a dict **subclass** could execute its overridden `.get()` or raising attribute hooks when used as the top-level response, a content block, or the usage container. Reproduced at `f6e3e25` before editing: hostile `.get()` executed at all three positions; hostile `__getattr__` executed at the top level; a benign subclass was silently accepted as a supported mapping.

Supported-container contract now explicit in the helper: an exact built-in dict takes the built-in dict lookup path first; a dict subclass is **refused** as an unsupported mapping container — checked before any attribute access, so neither its `.get()` nor its attribute hooks are ever invoked; SDK-style typed objects retain ordinary attribute access; missing fields keep their defaults. A dict-subclass usage container now produces an **empty** usage result, not `{"input_tokens": None, "output_tokens": None}`. No broad exception handling was added to make arbitrary proxy objects appear supported; no supplied values, exception text, or supplied type names are exposed.

**Narrowed claim (supersedes this body's earlier unrestricted "every wire value … total and hook-free" wording):** totality and hook-free refusal apply to **exact dictionary containers and extracted field values**; ordinary attribute access remains inherent for supported SDK-style typed objects, so an arbitrary hostile non-dict proxy with raising attribute hooks is outside the supported-container contract.

### Failing-before → passing-after (at `f6e3e25` → at `82e2316`)

| Case | At `f6e3e25` | At `82e2316` |
|---|---|---|
| Top-level dict subclass (hostile `.get` / `__getattr__`) | **hook executed, raised out** | refused cleanly: no blocks, `end_turn`, usage `{}` |
| Dict-subclass content block | **hook executed, raised out** | skipped, no hooks |
| Dict-subclass usage container (hostile) | **hook executed, raised out** | `{}` |
| Dict-subclass usage container (benign) | accepted, counters extracted | `{}` — narrowed contract |
| Mixed valid + refused blocks | **hostile block raised out** | accepted blocks keep relative order |
| Empty-string stop_reason `""` | `"other"` | `"end_turn"` — restored |
| Dict-subclass tool input | `{}` (already exact-dict-proven) | `{}` — now pinned |
| Str-subclass block type / stop_reason; known/absent stop_reason; non-list content variants incl. list-subclass (hostile `__iter__`), bool, float, exact dict, tuple | already correct | pinned as behavior locks |

### Test counts (counted directly from the amendment diff)

**+10 new test functions**, **1 renamed/inverted** (`test_empty_string_stop_reason_maps_to_other` → `test_empty_string_stop_reason_stays_end_turn`), **1 extended** (`test_non_list_content_yields_no_blocks`, 3 → 8 refused-content variants). Module total **30 → 40**. **5 of the new/changed tests fail at `f6e3e25`** (three dict-subclass container refusals, mixed-order preservation, empty-string restoration); the remainder are behavior locks. This supersedes nothing in the earlier test receipt for the original commit, which remains accurate for `f6e3e25`.

Local verification: Anthropic module 40 passed / 0 failed at `82e2316` (35 passed / 5 failed with the amendment tests against the `f6e3e25` production code); OpenAI-compat module 23 passed / 3 skipped / 0 failed; provider-parity module cannot run on this seat (`flask` not installed; installs not authorized) — covered by CI `verify-python`, which installs it; `py_compile` and `git diff --check` clean. Outbound translation byte-untouched; base dataclasses untouched; no `MemoryError` caught; no `except Exception` added.

### CI conclusions (Amendment head `82e2316`, observed to completion)

All newly triggered checks **PASS** — no failures, no cancellations: `verify-python` (PR run 1m34s, push run 1m39s) — **2087 passed / 12 skipped / 0 failed** (2077 at `f6e3e25` + the 10 new test functions, all executed); `agent-safety` pass; `frontend-quality` pass ×2; `Analyze Python` / `CodeQL` pass.

### Model identity (Amendment 1)

Opened and closed as **Claude Fable 5** (`claude-fable-5`), Ian seat 84, one foreground agent, no subagents/background tasks/parallel fan-out; no routing or crossover notice at any point.

---

## Merge reconciliation — 2026-07-23, Kev-authorized seal lane (Jack re-audit approved)

Pre-seal reconciliation under Kev's typed closure authorization (sequenced strictly after #409's conclusive squash to main): one ordinary merge-from-main commit (no rebase, no rewritten history) brought the branch up to date with live main for the repository's strict up-to-date protection.

- **Audited head (unchanged, Jack-approved):** `82e2316bbb1ed70f4b309ceb2232a81dfdf31b89`
- **Merged-in main:** `3040e049adfbbb6009161686eebd0a1ef0e59f8e` (the #409 squash; advances since base `c6b0dc7` = #411 medusa_api lane + #409 OpenAI-compat lane — proven disjoint from this PR's two files)
- **New head (merge commit):** `075ed051df7f93c5887a6d4afd7eaa2af2c6db4b`, fast-forward pushed after re-verifying the remote head was still exactly `82e2316`
- **Equivalence proof:** `git diff origin/main..075ed05` is **byte-identical** to the audited cumulative delta `git diff c6b0dc7..82e2316` — SHA-256 `86956ECF58DE22A69B099E851243E3EBAEF8379FEAB564312A8A8A1E71528C40` over both patch texts; diffstat unchanged (2 files, +383 −16)
- **Fresh CI at `075ed05` (observed to completion):** all four runs pass — CI [push], CI [pull_request] with `verify-python` **2112 passed / 12 skipped / 0 failed** + `frontend-quality`, **Agent Safety Suite** [pull_request], **CodeQL (Python baseline)** [pull_request]; merge state CLEAN. (The pull_request-event runs arrived delayed — GitHub's PR-head sync lagged the ref update by ~10 minutes; observed to conclusion once delivered.)
- **Review threads at seal time:** zero
- **Model:** Claude Fable 5 end to end; no crossover

Next per authorization: mark ready → ordinary protected squash merge pinned to `075ed05` → branch deletion only via the repository's automatic setting.

---

## Closure receipt — 2026-07-23, merged

Record-only close-out under Kev's typed authorization. This PR landed through the repository's ordinary protected squash-merge lane.

- **Merged head (pinned):** `075ed051df7f93c5887a6d4afd7eaa2af2c6db4b`
- **Squash commit on `main`:** `44c5d9cae1c9fe37053bd2945a4078ef3db681e5`
- **Merge outcome:** successful ordinary protected squash merge; no admin bypass, no auto-merge; `mergedAt` 2026-07-23T07:29:40Z
- **Landed file scope (exact):** `scripts/agent_backends/anthropic_backend.py` + `tests/test_anthropic_backend.py` — the two audited files, nothing else
- **Source branch `fix/anthropic-response-decode-totality`:** removed via the repository's ordinary automatic-deletion setting (absent from origin post-merge)
- **Review threads:** zero
- **Pre-merge CI at the pinned head `075ed05`:** all success — `verify-python` **2112 passed / 12 skipped / 0 failed**, plus CI [push], `frontend-quality`, Agent Safety Suite, CodeQL (Python baseline)
- **Post-merge CI on `44c5d9c`:** attached and conclusive — **CI [push]** success (`verify-python` 2112 passed / 12 skipped / 0 failed) and **CodeQL (Python baseline) [push]** success. (`agent-safety` is `pull_request`-only, so no post-merge push run exists for it — expected; it was satisfied pre-merge on the PR head.)

**Model trajectory:** the full seal sequence (merge-from-main, equivalence proof, fresh CI, ready-flip, squash) was performed as **Claude Fable 5** (`claude-fable-5`); this record-only closure receipt was appended as **Claude Opus 4.8** (`claude-opus-4-8`) after the merge had conclusively landed, per Kev's model switch and fresh authorization. No code, tests, branches, PR states, workflows, or settings were changed by this closure step — body append only.

---

## Actions-index reconciliation — 2026-07-23, Kev-authorized (Ian seat, Claude Opus 4.8)

Record-only, body-append-only reconciliation of the post-merge GitHub Actions runs attached to the squash commit `44c5d9cae1c9fe37053bd2945a4078ef3db681e5`. The Closure receipt above already noted these runs qualitatively (workflow names, conclusions, and the `verify-python` count); this append pins their **exact run records** — run IDs and direct run URLs — which were not previously captured, so the earlier index gap cannot recur. The runs were located independently via the authoritative Actions API filtered on `head_sha=44c5d9c…`; both were conclusively found with head SHA exactly `44c5d9cae1c9fe37053bd2945a4078ef3db681e5`, head branch `main`, event `push`. Total run count for that head SHA: 2 (no ambiguity).

| Workflow | Run ID | Direct URL | Event | Conclusion |
|---|---|---|---|---|
| **CI** (`.github/workflows/ci.yml`, run #1803) | `29988555439` | https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/29988555439 | push | **success** |
| **CodeQL (Python baseline)** | `29988555677` | https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/29988555677 | push | **success** |

**CI run `29988555439` jobs (both success):**

| Job | Job ID | Conclusion |
|---|---|---|
| `verify-python` | `89145839251` | **success** |
| `frontend-quality` | `89145839207` | **success** |

**Authoritative `verify-python` count** — from job `89145839251` (`python -m pytest tests/ -q`): **2112 passed, 12 skipped, 0 failed** (`in 39.35s`), consistent with the pre-merge PR-head figure recorded above. `agent-safety` is `pull_request`-only, so it has no post-merge push run on `44c5d9c` (expected; satisfied pre-merge on the PR head).

No workflow was dispatched, rerun, cancelled, deleted, or otherwise mutated to produce this receipt; the runs and their logs were read only. Everything in this PR body above this section is preserved byte-for-byte.

**Model:** appended as Claude Opus 4.8 (`claude-opus-4-8`), Ian seat 84, single foreground agent.
