### PR TITLE
fix(medusa-api): report configured launch port + single-source API version

### DIFF
--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -46,8 +46,14 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data"
 API_PORT = 8080
 API_HOST = "0.0.0.0"  # Listen on all interfaces for cluster access
+API_VERSION = "1.2.0"  # Semantic API version — single source for / and /api/health.
 
 app = Flask(__name__)
+# The launch port surfaced by /api/status. Defaults to the module API_PORT at
+# import time; the public CLI overrides it via configure_runtime() before
+# app.run (see the __main__ block). This is the *configured* launch port — with
+# --port 0 it is 0, not the OS-selected bound port.
+app.config["API_PORT"] = API_PORT
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -101,8 +107,15 @@ def _read_engine_log():
 
 @app.route("/api/health")
 def health():
-    """Simple health check."""
-    return jsonify({"status": "ok", "service": "medusa-api", "timestamp": time.time()})
+    """API-process liveness. Reports the process is up and its version; it is
+    deliberately independent of snapshot presence or engine freshness (that
+    signal lives in /api/status)."""
+    return jsonify({
+        "status": "ok",
+        "service": "medusa-api",
+        "timestamp": time.time(),
+        "version": API_VERSION,
+    })
 
 
 @app.route("/api/status")
@@ -124,7 +137,9 @@ def status():
         "snapshot_size_mb": round(snap_size / 1024 / 1024, 1),
         "total_snapshots": len(all_snaps),
         "engine_alive": snap_age < 900,  # 15 min threshold
-        "api_port": API_PORT,
+        # The configured launch port (set by the public CLI via
+        # configure_runtime), falling back to the module default at import time.
+        "api_port": app.config.get("API_PORT", API_PORT),
     })
 
 
