### PR TITLE
fix(dandelion): non-object genome refusal — typed DandelionGenomeError

### DIFF
--- a/scripts/dandelion.py
+++ b/scripts/dandelion.py
@@ -50,6 +50,21 @@ STATE_PRINT_COLORS = {
 STATE_NAMES = {0: "VOID", 1: "STRUCTURAL", 2: "COMPUTE", 3: "ENERGY", 4: "SENSOR"}
 
 
+class DandelionGenomeError(ValueError):
+    """Refusal for a non-object genome root on the compression / ``info`` path.
+
+    Raised by :func:`genome_to_compressed_bytes` (and the public ``info`` path)
+    when a genome JSON file's root is not a JSON object, before any object
+    operation such as ``.pop()``. A subclass of :class:`ValueError`; the public
+    ``qr`` / ``info`` CLI branches catch this type specifically.
+
+    Scope: this covers only the non-object-root refusal. It is NOT a claim of
+    whole-module or whole-pipeline totality — other malformed shapes (and the
+    separate empty-GLB-mesh residual) remain out of scope and keep their
+    existing behavior.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Seed 1: QR Code Generator
 # ---------------------------------------------------------------------------
@@ -58,6 +73,9 @@ def genome_to_compressed_bytes(genome_path: str) -> bytes:
     """Load a genome JSON, strip epigenetic data, minify, and zlib compress."""
     with open(genome_path, "r") as f:
         genome = json.load(f)
+
+    if type(genome) is not dict:
+        raise DandelionGenomeError("genome must be a JSON object")
 
     # Strip epigenetic snapshot (too large for QR)
     genome.pop("epigenetic_snapshot", None)
@@ -605,12 +623,19 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     if args.command == "qr":
-        meta = generate_qr(
-            args.genome,
-            output_path=args.output,
-            box_size=args.box_size,
-            error_correction=args.error_correction,
-        )
+        try:
+            meta = generate_qr(
+                args.genome,
+                output_path=args.output,
+                box_size=args.box_size,
+                error_correction=args.error_correction,
+            )
+        except DandelionGenomeError as exc:
+            # Route only the JSON-object refusal through argparse (exit code 2).
+            # The optional-qrcode ImportError and QR-library errors are NOT caught
+            # here; the qrcode dependency check keeps its original ordering (it
+            # runs first inside generate_qr, before the genome is loaded).
+            parser.error(str(exc))
         print(f"QR Code generated: {meta['output_path']}")
         print(f"  Original JSON:    {meta['original_json_bytes']:,} bytes")
         print(f"  Minified:         {meta['minified_bytes']:,} bytes")
@@ -624,13 +649,21 @@ def main(argv=None):
         print(f"  Compression:      {cr:.1f}% reduction")
 
     elif args.command == "info":
-        compressed = genome_to_compressed_bytes(args.genome)
-        b85 = compressed_to_b85(compressed)
-        with open(args.genome, "r") as f:
-            orig = f.read()
-        genome = json.loads(orig)
-        genome.pop("epigenetic_snapshot", None)
-        minified = json.dumps(genome, separators=(",", ":"), sort_keys=True)
+        try:
+            compressed = genome_to_compressed_bytes(args.genome)
+            b85 = compressed_to_b85(compressed)
+            with open(args.genome, "r") as f:
+                orig = f.read()
+            genome = json.loads(orig)
+            if type(genome) is not dict:
+                raise DandelionGenomeError("genome must be a JSON object")
+            genome.pop("epigenetic_snapshot", None)
+            minified = json.dumps(genome, separators=(",", ":"), sort_keys=True)
+        except DandelionGenomeError as exc:
+            # Only the JSON-object refusal routes through argparse (exit code 2).
+            # JSON syntax errors, filesystem errors and unrelated exceptions are
+            # deliberately NOT caught here.
+            parser.error(str(exc))
 
         print(f"Genome: {args.genome}")
         print(f"  Original:   {len(orig.encode()):,} bytes")

--- a/tests/test_dandelion.py
+++ b/tests/test_dandelion.py
@@ -1,0 +1,172 @@
+"""Tests for the non-object-genome refusal in ``scripts/dandelion.py``.
+
+Scope: ONLY the verified non-object-genome-root refusal on the genome
+compression path (``genome_to_compressed_bytes``) and the public ``info`` / ``qr``
+CLI paths. This is deliberately NOT a claim of whole-module or whole-pipeline
+totality — other malformed shapes, and the separate empty-GLB-mesh residual,
+are out of scope and unexercised here.
+
+Reachability is checked on two separate surfaces:
+  * DIRECT — ``genome_to_compressed_bytes()`` raises ``DandelionGenomeError``
+    with an exact, value-free message.
+  * PUBLIC — ``python -m scripts.dandelion info <file>`` (and ``qr``) route a
+    ``DandelionGenomeError`` through argparse's ordinary error path (exit code 2)
+    with no successful-output leakage, and do NOT broadly catch JSON syntax
+    errors, filesystem errors, or the optional-``qrcode`` ImportError.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+from scripts.dandelion import DandelionGenomeError, genome_to_compressed_bytes
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(tmp_path: Path, obj) -> Path:
+    p = tmp_path / "genome.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def _write_raw(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "genome.json"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _run(*cli_args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.dandelion", *cli_args],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+_NON_OBJECT_ROOTS = [None, [1, 2, 3], "a string", 42, 3.14, True, False]
+
+
+# --------------------------------------------------------------------------
+# DIRECT refusals — genome_to_compressed_bytes() raises DandelionGenomeError
+# --------------------------------------------------------------------------
+
+
+def test_error_type_is_valueerror_subclass():
+    assert issubclass(DandelionGenomeError, ValueError)
+
+
+def test_direct_non_object_roots_refused(tmp_path):
+    for root in _NON_OBJECT_ROOTS:
+        p = _write(tmp_path, root)
+        with pytest.raises(DandelionGenomeError) as exc:
+            genome_to_compressed_bytes(str(p))
+        assert str(exc.value) == "genome must be a JSON object"
+
+
+def test_direct_message_leaks_no_supplied_value(tmp_path):
+    p = _write(tmp_path, ["SUPERSECRETVALUE"])
+    with pytest.raises(DandelionGenomeError) as exc:
+        genome_to_compressed_bytes(str(p))
+    assert "SUPERSECRETVALUE" not in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# Behavior locks — valid object genomes are byte-for-byte unchanged
+# --------------------------------------------------------------------------
+
+
+def _expected_compressed(genome_obj: dict) -> bytes:
+    """Independent reference for the exact compressed-bytes contract."""
+    stripped = {k: v for k, v in genome_obj.items() if k != "epigenetic_snapshot"}
+    minified = json.dumps(stripped, separators=(",", ":"), sort_keys=True)
+    return zlib.compress(minified.encode("utf-8"), level=9)
+
+
+def test_valid_object_compressed_bytes_byte_for_byte(tmp_path):
+    genome = {"format": {"format_id": "utilityfog-portable-genome"},
+              "metadata": {"name": "demo", "version": "1.0"},
+              "b": 2, "a": 1}
+    p = _write(tmp_path, genome)
+    out = genome_to_compressed_bytes(str(p))
+    assert out == _expected_compressed(genome)
+
+
+def test_epigenetic_snapshot_stripped_exactly(tmp_path):
+    core = {"format": {"format_id": "utilityfog-portable-genome"}, "metadata": {"name": "x"}}
+    with_snapshot = dict(core)
+    with_snapshot["epigenetic_snapshot"] = {"lattice_b64": "AAAA" * 1000, "included": True}
+    p_with = tmp_path / "with.json"
+    p_with.write_text(json.dumps(with_snapshot), encoding="utf-8")
+    p_without = tmp_path / "without.json"
+    p_without.write_text(json.dumps(core), encoding="utf-8")
+    # Stripping is exact: the snapshot is removed, so both compress identically.
+    assert genome_to_compressed_bytes(str(p_with)) == genome_to_compressed_bytes(str(p_without))
+    # And identical to the reference for the stripped core.
+    assert genome_to_compressed_bytes(str(p_with)) == _expected_compressed(core)
+
+
+# --------------------------------------------------------------------------
+# PUBLIC CLI — info exit codes and output
+# --------------------------------------------------------------------------
+
+
+def test_public_info_non_object_exits_2_no_output_leak(tmp_path):
+    p = _write(tmp_path, [1, 2, 3])
+    res = _run("info", str(p))
+    assert res.returncode == 2
+    assert "genome must be a JSON object" in res.stderr
+    # No successful info output leaked to stdout.
+    assert "Minified:" not in res.stdout
+    assert "Fits single QR code" not in res.stdout
+
+
+def test_public_info_valid_genome_success_output_unchanged(tmp_path):
+    genome = {"format": {"format_id": "utilityfog-portable-genome"}, "metadata": {"name": "demo"}}
+    p = _write(tmp_path, genome)
+    res = _run("info", str(p))
+    assert res.returncode == 0
+    assert f"Genome: {p}" in res.stdout
+    assert "Minified:" in res.stdout
+    assert "Compressed:" in res.stdout
+    assert "Fits single QR code" in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_json_syntax_error(tmp_path):
+    p = _write_raw(tmp_path, "{not valid json")
+    res = _run("info", str(p))
+    assert res.returncode != 2
+    assert "Minified:" not in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_missing_file(tmp_path):
+    missing = tmp_path / "nope.json"
+    res = _run("info", str(missing))
+    assert res.returncode != 2
+    assert "Minified:" not in res.stdout
+
+
+# --------------------------------------------------------------------------
+# PUBLIC CLI — qr routes only DandelionGenomeError through argparse
+# --------------------------------------------------------------------------
+
+
+def test_public_qr_non_object_routes_dandelion_error_exit_2(tmp_path):
+    # Requires the optional qrcode dependency: only then does the genome load
+    # (and its refusal) run — the qrcode check is deliberately first.
+    pytest.importorskip("qrcode")
+    p = _write(tmp_path, "not-an-object")
+    out_png = tmp_path / "out.png"
+    res = _run("qr", str(p), "--output", str(out_png))
+    assert res.returncode == 2
+    assert "genome must be a JSON object" in res.stderr
+    # No QR file written and no success output.
+    assert not out_png.exists()
+    assert "QR Code generated" not in res.stdout


