### PR TITLE
fix(agent-backends): OpenAI inbound-response shape totality — match Anthropic boundary

### DIFF
--- a/scripts/agent_backends/openai_compat_backend.py
+++ b/scripts/agent_backends/openai_compat_backend.py
@@ -265,27 +265,53 @@ class OpenAICompatBackend(AgentBackend):
 
     @staticmethod
     def _response_from_wire(response: Any) -> AgentResponse:
-        choices = _attr_or_key(response, "choices", None) or []
-        if not choices:
+        """Convert an OpenAI-compatible ChatCompletion into our `AgentResponse`.
+
+        Supported containers are SDK-style typed objects (ordinary attribute
+        access, which is inherent to supporting them) and exact built-in dicts
+        (built-in lookup first); dict SUBCLASSES are refused as unsupported
+        mapping containers without invoking their overridden `.get()` or
+        attribute hooks — see `_attr_or_key`. Arbitrary hostile NON-dict
+        proxies are outside the supported SDK-object contract (supporting real
+        SDK typed objects requires ordinary attribute access). This matches the
+        established AnthropicBackend boundary contract.
+
+        Within that contract decoding is total and hook-free over extracted
+        field values: `choices` and `tool_calls` are iterated only after an
+        exact-`list` proof (a list SUBCLASS is refused); `content`, the
+        tool-call `type` discriminator, `finish_reason`, and the tool-call
+        `id`/`name` are exact-type-checked before any truth, equality, hashing,
+        iteration, mapping-conversion, or string-conversion could run, and
+        `id`/`name` are handed to `ToolUseBlock` for its established
+        normalization (no truth-testing `or`). `finish_reason` keeps the
+        established semantics — absent, None, or empty exact string →
+        "end_turn"; a known exact string → its mapped value; any other exact
+        string → "other"; a non-string → "other". A dict-subclass `usage`
+        container is refused to empty usage.
+        """
+        choices = _attr_or_key(response, "choices", None)
+        if type(choices) is not list or not choices:
             return AgentResponse.from_content([], stop_reason="other", usage={})
         choice = choices[0]
         msg = _attr_or_key(choice, "message", None)
 
         blocks: list[ContentBlock] = []
         text = _attr_or_key(msg, "content", None) if msg is not None else None
-        if isinstance(text, str) and text:
+        if type(text) is str and text:
             blocks.append(TextBlock(text=text))
 
         tool_calls = _attr_or_key(msg, "tool_calls", None) if msg is not None else None
-        if tool_calls:
+        if type(tool_calls) is list:
             for tc in tool_calls:
                 tc_type = _attr_or_key(tc, "type", "function")
-                if tc_type != "function":
-                    continue  # unknown tool-call kind; ignore for now
+                # The discriminator is proven exact str before the equality
+                # check, so a non-str / hostile-__eq__ type never runs a hook.
+                if type(tc_type) is not str or tc_type != "function":
+                    continue  # unknown / absent-typed tool-call kind; ignore
                 fn = _attr_or_key(tc, "function", None)
                 if fn is None:
                     continue
-                name = _attr_or_key(fn, "name", "") or ""
+                name = _attr_or_key(fn, "name", "")
                 # `arguments` is model/server-reachable and can be any value,
                 # so decoding is total and hook-free: the value's truthiness,
                 # iteration, mapping-conversion, and string-conversion hooks
@@ -310,16 +336,31 @@ class OpenAICompatBackend(AgentBackend):
                     args = args_raw
                 else:
                     args = {}
+                # `id`/`name` are handed to ToolUseBlock unchanged (no `or`
+                # truth-test); ToolUseBlock keeps them only when exactly str.
                 blocks.append(ToolUseBlock(
-                    id=_attr_or_key(tc, "id", "") or "",
+                    id=_attr_or_key(tc, "id", ""),
                     name=name,
                     input=args,
                 ))
 