@@ -383,7 +398,7 @@ def index():
     """API documentation."""
     return jsonify({
         "service": "Medusa REST API (Phase 16a + Phase 18 PRs 2+3)",
-        "version": "1.2.0",
+        "version": API_VERSION,
         "endpoints": {
             "/api/health": "Health check",
             "/api/status": "Engine status",
@@ -415,12 +430,28 @@ def index():
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
-if __name__ == "__main__":
+def _build_arg_parser():
+    """The public CLI parser. Its grammar is authoritative and mirrored by
+    tests/test_medusa_start.py — keep the --port/--host spellings, types, and
+    defaults stable."""
     import argparse
     parser = argparse.ArgumentParser(description="Medusa REST API (Phase 16a)")
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("--host", type=str, default="0.0.0.0")
-    args = parser.parse_args()
+    return parser
+
+
+def configure_runtime(args):
+    """Wire the parsed public-CLI arguments into the app's runtime config
+    before app.run, so /api/status reports the configured launch port rather
+    than the module default. Returns the configured app (for testability)."""
+    app.config["API_PORT"] = args.port
+    return app
+
+
+if __name__ == "__main__":
+    args = _build_arg_parser().parse_args()
+    configure_runtime(args)
 
     print("=" * 60)
     print("  MEDUSA REST API — Phase 16a")

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -449,8 +449,13 @@ def configure_runtime(args):
     return app
 
 
-if __name__ == "__main__":
-    args = _build_arg_parser().parse_args()
+def main(argv=None):
+    """Production entry point. Parses the public CLI (``argv`` defaults to
+    ``sys.argv[1:]``), wires the configured port into runtime config, prints
+    the startup banner, and runs the server. Kept small and importable so a
+    test can drive the real parse -> configure_runtime -> app.run chain with
+    ``app.run`` monkeypatched (socket-free)."""
+    args = _build_arg_parser().parse_args(argv)
     configure_runtime(args)
 
     print("=" * 60)
@@ -460,3 +465,7 @@ if __name__ == "__main__":
     print("=" * 60)
 
     app.run(host=args.host, port=args.port, debug=False, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_medusa_api.py
+++ b/tests/test_medusa_api.py
@@ -1,0 +1,208 @@
+"""Behavioral tests for scripts/medusa_api.py runtime reporting.
+
+Scope (bounded task): the REST API's runtime-reporting contracts only —
+  * /api/status must report the *configured* launch port, not the module
+    default;
+  * a single-sourced semantic API version is surfaced by both / and
+    /api/health;
+  * /api/health stays a process-liveness endpoint (status/service/timestamp
+    preserved, version added), independent of snapshot or engine freshness.
+
+These are the first behavioral tests for this module. They run entirely
+in-process via Flask's test client: no live server is started, no network
+port is bound, no OS process is launched, and no real repository data is read
+(the snapshot directory is monkeypatched to a temp path and any snapshot file
+is a synthetic byte blob — /api/status only stats it, never loads it).
+
+The event bus (a ZMQ PUB socket + telemetry watcher thread) is disabled BEFORE
+the module is imported, so importing it here binds no socket and starts no
+thread.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Disable the event-bus PUB socket / watcher thread before importing the module
+# under test, so import binds no network port and starts no background thread.
+os.environ["MEDUSA_EVENT_BUS_DISABLED"] = "1"
+
+import pytest
+
+pytest.importorskip("flask")  # flask is an optional dependency for the REST API.
+
+from scripts import medusa_api  # noqa: E402  (import after env flag is set)
+
+
+# -- fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    return medusa_api.app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _restore_configured_port():
+    """The Flask app is a module singleton; restore its configured port after
+    every test so port mutations never leak across tests."""
+    saved = medusa_api.app.config.get("API_PORT")
+    yield
+    medusa_api.app.config["API_PORT"] = saved
+
+
+@pytest.fixture
+def empty_data_dir(tmp_path, monkeypatch):
+    """Point the module's DATA_DIR at an empty temp dir (no snapshots)."""
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def snapshot_data_dir(tmp_path, monkeypatch):
+    """Point DATA_DIR at a temp dir containing one synthetic snapshot file.
+
+    The file is a >1 MiB byte blob so _find_latest_snapshot returns it; its
+    contents are never parsed by /api/status (which only stats it)."""
+    snap = tmp_path / "v070_gen000123.npz"
+    snap.write_bytes(b"\x00" * 2_000_000)
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+    return tmp_path
+
+
+_STATUS_KEYS = {
+    "latest_snapshot",
+    "snapshot_age_seconds",
+    "snapshot_size_mb",
+    "total_snapshots",
+    "engine_alive",
+    "api_port",
+}
+
+
+# -- failing-first pins (RED on pre-fix code) -------------------------------
+
+
+def test_status_reports_configured_port_not_module_default(client, snapshot_data_dir):
+    """FAILING-FIRST: a launch configured for port 9090 must be reported as
+    9090. Pre-fix /api/status hard-codes the module default, so it reports
+    8080 and this assertion fails."""
+    medusa_api.app.config["API_PORT"] = 9090
+    body = client.get("/api/status").get_json()
+    assert body["api_port"] == 9090
+
+
+def test_health_includes_api_version(client):
+    """FAILING-FIRST: /api/health must carry the semantic API version. Pre-fix
+    the health body has no 'version' key, so this fails."""
+    body = client.get("/api/health").get_json()
+    assert body.get("version") == "1.2.0"
+
+
+# -- version single-sourcing ------------------------------------------------
+
+
+def test_api_version_constant_is_the_existing_semantic_value():
+    assert medusa_api.API_VERSION == "1.2.0"
+
+
+def test_root_and_health_share_the_single_sourced_version(client):
+    root_version = client.get("/").get_json()["version"]
+    health_version = client.get("/api/health").get_json()["version"]
+    assert root_version == health_version == medusa_api.API_VERSION
+
+
+# -- /api/health liveness semantics preserved -------------------------------
+
+
+def test_health_preserves_status_service_timestamp(client):
+    body = client.get("/api/health").get_json()
+    assert body["status"] == "ok"
+    assert body["service"] == "medusa-api"
+    assert isinstance(body["timestamp"], (int, float))
+
+
+def test_health_is_ok_with_no_snapshot_or_stale_engine_evidence(client, empty_data_dir):
+    """Health is process-liveness only: it stays 200/"ok" even when there is
+    no snapshot at all (and therefore no fresh-engine evidence)."""
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert body["service"] == "medusa-api"
+    assert body["version"] == medusa_api.API_VERSION
+    # Liveness must not encode snapshot/engine freshness fields.
+    assert "engine_alive" not in body
+    assert "snapshot_age_seconds" not in body
+
+
+# -- /api/status contracts preserved ----------------------------------------
+
+
+def test_status_returns_404_without_snapshots(client, empty_data_dir):
+    """Existing 404 contract is unchanged when no snapshot exists."""
+    resp = client.get("/api/status")
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "No snapshots found"}
+
+
+def test_status_with_snapshot_reports_configured_port_and_all_keys(client, snapshot_data_dir):
+    """With a snapshot present, /api/status is 200, reports the configured
+    custom port, and retains every existing response key."""
+    medusa_api.app.config["API_PORT"] = 9090
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["api_port"] == 9090
+    assert _STATUS_KEYS.issubset(body.keys())
+    assert body["latest_snapshot"] == "v070_gen000123.npz"
+    assert body["total_snapshots"] == 1
+    assert body["engine_alive"] in (True, False)
+
+
+def test_status_default_port_is_module_default_at_import_time(client, snapshot_data_dir):
+    """Import-time / unconfigured fallback is the module default 8080."""
+    body = client.get("/api/status").get_json()
+    assert body["api_port"] == 8080
+
+
+# -- public CLI -> app configuration wiring (socket-free) -------------------
+
+
+def test_public_cli_port_wires_into_runtime_config():
+    """Prove the public --port value flows into the app's runtime config via
+    the same parser the __main__ block uses — without binding a socket or
+    running a server."""
+    parser = medusa_api._build_arg_parser()
+    args = parser.parse_args(["--port", "9090"])
+    returned = medusa_api.configure_runtime(args)
+    assert returned is medusa_api.app
+    assert medusa_api.app.config["API_PORT"] == 9090
+
+
+def test_public_cli_default_port_is_8080():
+    parser = medusa_api._build_arg_parser()
+    args = parser.parse_args([])
+    medusa_api.configure_runtime(args)
+    assert medusa_api.app.config["API_PORT"] == 8080
+
+
+def test_configured_port_zero_is_reported_verbatim(client, snapshot_data_dir):
+    """--port 0 is honestly the *configured* launch port (0), not the OS-bound
+    port an actual server would select at bind time."""
+    parser = medusa_api._build_arg_parser()
+    args = parser.parse_args(["--port", "0"])
+    medusa_api.configure_runtime(args)
+    body = client.get("/api/status").get_json()
+    assert body["api_port"] == 0
+
+
+# -- event-bus disabled during tests ----------------------------------------
+
+
+def test_event_bus_disabled_during_tests():
+    """The module was imported with the event bus disabled: no publisher and
+    no watcher were constructed (no socket bound, no thread started)."""
+    assert os.environ.get("MEDUSA_EVENT_BUS_DISABLED") == "1"
+    assert medusa_api._event_publisher is None
+    assert medusa_api._state_watcher is None

--- a/tests/test_medusa_api.py
+++ b/tests/test_medusa_api.py
@@ -14,24 +14,34 @@ port is bound, no OS process is launched, and no real repository data is read
 (the snapshot directory is monkeypatched to a temp path and any snapshot file
 is a synthetic byte blob — /api/status only stats it, never loads it).
 
-The event bus (a ZMQ PUB socket + telemetry watcher thread) is disabled BEFORE
-the module is imported, so importing it here binds no socket and starts no
-thread.
+The event bus (a ZMQ PUB socket + telemetry watcher thread) is disabled for the
+duration of importing the module — via a scoped ``patch.dict`` that restores
+the prior environment immediately afterward — so importing binds no socket and
+starts no thread, and leaks no env flag into the rest of the pytest process.
 """
 
 from __future__ import annotations
 
 import os
-
-# Disable the event-bus PUB socket / watcher thread before importing the module
-# under test, so import binds no network port and starts no background thread.
-os.environ["MEDUSA_EVENT_BUS_DISABLED"] = "1"
+from unittest import mock
 
 import pytest
 
 pytest.importorskip("flask")  # flask is an optional dependency for the REST API.
 
-from scripts import medusa_api  # noqa: E402  (import after env flag is set)
+# Record the ambient environment before the scoped import so a test can prove
+# the override restored it exactly — including the originally-absent case.
+_EVENT_BUS_ENV_KEY = "MEDUSA_EVENT_BUS_DISABLED"
+_ENV_BEFORE_IMPORT = os.environ.get(_EVENT_BUS_ENV_KEY)
+
+# Disable the event-bus PUB socket / watcher thread ONLY for the duration of
+# importing the module under test, then restore the exact prior environment.
+# Unlike a bare ``os.environ`` assignment, ``patch.dict`` leaks nothing into
+# the rest of the pytest process (Jack re-audit: collection-time containment).
+with mock.patch.dict(os.environ, {_EVENT_BUS_ENV_KEY: "1"}):
+    from scripts import medusa_api  # noqa: E402  (import inside the scoped override)
+
+_ENV_AFTER_IMPORT = os.environ.get(_EVENT_BUS_ENV_KEY)
 
 
 # -- fixtures ---------------------------------------------------------------
@@ -197,12 +207,47 @@ def test_configured_port_zero_is_reported_verbatim(client, snapshot_data_dir):
     assert body["api_port"] == 0
 
 
+def test_main_entry_point_configures_port_before_app_run(monkeypatch):
+    """Production entry-point regression (Jack re-audit): main() must drive the
+    real parse -> configure_runtime -> app.run chain, wiring the configured
+    port BEFORE app.run. app.run is monkeypatched to capture its arguments and
+    the config value at the instant it is invoked — socket-free, no server, no
+    bound port. Fails if configure_runtime(args) is removed from main() or
+    moved after app.run (the captured port-at-run would not be 9090)."""
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        # Snapshot app config at the exact moment app.run is invoked.
+        captured["api_port_at_run"] = medusa_api.app.config.get("API_PORT")
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(medusa_api.app, "run", fake_run)
+    medusa_api.main(["--host", "127.0.0.1", "--port", "9090"])
+
+    assert captured["api_port_at_run"] == 9090          # configured BEFORE run
+    assert medusa_api.app.config["API_PORT"] == 9090
+    assert captured["kwargs"]["host"] == "127.0.0.1"
+    assert captured["kwargs"]["port"] == 9090
+    assert captured["kwargs"]["debug"] is False
+    assert captured["kwargs"]["threaded"] is True
+
+
 # -- event-bus disabled during tests ----------------------------------------
 
 
-def test_event_bus_disabled_during_tests():
-    """The module was imported with the event bus disabled: no publisher and
-    no watcher were constructed (no socket bound, no thread started)."""
-    assert os.environ.get("MEDUSA_EVENT_BUS_DISABLED") == "1"
+def test_event_bus_was_disabled_at_import():
+    """The module was imported with the event bus disabled: neither the ZMQ
+    publisher nor the watcher thread was constructed (no socket bound, no
+    thread started)."""
     assert medusa_api._event_publisher is None
     assert medusa_api._state_watcher is None
+
+
+def test_scoped_import_restored_the_environment_exactly():
+    """The scoped import override restored the ambient environment exactly —
+    including when MEDUSA_EVENT_BUS_DISABLED was originally absent (None ==
+    None) — so this module's collection-time env leakage cannot return. A
+    reintroduced permanent ``os.environ[...] = "1"`` would make the after-value
+    differ from the before-value and fail this pin."""
+    assert _ENV_AFTER_IMPORT == _ENV_BEFORE_IMPORT


### PR DESCRIPTION
# fix(medusa-api): report configured launch port + single-source API version

Bounded REST-API runtime-reporting task. **Boundary: exactly two files** —
`scripts/medusa_api.py` and new `tests/test_medusa_api.py`.

## 1. Confirmed defect — `/api/status` misreported the configured port

`/api/status` returned the module constant `API_PORT` (8080) regardless of the
public `--port` value, which was only threaded into `app.run(...)`. Launching
`--port 9090` made the server listen on 9090 while `/api/status` still
advertised `"api_port": 8080` — a genuine operator-visibility defect
(reproduced by the failing-first pin below).

**Fix:** the public CLI now wires the parsed `--port` into the app's runtime
config before `app.run`, and `/api/status` reports that configured value:

- `_build_arg_parser()` holds the public parser (grammar byte-identical to
  before — see §Preserved).
- `configure_runtime(args)` sets `app.config["API_PORT"] = args.port` and is
  called from `__main__` before `app.run`.
- `/api/status` reports `app.config.get("API_PORT", API_PORT)` — the
  **configured launch port**, with `8080` remaining the import-time/default
  fallback.

This is honestly the *configured* launch port: with `--port 0` it reports `0`,
**not** the OS-selected bound port an actual server would choose at bind time
(pinned by `test_configured_port_zero_is_reported_verbatim`).

## 2. Additive version visibility

The semantic version `"1.2.0"` was a bare literal on the root endpoint and
absent from `/api/health`. It is now single-sourced as `API_VERSION = "1.2.0"`,
used by `/`, and added to `/api/health`. No new `/api/version` route.

## 3. Preserved `/api/health` semantics

`/api/health` remains the **API-process liveness** endpoint:
`status:"ok"`, `service`, and `timestamp` are retained; `version` is added; and
it is deliberately **independent of snapshot presence or engine freshness**
(no `engine_alive`/`snapshot_age` coupling). Verified by
`test_health_is_ok_with_no_snapshot_or_stale_engine_evidence`.

## Preserved contracts

- Public argparse grammar unchanged (`--port type=int default=8080`,
  `--host type=str default=0.0.0.0`) — the `add_argument` lines are
  byte-identical, only relocated into `_build_arg_parser()`.
- The docstring usage strings pinned by `tests/test_medusa_start.py`
  (`python -m scripts.medusa_api` present; `python scripts/medusa_api.py`
  absent) are unchanged (`test_medusa_start.py` passes).
- Every existing successful response key is retained; the `/api/status`
  no-snapshot `404 {"error": "No snapshots found"}` contract is unchanged.

## Explicit non-goals honored

No `/api/version` route; no engine-liveness coupling in `/api/health`; no
corrupt-`.npz`/malformed-JSON error policy; no global Flask error handler; no
`allow_pickle` change; no dependency/README/AGENT_HANDOFF/phase-doc/
`medusa_start.py` edit; no dead-flag cleanup; no endpoint-wide hardening or
refactor; no tuning/event-bus/orchestrator/engine/agent-backend/OpenAI/
Anthropic/Ian-lane edits.

## Jack re-audit repair (commit 2 — two test-integrity closures)

**Closure 1 — environment containment.** The test module set
`os.environ["MEDUSA_EVENT_BUS_DISABLED"] = "1"` at collection time and left it
set for the rest of the pytest process. It now uses a scoped
`unittest.mock.patch.dict` around the module import that restores the exact
prior environment immediately afterward (correct when the var was originally
absent). The "no publisher / no watcher constructed" proof is preserved; the
stale `env == "1"` assertion is removed; a new pin records the env value
immediately before and after the scoped import and fails if collection-time
leakage returns. *Proof:* fresh process with the flag ambient-absent →
after import the env is still `None` (contained); the recorded before/after are
`None`/`None`.

**Closure 2 — real entry-point wiring.** The wiring test previously called
`_build_arg_parser()` / `configure_runtime()` itself and never exercised the
production chain. A small importable `main(argv=None)` now parses via the
existing authoritative parser, calls `configure_runtime(args)`, prints the
unchanged startup banner, and calls `app.run(host=…, port=…, debug=False,
threaded=True)`; the `__main__` guard calls `main()`. A new socket-free
regression monkeypatches `app.run`, calls
`main(["--host","127.0.0.1","--port","9090"])`, and asserts that **at the moment
`app.run` is invoked** `app.config["API_PORT"] == 9090` and the run call
received host `127.0.0.1`, port `9090`, `debug` False, `threaded` True.
*Failing-first:* without the production `main()` the regression is RED
(`AttributeError`); with `configure_runtime` bypassed the captured port-at-run
is `8080`, not `9090` — so the test fails if `configure_runtime` is removed from
`main()` or moved after `app.run`.

Production behavior from commit 1 is unchanged (the startup sequence and the
`app.run` call are byte-for-byte the same, only relocated into `main()`).

## Failing-first & green receipts

**Failing-first — original defect (commit 1, only `medusa_api.py` reverted):**
```
FAILED tests/test_medusa_api.py::test_status_reports_configured_port_not_module_default
FAILED tests/test_medusa_api.py::test_health_includes_api_version
  AssertionError: assert None == '1.2.0'
  pre-fix health body = {'service': 'medusa-api', 'status': 'ok', 'timestamp': ...}
```
- Port pin: pre-fix `/api/status` reported `8080` where `9090` was configured.
- Health pin: pre-fix `/api/health` had no `version` key.

**Failing-first — re-audit (commit 2):** the entry-point regression is RED
without the production `main()` (`AttributeError: module 'scripts.medusa_api'
has no attribute 'main'`).

**Green after both commits:**
- Focused `tests/test_medusa_api.py`: **15 passed** (in-process Flask
  `test_client` — no live server, no bound network port, no OS process, no real
  repository data; the event bus is disabled *for the scoped import* and the
  environment is restored; snapshots are synthetic byte blobs in a monkeypatched
  temp `DATA_DIR`).
- Adjacent `test_medusa_start.py` + `test_tuning_api.py` +
  `test_params_schema.py` + `test_event_bus.py`: **279 passed**.
- Full suite: **1956 passed, 48 skipped** (was 1941/48 on main; +15).
- `python -m py_compile` clean on both files.

## Boundary & diffstat

Exactly the two authorized files, cumulative vs base `c6b0dc7`:
```
 scripts/medusa_api.py    |  52 +++++++--
 tests/test_medusa_api.py | 253 +++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 299 insertions(+), 6 deletions(-)
```

## Head & parent

- Head: `6869adff101813b76728fad0c5e904a249fe96d9`
  (commit 2; parent `6af70e3fa1b74d89d48fdd00552889486c62855f`).
- Two ordinary commits on base `c6b0dc77926c6133aa81e38b5eac48a3d15a7079`
  (current `main`, the #408 squash; single parent `6b7a01c0`).

## Live checks

All registered checks on the current head `6869adf` are conclusive **success**:

| Check | Result |
|---|---|
| verify-python (×2) | success |
| frontend-quality (×2) | success |
| Analyze Python | success |
| CodeQL | success |
| agent-safety | success |

No failures; no follow-up repair required. (The label/open-triggered Theory
Tripwire does not re-register on a push to an existing PR; it ran success on the
open head and is non-blocking by design.)

## Isolation confirmation

`#409` (`fix/openai-argument-decode-totality`) and `#410`
(`fix/anthropic-response-decode-totality`) were **not inspected** beyond board
metadata; the agent-backend / OpenAI / Anthropic decoding surface and Ian's
lane were **not touched** (`medusa_api.py` imports none of them — only
`tuning_api`, `event_bus`, flask, numpy, lazy trimesh). During the build and
re-audit repair there was no review-thread action, no process launch, and no
deployment.

## Status — MERGED

**Merged 2026-07-23 (Sydney)** by ordinary head-pinned squash
(`--match-head-commit 6869adf`; no admin/bypass/force/rebase) → `main`
**`6f035bff6d6800f03f823f21a4c0615e05c846ca`** (single parent
`c6b0dc77926c6133aa81e38b5eac48a3d15a7079`, the #408 squash). Kev authorized the
merge on-seat; Jack's audit completed. The squash contains exactly the two
authorized files, `+299 / −6`. No review-thread action and no deployment
occurred; the remote branch was removed **automatically** by the repository's
delete-branch-on-merge setting (not manually). The technical and failing-first
history above is preserved.
