### PR TITLE
fix(event-bus): StateWatcher retry/accounting — mark seen only on successful publish

### DIFF
--- a/scripts/event_bus.py
+++ b/scripts/event_bus.py
@@ -220,7 +220,9 @@ class StateWatcher(threading.Thread):
             self._stop.wait(self.poll_interval_s)
 
     def poll_once(self) -> int:
-        """Run one polling iteration. Returns the number of events published.
+        """Run one polling iteration. Returns the number of telemetry artifacts
+        successfully decoded and handed to the publisher (not a proof of wire
+        delivery — see `_publish_for`).
         Exposed for tests — lets them drive the watcher synchronously without
         waiting for the real poll interval.
         """
@@ -233,9 +235,10 @@ class StateWatcher(threading.Thread):
         new_files = [p for p in current if p.name not in self._seen]
         count = 0
         for path in new_files:
-            # Only mark a file seen (and count it) once it has actually been
-            # decoded and published. A file caught mid-write returns failure
-            # here and stays unseen, so a later poll retries it.
+            # Only mark a file seen (and count it) once it has decoded
+            # successfully and publisher.publish() has returned normally. A
+            # file caught mid-write returns failure here and stays unseen, so
+            # a later poll retries it.
             if self._publish_for(path):
                 self._seen.add(path.name)
                 count += 1
@@ -244,10 +247,14 @@ class StateWatcher(threading.Thread):
     def _publish_for(self, path: Path) -> bool:
         """Decode a telemetry artifact and hand it to the publisher.
 