-        raw_finish = _attr_or_key(choice, "finish_reason", "stop") or "stop"
-        stop_reason: StopReason = _FINISH_REASON_MAP.get(raw_finish, "other")
+        # finish_reason: preserve established absent/None/empty → "end_turn";
+        # exact-type-checked before the mapping lookup so a non-str value is
+        # never hashed or compared (no __hash__/__eq__ hook).
+        raw_finish = _attr_or_key(choice, "finish_reason", None)
+        if raw_finish is None:
+            stop_reason: StopReason = "end_turn"
+        elif type(raw_finish) is str:
+            if raw_finish == "":
+                stop_reason = "end_turn"
+            else:
+                stop_reason = _FINISH_REASON_MAP.get(raw_finish, "other")
+        else:
+            stop_reason = "other"
 
         usage_obj = _attr_or_key(response, "usage", None)
+        if isinstance(usage_obj, dict) and type(usage_obj) is not dict:
+            usage_obj = None  # dict-subclass usage container refused → empty usage
         usage: dict[str, Any] = {}
         if usage_obj is not None:
             usage = {
@@ -334,14 +375,32 @@ class OpenAICompatBackend(AgentBackend):
 
 
 def _attr_or_key(obj: Any, name: str, default: Any = None) -> Any:
-    """Read `name` from an object via attribute access, falling back to dict."""
-    if obj is None:
+    """Read `name` from a supported container, else return `default`.
+
+    Supported-container contract (matches AnthropicBackend._attr_or_key):
+      - an exact built-in dict takes the built-in dict lookup path first
+        (its `.get` cannot be overridden);
+      - a dict SUBCLASS is refused as an unsupported mapping container —
+        checked before any attribute access, so neither its overridden
+        `.get()` nor its attribute hooks are ever invoked;
+      - anything else keeps ordinary attribute access, which is inherent to
+        supporting SDK-style typed objects (and SimpleNamespace test fixtures);
+      - missing fields return `default`.
+
+    Arbitrary hostile NON-dict proxies (objects with adversarial `__getattr__`)
+    are outside the supported SDK-object contract: supporting real SDK typed
+    objects requires ordinary attribute access, and JSON received through an
+    ordinary provider deserializes to builtins only, so a dict subclass or a
+    hostile proxy is unreachable via PUBLIC provider traffic and reachable only
+    by DIRECT / injected-client construction.
+    """
+    if type(obj) is dict:
+        return obj.get(name, default)
+    if isinstance(obj, dict):
         return default
     val = getattr(obj, name, None)
     if val is not None:
         return val
-    if isinstance(obj, dict):
-        return obj.get(name, default)
     return default
 
 

--- a/tests/test_openai_compat_backend.py
+++ b/tests/test_openai_compat_backend.py
@@ -677,3 +677,397 @@ def test_response_shape_compatible_with_orchestrator_loop():
     assert resp.tool_calls[0].id == "tu_1"
     assert resp.tool_calls[0].name == "f"
     assert resp.tool_calls[0].arguments == {"x": 1}
+
+
+# ============================================================================
+# Inbound-response shape totality (Kev-owned lane): the OpenAI-compatible
+# inbound decoder matches the established AnthropicBackend boundary contract —
+# exact-dict lookup (built-in .get, never a subclass override), an exact-list
+# proof before iterating `choices` / `tool_calls`, and exact-type checks on
+# content, the tool-call `type` discriminator, `finish_reason`, `id` and `name`
+# before any truth / equality / hashing / iteration / mapping / string
+# conversion could run.
+#
+# DIRECT vs PUBLIC reachability: JSON received through an ordinary provider
+# deserializes to builtins only (exact dict / list / str / int / float / bool /
+# None), so a dict-or-list SUBCLASS or a hostile proxy CANNOT arrive over
+# PUBLIC provider traffic — these cells are reachable only by DIRECT /
+# injected-client construction (a local-server shim, a proxy, a test double).
+# They are pinned because an injected client can construct exactly them.
+# ============================================================================
+
+
+def _from_wire(response: Any) -> AgentResponse:
+    """Call the inbound decoder directly. Equivalent to the injected-client
+    path: `complete()` forwards the client's response into `_response_from_wire`
+    (see `_complete_with_injected_response`)."""
+    return openai_compat_backend_module.OpenAICompatBackend._response_from_wire(response)
+
+
+def _complete_with_injected_response(response: Any) -> AgentResponse:
+    """Drive the FULL public path with a dependency-injected client whose
+    `.create()` returns `response` — the literal DIRECT/injected-client lane."""
+    client = _MockClient()
+    client.chat.completions.response = response
+    backend = OpenAICompatBackend(client=client)
+    return backend.complete(messages=[Message(role="user", content="x")], tools=[])
+
+
+def _wrap(*, message: Any, finish_reason: Any = "stop", usage: Any = None) -> SimpleNamespace:
+    """A response envelope around one choice (all exact SimpleNamespace/list)."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=usage,
+    )
+
+
+class _RecordingGetDict(dict):
+    """A dict SUBCLASS whose overridden `.get()` records every call. A decoder
+    honoring the exact-dict contract must never invoke it."""
+
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.get_calls: list = []
+
+    def get(self, key, default=None):
+        self.get_calls.append(key)
+        return super().get(key, default)
+
+
+class _BenignDictSub(dict):
+    """A dict subclass with no overridden behavior — still refused, because the
+    contract is exact-type, not behavior-sniffing."""
+
+
+class _ListSub(list):
+    """A list subclass — refused by the exact-list proof for envelopes."""
+
+
+class _HostileEq:
+    """A non-str discriminator/value whose equality and hash hooks must never
+    run (default truthiness is used, so `or` would slip past __bool__)."""
+
+    def __eq__(self, other):
+        raise AssertionError("hook invoked: __eq__")
+
+    def __hash__(self):
+        raise AssertionError("hook invoked: __hash__")
+
+
+class _HostileScalar:
+    """A value whose truth / iteration / str / hash / eq hooks all raise."""
+
+    def __bool__(self):
+        raise AssertionError("hook invoked: __bool__")
+
+    def __iter__(self):
+        raise AssertionError("hook invoked: __iter__")
+
+    def __str__(self):
+        raise AssertionError("hook invoked: __str__")
+
+    def __hash__(self):
+        raise AssertionError("hook invoked: __hash__")
+
+    def __eq__(self, other):
+        raise AssertionError("hook invoked: __eq__")
+
+
+# -- FAILING-FIRST reproduction: dict-subclass function container -------------
+
+
+def test_dict_subclass_function_container_get_hook_not_invoked():
+    """CONFIRMED DIRECT/injected-client defect reproduction. A dict-subclass
+    `function` container with an overridden `.get()` previously had that hook
+    executed while `arguments` (and `name`) were retrieved. The exact-dict
+    contract refuses the subclass before any `.get()` runs; extracted values
+    fall back to defaults (name "", input {}). This is DIRECT/injected only —
+    a provider's JSON deserializes to an exact dict, never a dict subclass."""
+    fn = _RecordingGetDict({"name": "f", "arguments": '{"k": 1}'})
+    tc = SimpleNamespace(id="tu_x", type="function", function=fn)
+    resp = _complete_with_injected_response(
+        _wrap(message=SimpleNamespace(content=None, tool_calls=[tc]),
+              finish_reason="tool_calls"))
+    assert fn.get_calls == []                 # overridden .get() never invoked
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].arguments == {}
+    assert resp.tool_calls[0].name == ""
+    assert resp.tool_calls[0].id == "tu_x"    # id read from the exact-object tc
+
+
+# -- container matrix: exact dict vs benign/hostile dict subclass ------------
+
+
+def test_top_level_exact_dict_response_translates():
+    resp = _from_wire({
+        "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 4},
+    })
+    assert resp.text == "hi"
+    assert resp.stop_reason == "end_turn"
+    assert resp.usage == {"input_tokens": 3, "output_tokens": 4}
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_top_level_response_refused(factory):
+    r = factory({"choices": [{"message": {"content": "hi"}}], "usage": {}})
+    resp = _from_wire(r)
+    assert resp.text is None
+    assert resp.tool_calls == []
+    assert resp.stop_reason == "other"
+    if isinstance(r, _RecordingGetDict):
+        assert r.get_calls == []
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_choice_refused(factory):
+    choice = factory({"message": {"content": "hi"}, "finish_reason": "stop"})
+    resp = _from_wire(SimpleNamespace(choices=[choice], usage=None))
+    assert resp.text is None                 # message on a subclass choice refused
+    assert resp.stop_reason == "end_turn"    # finish_reason refused → None → end_turn
+    if isinstance(choice, _RecordingGetDict):
+        assert choice.get_calls == []
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_message_refused(factory):
+    msg = factory({
+        "content": "hi",
+        "tool_calls": [{"id": "t", "type": "function",
+                        "function": {"name": "f", "arguments": "{}"}}],
+    })
+    resp = _from_wire(_wrap(message=msg, finish_reason="stop"))
+    assert resp.text is None
+    assert resp.tool_calls == []
+    if isinstance(msg, _RecordingGetDict):
+        assert msg.get_calls == []
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_tool_call_container_skipped(factory):
+    tc = factory({"id": "t", "type": "function",
+                  "function": {"name": "f", "arguments": "{}"}})
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    # subclass tc: `type` refused → default "function"; `function` refused →
+    # None → the call is skipped. No .get() hook.
+    assert resp.tool_calls == []
+    if isinstance(tc, _RecordingGetDict):
+        assert tc.get_calls == []
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_function_container_refused(factory):
+    fn = factory({"name": "f", "arguments": '{"k": 1}'})
+    tc = SimpleNamespace(id="tu_x", type="function", function=fn)
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].name == ""
+    assert resp.tool_calls[0].arguments == {}
+    if isinstance(fn, _RecordingGetDict):
+        assert fn.get_calls == []
+
+
+@pytest.mark.parametrize("factory", [_BenignDictSub, _RecordingGetDict])
+def test_dict_subclass_usage_refused_to_empty(factory):
+    u = factory({"prompt_tokens": 5, "completion_tokens": 7})
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="x", tool_calls=None),
+        finish_reason="stop", usage=u))
+    assert resp.usage == {}
+    if isinstance(u, _RecordingGetDict):
+        assert u.get_calls == []
+
+
+# -- exact list vs list subclass for response envelopes ----------------------
+
+
+def test_list_subclass_choices_refused():
+    choices = _ListSub([SimpleNamespace(
+        message=SimpleNamespace(content="hi", tool_calls=None), finish_reason="stop")])
+    resp = _from_wire(SimpleNamespace(choices=choices, usage=None))
+    assert resp.text is None
+    assert resp.tool_calls == []
+    assert resp.stop_reason == "other"
+
+
+def test_list_subclass_tool_calls_not_iterated():
+    tcs = _ListSub([_tc("t", "f", {})])
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="hi", tool_calls=tcs), finish_reason="stop"))
+    assert resp.text == "hi"
+    assert resp.tool_calls == []
+
+
+def test_exact_list_choices_and_tool_calls_iterated():
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="hi", tool_calls=[_tc("t", "f", {"a": 1})]),
+        finish_reason="tool_calls"))
+    assert resp.text == "hi"
+    assert [t.name for t in resp.tool_calls] == ["f"]
+
+
+# -- hostile / malformed tool-call discriminators ----------------------------
+
+
+def test_hostile_tool_call_type_discriminator_skipped_without_hook():
+    tc = SimpleNamespace(id="t", type=_HostileEq(),
+                         function=SimpleNamespace(name="f", arguments="{}"))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert resp.tool_calls == []             # non-str discriminator → skip; __eq__ never called
+
+
+def test_unknown_string_tool_call_type_skipped():
+    tc = SimpleNamespace(id="t", type="web_search",
+                         function=SimpleNamespace(name="f", arguments="{}"))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert resp.tool_calls == []
+
+
+def test_absent_tool_call_type_defaults_to_function():
+    tc = SimpleNamespace(id="t", function=SimpleNamespace(name="f", arguments='{"a": 1}'))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert [t.name for t in resp.tool_calls] == ["f"]     # missing type → "function"
+
+
+# -- content exact-type ------------------------------------------------------
+
+
+def test_str_subclass_content_ignored():
+    class _S(str):
+        pass
+
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=_S("hi"), tool_calls=None), finish_reason="stop"))
+    assert resp.text is None                 # content kept only when exactly str
+
+
+def test_hostile_content_value_yields_no_text_no_hook():
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=_HostileScalar(), tool_calls=None),
+        finish_reason="stop"))
+    assert resp.text is None                 # non-str content → no TextBlock, no hook
+
+
+# -- supplied id / name values (no truth-testing `or`) -----------------------
+
+
+def test_hostile_id_value_no_truth_hook():
+    tc = SimpleNamespace(id=_HostileScalar(), type="function",
+                         function=SimpleNamespace(name="f", arguments="{}"))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert resp.tool_calls[0].id == ""       # hostile id → ToolUseBlock normalizes, no `or`
+    assert resp.tool_calls[0].name == "f"
+
+
+def test_hostile_name_value_no_truth_hook():
+    tc = SimpleNamespace(id="t", type="function",
+                         function=SimpleNamespace(name=_HostileScalar(), arguments="{}"))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert resp.tool_calls[0].name == ""     # hostile name → ToolUseBlock normalizes, no `or`
+    assert resp.tool_calls[0].id == "t"
+
+
+def test_non_str_id_and_name_normalized_to_empty():
+    tc = SimpleNamespace(id=12345, type="function",
+                         function=SimpleNamespace(name=None, arguments="{}"))
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content=None, tool_calls=[tc]),
+        finish_reason="tool_calls"))
+    assert resp.tool_calls[0].id == ""
+    assert resp.tool_calls[0].name == ""
+
+
+# -- finish_reason matrix ----------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("stop", "end_turn"),
+    ("tool_calls", "tool_use"),
+    ("length", "max_tokens"),
+    ("content_filter", "other"),
+    ("function_call", "tool_use"),
+    ("stop_sequence", "stop_sequence"),
+    ("", "end_turn"),
+    ("totally-unknown", "other"),
+])
+def test_finish_reason_string_cases(raw, expected):
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="x", tool_calls=None), finish_reason=raw))
+    assert resp.stop_reason == expected
+
+
+def test_finish_reason_none_is_end_turn():
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="x", tool_calls=None), finish_reason=None))
+    assert resp.stop_reason == "end_turn"
+
+
+def test_finish_reason_missing_is_end_turn():
+    resp = _from_wire(SimpleNamespace(choices=[{"message": {"content": "x"}}], usage=None))
+    assert resp.stop_reason == "end_turn"
+
+
+def test_finish_reason_unhashable_list_is_other_without_hashing():
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="x", tool_calls=None), finish_reason=["x"]))
+    assert resp.stop_reason == "other"       # non-str → "other"; never hashed into the map
+
+
+def test_finish_reason_hostile_is_other_without_hook():
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(content="x", tool_calls=None), finish_reason=_HostileEq()))
+    assert resp.stop_reason == "other"       # non-str → no __eq__ / __hash__
+
+
+# -- mixed accepted / refused tool calls, order preserved --------------------
+
+
+def test_mixed_accepted_and_refused_tool_calls_preserve_order():
+    good1 = _tc("id1", "alpha", {"a": 1})
+    bad_type = SimpleNamespace(id="idX", type="web_search",
+                               function=SimpleNamespace(name="x", arguments="{}"))
+    sub_tc = _BenignDictSub({"id": "idY", "type": "function",
+                             "function": {"name": "y", "arguments": "{}"}})
+    hostile_type = SimpleNamespace(id="idZ", type=_HostileEq(),
+                                   function=SimpleNamespace(name="z", arguments="{}"))
+    good2 = _tc("id2", "beta", {"b": 2})
+    resp = _from_wire(_wrap(
+        message=SimpleNamespace(
+            content=None, tool_calls=[good1, bad_type, sub_tc, hostile_type, good2]),
+        finish_reason="tool_calls"))
+    assert [t.name for t in resp.tool_calls] == ["alpha", "beta"]
+    assert [t.id for t in resp.tool_calls] == ["id1", "id2"]
+    assert [t.arguments for t in resp.tool_calls] == [{"a": 1}, {"b": 2}]
+
+
+# -- accepted-value / output-byte behavior preserved -------------------------
+
+
+def test_exact_object_happy_path_roundtrips_unchanged():
+    """Ordinary SDK-object response still produces the exact accepted output —
+    text, tool call, mapped stop reason, and translated usage bytes."""
+    resp = _from_wire(_make_response(
+        content="checking",
+        tool_calls=[_tc("tu_1", "get_params", {"verbose": True})],
+        finish_reason="tool_calls",
+        prompt_tokens=11, completion_tokens=22))
+    assert resp.text == "checking"
+    assert resp.tool_calls[0].id == "tu_1"
+    assert resp.tool_calls[0].name == "get_params"
+    assert resp.tool_calls[0].arguments == {"verbose": True}
+    assert resp.stop_reason == "tool_use"
+    assert resp.usage == {"input_tokens": 11, "output_tokens": 22}


