### PR TITLE
fix(agent-backends): ToolResultBlock.tool_use_id + is_error shape totality

### DIFF
--- a/scripts/agent_backends/base.py
+++ b/scripts/agent_backends/base.py
@@ -47,12 +47,12 @@ def _bounded_exact_str(value: Any, limit: int) -> str:
 def _exact_str(value: Any) -> str:
     """Keep `value` unchanged only when it is exactly `str` — no length ceiling.
 
-    A `TextBlock` has no established maximum length, so an accepted exact
-    string is retained byte-for-byte (unlike `_bounded_exact_str`, this
-    applies no slice). str subclasses (whose methods may be overridden) and
-    every other type become "" without any truth, length, iteration,
-    conversion, representation, comparison, attribute, or type-name method
-    being requested on the value.
+    A `TextBlock`'s text and a `ToolResultBlock`'s `tool_use_id` have no
+    established maximum length, so an accepted exact string is retained
+    byte-for-byte (unlike `_bounded_exact_str`, this applies no slice). str
+    subclasses (whose methods may be overridden) and every other type become
+    "" without any truth, length, iteration, conversion, representation,
+    comparison, attribute, or type-name method being requested on the value.
     """
     if type(value) is str:
         return value
@@ -117,8 +117,30 @@ class ToolResultBlock:
     a hostile `__iter__`) and raise, or hit `_block_to_wire`'s "unexpected
     content block" on a foreign element; the OpenAI-compat encoder would
     otherwise raise on a non-iterable content or emit corrupt output for
-    foreign elements. `tool_use_id` and `is_error` are outside this
-    normalization's scope (see the shape-totality tests).
+    foreign elements.
+
+    The two metadata fields are normalized at the same shared boundary so
+    the encoders' established paths are total over every constructed block:
+
+    - `tool_use_id` is kept only when exactly built-in `str` (byte-for-byte,
+      no length ceiling, via `_exact_str`); every other shape — including str
+      subclasses and hostile objects — becomes "" without any conversion,
+      length, comparison, or representation hook. A refused id can therefore
+      no longer flow as a foreign object into the Anthropic
+      `payload["tool_use_id"]` or the OpenAI-compat `"tool_call_id"` wire
+      field; it becomes an exact empty-string field.
+    - `is_error` is kept only when exactly built-in `bool` (`True`/`False`,
+      by `type(...) is bool` identity — `bool` cannot be subclassed);
+      every other shape becomes exact built-in `False` without calling
+      `bool()`, equality, hashing, iteration, or any supplied hook. Both
+      encoders truth-test `if b.is_error:`, so this stops a hostile
+      `__bool__` from escaping and stops a malformed truthy value (e.g. `1`,
+      `"yes"`) from producing the Anthropic `is_error: true` flag or the
+      OpenAI-compat `"[ERROR] "` prefix. Exact `True` retains both.
+
+    No supplied value, type name, representation, or exception text is ever
+    exposed; the claim is bounded to `tool_use_id` and `is_error` (plus the
+    unchanged `content` normalization) — not to any other field or block.
     """
 
     tool_use_id: str
@@ -127,9 +149,12 @@ class ToolResultBlock:
     type: Literal["tool_result"] = "tool_result"
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "tool_use_id", _exact_str(self.tool_use_id))
         object.__setattr__(
             self, "content", _normalized_result_content(self.content)
         )
+        if type(self.is_error) is not bool:
+            object.__setattr__(self, "is_error", False)
 
 
 ContentBlock = Union[TextBlock, ToolUseBlock, ToolResultBlock]

--- a/tests/test_agent_backend.py
+++ b/tests/test_agent_backend.py
@@ -12,6 +12,11 @@ Covers:
   - ToolUseBlock value-shape normalization: exact-str id/name bounded to
     256/128 chars, exact-dict input, hostile shapes replaced without
     invoking any conversion/length/representation hook.
+  - ToolResultBlock metadata shape totality: tool_use_id kept only as an
+    exact built-in str (no length ceiling, else ""), is_error kept only as
+    an exact built-in bool (else exact False), so neither can carry a
+    foreign object into a provider wire dict or a hostile __bool__ into an
+    encoder.
 """
 
 from __future__ import annotations
