### PR TITLE
fix(portable-genome): transition-table structural refusals — typed PortableGenomeError

### DIFF
--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -43,6 +43,23 @@ MEMORY_CHANNEL_DEFS = [
 ]
 
 
+class PortableGenomeError(ValueError):
+    """Structural refusal for malformed portable-genome shapes.
+
+    Raised by :func:`import_genome` for the narrow set of top-level and
+    transition-table structural shapes validated in this module: the genome
+    root, ``format``, ``transition_table``, each source-state mapping, and each
+    source/target state name and neighbor-count key. Subclasses
+    :class:`ValueError` so existing callers that catch ``ValueError`` keep
+    working; the public ``info`` CLI catches this type specifically.
+
+    This does NOT make the whole importer total. Malformed shapes elsewhere in
+    the genome (e.g. non-object ``stochastic``/``contagion``/``metadata`` config
+    sections or the epigenetic snapshot) remain outside this package's scope and
+    still surface as their original exceptions.
+    """
+
+
 def export_genome(filepath, rule_spec, generation=0, ca_step=0, best_fitness=0.0,
                   lattice=None, memory_grid=None, include_epigenetic=False, pretty=True):
     """Export the organism complete genome to a portable JSON file."""
@@ -236,13 +253,22 @@ def import_genome(filepath):
     with open(filepath, "r", encoding="utf-8") as f:
         genome = json.load(f)
 
+    if type(genome) is not dict:
+        raise PortableGenomeError("genome must be a JSON object")
+
     fmt = genome.get("format", {})
+    if type(fmt) is not dict:
+        raise PortableGenomeError("format must be a JSON object")
     if fmt.get("format_id") != "utilityfog-portable-genome":
-        raise ValueError(f"Unknown genome format: {fmt.get('format_id')}")
+        raise PortableGenomeError("unknown genome format")
 
     tt_raw = genome.get("transition_table", {})
+    if type(tt_raw) is not dict:
+        raise PortableGenomeError("transition_table must be a JSON object")
     transitions = {}
     for src_name, mappings in tt_raw.items():
+        if type(mappings) is not dict:
+            raise PortableGenomeError("transition mappings must be a JSON object")
         transitions[src_name] = {}
         for count_str, target_name in mappings.items():
             transitions[src_name][count_str] = target_name
@@ -342,10 +368,20 @@ def import_genome(filepath):
 
     int_table = {}
     for src_name, mappings in transitions.items():
+        if type(src_name) is not str or src_name.upper() not in STATE_NAME_TO_ID:
+            raise PortableGenomeError("transition source state must be a known state name")
         src_id = STATE_NAME_TO_ID[src_name.upper()]
         int_table[src_id] = {}
         for count_str, target_name in mappings.items():
-            int_table[src_id][int(count_str)] = STATE_NAME_TO_ID[target_name.upper()]
+            if type(count_str) is not str:
+                raise PortableGenomeError("transition neighbor count must be an integer string")
+            try:
+                neighbor_count = int(count_str)
+            except ValueError:
+                raise PortableGenomeError("transition neighbor count must be an integer string") from None
+            if type(target_name) is not str or target_name.upper() not in STATE_NAME_TO_ID:
+                raise PortableGenomeError("transition target state must be a known state name")
+            int_table[src_id][neighbor_count] = STATE_NAME_TO_ID[target_name.upper()]
 
     ca_config = CAConfig(
         stochastic=stoch_cfg, contagion=contagion_cfg, decay=decay_cfg,
@@ -414,7 +450,13 @@ if __name__ == "__main__":
                              include_epigenetic=args.include_epigenetic)
         print(f"Genome exported to: {path} ({path.stat().st_size:,} bytes)")
     elif args.command == "info":
-        _, config, md = import_genome(args.genome)
+        try:
+            _, config, md = import_genome(args.genome)
+        except PortableGenomeError as exc:
+            # Only structural refusals route through argparse's ordinary error
+            # path (exit code 2). JSON syntax errors, filesystem errors,
+            # MemoryError and unrelated exceptions are deliberately NOT caught.
+            parser.error(str(exc))
         for k in ["name", "version", "author", "exported_at", "source_generation", "source_ca_step", "best_fitness"]:
             print(f"  {k}: {md.get(k, '?')}")
         print(f"  states: {len(config.transition_table)} with transitions")