### PR DESCRIPTION
# fix(agent-backends): OpenAI inbound-response shape totality — match Anthropic boundary

New Kev-owned lane. Brings the OpenAI-compatible inbound-response decoder up to
the established `AnthropicBackend` boundary contract. **Boundary: exactly two
files** — `scripts/agent_backends/openai_compat_backend.py` and
`tests/test_openai_compat_backend.py`.

## SHAs

- Base / parent: `44c5d9cae1c9fe37053bd2945a4078ef3db681e5` (live `main`; the
  #410 Anthropic-decoder squash).
- Head: `9118876a18d7c4d9a3a7dbeb4e527447812b5e31` (one commit).

## Confirmed defect (failing-first reproduction)

A dict-**subclass** `function` container with an overridden `.get()` had that
hook executed while `arguments` (and `name`) were retrieved. Root cause in
`_attr_or_key`: it did attribute access first, then `isinstance(obj, dict)`
(which accepts subclasses) and called `obj.get(name, default)` — invoking the
subclass override.

`test_dict_subclass_function_container_get_hook_not_invoked` records every
`.get()` call on the container. On the pre-fix decoder the override fires
(`get_calls == ["name", "arguments"]`) and arguments are parsed; the test is
RED. After the fix the subclass is refused, `get_calls == []`, `name == ""`,
`arguments == {}`.

## DIRECT vs PUBLIC reachability

**DIRECT / injected-client only.** JSON received through an ordinary provider
deserializes to builtins (exact `dict`/`list`/`str`/`int`/`float`/`bool`/
`None`), so a dict-or-list **subclass** or a hostile proxy cannot arrive over
PUBLIC provider traffic. These shapes are constructible only by a
dependency-injected client (a local-server shim, a proxy, a test double), which
is exactly the lane the regression matrix pins.

## Repair (matches `AnthropicBackend`)

- `_attr_or_key`: exact built-in `dict` → built-in `.get` **first**; a dict
  **subclass** is refused before any attribute access (neither its overridden
  `.get()` nor attribute hooks run); otherwise ordinary attribute access (SDK
  typed objects / `SimpleNamespace`). Arbitrary hostile non-dict proxies are
  honestly outside the supported SDK-object contract.
- `_response_from_wire`: iterate `choices` and `tool_calls` only after an
  exact-`list` proof (list subclasses refused); exact-type-check `content`, the
  tool-call `type` discriminator, `finish_reason`, `id`, and `name` before any
  truth / equality / hashing / iteration / mapping / string conversion; remove
  the truth-testing `or` from `id`/`name` and let `ToolUseBlock` normalize;
  refuse a dict-subclass `usage` container to empty usage.
- **#409 argument parser retained byte-identical:** `""` → fresh `{}`; valid
  JSON object → kept; valid non-object JSON → fresh `{}`; malformed / parser
  recursion → established `{"_raw_arguments": original}` fallback; exact `dict`
  → kept for downstream `ToolUseBlock` normalization; every other shape → fresh
  `{}`; `MemoryError` remains uncaught.

## Exception policy

Transport errors propagate (unchanged). Decoding is total over field values and
never raises on a hostile/malformed shape (no hook is invoked before an
exact-type gate). `MemoryError` in the argument parser is deliberately not
caught. `finish_reason`: absent / `None` / empty exact string → `"end_turn"`;
known exact string → mapped; other exact string → `"other"`; non-string →
`"other"` (never hashed/compared).

## Preserved behavior

Public provider behavior, outbound translation, request construction,
configuration, model selection, wire schemas, and accepted output bytes. All
**36 pre-existing tests** are unchanged and green, including the
dict-shaped-response translation and the finish-reason mapping.

## Regression matrix (39 new tests)

- top-level response / choice / message / tool-call / function / usage
  containers as **exact dict** vs **benign** and **hostile** (recording-`.get()`)
  dict subclasses;
- **exact list** vs **list subclass** for `choices` and `tool_calls`;
- hostile (`__eq__`-raising) and unknown-string tool-call discriminators; absent
  `type` → `"function"`;
- hostile and non-`str` `id` / `name` (normalized by `ToolUseBlock`, no `or`);
- `str`-subclass and hostile `content`;
- missing / `None` / empty / known / unknown / **unhashable** / **hostile**
  finish reasons;
- mixed accepted + refused tool calls with **order preserved**;
- an accepted-value / output-byte round-trip pin.

## Receipts

- **Failing-first:** 20 new matrix tests RED on the pre-fix decoder (production
  file reverted, tests kept), including the dict-subclass `.get()` reproduction.
- Focused `tests/test_openai_compat_backend.py`: **75 passed**.
- Adjacent (openai-compat + anthropic + agent-backend + provider-parity +
  orchestrator + event-bus): **408 passed**.
- Full suite — **dependency-limited Kev-seat local run**: **2028 passed,
  48 skipped**. This local environment omits some optional dependencies, so it
  skips suites the fully provisioned CI runs; it is NOT the CI total.
- Full suite — **fully provisioned CI (`verify-python`, exact head
  `9118876`)**: **2151 passed, 12 skipped, 0 failed** on BOTH triggered runs
  (measured from the job logs, not inferred from the local count):
  - `pull_request`: run `30001354054`, verify-python job `89187049831`
  - `push`: run `30001304743`, verify-python job `89186890402`
- `python -m py_compile` clean on both files.

## Diffstat (exact two-file boundary)

```
 scripts/agent_backends/openai_compat_backend.py |  87 +++++-
 tests/test_openai_compat_backend.py             | 394 ++++++++++++++++++++++++
 2 files changed, 467 insertions(+), 14 deletions(-)
```

## Registered checks

All 8 registered checks on head `9118876` are conclusive **success**:

| Check | Result |
|---|---|
| verify-python (×2) | success |
| frontend-quality (×2) | success |
| Analyze Python | success |
| CodeQL | success |
| agent-safety | success |
| tripwire | success (non-blocking) |

## Review-thread count

0 review threads, 0 reviews.

## Residuals (honest)

- The contract accepts SDK-style typed objects via ordinary attribute access;
  an adversarial non-dict proxy with a hostile `__getattr__` is **outside** the
  supported SDK-object contract by design (supporting real SDK objects requires
  attribute access). This is stated, not defended against — it is DIRECT-only
  and unreachable via PUBLIC provider traffic.
- A dict-subclass `function` container yields a `ToolUseBlock` with empty
  `name` and `{}` input (refused-to-default), rather than being skipped — this
  mirrors the Anthropic contract's "append with defaults" for tool blocks.
- No scalar-length or total-byte ceiling is added here; `ToolUseBlock` already
  bounds `id`/`name` (256/128) and input-shape, and this PR does not change
  those bounds.

**MERGED 2026-07-23 (Sydney)** by ordinary head-pinned squash → `main`
`79e8868fc35cc900cc2946fcb5120640c47444fb` (single parent `44c5d9c`); Kev
authorized the merge on-seat, Jack's audit completed, and no review-thread
actions were taken. #412 (Ian's content-block lane) was not inspected beyond
board metadata; no other PR touched.