@@ -743,6 +748,291 @@ def test_openai_encoder_total_for_malformed_text_and_content():
     assert OpenAICompatBackend._message_to_wire(
         Message(role="user", content=[ToolResultBlock(tool_use_id="t", content=[5])])
     ) == [{"role": "tool", "tool_call_id": "t", "content": "[]"}]
+
+
+# -- ToolResultBlock.tool_use_id / is_error metadata shape totality ----------
+#
+# The two documented residuals left by #412 (see the ToolResultBlock
+# docstring). Both fields are model/tool-reachable and were previously
+# unnormalized, so a non-str/hostile `tool_use_id` flowed straight into both
+# providers' outbound wire dicts, and `is_error` was truth-tested by both
+# encoders — letting a hostile `__bool__` escape and letting a malformed
+# truthy value (e.g. `1`, `"yes"`) produce false error semantics.
+# Construction now proves `tool_use_id` an exact built-in `str` (byte-for-
+# byte, no length ceiling, reusing `_exact_str`, else "") and `is_error` an
+# exact built-in `bool` (`True`/`False` by `type(x) is bool` identity, else
+# exact `False`) — without invoking any hook on a refused value.
+#
+# Failing-before (observed on the pre-fix base, on-seat): a hostile
+# `is_error.__bool__` raised out of BOTH encoders; a malformed truthy
+# `is_error` set the Anthropic `is_error` flag + the OpenAI "[ERROR] "
+# prefix; a non-str/hostile `tool_use_id` survived construction and entered
+# BOTH wire dicts. Passing-after: every case below is total and correct.
+# Assertions use type()/is/`in`/`==`-against-builtins and never invoke a
+# refused value's own equality, hash, or representation hooks.
+
+
+class _HostileBool:
+    """Object whose truth, comparison, hash, and representation hooks all
+    raise — proves `is_error` normalization refuses it by exact-type identity
+    (`type(x) is bool`) without calling bool(), ==, !=, hash(), str(), repr(),
+    iteration, or length. (`_HostileValue` above omits __eq__/__hash__, which
+    default to identity; this instrument closes that gap for the is_error
+    matrix.)"""
+
+    def __bool__(self):
+        raise _HookCalled("__bool__")
+
+    def __eq__(self, other):
+        raise _HookCalled("__eq__")
+
+    def __ne__(self, other):
+        raise _HookCalled("__ne__")
+
+    def __hash__(self):
+        raise _HookCalled("__hash__")
+
+    def __str__(self):
+        raise _HookCalled("__str__")
+
+    def __repr__(self):
+        raise _HookCalled("__repr__")
+
+    def __len__(self):
+        raise _HookCalled("__len__")
+
+    def __iter__(self):
+        raise _HookCalled("__iter__")
+
+    def __index__(self):
+        raise _HookCalled("__index__")
+
+    def __int__(self):
+        raise _HookCalled("__int__")
+
+
+# Refused tool_use_id shapes (plain builtins). str subclasses + hostile
+# objects are exercised in dedicated bodies below so no hook runs.
+_REFUSED_ID_BUILTINS = [None, 0, 123, True, False, 1.5, b"bytes", ["l"], ("t",), {"d": 1}, {1, 2}]
+_REFUSED_ID_IDS = ["none", "int0", "int", "true", "false", "float", "bytes", "list", "tuple", "dict", "set"]
+
+# Refused is_error shapes (plain builtins): 0/1, None, empty/non-empty
+# strings, bytes, list, tuple, dict, set, floats — every one must become
+# exact built-in False.
+_MALFORMED_IS_ERROR = [
+    0, 1, 2, None, "", "yes", b"", b"x", [], [1], (), ("t",),
+    {}, {"k": 1}, set(), {1, 2}, 0.0, 3.14,
+]
+_MALFORMED_IS_ERROR_IDS = [
+    "int0", "int1", "int2", "none", "empty_str", "nonempty_str",
+    "empty_bytes", "nonempty_bytes", "empty_list", "nonempty_list",
+    "empty_tuple", "nonempty_tuple", "empty_dict", "nonempty_dict",
+    "empty_set", "nonempty_set", "float0", "float",
+]
+
+
+# -- tool_use_id: exact-string retention ------------------------------------
+
+
+def test_tool_result_tool_use_id_exact_str_retained_byte_for_byte():
+    for value in ("tu_1", "", "  spaced  ", "line\nbreak\tid", "🌟unicode✓"):
+        b = ToolResultBlock(tool_use_id=value, content="c")
+        assert type(b.tool_use_id) is str
+        assert b.tool_use_id == value
+
+
+def test_tool_result_tool_use_id_no_length_ceiling_introduced():
+    long_id = "z" * 100_000
+    b = ToolResultBlock(tool_use_id=long_id, content="c")
+    assert b.tool_use_id == long_id
+    assert len(b.tool_use_id) == 100_000  # no new ceiling (unlike ToolUseBlock.id)
+
+
+# -- tool_use_id: refused shapes become exact "" ----------------------------
+
+
+@pytest.mark.parametrize("value", _REFUSED_ID_BUILTINS, ids=_REFUSED_ID_IDS)
+def test_tool_result_tool_use_id_refuses_non_str_builtins(value):
+    b = ToolResultBlock(tool_use_id=value, content="c")
+    assert type(b.tool_use_id) is str
+    assert b.tool_use_id == ""  # no conversion, no type-name reporting
+
+
+def test_tool_result_tool_use_id_refuses_plain_str_subclass():
+    b = ToolResultBlock(tool_use_id=_PlainStrSub("sub"), content="c")
+    assert type(b.tool_use_id) is str
+    assert b.tool_use_id == ""  # exact-type gate, not isinstance
+
+
+def test_tool_result_tool_use_id_refuses_hostile_str_subclass_without_hooks():
+    b = ToolResultBlock(tool_use_id=_HostileStr("evil"), content="c")
+    assert b.tool_use_id == ""
+
+
+def test_tool_result_tool_use_id_refuses_hostile_object_without_hooks():
+    b = ToolResultBlock(tool_use_id=_HostileValue(), content="c")
+    assert b.tool_use_id == ""
+
+
+def test_tool_result_tool_use_id_and_content_gated_independently():
+    # A hostile value in one field never disturbs a well-formed value in
+    # another, and no hook runs on the refused one.
+    b1 = ToolResultBlock(tool_use_id=_HostileValue(), content="keep")
+    assert b1.tool_use_id == ""
+    assert b1.content == "keep"
+    b2 = ToolResultBlock(tool_use_id="keep", content=_HostileValue())
+    assert b2.tool_use_id == "keep"
+    assert b2.content == ""
+
+
+def test_tool_result_tool_use_id_remains_frozen_after_normalization():
+    b = ToolResultBlock(tool_use_id=123, content="c")
+    assert b.tool_use_id == ""
+    with pytest.raises(Exception):
+        b.tool_use_id = "x"  # frozen dataclass → FrozenInstanceError
+
+
+# -- is_error: exact True / False retention ---------------------------------
+
+
+def test_tool_result_is_error_retains_exact_true_and_false():
+    bt = ToolResultBlock(tool_use_id="t", content="c", is_error=True)
+    assert type(bt.is_error) is bool
+    assert bt.is_error is True
+    bf = ToolResultBlock(tool_use_id="t", content="c", is_error=False)
+    assert type(bf.is_error) is bool
+    assert bf.is_error is False
+
+
+def test_tool_result_is_error_defaults_to_exact_false():
+    b = ToolResultBlock(tool_use_id="t", content="c")
+    assert type(b.is_error) is bool
+    assert b.is_error is False
+
+
+# -- is_error: refused shapes become exact False ----------------------------
+
+
+@pytest.mark.parametrize("value", _MALFORMED_IS_ERROR, ids=_MALFORMED_IS_ERROR_IDS)
+def test_tool_result_is_error_refuses_non_bool_builtins(value):
+    b = ToolResultBlock(tool_use_id="t", content="c", is_error=value)
+    assert type(b.is_error) is bool
+    assert b.is_error is False  # exact False; no bool()/==/hash on the value
+
+
+def test_tool_result_is_error_refuses_hostile_objects_without_hooks():
+    # Constructing must not raise _HookCalled: no bool()/==/hash()/repr on it.
+    for hostile in (_HostileValue(), _HostileBool()):
+        b = ToolResultBlock(tool_use_id="t", content="c", is_error=hostile)
+        assert type(b.is_error) is bool
+        assert b.is_error is False
+
+
+def test_tool_result_is_error_remains_frozen_after_normalization():
+    b = ToolResultBlock(tool_use_id="t", content="c", is_error="yes")
+    assert b.is_error is False
+    with pytest.raises(Exception):
+        b.is_error = True  # frozen dataclass → FrozenInstanceError
+
+
+# -- both encoders total over malformed tool_use_id (exact "" wire field) ---
+
+
+def test_anthropic_encoder_refused_tool_use_id_becomes_exact_empty_str():
+    for bad in (None, 123, _HostileValue(), _HostileStr("x"), _PlainStrSub("s"), ["l"]):
+        w = AnthropicBackend._block_to_wire(
+            ToolResultBlock(tool_use_id=bad, content="ok")
+        )
+        # exact empty string — NOT a converted, represented, or retained
+        # foreign object
+        assert type(w["tool_use_id"]) is str
+        assert w["tool_use_id"] == ""
+        assert w["content"] == "ok"
+        assert "is_error" not in w
+
+
+def test_openai_encoder_refused_tool_use_id_becomes_exact_empty_str():
+    for bad in (None, 123, _HostileValue(), _HostileStr("x"), _PlainStrSub("s"), ["l"]):
+        out = OpenAICompatBackend._message_to_wire(
+            Message(role="user", content=[ToolResultBlock(tool_use_id=bad, content="ok")])
+        )
+        assert out == [{"role": "tool", "tool_call_id": "", "content": "ok"}]
+
+
+# -- both encoders total over malformed is_error (no error semantics) -------
+
+
+def test_anthropic_encoder_malformed_is_error_never_flags_error():
+    # Pre-fix: `1`/`"yes"`/`[1]` set the flag; a hostile __bool__ escaped.
+    for bad in (1, "yes", "true", [1], {1: 1}, 3.14, _HostileValue(), _HostileBool()):
+        w = AnthropicBackend._block_to_wire(
+            ToolResultBlock(tool_use_id="t", content="ok", is_error=bad)
+        )
+        assert "is_error" not in w  # normalized False → no flag
+        assert w["content"] == "ok"
+
+
+def test_openai_encoder_malformed_is_error_never_prefixes_error():
+    for bad in (1, "yes", "true", [1], {1: 1}, 3.14, _HostileValue(), _HostileBool()):
+        out = OpenAICompatBackend._message_to_wire(
+            Message(role="user", content=[ToolResultBlock(tool_use_id="t", content="ok", is_error=bad)])
+        )
+        assert out == [{"role": "tool", "tool_call_id": "t", "content": "ok"}]
+
+
+# -- accepted-value wire retention (both providers) + exact True semantics ---
+
+
+def test_anthropic_encoder_accepted_metadata_wire_unchanged():
+    # Exact True retains the established Anthropic is_error:true flag.
+    assert AnthropicBackend._block_to_wire(
+        ToolResultBlock(tool_use_id="tu_1", content="ok", is_error=True)
+    ) == {"type": "tool_result", "tool_use_id": "tu_1", "content": "ok", "is_error": True}
+    # Exact False emits no flag (established behavior).
+    assert AnthropicBackend._block_to_wire(
+        ToolResultBlock(tool_use_id="tu_2", content="ok", is_error=False)
+    ) == {"type": "tool_result", "tool_use_id": "tu_2", "content": "ok"}
+
+
+def test_openai_encoder_accepted_metadata_wire_unchanged():
+    # Exact True retains the established OpenAI "[ERROR] " prefix.
+    assert OpenAICompatBackend._message_to_wire(
+        Message(role="user", content=[ToolResultBlock(tool_use_id="tu_1", content="ok", is_error=True)])
+    ) == [{"role": "tool", "tool_call_id": "tu_1", "content": "[ERROR] ok"}]
+    assert OpenAICompatBackend._message_to_wire(
+        Message(role="user", content=[ToolResultBlock(tool_use_id="tu_2", content="ok", is_error=False)])
+    ) == [{"role": "tool", "tool_call_id": "tu_2", "content": "ok"}]
+
+
+# -- integration: every field malformed at once stays total -----------------
+
+
+def test_both_encoders_total_over_fully_malformed_tool_result():
+    b = ToolResultBlock(
+        tool_use_id=_HostileValue(), content=_HostileValue(), is_error=_HostileValue()
+    )
+    assert AnthropicBackend._block_to_wire(b) == {
+        "type": "tool_result",
+        "tool_use_id": "",
+        "content": "",
+    }
+    assert OpenAICompatBackend._message_to_wire(Message(role="user", content=[b])) == [
+        {"role": "tool", "tool_call_id": "", "content": ""}
+    ]
+
+
+def test_tool_result_content_normalization_unchanged_alongside_metadata():
+    # The #412 content normalization (str byte-for-byte; exact-list filtered
+    # to exact built-in blocks, in order; else "") is unchanged while the two
+    # metadata fields normalize independently.
+    blocks = [TextBlock(text="a"), ToolUseBlock(id="u", name="n"), 5, "x", TextBlock(text="b")]
+    b = ToolResultBlock(tool_use_id=123, content=blocks, is_error="yes")
+    assert type(b.content) is list
+    assert [type(x) for x in b.content] == [TextBlock, ToolUseBlock, TextBlock]
+    assert [x for x in b.content if type(x) is TextBlock][0].text == "a"
+    assert b.content[-1].text == "b"  # order preserved
+    assert b.tool_use_id == ""
+    assert b.is_error is False
 
 
 # -- AgentBackend ABC --------------------------------------------------------