### PR DESCRIPTION
## Dandelion non-object-genome refusal

A **narrowly-scoped** non-object-genome-root refusal on the genome compression + public `info`/`qr` paths, under an explicit Kev authorization (Kev seat, Opus 4.8), audited by Jack.

> **Scope disclosure (not whole-module/pipeline totality).** This PR adds only the non-object genome-root refusal. Other malformed shapes, and the **separate empty-GLB-mesh residual**, remain out of scope and keep their existing behavior. No totality is claimed for `dandelion.py` or the dispersal pipeline.

### Synchronization (2026-07-24)
Brought up to date with current `main` to clear the earlier `BEHIND` state via **one ordinary conflict-free `--no-ff` merge** — no rebase, force, amend, history rewrite, admin or bypass.

- **Merge-base** of the audited head and `main` is exactly `04b4b1c51ae05ca0e805e043ddf576b1ec732ff3` (the original audited base). `main` advanced independently to `67be0765bfac63f9d4b834b22a7418129e16bd01` (squash of #412), touching only `scripts/agent_backends/base.py` and `tests/test_agent_backend.py` — **disjoint** from the two #418 files, so the merge was conflict-free and no resolution edits were made.
- **Sync commit:** `af663c74c0e718c12b0c1543b89114ce94899c1b` — first parent `b357f5c9add7c389be3e69aaa6e3f90a76da6dfa` (audited head), second parent `67be0765bfac63f9d4b834b22a7418129e16bd01` (main).
- **Patch identity (byte-for-byte).** The #418 patch against its new base — `git diff 67be0765…af663c74…` — is **byte-identical** to the audited `git diff 04b4b1c…b357f5c…`: the same two files, the same cumulative `+218 / −13`, and the same SHA-256 `9b33d4f48f43110ee229890dc5e5ebd29980cf81772b60eec2562500d1176cd7` (an empty `diff` between the two patch texts).

### Base / head / parent (synchronized)
- **Base:** `main` at `67be0765bfac63f9d4b834b22a7418129e16bd01`.
- **Head:** `af663c74c0e718c12b0c1543b89114ce94899c1b` on `fix/dandelion-genome-object-refusal` (the sync merge commit).
- **Parents of head:** first parent `b357f5c9add7c389be3e69aaa6e3f90a76da6dfa` (audited head, unchanged), second parent `67be0765bfac63f9d4b834b22a7418129e16bd01` (main). The second parent only carries `main` forward; it contributes nothing to the #418 patch.

### File boundary and diffstat
| File | +/− |
|------|-----|
| `scripts/dandelion.py` | +46 / −13 |
| `tests/test_dandelion.py` (new) | +172 / −0 |
| **Total** | **+218 / −13** |

`67be076…af663c7` shows **only** these two files — the CA engine, agent backends, `data/`, NPZ files, deployment, Lane A, Swarm Hunter, `AGENT_HANDOFF.md`, and every Ian-owned branch/metadata are untouched. (The sync's second parent carries main's own `scripts/agent_backends/base.py` + `tests/test_agent_backend.py` forward, but those are **not** part of the #418 patch.)

### Contract implemented
- **`DandelionGenomeError(ValueError)`** — a `ValueError` subclass so existing `ValueError` catchers keep working; the public `qr`/`info` CLI branches catch this type specifically.
- **`genome_to_compressed_bytes()`**: after the `json.load()`, requires `type(genome) is dict` **before** `.pop()`; on failure raises `DandelionGenomeError("genome must be a JSON object")` — a fixed message containing **no supplied value, representation or type name**.
- **`info` path**: the second parse (`json.loads` of the re-read file) gets the same guard before its `.pop()`.
- **Preserved exactly**: `epigenetic_snapshot` removal, JSON minification separators `(",", ":")`, key sorting (`sort_keys=True`), UTF-8 encoding, and `zlib` level 9 — so valid compressed bytes are byte-for-byte identical. Successful `info`/`qr` output, parser grammar, defaults and output files are unchanged.

### Reachability (verified separately)
- **DIRECT** — `genome_to_compressed_bytes()` raises `DandelionGenomeError`.
- **PUBLIC `info`** — catches **only** `DandelionGenomeError` and routes it through argparse's ordinary error path → **exit code 2**, no successful-output leakage.
- **PUBLIC `qr`** — the CLI branch catches **only** `DandelionGenomeError` reaching it from `generate_qr()` and routes it through the same argparse path (exit 2). The **optional-`qrcode` dependency check keeps its original ordering** — it runs first inside `generate_qr()`, before the genome is loaded — so a missing `qrcode` still raises `ImportError` (uncaught, not reordered).
- **Not caught anywhere here:** JSON syntax errors, filesystem errors, `ImportError`, `MemoryError`, QR-library errors, or unrelated exceptions.

### Failing-first evidence (run against pre-guard code, class present)
```
$ python -m pytest tests/test_dandelion.py -v
... 4 failed, 6 passed ...
FAILED test_direct_non_object_roots_refused          - AttributeError/TypeError (str/list/... .pop)
FAILED test_direct_message_leaks_no_supplied_value
FAILED test_public_info_non_object_exits_2_no_output_leak   - exit 1 (traceback), not 2
FAILED test_public_qr_non_object_routes_dandelion_error_exit_2 - exit 1 (AttributeError in generate_qr), not 2
```
The 6 that passed pre-guard are the behavior locks (byte-for-byte, epigenetic stripping, valid `info` success) + the two no-broad-catch consistency locks (JSON-syntax / missing-file already exit ≠ 2 because the old CLI caught nothing) + the `ValueError`-subclass check — confirming preserved behavior. After the guards: **all 10 pass.**

### Preserved behavior (regression locks)
- valid-object compressed bytes are **byte-for-byte identical** to an independent reference (`strip epigenetic_snapshot` → `json.dumps(separators, sort_keys)` → UTF-8 → `zlib.compress(level=9)`);
- **epigenetic stripping is exact** (a genome with vs without the snapshot compresses identically, and matches the stripped-core reference);
- unchanged successful `info` output (exit 0, `Genome:`/`Minified:`/`Compressed:`/`Fits single QR code`);
- the `qr` CLI branch routes **only** `DandelionGenomeError` (exit 2), verified with `qrcode` present (`importorskip`);
- invalid JSON and missing files remain **uncaught** by this new boundary (exit ≠ 2).

### Residual scope (explicitly out of this PR)
- The **empty-GLB-mesh residual** (`lattice_to_glb` lacks the empty-mesh guard `lattice_to_stl` has) is untouched.
- Other malformed genome shapes beyond a non-object root are not addressed.
- The later `json.load(...)` inside `generate_qr` (a size-metadata calculation feeding `json.dumps`, no `.pop`) is left unchanged. For a stable file, the first compression read refuses a non-object before the later QR metadata read; concurrent replacement of the file between those two reads remains a separate, out-of-scope residual. (No code or test is changed for this wording point.)

### Test receipts
- **Focused** (`tests/test_dandelion.py`): **10 passed** (3 DIRECT + subclass + 2 behavior locks + 4 PUBLIC `info`/`qr`).
- **Compilation:** `python -m py_compile scripts/dandelion.py tests/test_dandelion.py` — clean. `git diff --check` — clean.
- **Local full maintained suite** (dependency-limited on this seat — `uft_ca` extension + some optional providers absent): **2062 passed / 48 skipped / 0 failed** on the audited change; the sync adds no #418 code or tests.
- **CI on the synchronized head `af663c74`** (fully provisioned, `qrcode` absent): **2229 passed / 13 skipped / 0 failed** (`verify-python`, ×2 runs). This is the audited head's `2184` plus the **45 `test_agent_backend.py` cases from main's #412** now present on the branch through the sync; the 9 dandelion CI tests are included and the PUBLIC-`qr` test still `importorskip`s `qrcode` (→ 13 skipped). No #418 test count changed.

### Registered check results (synchronized head `af663c74`)
All registered checks on the synchronized head are conclusive and green (`statusCheckRollup`: 7/7 SUCCESS); `mergeStateStatus` is `CLEAN`, `mergeable` is `MERGEABLE`:

| Check | Conclusion |
|-------|------------|
| `verify-python` | **SUCCESS** — `2229 passed, 13 skipped in 34.44s` (×2 runs) |
| `frontend-quality` | **SUCCESS** (×2 runs) |
| `agent-safety` | **SUCCESS** (required) |
| `Analyze Python` | **SUCCESS** |
| `CodeQL` | **SUCCESS** |

The three **required** contexts — `agent-safety`, `verify-python`, `frontend-quality` — are all green. `tripwire` is a label-gated check; with no trigger labels present it did not register on this sync-merge push (on the audited head `b357f5c` it appeared as a no-op SUCCESS, giving 8 rows there vs 7 here). It is not a required context and does not gate the merge.

### Status
**Merged.** Squashed to `main` as `2d6ba881c8fd030e07db985f6fbcbaefc2e9a363` on 2026-07-24 (Sydney/AEST), under Kev's explicit authorization (repo owner, Kev seat, Opus 4.8) and after Jack's completed audit. Synchronization and seal used only ordinary operations — no admin, bypass, force, rebase, or auto-merge — and **no review-thread actions were taken** (there were zero review threads throughout; the single conversation comment is an unrelated `gemini-code-assist[bot]` notice, left untouched). The source branch `fix/dandelion-genome-object-refusal` was deleted automatically by the repository's delete-branch-on-merge setting, not by hand.