-        Returns True iff the file decoded cleanly and was published. Returns
-        False for a transient read/JSON failure (e.g. a file still mid-write),
-        so `poll_once` leaves the name unseen and retries it on a later pass.
-        Exceptions outside the caught read/JSON set propagate unchanged.
+        Returns True iff the file decoded cleanly and publisher.publish
+        returned normally. Caught read/JSON failures (e.g. a file still
+        mid-write) return False, so `poll_once` leaves the name unseen and
+        retries it on a later pass; exceptions outside that caught set
+        propagate unchanged.
+
+        Note: a normally-returning publish is not proof of wire delivery — the
+        publisher deliberately drops when closed or at its high-water mark.
         """
         try:
             raw = path.read_text(encoding="utf-8")

--- a/scripts/event_bus.py
+++ b/scripts/event_bus.py
@@ -233,23 +233,34 @@ class StateWatcher(threading.Thread):
         new_files = [p for p in current if p.name not in self._seen]
         count = 0
         for path in new_files:
-            self._publish_for(path)
-            self._seen.add(path.name)
-            count += 1
+            # Only mark a file seen (and count it) once it has actually been
+            # decoded and published. A file caught mid-write returns failure
+            # here and stays unseen, so a later poll retries it.
+            if self._publish_for(path):
+                self._seen.add(path.name)
+                count += 1
         return count
 
-    def _publish_for(self, path: Path) -> None:
+    def _publish_for(self, path: Path) -> bool:
+        """Decode a telemetry artifact and hand it to the publisher.
+
+        Returns True iff the file decoded cleanly and was published. Returns
+        False for a transient read/JSON failure (e.g. a file still mid-write),
+        so `poll_once` leaves the name unseen and retries it on a later pass.
+        Exceptions outside the caught read/JSON set propagate unchanged.
+        """
         try:
             raw = path.read_text(encoding="utf-8")
             data = json.loads(raw)
         except (OSError, ValueError):
-            # File may still be mid-write; skip this round and try next poll.
-            self._seen.discard(path.name)
-            return
+            # File may still be mid-write or transiently unreadable; report
+            # failure so poll_once leaves the name unseen and retries it.
+            return False
         self.publisher.publish(
             TOPIC_TELEMETRY_5MIN,
             {"file": path.name, "telemetry": data},
         )
+        return True
 
     def stop(self) -> None:
         self._stop.set()

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -179,10 +179,115 @@ def test_state_watcher_ignores_malformed_json(tmp_path):
     try:
         watcher = StateWatcher(pub, tmp_path)
         (tmp_path / "telemetry_bad.json").write_text("{not valid json")
-        # poll_once reports it as "attempted" but _seen is kept clean for retry;
-        # we just verify no event leaked out.
-        watcher.poll_once()
+        # A malformed file publishes nothing, is NOT counted as a published
+        # event, and is left retry-eligible (kept out of _seen) so a later poll
+        # can retry it once it becomes valid.
+        assert watcher.poll_once() == 0
         assert sub.recv(timeout_ms=100) is None
+        assert "telemetry_bad.json" not in watcher._seen
+    finally:
+        sub.close()
+        pub.close()
+
+
+def test_state_watcher_incomplete_then_completed_retries_and_emits_once(tmp_path):
+    """Regression (retry + accounting): a telemetry file caught mid-write must
+    not be consumed. The first poll returns 0 and leaves the name retry-eligible;
+    once the file is completed a later poll emits exactly one correct event and
+    marks it seen; a further poll is a no-op (no duplicate).
+    """
+    pub = EventPublisher(_unique_inproc_endpoint())
+    sub = EventSubscriber(pub.endpoint, topics=[TOPIC_TELEMETRY_5MIN])
+    time.sleep(0.05)
+    try:
+        watcher = StateWatcher(pub, tmp_path)
+        name = "telemetry_20260724T090000.json"
+        path = tmp_path / name
+
+        # 1. Incomplete (mid-write) JSON: no event, count 0, name retry-eligible.
+        path.write_text('{"gen": ')  # truncated → json.loads raises ValueError
+        assert watcher.poll_once() == 0
+        assert sub.recv(timeout_ms=100) is None
+        assert name not in watcher._seen
+
+        # 2. Complete the same file: the next poll emits exactly one event.
+        telemetry = {"gen": 1_500_001, "entropy": 0.5}
+        path.write_text(json.dumps(telemetry))
+        assert watcher.poll_once() == 1
+        msg = sub.recv(timeout_ms=500)
+        assert msg is not None
+        topic, _ts, payload = msg
+        assert topic == TOPIC_TELEMETRY_5MIN
+        assert payload["file"] == name
+        assert payload["telemetry"] == telemetry
+        assert name in watcher._seen
+
+        # 3. A further poll: no duplicate.
+        assert watcher.poll_once() == 0
+        assert sub.recv(timeout_ms=100) is None
+    finally:
+        sub.close()
+        pub.close()
+
+
+def test_state_watcher_mixed_poll_counts_only_valid_and_retains_incomplete(tmp_path):
+    """Regression (mixed batch): a single poll containing one valid and one
+    incomplete file counts/emits only the valid one and retains the incomplete
+    one for a later retry.
+    """
+    pub = EventPublisher(_unique_inproc_endpoint())
+    sub = EventSubscriber(pub.endpoint, topics=[TOPIC_TELEMETRY_5MIN])
+    time.sleep(0.05)
+    try:
+        watcher = StateWatcher(pub, tmp_path)
+        good_name = "telemetry_aaa_good.json"
+        bad_name = "telemetry_bbb_incomplete.json"
+        good = {"gen": 7, "ok": True}
+        (tmp_path / good_name).write_text(json.dumps(good))
+        (tmp_path / bad_name).write_text('{"gen":')  # incomplete
+
+        # Only the valid file is counted and emitted.
+        assert watcher.poll_once() == 1
+        msg = sub.recv(timeout_ms=500)
+        assert msg is not None
+        _topic, _ts, payload = msg
+        assert payload["file"] == good_name
+        assert payload["telemetry"] == good
+        assert sub.recv(timeout_ms=100) is None  # no second event
+
+        assert good_name in watcher._seen        # valid marked seen
+        assert bad_name not in watcher._seen      # incomplete retained for retry
+
+        # Completing the incomplete file lets a later poll emit it exactly once.
+        (tmp_path / bad_name).write_text(json.dumps({"gen": 8}))
+        assert watcher.poll_once() == 1
+        msg2 = sub.recv(timeout_ms=500)
+        assert msg2 is not None
+        assert msg2[2]["file"] == bad_name
+        assert bad_name in watcher._seen
+    finally:
+        sub.close()
+        pub.close()
+
+
+def test_state_watcher_transient_read_failure_is_retry_eligible(tmp_path):
+    """Regression (caught read-failure path): a glob-matching entry that cannot
+    be read as a text file (here a directory) exercises the OSError arm of
+    _publish_for. poll_once must count 0, emit nothing, and leave it
+    retry-eligible rather than consuming it.
+    """
+    pub = EventPublisher(_unique_inproc_endpoint())
+    sub = EventSubscriber(pub.endpoint, topics=[TOPIC_TELEMETRY_5MIN])
+    time.sleep(0.05)
+    try:
+        watcher = StateWatcher(pub, tmp_path)
+        # A directory whose name matches the telemetry glob: read_text() raises
+        # an OSError subclass (IsADirectoryError / PermissionError).
+        dir_name = "telemetry_readfail.json"
+        (tmp_path / dir_name).mkdir()
+        assert watcher.poll_once() == 0
+        assert sub.recv(timeout_ms=100) is None
+        assert dir_name not in watcher._seen
     finally:
         sub.close()
         pub.close()


### PR DESCRIPTION
## StateWatcher retry / accounting repair

Fixes a real correctness + observability defect in the Phase-18 event bus: a telemetry file caught mid-write is permanently marked seen so its eventual completed-file event is **lost forever**, plus a `poll_once()` return count that **overstated the artifacts it decoded and handed off** (it counted files it never even decoded). Bounded, two-file change under an explicit Kev authorization (Kev seat, Opus 4.8). **MERGED 2026-07-24 (Sydney) as ordinary head-pinned squash `dbc6cf0f4f247e95c67add5e3d406b3a1ba0699d` (single parent `a2f824b9f3c170bcbd8b5bd38e6c8d9ade2c9251`), under Kev's authorization with Jack's audit — no admin, bypass, force, rebase, or manual branch deletion; post-merge main CI green (`verify-python` 2154 passed / 12 skipped / 0 failed).**

### Base / head / parent
- **Base:** `main` at `a2f824b9f3c170bcbd8b5bd38e6c8d9ade2c9251`.
- **Head:** `fd1cf62087783d981b1907dea11a96e57a95d5db` on `fix/event-bus-state-watcher-retry-accounting` (2 commits: `af914f1` repair + `fd1cf62` claim-precision follow-up — docstrings/comments only, no executable or test change).
- **Parent of `af914f1`:** `a2f824b9f3c170bcbd8b5bd38e6c8d9ade2c9251` (single parent = base main).

### Two-file boundary and diffstat (cumulative)
| File | +/− |
|------|-----|
| `scripts/event_bus.py` | +26 / −8 |
| `tests/test_event_bus.py` | +108 / −3 |
| **Total** | **+134 / −11** |

`git diff --check` clean; `python -m py_compile` clean on both files.

### The defect
`StateWatcher.poll_once()` called `_publish_for(path)` and then **unconditionally** `self._seen.add(path.name)` + `count += 1`. `_publish_for()` tried to keep a mid-write file retry-eligible via `self._seen.discard(path.name)` in its `except (OSError, ValueError)` arm — but that discard ran *before* `poll_once()` added the name (and `new_files` already excludes seen names), so **the discard was a dead no-op**. Consequences on `main`:
- a `telemetry_*.json` caught mid-write was permanently marked seen → its eventual completed-file `telemetry.5min` event was **silently lost forever** (this consequence is exact — the completed event never fires again);
- `poll_once()` returned a count that **overstated the artifacts it decoded and handed off** — it counted files it never even decoded (its documented contract, now corrected, read "the number of events published").

### Failing-first receipt (run against pre-repair production behaviour)
```
$ python -m pytest tests/test_event_bus.py -k state_watcher -v
FAILED tests/test_event_bus.py::test_state_watcher_ignores_malformed_json
FAILED tests/test_event_bus.py::test_state_watcher_incomplete_then_completed_retries_and_emits_once
FAILED tests/test_event_bus.py::test_state_watcher_mixed_poll_counts_only_valid_and_retains_incomplete
FAILED tests/test_event_bus.py::test_state_watcher_transient_read_failure_is_retry_eligible
================= 4 failed, 2 passed, 10 deselected in 0.86s ==================
```
Each failure was `assert 1 == 0` — `poll_once()` counting/consuming an artifact it never decoded or handed off. The two pre-existing StateWatcher tests (`publishes_for_new_telemetry_file`, `bootstrap_skips_existing_files`) passed both before and after, confirming preserved behaviour.

### The repair (minimal)
- `_publish_for()` now returns `bool`: `True` iff the artifact **decoded cleanly and `publisher.publish()` returned normally** (a decode + hand-off — see the claim-precision note below); `False` for the existing caught read/JSON failures (`OSError`/`ValueError`, incl. a mid-write file).
- `poll_once()` adds the name to `_seen` and increments the count **only on success**, so a failed file stays retry-eligible for a later poll.
- Removed the dead `_seen.discard()` (the name was never present at that point).

### Claim-precision follow-up (commit `fd1cf62`, Jack audit — wording only)
`EventPublisher.publish()` can return normally while **deliberately dropping** a message — when the publisher is closed, or at its ZMQ high-water mark. So `_publish_for()` proves a successful decode and a *normally-returning* publish call, **not** actual wire delivery, and `poll_once()`'s count is "artifacts successfully decoded and handed to the publisher", **not** "events published on the wire". `fd1cf62` corrects `poll_once()`'s return doc, the loop comment, and `_publish_for()`'s docstring to state exactly that. No executable behaviour or test changed (full suite total unchanged).

### Preserved behaviour
Glob sort order; `run()` bootstrap of `_seen`; topic + payload bytes handed to `publish()`; daemon-thread containment (`run()`'s `try/except`); valid-file exactly-once hand-off; and **all `EventPublisher` / `EventSubscriber` public contracts unchanged** (no failing-first test proved a change necessary).

### Exception policy
Only the pre-existing caught set — `except (OSError, ValueError)` in `_publish_for()` — is treated as a transient failure and reported as `False`. Every other exception (including anything from `publisher.publish`) propagates unchanged out of `_publish_for()` and `poll_once()`; the daemon's `run()` loop retains its own `except Exception` containment so the thread still never dies.

### Reachability (honest)
DIRECT / **operational** — `StateWatcher` is an in-process daemon tailing `data/telemetry_*.json` on the filesystem. This is **not** a public CLI or REST-input defect; there is no untrusted-network boundary here. The trigger is the ordinary operational race between the engine's 5-minute telemetry dump and the watcher's 10-second poll.

### Test receipts
- **Focused** (`tests/test_event_bus.py`): **16 passed** (the 4 repaired pins + 2 pre-existing StateWatcher tests + publish/subscribe + TuningState integration).
- **Adjacent** (`test_event_bus.py` + `test_tuning_api.py` + `test_orchestrator.py` + `test_params_schema.py`): **449 passed**.
- **Local full maintained suite** (dependency-limited on this seat — the `uft_ca` Rust extension and some optional providers are absent, hence the skips): **2031 passed / 48 skipped / 0 failed** (+3 vs the prior 2028 local baseline = the three new pins; the strengthened test was already counted). Unchanged across the `fd1cf62` docstring follow-up.
- **CI** (fully provisioned — `uft_ca` extension built + optional providers installed): **2154 passed / 12 skipped / 0 failed** (`verify-python`), i.e. `2151` prior + the 3 new pins. Kept separate from the dependency-limited local figure above. (Finalized on the corrected head in the check table below.)

### Regression pins added / strengthened (`tests/test_event_bus.py`)
- `test_state_watcher_ignores_malformed_json` — **strengthened** the previously under-asserting test: now asserts `poll_once() == 0`, no event, and the name is left out of `_seen` (retry-eligible).
- `test_state_watcher_incomplete_then_completed_retries_and_emits_once` — incomplete → `0` + retry-eligible; completed → `1` + correct event + seen; further poll → `0`, no duplicate.
- `test_state_watcher_mixed_poll_counts_only_valid_and_retains_incomplete` — a single poll with one valid + one incomplete file counts/emits only the valid one and retains the incomplete one for retry.
- `test_state_watcher_transient_read_failure_is_retry_eligible` — a glob-matching directory exercises the caught `OSError` arm; `poll_once() == 0`, nothing emitted, retry-eligible (cleanly pinnable cross-platform without enlarging the production boundary).

### Honest residuals
- The **transient read-failure pin uses a directory** to raise an `OSError` subclass (`IsADirectoryError` on POSIX / `PermissionError` on Windows) — verified RED→GREEN on this Windows seat; it is a proxy for a genuine mid-write `OSError`, not a byte-for-byte reproduction of a specific I/O error.
- The count/`True` reflect **decode + a normally-returning hand-off, not wire delivery** — a publish dropped at HWM or after close still counts as handed off. This is now stated explicitly in the code and above; a delivery-confirmed contract would require a different mechanism and is out of scope.
- Two **known non-goals left untouched** (noted, not fixed here): `EventPublisher.publish` raises `AttributeError` on a non-`str` topic (`event_bus.py:109`) — developer-controlled topic constants, low value; and there is no upper bound on telemetry file size read into memory. Neither is part of this retry/accounting repair.
- No `EventPublisher`/`EventSubscriber` contract change was needed.

### Registered check results
All registered checks on the corrected head `fd1cf62` are conclusive and green (`statusCheckRollup`: SUCCESS):

| Check | Conclusion |
|-------|------------|
| `verify-python` | **SUCCESS** — `2154 passed, 12 skipped, 0 failed in 42.52s` (job `89393783382`; also SUCCESS on the second run) |
| `frontend-quality` | **SUCCESS** (×2 runs) |
| `agent-safety` | **SUCCESS** |
| `Analyze Python` / `CodeQL` | **SUCCESS** |
| `tripwire` | **SUCCESS** (label-only; no trigger labels present) |

The count is unchanged from head `af914f1` (`2154 / 12 / 0`), as expected for a docstring-only follow-up. Sealed under Kev's authorization with Jack's audit — see the merged-status line at the top.