### PR DESCRIPTION
## `ToolResultBlock` metadata shape totality — closes the two documented #412 residuals

Bounded, Ian-seat package. Normalizes `ToolResultBlock.tool_use_id` and
`ToolResultBlock.is_error` at the shared dataclass boundary so both provider
encoders receive proven built-in values. **Draft — do NOT merge.** Merge
authority is Kev's later explicit word only.

### Base / head / parent
- **base:** `main` @ `67be0765bfac63f9d4b834b22a7418129e16bd01`
- **head:** `fix/tool-result-metadata-shape-totality` @ `dbe108ebeeebf463a6a0abc05befe6c71ead2023`
- **parent of head:** `67be0765bfac63f9d4b834b22a7418129e16bd01` (single parent; branch cut fresh from freshly-verified live main)

### Files & diffstat (exactly two permitted files)
```
 scripts/agent_backends/base.py |  41 ++++--
 tests/test_agent_backend.py    | 290 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 323 insertions(+), 8 deletions(-)
```
No other file changed. `anthropic_backend.py` and `openai_compat_backend.py`
are **byte-identical to `main`** (`git diff origin/main` empty for both).

### Root cause
`ToolResultBlock.__post_init__` (post-#412) normalized only `content`; its
docstring recorded `tool_use_id` and `is_error` as explicitly out of scope.
Both fields are model/tool-reachable, so:

1. **`tool_use_id`** — a non-string or hostile object flowed unchanged into
   both providers' outbound wire dictionaries: Anthropic
   `payload["tool_use_id"] = b.tool_use_id` and OpenAI-compat
   `"tool_call_id": b.tool_use_id`.
2. **`is_error`** — both encoders truth-test `if b.is_error:`. A hostile
   `__bool__` therefore escaped both encoders, and a malformed truthy value
   such as `1` or `"yes"` incorrectly produced error semantics (Anthropic
   `is_error: true`; OpenAI-compat `"[ERROR] "` prefix).

### Exact normalization semantics (in `ToolResultBlock.__post_init__`)
- **`tool_use_id`** → `_exact_str(...)` (reused): kept only when
  `type(value) is str`, byte-for-byte, **no length ceiling**. Empty,
  whitespace, Unicode, newline, and long strings are preserved unchanged.
  Every non-exact-string shape — including `str` subclasses and hostile
  objects — becomes `""`. A refused value is never converted, stringified,
  represented, compared, iterated, length-tested, or truth-tested.
- **`is_error`** → exact built-in-bool proof `if type(self.is_error) is not
  bool: -> False`. Exact `True`/`False` are retained (`bool` cannot be
  subclassed, so `type(x) is bool` proves an exact built-in bool). Every
  other shape becomes exact built-in `False`. No `bool()`, equality,
  hashing, representation, conversion, iteration, or supplied hook is called.
- **`content`** normalization from #412 is preserved **byte-identically**
  (same `_normalized_result_content(self.content)` call, unchanged).
- Dataclass remains **frozen**.
- **Encoders untouched**: the shared-root repair makes their established
  `payload["tool_use_id"]` / `"tool_call_id"` / `if b.is_error:` paths total.

### Exception policy
No exception handling added. No blanket catch; `MemoryError` remains
uncaught. No supplied value, type name, representation, or exception text is
exposed. Normalization is pure exact-type identity (`type(x) is str/bool`)
plus reuse of the existing `_exact_str` helper.

### Bounded claim & residual scope
The claim is limited to `ToolResultBlock.tool_use_id` and
`ToolResultBlock.is_error` (plus the unchanged `content` normalization). This
is **not** a whole-backend, whole-dataclass-family, or whole-pipeline
totality claim. Other blocks/fields are out of scope for this seat.

### Failing-before / passing-after evidence
Measured on-seat by running the **entire committed `tests/test_agent_backend.py`**
through a pytest-free runner (see "Local verification limitations"), toggling
only `scripts/agent_backends/base.py` between the pre-fix `origin/main`
version and this change:

| Base | passed | failed | total |
|------|--------|--------|-------|
| **failing-before** (pre-fix `base.py`) | 120 | **42** | 162 |
| **passing-after** (this change)        | **162** | 0 | 162 |

The 42 failing-before cases are exactly the newly-added metadata cases; the
114 pre-existing tests (incl. all #412 content regressions) and the 6
retention/accepted-value new cases pass in both states.

Representative failures proven against the pre-fix base (direct
production-type + both-encoder drive):
- a hostile `is_error.__bool__` **raised out of both encoders**
  (`ENCODER ESCAPED via hostile hook __bool__`);
- malformed truthy `is_error` (`1`, `"yes"`, `"true"`, `[1]`, `{1:1}`,
  `3.14`) set the Anthropic `is_error` flag **and** the OpenAI `"[ERROR] "`
  prefix;
- non-string / hostile `tool_use_id` (`None`, `int`, `bool`, `float`,
  `bytes`, `list`, `tuple`, `dict`, `set`, str subclass, hostile object)
  **survived construction and entered both wire dicts**.

### Adversarial matrix coverage (+48 cases)
- **Exact-string id retention:** ordinary, empty, whitespace, Unicode,
  newline-containing, and a 100k-char string proving no ceiling.
- **Refused ids → exact `""`:** `None`, ints, booleans, float, bytes, list,
  tuple, dict, set, benign `str` subclass, hostile `str` subclass, hostile
  general object.
- **Exact `True` / exact `False` retention** + default `False`.
- **Refused `is_error` → exact `False`:** `0`, `1`, `2`, `None`,
  empty/non-empty strings, empty/non-empty bytes, list, tuple, dict, set,
  floats; and objects whose `__bool__` / `__eq__` / `__hash__` / `__str__` /
  `__repr__` / iteration / length hooks raise (`_HostileValue`,
  new `_HostileBool`).
- **Construction results are exact built-in `str` and exact built-in `bool`**
  (`type(...) is str` / `is bool` asserted throughout).
- **Both encoders total over every malformed case**, with a malformed
  `tool_use_id` becoming an **exact empty-string wire field** (not a
  converted/represented/retained foreign object), and a malformed/hostile
  `is_error` **never** triggering an error flag or `"[ERROR] "` prefix.
- **Accepted-value wire dictionaries unchanged for both providers**
  (Anthropic `is_error: true`; OpenAI `"[ERROR] "` prefix for exact `True`;
  no flag/prefix for exact `False`).
- **Existing `content` normalization, block ordering, frozen behavior, and
  all #412 regressions remain unchanged** (dedicated integration case +
  the 114 pre-existing tests).

Assertions use `type()` / `is` / `in` / equality-against-builtins only, so a
failing-before check never itself executes a refused value's equality, hash,
or representation hook. The existing hostile-value toolkit is reused;
extended only by one new `_HostileBool` instrument for the `__eq__`/`__hash__`
requirement.

### Local verification limitations
This seat (Ian's lounge) has **no `pytest` installed** and no repo toolchain;
per standing seat policy nothing was installed. Python 3.13.7 (`py`) is
present and the package imports cleanly. Evidence above was produced by a
**pytest-free runner** (a minimal `pytest.mark.parametrize`/`pytest.raises`
shim, scratchpad-only, not committed) that imports and executes every
`test_*` function in the committed file with parametrize expanded — mirroring
pytest per-case accounting. `py -m py_compile` is clean for both files and
all `scripts/agent_backends/*`; `git diff --check` clean; no tabs; final
newline present. **The authoritative gate remains CI `verify-python`** (which
provisions the `uft_ca` extension + optional providers this seat lacks); a
body-only CI receipt will be appended once checks conclude.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 4.8** (model ID
`claude-opus-4-8`, the "84" seat). No model crossover during the work.

### Fences (confirmed)
- Fresh branch `fix/tool-result-metadata-shape-totality` cut from
  freshly-verified live `main` `67be076`; single-parent commit; normal
  push, **no force**.
- Exactly one focused commit; exactly two permitted files; encoders and all
  other files untouched.
- Kev-seat draft **#418** (`fix/dandelion-genome-object-refusal`,
  `scripts/dandelion.py` + `tests/test_dandelion.py`) treated as an
  integration fence — **not** inspected, edited, or mutated; **no overlap**
  with the two permitted files.
- No merge / auto-merge / admin bypass / rebase / force-push / history
  rewrite / protection or settings change / workflow rerun / merge-from-main
  after branch creation / close-reopen / manual source-branch deletion.
- No review-thread replies, resolutions, reactions, labels, or unrelated
  comments. Leave OPEN, draft, unmerged. Hand back to Jack for audit.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed to conclusive result on PR head `dbe108ebeeebf463a6a0abc05befe6c71ead2023`:

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m39s) | run `30073325901` / job `89418610794` — **2268 passed, 12 skipped, 0 failed** (44.47s; fully-provisioned CI: `uft_ca` extension built + optional providers) |
| Analyze Python (CodeQL) | ✅ pass | run `30073325903` |
| agent-safety | ✅ pass | run `30073325927` |
| frontend-quality | ✅ pass | run `30073325901` |
| tripwire | ✅ pass | run `30073325956` |

All registered checks green; zero failures. CI's full-suite figure (2268/12/0)
supersedes the seat-local pytest-free figure (162/0 for `test_agent_backend.py`)
as the authoritative gate. PR remains **OPEN, draft, unmerged** — handing back
to Jack for audit; merge authority is Kev's later explicit word only.