--- a/tests/test_portable_genome.py
+++ b/tests/test_portable_genome.py
@@ -1,0 +1,256 @@
+"""Tests for the transition-table structural-refusal package in
+``scripts/portable_genome.py`` (``import_genome`` + the public ``info`` CLI).
+
+Scope: this module tests ONLY the narrow structural refusals introduced for the
+genome root, ``format``, ``transition_table``, each source-state mapping, and
+each source/target state name and neighbor-count key. It deliberately does NOT
+assert whole-importer totality — malformed shapes elsewhere in the genome
+(config sections, metadata, epigenetic snapshot) are out of scope and are not
+exercised here.
+
+Reachability is checked on two separate surfaces:
+  * DIRECT — ``import_genome()`` raises ``PortableGenomeError`` with an exact,
+    value-free message.
+  * PUBLIC — ``python -m scripts.portable_genome info <file>`` routes a
+    ``PortableGenomeError`` through argparse's ordinary error path (exit code 2)
+    with no successful-output leakage, and does NOT broadly catch JSON syntax
+    errors or filesystem errors.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.portable_genome import (
+    STATE_NAME_TO_ID,
+    PortableGenomeError,
+    import_genome,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_VALID_FMT = {"format_id": "utilityfog-portable-genome"}
+
+
+def _write(tmp_path: Path, obj) -> Path:
+    """Write ``obj`` as JSON to a genome file and return its path."""
+    p = tmp_path / "genome.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def _write_raw(tmp_path: Path, text: str) -> Path:
+    """Write raw text (possibly invalid JSON) to a genome file."""
+    p = tmp_path / "genome.json"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _info(genome_path: Path) -> subprocess.CompletedProcess:
+    """Run the PUBLIC ``info`` CLI on a genome path and capture the result."""
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.portable_genome", "info", str(genome_path)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# DIRECT refusals — import_genome() raises PortableGenomeError, exact message
+# --------------------------------------------------------------------------
+
+
+def test_error_type_is_valueerror_subclass():
+    # Backward compatibility: existing callers that catch ValueError still work.
+    assert issubclass(PortableGenomeError, ValueError)
+
+
+def test_non_object_genome_root(tmp_path):
+    for root in ([], "x", 5, True, None):
+        p = _write(tmp_path, root)
+        with pytest.raises(PortableGenomeError) as exc:
+            import_genome(p)
+        assert str(exc.value) == "genome must be a JSON object"
+
+
+def test_non_object_format(tmp_path):
+    p = _write(tmp_path, {"format": []})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "format must be a JSON object"
+
+
+def test_wrong_format_identifier(tmp_path):
+    p = _write(tmp_path, {"format": {"format_id": "some-other-format"}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "unknown genome format"
+
+
+def test_missing_format_identifier_is_unknown_format(tmp_path):
+    # Absent format defaults to {} (a dict) and falls through to the format-id
+    # check, preserving the original "unknown format" outcome.
+    p = _write(tmp_path, {"metadata": {"name": "x"}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "unknown genome format"
+
+
+def test_non_object_transition_table(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": []})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition_table must be a JSON object"
+
+
+def test_non_object_source_mapping(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": []}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition mappings must be a JSON object"
+
+
+def test_unknown_source_state(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"BOGUS": {"0": "VOID"}}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition source state must be a known state name"
+
+
+def test_malformed_neighbor_count_string(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": {"notanum": "VOID"}}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition neighbor count must be an integer string"
+
+
+def test_numeric_non_string_target(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": {"0": 5}}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition target state must be a known state name"
+
+
+def test_unknown_target_state(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": {"0": "BOGUS"}}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition target state must be a known state name"
+
+
+def test_messages_leak_no_supplied_value(tmp_path):
+    # The refusal message must not echo the offending value/representation.
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"SUPERSECRETSTATE": {"0": "VOID"}}})
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert "SUPERSECRETSTATE" not in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# Behavior locks — valid genomes still import exactly as before
+# --------------------------------------------------------------------------
+
+
+def test_minimal_wellformed_genome_imports(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT})
+    rule_spec, ca_config, metadata = import_genome(p)
+    assert isinstance(rule_spec, dict)
+    assert ca_config.transition_table == {}
+    assert isinstance(metadata, dict)
+
+
+def test_all_previously_accepted_integer_spellings(tmp_path):
+    # Whitespace, signs and leading zeros are preserved via int()'s own semantics.
+    spellings = {"  4  ": "STRUCTURAL", "+1": "COMPUTE", "007": "ENERGY", "0": "VOID"}
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": spellings}})
+    _rs, ca_config, _md = import_genome(p)
+    void_id = STATE_NAME_TO_ID["VOID"]
+    assert ca_config.transition_table[void_id] == {
+        4: STATE_NAME_TO_ID["STRUCTURAL"],
+        1: STATE_NAME_TO_ID["COMPUTE"],
+        7: STATE_NAME_TO_ID["ENERGY"],
+        0: STATE_NAME_TO_ID["VOID"],
+    }
+
+
+def test_duplicate_after_conversion_last_wins(tmp_path):
+    # "5" and "05" both convert to 5; last mapping wins (unchanged behavior).
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": {"5": "COMPUTE", "05": "ENERGY"}}})
+    _rs, ca_config, _md = import_genome(p)
+    void_id = STATE_NAME_TO_ID["VOID"]
+    assert ca_config.transition_table[void_id] == {5: STATE_NAME_TO_ID["ENERGY"]}
+
+
+def test_valid_metadata_and_transition_reconstruction(tmp_path):
+    genome = {
+        "format": _VALID_FMT,
+        "metadata": {"name": "demo-organism", "version": "1.2.3"},
+        "transition_table": {"VOID": {"3": "STRUCTURAL"}, "ENERGY": {"2": "COMPUTE"}},
+    }
+    p = _write(tmp_path, genome)
+    rule_spec, ca_config, metadata = import_genome(p)
+    # Metadata carried through.
+    assert metadata["name"] == "demo-organism"
+    assert metadata["version"] == "1.2.3"
+    # Int-keyed reconstruction is exact.
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {3: STATE_NAME_TO_ID["STRUCTURAL"]}
+    assert ca_config.transition_table[STATE_NAME_TO_ID["ENERGY"]] == {2: STATE_NAME_TO_ID["COMPUTE"]}
+    # String-keyed transitions preserved on the rule_spec side.
+    assert rule_spec["params"]["transitions"]["VOID"]["3"] == "STRUCTURAL"
+
+
+def test_case_insensitive_state_names_preserved(tmp_path):
+    # The importer upper-cases names; lowercase names remain acceptable.
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"void": {"1": "structural"}}})
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {1: STATE_NAME_TO_ID["STRUCTURAL"]}
+
+
+# --------------------------------------------------------------------------
+# PUBLIC CLI reachability — info exit codes and output
+# --------------------------------------------------------------------------
+
+
+def test_public_info_malformed_exits_2_no_output_leak(tmp_path):
+    p = _write(tmp_path, {"format": _VALID_FMT, "transition_table": {"VOID": {"0": "BOGUS"}}})
+    res = _info(p)
+    assert res.returncode == 2
+    # Routed through argparse's error path — the generic message is on stderr.
+    assert "transition target state must be a known state name" in res.stderr
+    # No successful info output leaked to stdout.
+    assert "with transitions" not in res.stdout
+
+
+def test_public_info_valid_genome_success_output_unchanged(tmp_path):
+    genome = {
+        "format": _VALID_FMT,
+        "metadata": {"name": "demo-organism"},
+        "transition_table": {"VOID": {"1": "STRUCTURAL"}},
+    }
+    p = _write(tmp_path, genome)
+    res = _info(p)
+    assert res.returncode == 0
+    assert "with transitions" in res.stdout
+    assert "name: demo-organism" in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_json_syntax_error(tmp_path):
+    # Invalid JSON is a syntax error, NOT a PortableGenomeError — it must not be
+    # caught and turned into an exit-2; it propagates (non-2 exit).
+    p = _write_raw(tmp_path, "{not valid json")
+    res = _info(p)
+    assert res.returncode != 2
+    assert "with transitions" not in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_missing_file(tmp_path):
+    # A filesystem error must not be caught and turned into an exit-2.
+    missing = tmp_path / "does_not_exist.json"
+    res = _info(missing)
+    assert res.returncode != 2
+    assert "with transitions" not in res.stdout


### PR DESCRIPTION
## Portable-genome transition-table structural refusals

A **narrowly-scoped** structural-refusal package for `import_genome()`'s top-level and transition-table shapes, under an explicit Kev authorization (Kev seat, Opus 4.8). **MERGED 2026-07-24 (Sydney) as ordinary head-pinned squash `04b4b1c51ae05ca0e805e043ddf576b1ec732ff3` (single parent `e8e676c10d71f1b20d4bf6059fc17299489dd19d`), under Kev's authorization with Jack's audit completed — no admin, bypass, force, rebase, history rewriting, or manual branch deletion; post-merge main CI green (`verify-python`, `frontend-quality`, `Analyze Python`). No review-thread actions were taken — neither on this PR nor on #414's preserved thread.**

> **Scope disclosure (not whole-importer totality).** This PR hardens only the genome root, `format`, `transition_table`, each source-state mapping, and each source/target state name and neighbor-count key. **Malformed shapes elsewhere in the importer remain out of scope** — e.g. non-object `stochastic`/`contagion`/`decay`/`cosmic_garden`/`experimental`/`metadata` config sections, and the epigenetic snapshot — and still surface as their original exceptions. This is deliberately not a claim of totality for the entire importer.

### Base / head / parent
- **Base:** `main` at `e8e676c10d71f1b20d4bf6059fc17299489dd19d`.
- **Head:** `2ac2a6f816bcc0dd3336307838ecb02f73924b24` on `fix/portable-genome-transition-table-refusals`.
- **Parent of head:** `e8e676c10d71f1b20d4bf6059fc17299489dd19d` (single parent = base main).

### File boundary and diffstat
| File | +/− |
|------|-----|
| `scripts/portable_genome.py` | +45 / −3 |
| `tests/test_portable_genome.py` (new) | +256 / −0 |
| **Total** | **+301 / −3** |

No other files touched — the CA engine, `data/`, NPZ files, agent backends, `AGENT_HANDOFF.md`, and #412 are all untouched. **`import_genome()` has no in-repository production caller.** The only in-repo importer of `scripts/portable_genome.py` is `vis/observatory/loader.py`, which dynamically imports `extract_epigenetic_snapshot()` — a *different* function, left **untouched** by this PR.

### Contract implemented
- **`PortableGenomeError(ValueError)`** — a `ValueError` subclass so existing callers that catch `ValueError` keep working; the public `info` CLI catches this type specifically.
- **`import_genome()`** validates, with fixed **value-free** messages, that:
  - the genome root, `format`, `transition_table`, and each source-state mapping are **exact JSON objects** (`type(x) is dict`) before any mapping operation;
  - source and target state names are **exact strings and recognized state names** before any `.upper()` or `STATE_NAME_TO_ID` indexing (short-circuit keeps `.upper()` off non-strings);
  - neighbor-count keys are **exact strings**, converted with the existing built-in `int()` — **only the conversion `ValueError` is caught** (`from None`, so no supplied value leaks via chaining).
- **Preserved:** every previously accepted integer spelling (whitespace, signs, leading zeros) via `int()`'s own semantics; the existing **duplicate-after-conversion (last-wins)** behavior; **no new range ceiling**; the successful `info` output, parser grammar, valid-genome return values, transition-table bytes/values, defaults and ordering.
- **Exact messages** (deterministic, no supplied value / representation / type name): `genome must be a JSON object` · `format must be a JSON object` · `unknown genome format` · `transition_table must be a JSON object` · `transition source state must be a known state name` · `transition mappings must be a JSON object` · `transition neighbor count must be an integer string` · `transition target state must be a known state name`.

### Reachability (verified separately)
- **DIRECT** — `import_genome()` raises `PortableGenomeError` with the applicable exact message.
- **PUBLIC** — `python -m scripts.portable_genome info <file>` catches **only** `PortableGenomeError` and routes it through argparse's ordinary error path → **exit code 2**, with no successful-output leakage. JSON syntax errors, filesystem errors, `MemoryError` and unrelated exceptions are **deliberately not caught** (they propagate; exit ≠ 2).

### Failing-first evidence (run against pre-guard code, class present)
```
$ python -m pytest tests/test_portable_genome.py -v
... 12 failed, 9 passed ...
FAILED test_non_object_genome_root            - AttributeError ('list'/'str'/... has no .get)
FAILED test_non_object_format                 - AttributeError
FAILED test_wrong_format_identifier           - ValueError (old "Unknown genome format: …", not PortableGenomeError)
FAILED test_missing_format_identifier_is_unknown_format
FAILED test_non_object_transition_table       - AttributeError (.items on a list)
FAILED test_non_object_source_mapping         - AttributeError
FAILED test_unknown_source_state              - KeyError: 'BOGUS'
FAILED test_malformed_neighbor_count_string   - ValueError (raw int() failure)
FAILED test_numeric_non_string_target         - AttributeError ((5).upper())
FAILED test_unknown_target_state              - KeyError: 'BOGUS'
FAILED test_messages_leak_no_supplied_value
FAILED test_public_info_malformed_exits_2_no_output_leak  - exit 1 (traceback), not 2
```
The 9 that passed pre-guard are the behavior locks + the two no-broad-catch consistency locks (JSON-syntax / missing-file already exit ≠ 2 because the old `info` caught nothing) + the `ValueError`-subclass check — confirming preserved behavior. After the guards: **all 21 pass.**

### Test receipts
- **Focused** (`tests/test_portable_genome.py`): **21 passed** (11 DIRECT refusals + value-free-message + 5 behavior locks + 4 PUBLIC CLI).
- **Adjacent:** `import_genome()` has no in-repository production caller, so the new focused module is the direct adjacent set for the changed function. The one in-repo importer of the module, `vis/observatory/loader.py`, uses the untouched `extract_epigenetic_snapshot()`; the full maintained suite (which exercises the observatory loader) covers that path and the rest.
- **Compilation:** `python -m py_compile scripts/portable_genome.py tests/test_portable_genome.py` — clean. `git diff --check` — clean.
- **Local full maintained suite** (dependency-limited on this seat — `uft_ca` extension + some optional providers absent, hence the skips): **2052 passed / 48 skipped / 0 failed** (= 2031 prior + 21 new).
- **CI** (fully provisioned — `uft_ca` extension built + optional providers installed): **2175 passed / 12 skipped / 0 failed** (`verify-python` on head `2ac2a6f`), i.e. `2154` prior + the 21 new tests. Kept separate from the dependency-limited local figure above.

### Behavior locks (proving no regression)
- well-formed minimal genome imports;
- all previously accepted integer spellings (`"  4  "`, `"+1"`, `"007"`, `"0"`) reconstruct exactly;
- duplicate-after-conversion (`"5"` + `"05"`) is last-wins, unchanged;
- valid metadata + int-keyed transition-table reconstruction;
- case-insensitive state names still accepted;
- unchanged successful PUBLIC `info` output (exit 0, `… with transitions`, metadata line).

### Residual scope (explicitly out of this PR)
- Non-object / malformed **config sections** (`stochastic`, `contagion`, `decay`, `cosmic_garden`, `experimental`) and **metadata** still raise their original exceptions.
- The **epigenetic snapshot** path (`extract_epigenetic_snapshot`) is untouched (a separate DIRECT boundary noted previously).
- No range ceiling on neighbor counts, and no dedup of duplicate-after-conversion keys — both **intentionally preserved**.

### Registered check results
All registered checks on head `2ac2a6f` are conclusive and green (`statusCheckRollup`: 8/8 SUCCESS):

| Check | Conclusion |
|-------|------------|
| `verify-python` | **SUCCESS** — `2175 passed, 12 skipped, 0 failed in 41.26s` (job `89400966911`; also SUCCESS on the second run) |
| `frontend-quality` | **SUCCESS** (×2 runs) |
| `agent-safety` | **SUCCESS** |
| `Analyze Python` / `CodeQL` | **SUCCESS** |
| `tripwire` | **SUCCESS** (label-only; no trigger labels present) |

Sealed under Kev's authorization with Jack's audit — see the merged-status line at the top.
