### PR TITLE
docs(nextness): define offline evidence campaign contract

### DIFF
--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -2,7 +2,7 @@
 
 **Proposed module (not created by this PR)**: `scripts/nextness_evidence_campaign.py` ·
 **Proposed tests (not created by this PR)**: `tests/test_nextness_evidence_campaign.py` ·
-**Proposed schema id**: `nextness-evidence-campaign-v1` · **Status**: **DESIGN ONLY**
+**Proposed schema id (new, not on `main`)**: `nextness-evidence-campaign-v1` · **Status**: **DESIGN ONLY**
 
 > **This document is a frozen design contract, not an implementation.** It
 > creates no runner, reads no real Medusa artifact, runs no observer, no
@@ -14,20 +14,32 @@
 > …", "the campaign …", "v1 …" statement below is a **proposed future
 > obligation**, never a description of existing behaviour.
 
+**Existing vs proposed (read this first).** Everything attributed to NP1–NP9
+below — schema ids `nextness-predictor-v1` / `nextness-monitor-v1` /
+`nextness-evaluation-v1` / `nextness-replay-lab-v1` /
+`nextness-replay-protocol-v1` / `nextness-evidence-packet-v1`, their bounds,
+their per-CLI exit codes, and the four NP8 provenance links — is a **fact found
+in current `main` source** and is **not changed** by this contract. Everything
+attributed to the *campaign* — the `nextness-evidence-campaign-v1` manifest, the
+eight-file publication set, the `--workspace-dir` staging model, and the campaign
+exit-code map — is **newly proposed here** and exists only as this design. The
+prose marks these as *(existing at `main`)* or *(proposed, new)* wherever
+confusion is possible.
+
 ## 1. What a "campaign" is — and is not
 
 A **campaign** is the deterministic, offline processing of **one
 already-recorded** Nextness Observer log into a single provenance-checked
-NP1 → NP2 → NP5 → NP6 → NP8 artifact chain, published as one directory of
-recorded artifacts.
+NP1 → NP2 → NP5 → NP6 → NP8 artifact chain, published — together with an outer
+campaign manifest — as one fixed set of files in one directory.
 
 "Campaign" means **recorded-log artifact processing only**. It explicitly does
 **not** mean, and the runner must never perform:
 
 - snapshot collection or any `process_snapshot()` call;
 - observer execution (`scripts/nextness_observer.py` is a log **producer**,
-  upstream of and outside the campaign — the campaign consumes its output
-  read-only, it never runs it);
+  upstream of and outside the campaign — the campaign consumes a recording of
+  its output read-only, it never runs it);
 - calibration experimentation (`scripts/nextness_calibration.py` is a
   sweeping / discriminating experiment orchestrator — a winner-seeking activity
   a descriptive campaign must not do);
@@ -59,274 +71,368 @@ this PR**):
 | Out-of-scope producer | `scripts/nextness_observer.py` | — | — |
 
 Where this contract names a bound, an exit code, a provenance field or a schema
-id, it is the value found in that source at `main`. If any such fact later stops
-matching source, **this document must change under its own gate** — nothing here
-licenses a silent drift, and nothing here proposes to *change* those interfaces.
+id **for an instrument**, it is the value found in that source at `main`, and it
+is left unchanged. Where it names the campaign manifest, publication set, or
+campaign exit map, that is **proposed here**. If any *(existing at `main`)* fact
+later stops matching source, **this document must change under its own gate** —
+nothing here licenses a silent drift, and nothing here proposes to *change* any
+instrument interface.
 
 ## 3. Frozen v1 decisions
 
-### 3.1 Inputs
+### 3.1 Inputs, the workspace, and the authoritative staged snapshot
 
 - Exactly **one** already-recorded `nextness_runs.jsonl` log.
 - Exactly **one** operator-authored NP6 protocol file
   (`nextness-replay-protocol-v1`).
-- Both inputs reside in an **operator-selected external workspace outside the
-  repository `data/` tree**. The runner discovers no live snapshots and reads no
-  raw snapshot input; the log is a recording, consumed read-only.
-- Both inputs remain **byte-identical** across the run: the runner is read-only
-  with respect to both, mirroring every instrument's own input-protection
-  guarantee (tested byte-for-byte in NP1/NP5/NP6/NP8).
+- **`--workspace-dir <existing-dir>` is required.** It must name an **already
+  existing** directory. The runner resolves it once (`os.path.realpath`) to a
+  `workspace_root`.
+- **Resolved-path containment.** The original log, the original protocol, the
+  staging parent, and the final output directory must each, after
+  `os.path.realpath`, be **equal to `workspace_root` or a descendant of it**
+  (compared on resolved paths — covering `..` segments and symlinks — with the
+  established fail-closed identity discipline; an inspection that cannot complete
+  is itself a refusal). `workspace_root` itself must resolve **outside the
+  repository `data/` tree**; consequently no campaign path may lie under `data/`.
+  A path failing containment is a fail-closed refusal (§3.9, exit 4).
+- **Authoritative staged snapshot.** Before running **any** instrument, the
+  runner copies the log and the protocol **byte-for-byte** into the unique
+  staging directory. **Every NP1 / NP2 / NP5 / NP6 / NP8 operation reads those
+  staged copies** (and the artifacts it writes into staging); it **never reopens
+  the original source paths** after the copy.
+- **Honest input-mutation statement.** The runner **never mutates the
+  originals**. It does not, however, freeze the operator's filesystem: a
+  concurrent actor that mutates or replaces a source **while its copy is being
+  taken** is a residual the runner cannot exclude. The **authoritative campaign
+  inputs are therefore the bytes successfully captured in staging**, whose hashes
+  the manifest records (§3.2); the campaign makes claims about those captured
+  bytes, not about the originals' later state.
 
-### 3.2 Exact output chain
+### 3.2 Exact output chain and the eight-file publication set
 
-From the two inputs, the proposed v1 runner produces, in dependency order, the
-following recorded artifacts, each the **byte-identical** output of the existing
-instrument:
+From the staged inputs, the proposed v1 runner produces, in dependency order,
+each the **byte-identical** output of the existing instrument run on the staged
+copies:
 
-1. one deterministic **NP1 predictor report** (`nextness-predictor-v1`) over the
-   log;
-2. one deterministic **NP2 checkpoint receipt** (`nextness-monitor-v1`), computed
-   for the single monitor configuration selected by an explicit
-   `receipt_config_label` (see §3.3);
-3. one **NP5 evaluation** (`nextness-evaluation-v1`) over the report and that
+1. **NP1 predictor report** (`nextness-predictor-v1`) over the staged log;
+2. **NP2 checkpoint receipt** (`nextness-monitor-v1`) for the single monitor
+   configuration selected by the exact `receipt_config_label` (§3.4, §3.5);
+3. **NP5 evaluation** (`nextness-evaluation-v1`) over the report and that
    receipt;
-4. one **NP6 replay-lab report** (`nextness-replay-lab-v1`) over the log and the
-   protocol, **retaining every protocol configuration** for descriptive
-   trajectories (see §3.3);
-5. one **NP8 evidence packet** (`nextness-evidence-packet-v1`) containing the
-   **six** existing roles, one artifact each:
-   - `report` — the NP1 report,
-   - `receipts` — the NP2 checkpoint receipt,
-   - `evaluation` — the NP5 evaluation,
-   - `lab` — the NP6 replay-lab report,
-   - `protocol` — the operator-authored NP6 protocol (input),
-   - `log` — the recorded `nextness_runs.jsonl` (input).
+4. **NP6 replay-lab report** (`nextness-replay-lab-v1`) over the staged log and
+   the staged protocol, retaining **every** protocol configuration (§3.4, §3.5);
+5. **NP8 evidence packet** (`nextness-evidence-packet-v1`) over the six existing
+   roles (`report`, `receipts`, `evaluation`, `lab`, `protocol`, `log`).
 
-**Provenance gate.** The NP8 packet records, per role, the artifact's schema id,
-byte length and SHA-256, and independently recomputes the **four** provenance
-links the v1 schemas themselves embed:
+**Frozen final directory — exactly these eight files** (no more, no fewer),
+relative names only:
 
-| Link | Recorded by | Verified against |
+| File | Contents |
+|---|---|
+| `nextness_runs.jsonl` | the staged log (authoritative captured bytes) |
+| `nextness_replay_protocol.json` | the staged NP6 protocol |
+| `nextness_predictor_report.json` | NP1 report |
+| `nextness_monitor_receipt.json` | NP2 checkpoint receipt |
+| `nextness_evaluation.json` | NP5 evaluation |
+| `nextness_replay_lab.json` | NP6 replay-lab report |
+| `nextness_evidence_packet.json` | NP8 evidence packet |
+| `nextness_evidence_campaign.json` | the outer campaign manifest *(proposed, new)* |
+
+**The outer campaign manifest** `nextness_evidence_campaign.json`
+(`nextness-evidence-campaign-v1`) is **the final campaign artifact, not an NP8
+role** — NP8's role set is unchanged and has no campaign entry. It has an exact
+schema, the same canonical serialization as the instruments (sorted keys, fixed
+separators, LF-only, no timestamp / random id / absolute path), **relative
+filenames only**, and its own explicit named ceiling `MAX_CAMPAIGN_MANIFEST_BYTES`
+= **64 KiB** (fail-closed; §3.9 exit 5). It records:
+
+- each input's byte size and SHA-256 (the **staged** log and protocol);
+- the campaign reader bounds (`max_rows`, `max_line_bytes`) actually applied;
+- the exact `receipt_config_label` and its configuration correspondence (§3.4);
+- the completeness evidence (§3.6);
+- every published artifact's relative filename, byte size and SHA-256;
+- the NP8 packet's SHA-256;
+- the **four NP8 link statuses** (§3.3), copied for auditability.
+
+**Direction of trust.** The manifest **points inward** to the NP8 packet (it
+records the packet's hash and echoes the packet's link statuses). **NP8 does not
+authenticate or provenance-link the campaign manifest** — the manifest is the
+outermost layer, verified by nothing above it; a consumer that re-verifies the
+chain re-hashes the eight files against the manifest itself.
+
+### 3.3 The four NP8 provenance checks (existing at `main`)
+
+The NP8 packet independently recomputes the four provenance checks the v1 schemas
+embed. These are **three artifact-byte hash links plus one
+accepted-sequence-representation hash link** — not four links of one identical
+kind:
+
+| Check | Kind | Recorded by → verified against |
 |---|---|---|
-| `evaluation_report_sha256` | NP5 evaluation `artifacts.report.sha256` | the report file's bytes |
-| `evaluation_receipts_sha256` | NP5 evaluation `artifacts.receipts.sha256` | the receipts file's bytes |
-| `lab_protocol_sha256` | NP6 lab report `input.protocol_sha256` | the protocol file's bytes |
-| `lab_sequence_sha256` | NP6 lab report `input.sequence_sha256` | the log's accepted dominant-token sequence, recomputed through NP1's bounded reader with the lab's recorded `max_rows` / `max_line_bytes` |
+| `evaluation_report_sha256` | artifact-byte hash | NP5 `artifacts.report.sha256` → the report **file's raw bytes** |
+| `evaluation_receipts_sha256` | artifact-byte hash | NP5 `artifacts.receipts.sha256` → the receipts **file's raw bytes** |
+| `lab_protocol_sha256` | artifact-byte hash | NP6 `input.protocol_sha256` → the protocol **file's raw bytes** |
+| `lab_sequence_sha256` | accepted-**sequence-representation** hash | NP6 `input.sequence_sha256` → the hash of the log's **accepted dominant-token sequence**, recomputed through NP1's bounded reader **with the lab's recorded `max_rows` / `max_line_bytes`** (not a hash of the log file's bytes) |
 
-**All four links must be `verified`** (byte-level hash match) before publication
-succeeds. A `broken` link, or a link that the packet types `not_computable`
-because a counterpart was absent, is a campaign failure: the v1 campaign always
-supplies all six roles, so every link is expected to be checkable, and a
-non-`verified` outcome fails closed (§3.8). The campaign invents no link the
-schemas do not already record and weakens none the packet already verifies.
+**All four must be `verified`** before publication succeeds; a non-`verified`
+outcome is an explicit **campaign** refusal (§3.9, exit 2 — *provenance not
+verified*), fail-closed. **These four checks verify hashes only** — they do not,
+by themselves, establish that the report, receipts and lab all came from the
+**same log under the same options**. That same-log / same-options coherence is
+supplied by the **campaign-level construction and the manifest** (§3.4), not by
+the NP8 links.
 
-### 3.3 No implicit winner
+### 3.4 Semantic lineage (campaign-level, proposed)
 
-- `receipt_config_label` is a **mandatory** CLI argument. It must match, by exact
+Because the campaign builds the whole chain, it can and must enforce lineage the
+individual instruments do not cross-check:
+
+- The protocol's **`smoothing`** and **`holdout_fraction`** drive **NP1**.
+- The protocol's **`model`**, **`smoothing`** and **`holdout_fraction`**,
+  together with the configuration identified by the exact `receipt_config_label`,
+  drive **NP2**.
+- **NP1, NP2 and NP6 use identical campaign `max_rows` and `max_line_bytes`.**
+- **NP6 retains every protocol configuration in operator order** (its existing
+  descriptive guarantee, unchanged).
+- The manifest **records the selected label and its exact configuration
+  correspondence**, because an **NP2 receipt records the configuration's *values*
+  but not the protocol *label*** — without the manifest, the receipt could not be
+  tied back to a named protocol configuration.
+- **Cross-artifact coherence gate.** If NP5 produces a **`computed`
+  cross-artifact contradiction** — a genuine disagreement the evaluator was able
+  to compute — where the campaign's same-source construction *should* have made
+  agreement possible, the runner **refuses publication** (§3.9, exit 2). A
+  legitimate **`not_computable`** result (for example `no_covering_receipt`, or
+  any typed absent-evidence reason) is an **evidence outcome, not a failure**:
+  the campaign still publishes, and the manifest carries it forward as recorded.
+
+### 3.5 No implicit winner
+
+- `receipt_config_label` is a **mandatory** CLI argument matching, by exact
   string, **exactly one** configuration label in the operator's NP6 protocol
-  (labels are unique and ≤ 64 chars — `MAX_LABEL_CHARS` — per
+  (labels are unique and ≤ 64 chars — `MAX_LABEL_CHARS` — in
   `nextness-replay-protocol-v1`).
 - The runner must **never** select the first configuration implicitly, and must
-  **never** rank, search, recommend, infer, or apply a "winning" configuration.
-  Selection is the operator's explicit, named act; the campaign performs no
-  optimisation of any kind.
+  **never** rank, search, recommend, infer, or apply a **winning
+  *configuration***. Configuration selection is the operator's explicit, named
+  act; the campaign performs no configuration optimisation.
+- **Scope of the prohibition (correction).** NP5 legitimately **ranks the three
+  prediction *models*** (`empirical_prior`, `persistence`, `first_order`) with
+  fixed tie-breaks — that is existing, descriptive NP5 behaviour and is
+  **retained unchanged**. The campaign adds no *configuration* ranking,
+  selection, recommendation, or application; model rankings inside the NP5
+  evaluation are not a winner over configurations and are left exactly as NP5
+  emits them.
 - A missing, unknown, or duplicate `receipt_config_label` is a fail-closed
-  validation refusal (§3.8); "matches more than one" cannot occur for a valid
-  protocol (labels are unique) but is still refused defensively rather than
-  resolved.
-- **NP6 continues to retain all configurations descriptively.** The single
-  checkpoint receipt is for the one named configuration only; the replay-lab
-  report still replays and reports **every** configuration side by side, in the
-  operator's input order, with no score, ranking, winner or recommendation field
-  anywhere (NP6's descriptive-only guarantee is preserved unchanged, and
-  abstention remains a first-class outcome, never a defect).
+  validation refusal (§3.9, exit 2).
+- **NP6 continues to retain all configurations descriptively** — every
+  configuration replayed and reported side by side, in operator order, with no
+  score / ranking / winner / recommendation field (NP6's guarantee, preserved);
+  abstention remains a first-class outcome, never a defect.
 
-### 3.4 Metrics decision (parked)
-
-- `nextness_metrics` output is **not part of campaign v1**. `nextness_metrics`
-  is an observer-lineage sidecar (it derives `nextness_run_metrics.jsonl` from
-  the log); it is **not** an NP role in the NP1→NP8 provenance chain.
-- The NP8 packet has **no metrics role** and **cannot presently provenance-link
-  that sidecar**: there is no `metrics` role, no metrics artifact schema entry,
-  and no provenance link for it in `nextness-evidence-packet-v1`. Emitting an
-  unlinked metrics file beside a provenance-checked packet would be an artifact
-  the chain cannot vouch for.
-- This contract **does not change, and must not silently change, the NP8
-  schema.** Metrics is **parked** until a separately-gated decision either (a)
-  adds explicit provenance support for a metrics role to the NP8 schema, or (b)
-  defines an **honestly unlinked** sidecar whose non-membership in the provenance
-  chain is stated in the output itself. Neither option is proposed or authorised
-  here.
-
-### 3.5 Complete-log semantics
+### 3.6 Complete-log semantics (exact)
 
 The campaign must process the **whole physical log**, never a summary of a
-prefix:
+prefix — stated precisely:
 
-- **No `max_rows` prefix may be treated as a complete campaign.** This is a
-  campaign-level obligation that the underlying reader does **not** provide on
-  its own: NP1's `read_dominant_sequence` silently reads at most `max_rows`
-  physical records and treats that prefix as complete (the `max_rows`+1-th
-  record is simply never read, still exit 0). By contrast `nextness_metrics`
-  already refuses excess rows outright ("metrics summarizes a COMPLETE run").
-  The campaign adopts the **metrics discipline**, not the predictor default: the
-  runner must **prove the full physical log was accepted** under the selected
-  bounds — e.g. by confirming ingestion reached end-of-file rather than the
-  `max_rows` cap — **or refuse the campaign**. No silent truncation and no
-  prefix summary is permitted.
-- **No continuation after an oversized terminal record.** A record whose content
-  exceeds `max_line_bytes` is counted `oversized_line` and terminates NP1
-  ingestion fail-closed, yet NP1 still emits an exit-0 report over the records
-  before it. The campaign must detect that ingestion was terminated by an
-  oversized record (e.g. `rejections.oversized_line > 0`, or equivalently that
-  the read stopped before EOF) and **refuse**, rather than accept the truncated
-  prefix.
-- The selected reader bounds are echoed into the campaign's own manifest so the
-  completeness proof is reproducible and auditable, not implicit.
+- The obligation is that the staged log is **fully traversed under the selected
+  bounds**, **not** that "every physical row is accepted". Ordinary malformed-row
+  rejections (the 12 NP1 `REJECT_REASONS`) **remain normal NP1 behaviour** and do
+  not fail the campaign; a fully-traversed log with rejected rows is still
+  complete.
+- The **completeness preflight runs against the staged log** (the authoritative
+  captured bytes), under the campaign `max_rows` / `max_line_bytes`.
+- The runner **refuses** (§3.9, exit 2 — *complete-log refusal*) if the physical
+  record count would exceed `max_rows` (a prefix that is not the whole log) **or**
+  if an **oversized record** (content over `max_line_bytes`) terminated ingestion
+  — **before** treating the campaign as complete. NP1 on its own would silently
+  read a `max_rows` prefix and emit an exit-0 report; the campaign adopts the
+  stricter, metrics-style "complete run" discipline instead.
+- **NP8's `log`-role manifest entry is not the campaign completeness witness.**
+  NP8 is unchanged: its `log` entry hashes the raw bytes and computes its own
+  `sequence_sha256` using **NP1 *default* reader bounds**, while only its
+  **`lab_sequence` link** uses the lab's recorded bounds. The
+  default-bound NP8 log entry therefore says nothing about traversal under the
+  campaign bounds; the **campaign preflight** is the completeness witness, and its
+  evidence is recorded in the manifest.
 
-### 3.6 Publication
+### 3.7 Publication
 
 - The runner builds **every** output inside a **unique staging directory that
   shares the final output directory's parent**, so promotion is a single
-  same-directory rename on one filesystem.
-- The **final output directory must be absent before the run**. If it already
-  exists, the run refuses (§3.8) — the runner **never overwrites** an existing
-  final directory.
-- Publication happens **only after** every produced artifact validates through
-  its own validator, the NP8 packet passes its **self-validation**
-  (`validate_evidence_packet`), and **all four provenance links are `verified`**.
-  A failure at any of these gates leaves the final directory uncreated.
-- **No output — staging or final — may be created under the repository `data/`
-  tree**, consistent with every instrument's `WriteOutsideLogDirError`
-  containment. All campaign output lives in the operator's external workspace.
-- **Concurrency / TOCTOU boundary, stated honestly.** The absence of the final
-  directory is checked at validation time; the later promotion does not re-verify
-  under a lock. A concurrent actor that creates the final directory between the
-  check and the rename is caught only to the extent the operating system refuses
-  a rename onto an existing directory; this residual validation-to-publish
-  interval is a **non-claim**, exactly as the instruments' own write guards state
-  their validation-to-write TOCTOU non-claim.
-- **Residual (hard kill).** A hard kill (or power loss) mid-run may leave an
-  **unpublished staging directory** behind; the final directory is either fully
-  absent or fully published, but the staging directory is not guaranteed to be
-  cleaned up on an uncatchable termination (see §3.8 for handled-failure
-  cleanup). The runner claims **no stronger cross-platform atomicity or
-  power-loss durability** than a single same-directory directory rename provides
-  — in particular it does not claim atomic multi-file publication on platforms
-  where directory rename semantics are weaker, and it does not claim fsync-level
-  durability.
+  same-directory rename on one filesystem. The byte-for-byte input copies (§3.1)
+  land there first; all eight files are assembled in staging.
+- The **final output directory must be absent at validation time**; if it already
+  exists then, the run **refuses** (§3.9, exit 4 — containment).
+- **No portable, absolute no-overwrite guarantee is claimed across the
+  validation-to-rename race.** The absence check and the later promotion are not
+  performed under a lock. If a destination is **created concurrently** between the
+  check and the rename, the outcome depends on the operating system: it may cause
+  a **reported publication failure** (§3.9, exit 7) where the OS reports the
+  collision or the rename failure; or, where the OS **permits replacement of an
+  empty directory**, the promotion may replace it. **Exit 7 applies exactly when
+  the OS reports the collision or rename failure**; an **unobservable replacement
+  remains an explicit non-claim** — the runner does not claim to detect or prevent
+  it.
+- Publication happens **only after** every produced artifact validates through its
+  own validator, the NP8 packet passes its **self-validation**, **all four
+  provenance checks are `verified`**, and the cross-artifact coherence gate (§3.4)
+  is satisfied. A failure at any of these gates leaves the final directory
+  uncreated.
+- **No output — staging or final — is created under the repository `data/`
+  tree** (guaranteed by the workspace containment of §3.1).
+- **Residuals (retained non-claims).** A hard kill (or power loss) mid-run may
+  leave an **unpublished staging directory** behind; a handled failure cleans its
+  staging directory, but an **uncatchable termination is not guaranteed to**. The
+  runner claims **no fsync-level power-loss durability** and **no atomicity
+  stronger than a single same-directory directory rename** — in particular no
+  atomic multi-file publication on platforms with weaker directory-rename
+  semantics. The validation-to-rename interval above is a standing non-claim,
+  consistent with every instrument's own validation-to-write TOCTOU non-claim.
 
-### 3.7 Determinism and bounds
+### 3.8 Determinism and bounds
 
-- **Byte-identical outputs.** The same input log bytes, the same protocol bytes,
-  the same explicit `receipt_config_label`, and the same CLI options must produce
-  **byte-identical** campaign outputs. Each instrument already guarantees
-  sorted-key, fixed-separator, LF-only, timestamp-free, randomness-free,
-  absolute-path-free serialization; the campaign **adds none of these** to any
-  generated artifact and introduces no wall-clock timestamp, random identifier,
-  or absolute path of its own (including in any campaign manifest it writes).
-- **Reuse existing ceilings where their contracts apply**, by name and value:
-  NP1/NP6 reader bounds `max_rows` (default 100 000, ceiling 1 000 000) and
-  `max_line_bytes` (default 65 536, ceiling `MAX_LINE_BYTES_CEILING` =
-  16 777 216); per-artifact serialized ceiling 64 KiB (`ReportTooLargeError` /
-  `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` /
-  `PacketTooLargeError`); NP5 `MAX_INPUT_BYTES` = 1 MiB per JSON artifact and
-  `MAX_SERIES_RECEIPTS` = 256; NP6 `MAX_LAB_CONFIGS` = 8 and `MAX_REPLAY_STEPS`
-  = 2000; NP8 `MAX_INPUT_BYTES` = 1 MiB, `MAX_LOG_BYTES` = 16 MiB,
-  `MAX_PACKET_ARTIFACTS` = 8, output ceiling 64 KiB.
-- **Define any campaign-level ceiling explicitly.** Any bound the campaign layer
-  needs that is not already one of the above — for example a cap on the number of
-  published files, or the size of a campaign manifest — must be declared as an
-  explicit named campaign constant with fail-closed enforcement, **never
-  inherited by implication** from an instrument whose contract does not actually
-  govern it.
+- **Byte-identical outputs.** The same staged input bytes, the same protocol
+  bytes, the same explicit `receipt_config_label`, and the same CLI options must
+  produce **byte-identical** campaign outputs — the eight files **including the
+  manifest**. Each instrument already guarantees sorted-key, fixed-separator,
+  LF-only, timestamp-free, randomness-free, absolute-path-free serialization; the
+  campaign and its manifest **add none** of timestamp, random identifier, or
+  absolute path, and the manifest uses **relative filenames only**.
+- **Reuse existing ceilings where their contracts apply** *(existing at `main`)*,
+  by name: NP1/NP6 reader bounds `max_rows` (default 100 000, ceiling
+  1 000 000) and `max_line_bytes` (default 65 536, ceiling
+  `MAX_LINE_BYTES_CEILING` = 16 777 216); per-artifact serialized ceiling 64 KiB
+  (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` /
+  `LabReportTooLargeError` / `PacketTooLargeError`); NP5 `MAX_INPUT_BYTES` = 1 MiB
+  and `MAX_SERIES_RECEIPTS` = 256; NP6 `MAX_LAB_CONFIGS` = 8 and
+  `MAX_REPLAY_STEPS` = 2000; NP8 `MAX_INPUT_BYTES` = 1 MiB, `MAX_LOG_BYTES`
+  = 16 MiB, `MAX_PACKET_ARTIFACTS` = 8, output ceiling 64 KiB.
+- **Declare campaign-level bounds explicitly** *(proposed, new)*, never inherited
+  by implication: the manifest ceiling `MAX_CAMPAIGN_MANIFEST_BYTES` = 64 KiB
+  (fail-closed), and the **fixed eight-file publication set** itself (an exact
+  set, neither extended nor reduced).
 
-### 3.8 CLI and failure contract (proposed, explicit, non-harmonising)
+### 3.9 CLI and failure contract (proposed, explicit, non-harmonising)
 
 The Nextness family deliberately keeps **four distinct exit-code sets across six
-CLIs** and does not harmonise them (`docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`).
-The campaign therefore defines **its own** explicit map rather than inheriting or
-normalising any existing one. The map below is the **proposed** v1 contract, to
-be ratified at implementation time under a separate gate.
+CLIs** *(existing at `main`)* and does not harmonise them
+(`docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`). The campaign therefore defines **its
+own** explicit map *(proposed, new)* — a **fifth** distinct set on a **seventh**
+CLI — rather than inheriting or normalising any existing one, to be ratified at
+implementation time under a separate gate.
 
 **Proposed CLI surface** (`nextness_evidence_campaign`):
 
-- **Positional**: `log_path` (the recorded `nextness_runs.jsonl`);
-  `protocol_path` (the operator NP6 protocol).
-- **Required option**: `--receipt-config-label <label>` (exact match to one
-  protocol configuration; §3.3).
-- **Output**: `--output-dir <dir>` — the **final** campaign directory, which must
-  be **absent** before the run, must resolve **outside** the repository `data/`
-  tree, and must not alias either input; staging is created in its parent (§3.6).
+- **Positional**: `log_path` (recorded `nextness_runs.jsonl`); `protocol_path`
+  (operator NP6 protocol).
+- **Required options**: `--workspace-dir <existing-dir>` (§3.1);
+  `--receipt-config-label <label>` (exact match to one protocol configuration,
+  §3.5); `--output-dir <dir>` (the **final** campaign directory — absent before
+  the run, inside the workspace, staging created in its parent).
 - **Reader-bound options**: `--max-rows` (default 100 000, ceiling 1 000 000) and
-  `--max-line-bytes` (default 65 536, ceiling 16 777 216), applied to the log
-  reads and **echoed** into the manifest for the completeness proof (§3.5).
-- **Success output**: a concise success line naming the published final directory
-  (and, optionally, the packet's self-reported role/link summary); exit 0.
+  `--max-line-bytes` (default 65 536, ceiling 16 777 216), applied identically to
+  NP1/NP2/NP6 and echoed into the manifest for the completeness evidence.
+- **Success output**: one concise line naming the published final directory;
+  exit 0.
 - **Error output**: exactly **one concise `error:` line** to stderr per expected
-  failure, never a traceback — matching the family's `error:` convention (the
-  campaign introduces no second prefix; it has no metrics-style `safety error:`
-  lane).
+  failure, never a traceback (the campaign introduces no second prefix; it has no
+  metrics-style `safety error:` lane).
 
-**Proposed exit-code map**:
+**Proposed exit-code map** *(new; the family's non-harmonisation is respected —
+this is a fifth distinct set, not a normalisation of the others)*:
 
 | Code | Category | Meaning |
 |---|---|---|
-| 0 | success | full chain built, all four provenance links `verified`, packet self-validated, published to the (previously absent) final directory |
-| 2 | validation | typed `CampaignInputError`: missing / malformed / oversized / unknown-variant input; missing / unknown / duplicate `receipt_config_label`; a produced or consumed artifact failing its validator or NP8 self-validation; **a provenance link not `verified`**; **a complete-log refusal** (a `max_rows` prefix that is not the whole log, or an oversized-terminal-record truncation) per §3.5 |
+| 0 | success | eight-file set built, all four provenance checks `verified`, packet self-validated, coherence gate satisfied, published to the (previously absent) final directory |
+| 2 | validation / campaign refusal | typed `CampaignInputError`: **malformed external input** (log / protocol / workspace) that arrives malformed; missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (excess physical rows, or an oversized-record ingestion termination — §3.6); **NP5 computed cross-artifact contradiction** refusal (§3.4) |
 | 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
-| 4 | containment | output-path failure: the final directory already exists; a staging or final path under the repository `data/` tree; a path outside the operator workspace; or a path aliasing either input (resolved-path + `os.path.samefile`, fail-closed identity) |
-| 5 | ceiling | a produced artifact over its 64 KiB serialized ceiling, a JSON input over `MAX_INPUT_BYTES` (1 MiB), or the log over `MAX_LOG_BYTES` (16 MiB) |
-| 6 | staging | staging-directory build failure (create / write inside the unique staging directory) |
-| 7 | publication | publication failure: the final directory appeared between the absence check and promotion, or the staging → final rename failed |
+| 4 | containment | `--workspace-dir` is not an existing directory; the final directory already exists at validation time; a staging or final path outside the workspace, under the repository `data/` tree, or aliasing an input (resolved-path + `os.path.samefile`, fail-closed identity) |
+| 5 | ceiling (named) | a **serialized-byte ceiling** breach only: a produced instrument artifact over its **64 KiB** ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB); or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB) |
+| 6 | staging | failure to create the unique staging directory, to **copy the log/protocol into it**, or to write a produced artifact inside it |
+| 7 | publication | the staging → final rename fails, or the OS **reports** a destination collision because the final directory appeared between the absence check and the rename (§3.7) |
 
-**Which exceptions remain loud internal failures.** Mirroring all six family
-`main()` clauses, the campaign `main()` catches **only** its documented typed
-classes (`CampaignInputError` and the instrument exceptions it deliberately
-surfaces — `InsufficientHistoryError`, the `*TooLargeError` ceiling family, the
-containment/output classes, and the proposed staging/publication classes). It
-**never** broadly catches plain `ValueError`; a plain `ValueError`, a
-`RuntimeError` (including the NP8 self-validation re-raise), a `MemoryError`, or
-any exception outside the documented catch set **propagates loudly** rather than
-masquerading as a concise input failure. Argparse usage errors exit 2 via
-argparse's own `SystemExit(2)` with its multi-line `usage:` output, outside this
-map — the standard family carve-out.
+**"Oversized" disambiguated.** The word covers two **distinct** lanes that map to
+**different** codes: an **oversized record** (content over `max_line_bytes`, which
+terminates NP1 ingestion) is a **complete-log refusal → exit 2**; a
+**serialized-byte ceiling** breach (64 KiB artifact/manifest, 1 MiB input, 16 MiB
+log) is the **ceiling lane → exit 5**. No lane is described by the bare word
+"oversized" alone.
 
-### 3.9 Future test plan (synthetic fixtures only)
+**Which failures stay loud internal failures (propagate, not exit 2).** Mirroring
+all six family `main()` clauses, the campaign `main()` catches **only** its
+documented typed classes (`CampaignInputError` and the instrument exceptions it
+deliberately surfaces — `InsufficientHistoryError`, the `*TooLargeError` ceiling
+family, the containment/output classes, and the proposed staging/publication
+classes). Outside that set:
+
+- **NP8's emitted-packet self-validation failure** is the **existing loud
+  internal `RuntimeError`** *(existing at `main`)* and is **not** reclassified as
+  exit 2 — it propagates loudly.
+- **Structural invalidity of a campaign-*generated* artifact** (an artifact the
+  runner produced from already-validated staged inputs failing its validator) is
+  likewise an **internal programming / contract failure, not malformed operator
+  input** — it propagates loudly, never exit 2. (Exit 2's validation lane is for
+  malformed **external** inputs and the explicit campaign refusals above, not for
+  the campaign's own generated output.)
+- Any other exception outside the documented catch set — a plain `ValueError`, a
+  `RuntimeError`, a `MemoryError` — **propagates loudly** rather than masquerading
+  as a concise input failure.
+
+Argparse usage errors exit 2 via argparse's own `SystemExit(2)` with its
+multi-line `usage:` output, outside this map — the standard family carve-out.
+
+### 3.10 Future test plan (synthetic fixtures only)
 
 The future implementation's tests must use **synthetic `tmp_path` fixtures
 only** — no real Medusa artifact, no network, no engine, no observer/calibration
 execution. The suite must include tests for:
 
-- deterministic **byte identity** (same inputs + label + options → identical
-  published bytes across two runs);
+- deterministic **byte identity** across two runs (all eight files, including the
+  manifest);
 - **explicit configuration selection** (the named label's configuration drives
   the single checkpoint receipt);
 - **missing, unknown, and duplicate** `receipt_config_label` (each a fail-closed
   refusal);
-- **all configurations retained by NP6** (every protocol configuration present in
-  the lab report, operator order, no winner/score field);
-- **all four NP8 provenance links `verified`** on a well-formed campaign;
-- **complete-log enforcement** (the full physical log accepted, or refusal);
-- **oversized-row and excess-row refusal** (oversized terminal record; a log
-  longer than `max_rows`);
-- **metrics absent from v1** (no metrics role or metrics artifact in the packet
-  or the published directory);
-- **input byte preservation** (both inputs byte-identical after every path,
-  including refusals);
-- **absent-final-directory requirement** (refusal when the final directory
-  pre-exists);
-- **no overwrite** of an existing final directory;
-- **staging cleanup on a handled failure** (a handled mid-run failure removes its
-  staging directory);
-- **honest hard-kill staging residual** (an uncatchable termination may leave a
-  staging directory — asserted as a documented residual, not a guarantee of
-  cleanup);
+- **all configurations retained by NP6** (every protocol configuration present,
+  operator order, no winner/score field);
+- **all four NP8 provenance checks `verified`** on a well-formed campaign;
+- **complete-log enforcement** (staged log fully traversed under the bounds, or
+  refusal);
+- **oversized-record and excess-row refusal** (an oversized terminal record; a
+  log longer than `max_rows`);
+- **metrics absent** from the eight-file set;
+- **input byte preservation** (originals byte-identical after every path);
+- **absent-final-directory requirement** and **no-overwrite at validation time**;
+- **staging cleanup on a handled failure**, and the **honest hard-kill staging
+  residual** (asserted as a documented residual, not a cleanup guarantee);
 - **no output under repository `data/`**;
 - **no engine, observer-execution, network, model, orchestration or tuning
-  imports** (static import audit of the runner module).
+  imports** (static import audit of the runner module);
+- **staged-input authority** — the campaign reads the staged copies, not the
+  originals (e.g. mutating an original after the copy does not change outputs);
+- **source-replacement residual** — a source replaced *during* copy yields the
+  captured-bytes behaviour the manifest hashes describe (residual asserted, not
+  excluded);
+- **exact eight-file publication** — precisely the eight named files, no more, no
+  fewer;
+- **manifest validation** — the `nextness-evidence-campaign-v1` schema, its 64 KiB
+  ceiling, relative filenames, and the recorded sizes/hashes/label/link-statuses;
+- **option lineage** — protocol `smoothing`/`holdout_fraction` reach NP1; protocol
+  `model`/`smoothing`/`holdout_fraction` + the labelled configuration reach NP2;
+  identical `max_rows`/`max_line_bytes` across NP1/NP2/NP6;
+- **selected-label recording** — the manifest ties the receipt to the named
+  protocol configuration;
+- **NP8 default-bound exception** — the NP8 `log` entry uses NP1 default bounds
+  and is not the completeness witness;
+- **computed cross-check contradiction refusal** — a `computed` NP5 contradiction
+  refuses publication, while a `not_computable` outcome publishes;
+- **destination-race semantics** — a concurrently created destination yields a
+  reported publication failure or a permitted empty-directory replacement, with
+  the unobservable-replacement non-claim respected.
 
-### 3.10 Non-claims and future implementation boundary
+### 3.11 Non-claims and future implementation boundary
 
 **Load-bearing non-claims (must be stated prominently in any future runner and
 its outputs):**
@@ -334,8 +440,9 @@ its outputs):**
 - **Design-only**: this document authorises **no runner implementation**.
 - No real Medusa artifact is read or processed; no snapshot, observer, or
   calibration execution occurs.
-- No engine, tuning, recommendation, or control path; no configuration is ranked,
-  selected as best, recommended, or applied.
+- No engine, tuning, recommendation, or control path; no **configuration** is
+  ranked, selected as best, recommended, or applied (NP5's descriptive **model**
+  rankings are unchanged and are not such a selection — §3.5).
 - No network, HTTP, ZMQ, or model invocation.
 - No consciousness, awareness, phenomenology, or biological-equivalence claim —
   the campaign is bookkeeping over recorded counting-model artifacts, nothing
@@ -347,39 +454,54 @@ audit and a fresh Kev authorisation** — nothing below is authorised by this PR
 
 - a new `scripts/nextness_evidence_campaign.py`;
 - a new `tests/test_nextness_evidence_campaign.py`;
-- **one factual update** to `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md` — adding a
-  single new row (and, if a genuinely new semantic is introduced, a short prose
-  note) for the campaign CLI to that document's existing six-map table, in
-  keeping with its descriptive, non-harmonising structure.
+- **factual updates to `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`** consistent with
+  its descriptive, non-harmonising structure. Because the campaign is a
+  **seventh** CLI carrying a **fifth** distinct exit-code map, keeping that
+  document factual requires **more than one row**: the new CLI **row** in the
+  six-map table, **plus** the mechanical corrections that the addition forces —
+  the map **count** ("four distinct code sets across six CLIs" → "five … across
+  seven"), the affected **headings/summary** wording, and the
+  **catch-set / unexpected-error-propagation list** (adding the campaign's typed
+  catch classes). No other file's content is implied.
 
 **No existing producer, validator, artifact schema, observer, calibration,
-metrics, or any other file is implicitly authorised to change.** In particular
-the NP1–NP9 modules, their schemas, their tests, and the NP7 contract guard
-remain untouched; the campaign is purely additive and composes them as-is.
+metrics, or any other file is authorised to change** by this contract. The
+NP1–NP9 modules, their schemas, their tests, and the NP7 contract guard remain
+untouched; the campaign is purely additive and composes them as-is.
 
 ## 4. Consistency with the merged interfaces
 
 These v1 decisions **coexist with the current-`main` contracts** — the reason
-this contract can be frozen without proposing any interface change:
+this contract can be frozen without proposing any instrument change:
 
-- The six packet roles, the four provenance links, and the per-role
-  schema/byte/SHA-256 records are exactly those `nextness-evidence-packet-v1`
-  already emits and verifies; the campaign supplies all six roles so all four
-  links are checkable.
-- The single-checkpoint-plus-all-configurations split is exactly the existing
-  NP2 (one deterministic receipt per configuration) and NP6 (all configurations,
-  descriptive) division of labour; "no implicit winner" restates NP5/NP6's
-  existing no-ranking / no-recommendation guarantees.
-- The complete-log obligation is stricter than NP1's silent-prefix default but
-  is the **discipline metrics already enforces**; it adds a campaign-level proof
-  and contradicts no instrument.
-- The staging/atomic-ish publication is **new** (no current CLI stages or renames
-  — metrics writes directly, non-atomically), so the campaign defines it
-  explicitly and, crucially, **claims no atomicity the mechanism cannot deliver**,
-  consistent with the family's standing write-lane and TOCTOU non-claims.
-- The exit-code map is the campaign's **own** explicit set, respecting the
-  family's deliberate non-harmonisation; the only documentation touch a future
-  implementation would make is a single additive factual row.
+- The six packet roles and the four provenance checks are exactly those
+  `nextness-evidence-packet-v1` already emits and verifies; the campaign supplies
+  all six roles from staged copies so all four checks are checkable, and it adds
+  the **outer manifest** as a new artifact NP8 neither defines nor authenticates.
+- The single-checkpoint-plus-all-configurations split is exactly the existing NP2
+  (one deterministic receipt per configuration) and NP6 (all configurations,
+  descriptive) division of labour. The "no implicit winner" rule restates NP6's
+  no-ranking guarantee and adds a campaign-level no-**configuration**-selection
+  rule; it does **not** contradict NP5's existing descriptive **model** ranking,
+  which is retained.
+- The same-log / same-options coherence the NP8 hash links do **not** by
+  themselves guarantee is supplied by the campaign construction and recorded in
+  the manifest (§3.4) — an additive invariant, not a change to NP8.
+- The complete-log obligation is stricter than NP1's silent-prefix default but is
+  the discipline metrics already enforces; it is expressed as "fully traversed
+  under the selected bounds" and runs against the staged log — it adds a
+  campaign-level proof and contradicts no instrument.
+- The staging / rename publication and the byte-for-byte input capture are
+  **new** (no current CLI stages, copies inputs, or renames — metrics writes
+  directly, non-atomically), so the campaign defines them explicitly and **claims
+  no atomicity, no-overwrite absoluteness, or durability the mechanism cannot
+  deliver**, consistent with the family's standing write-lane and TOCTOU
+  non-claims.
+- The exit-code map is the campaign's **own** explicit set — a fifth distinct set
+  on a seventh CLI — respecting the family's deliberate non-harmonisation; the
+  documentation it would later touch is `NEXTNESS_CLI_FAILURE_CONTRACTS.md`, whose
+  factual upkeep needs the new row plus the count/heading/catch-set corrections
+  above.
 
 If a future reader finds any of these decisions has drifted out of consistency
 with the merged contracts, the correct action is to **revise this contract under

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -1,0 +1,386 @@
+# Nextness Offline Evidence Campaign Contract (design-only)
+
+**Proposed module (not created by this PR)**: `scripts/nextness_evidence_campaign.py` ·
+**Proposed tests (not created by this PR)**: `tests/test_nextness_evidence_campaign.py` ·
+**Proposed schema id**: `nextness-evidence-campaign-v1` · **Status**: **DESIGN ONLY**
+
+> **This document is a frozen design contract, not an implementation.** It
+> creates no runner, reads no real Medusa artifact, runs no observer, no
+> calibration, no engine, no model, and no network call. It only records the
+> v1 decisions a future deterministic, offline **evidence campaign runner**
+> must satisfy so that a later, separately-gated implementation can be audited
+> against a fixed target. No implementation, ready transition, or merge is
+> authorised by the pull request that introduces this file. Every "the runner
+> …", "the campaign …", "v1 …" statement below is a **proposed future
+> obligation**, never a description of existing behaviour.
+
+## 1. What a "campaign" is — and is not
+
+A **campaign** is the deterministic, offline processing of **one
+already-recorded** Nextness Observer log into a single provenance-checked
+NP1 → NP2 → NP5 → NP6 → NP8 artifact chain, published as one directory of
+recorded artifacts.
+
+"Campaign" means **recorded-log artifact processing only**. It explicitly does
+**not** mean, and the runner must never perform:
+
+- snapshot collection or any `process_snapshot()` call;
+- observer execution (`scripts/nextness_observer.py` is a log **producer**,
+  upstream of and outside the campaign — the campaign consumes its output
+  read-only, it never runs it);
+- calibration experimentation (`scripts/nextness_calibration.py` is a
+  sweeping / discriminating experiment orchestrator — a winner-seeking activity
+  a descriptive campaign must not do);
+- any Medusa runtime, engine (`continuous_evolution_ca.py`), tuning,
+  orchestrator, Lane-A, Swarm-Hunter, REST/HTTP, ZMQ, Ollama or model activity.
+
+The campaign is a **composition** of the already-merged Nextness instruments;
+it introduces no new metric, no new semantics, and no new decision. It measures
+nothing the instruments do not already measure.
+
+## 2. Source grounding (audited current-main interfaces)
+
+This contract is grounded in the following current-`main` modules, their tests
+and their contract documents (read-only source audit; **none is modified by
+this PR**):
+
+| Role in the chain | Module | Schema id | Contract doc |
+|---|---|---|---|
+| NP1 predictor report | `scripts/nextness_predictor.py` | `nextness-predictor-v1` | `docs/NEXTNESS_PREDICTION_BASELINE.md` |
+| NP2 monitor receipt | `scripts/nextness_monitor.py` | `nextness-monitor-v1` | `docs/NEXTNESS_MONITOR_CONTRACT.md` |
+| NP5 evaluation | `scripts/nextness_evaluator.py` | `nextness-evaluation-v1` | `docs/NEXTNESS_EVALUATOR_CONTRACT.md` |
+| NP6 replay-lab report / protocol | `scripts/nextness_replay_lab.py` | `nextness-replay-lab-v1` / `nextness-replay-protocol-v1` | `docs/NEXTNESS_REPLAY_LAB_CONTRACT.md` |
+| NP8 evidence packet | `scripts/nextness_evidence_packet.py` | `nextness-evidence-packet-v1` | `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md` |
+| NP9 structural validators | `scripts/nextness_artifact_validation.py` | — | `docs/NEXTNESS_ARTIFACT_VALIDATION_CONTRACT.md` |
+| NP7 contract guard | *(test-owned)* `tests/test_nextness_contracts.py` | — | `docs/NEXTNESS_CONTRACT_GUARD.md` |
+| Cross-CLI failure facts | *(reference)* | — | `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md` |
+| Parked sidecar | `scripts/nextness_metrics.py` | *(observer-lineage)* | — |
+| Out-of-scope experiment | `scripts/nextness_calibration.py` | — | — |
+| Out-of-scope producer | `scripts/nextness_observer.py` | — | — |
+
+Where this contract names a bound, an exit code, a provenance field or a schema
+id, it is the value found in that source at `main`. If any such fact later stops
+matching source, **this document must change under its own gate** — nothing here
+licenses a silent drift, and nothing here proposes to *change* those interfaces.
+
+## 3. Frozen v1 decisions
+
+### 3.1 Inputs
+
+- Exactly **one** already-recorded `nextness_runs.jsonl` log.
+- Exactly **one** operator-authored NP6 protocol file
+  (`nextness-replay-protocol-v1`).
+- Both inputs reside in an **operator-selected external workspace outside the
+  repository `data/` tree**. The runner discovers no live snapshots and reads no
+  raw snapshot input; the log is a recording, consumed read-only.
+- Both inputs remain **byte-identical** across the run: the runner is read-only
+  with respect to both, mirroring every instrument's own input-protection
+  guarantee (tested byte-for-byte in NP1/NP5/NP6/NP8).
+
+### 3.2 Exact output chain
+
+From the two inputs, the proposed v1 runner produces, in dependency order, the
+following recorded artifacts, each the **byte-identical** output of the existing
+instrument:
+
+1. one deterministic **NP1 predictor report** (`nextness-predictor-v1`) over the
+   log;
+2. one deterministic **NP2 checkpoint receipt** (`nextness-monitor-v1`), computed
+   for the single monitor configuration selected by an explicit
+   `receipt_config_label` (see §3.3);
+3. one **NP5 evaluation** (`nextness-evaluation-v1`) over the report and that
+   receipt;
+4. one **NP6 replay-lab report** (`nextness-replay-lab-v1`) over the log and the
+   protocol, **retaining every protocol configuration** for descriptive
+   trajectories (see §3.3);
+5. one **NP8 evidence packet** (`nextness-evidence-packet-v1`) containing the
+   **six** existing roles, one artifact each:
+   - `report` — the NP1 report,
+   - `receipts` — the NP2 checkpoint receipt,
+   - `evaluation` — the NP5 evaluation,
+   - `lab` — the NP6 replay-lab report,
+   - `protocol` — the operator-authored NP6 protocol (input),
+   - `log` — the recorded `nextness_runs.jsonl` (input).
+
+**Provenance gate.** The NP8 packet records, per role, the artifact's schema id,
+byte length and SHA-256, and independently recomputes the **four** provenance
+links the v1 schemas themselves embed:
+
+| Link | Recorded by | Verified against |
+|---|---|---|
+| `evaluation_report_sha256` | NP5 evaluation `artifacts.report.sha256` | the report file's bytes |
+| `evaluation_receipts_sha256` | NP5 evaluation `artifacts.receipts.sha256` | the receipts file's bytes |
+| `lab_protocol_sha256` | NP6 lab report `input.protocol_sha256` | the protocol file's bytes |
+| `lab_sequence_sha256` | NP6 lab report `input.sequence_sha256` | the log's accepted dominant-token sequence, recomputed through NP1's bounded reader with the lab's recorded `max_rows` / `max_line_bytes` |
+
+**All four links must be `verified`** (byte-level hash match) before publication
+succeeds. A `broken` link, or a link that the packet types `not_computable`
+because a counterpart was absent, is a campaign failure: the v1 campaign always
+supplies all six roles, so every link is expected to be checkable, and a
+non-`verified` outcome fails closed (§3.8). The campaign invents no link the
+schemas do not already record and weakens none the packet already verifies.
+
+### 3.3 No implicit winner
+
+- `receipt_config_label` is a **mandatory** CLI argument. It must match, by exact
+  string, **exactly one** configuration label in the operator's NP6 protocol
+  (labels are unique and ≤ 64 chars — `MAX_LABEL_CHARS` — per
+  `nextness-replay-protocol-v1`).
+- The runner must **never** select the first configuration implicitly, and must
+  **never** rank, search, recommend, infer, or apply a "winning" configuration.
+  Selection is the operator's explicit, named act; the campaign performs no
+  optimisation of any kind.
+- A missing, unknown, or duplicate `receipt_config_label` is a fail-closed
+  validation refusal (§3.8); "matches more than one" cannot occur for a valid
+  protocol (labels are unique) but is still refused defensively rather than
+  resolved.
+- **NP6 continues to retain all configurations descriptively.** The single
+  checkpoint receipt is for the one named configuration only; the replay-lab
+  report still replays and reports **every** configuration side by side, in the
+  operator's input order, with no score, ranking, winner or recommendation field
+  anywhere (NP6's descriptive-only guarantee is preserved unchanged, and
+  abstention remains a first-class outcome, never a defect).
+
+### 3.4 Metrics decision (parked)
+
+- `nextness_metrics` output is **not part of campaign v1**. `nextness_metrics`
+  is an observer-lineage sidecar (it derives `nextness_run_metrics.jsonl` from
+  the log); it is **not** an NP role in the NP1→NP8 provenance chain.
+- The NP8 packet has **no metrics role** and **cannot presently provenance-link
+  that sidecar**: there is no `metrics` role, no metrics artifact schema entry,
+  and no provenance link for it in `nextness-evidence-packet-v1`. Emitting an
+  unlinked metrics file beside a provenance-checked packet would be an artifact
+  the chain cannot vouch for.
+- This contract **does not change, and must not silently change, the NP8
+  schema.** Metrics is **parked** until a separately-gated decision either (a)
+  adds explicit provenance support for a metrics role to the NP8 schema, or (b)
+  defines an **honestly unlinked** sidecar whose non-membership in the provenance
+  chain is stated in the output itself. Neither option is proposed or authorised
+  here.
+
+### 3.5 Complete-log semantics
+
+The campaign must process the **whole physical log**, never a summary of a
+prefix:
+
+- **No `max_rows` prefix may be treated as a complete campaign.** This is a
+  campaign-level obligation that the underlying reader does **not** provide on
+  its own: NP1's `read_dominant_sequence` silently reads at most `max_rows`
+  physical records and treats that prefix as complete (the `max_rows`+1-th
+  record is simply never read, still exit 0). By contrast `nextness_metrics`
+  already refuses excess rows outright ("metrics summarizes a COMPLETE run").
+  The campaign adopts the **metrics discipline**, not the predictor default: the
+  runner must **prove the full physical log was accepted** under the selected
+  bounds — e.g. by confirming ingestion reached end-of-file rather than the
+  `max_rows` cap — **or refuse the campaign**. No silent truncation and no
+  prefix summary is permitted.
+- **No continuation after an oversized terminal record.** A record whose content
+  exceeds `max_line_bytes` is counted `oversized_line` and terminates NP1
+  ingestion fail-closed, yet NP1 still emits an exit-0 report over the records
+  before it. The campaign must detect that ingestion was terminated by an
+  oversized record (e.g. `rejections.oversized_line > 0`, or equivalently that
+  the read stopped before EOF) and **refuse**, rather than accept the truncated
+  prefix.
+- The selected reader bounds are echoed into the campaign's own manifest so the
+  completeness proof is reproducible and auditable, not implicit.
+
+### 3.6 Publication
+
+- The runner builds **every** output inside a **unique staging directory that
+  shares the final output directory's parent**, so promotion is a single
+  same-directory rename on one filesystem.
+- The **final output directory must be absent before the run**. If it already
+  exists, the run refuses (§3.8) — the runner **never overwrites** an existing
+  final directory.
+- Publication happens **only after** every produced artifact validates through
+  its own validator, the NP8 packet passes its **self-validation**
+  (`validate_evidence_packet`), and **all four provenance links are `verified`**.
+  A failure at any of these gates leaves the final directory uncreated.
+- **No output — staging or final — may be created under the repository `data/`
+  tree**, consistent with every instrument's `WriteOutsideLogDirError`
+  containment. All campaign output lives in the operator's external workspace.
+- **Concurrency / TOCTOU boundary, stated honestly.** The absence of the final
+  directory is checked at validation time; the later promotion does not re-verify
+  under a lock. A concurrent actor that creates the final directory between the
+  check and the rename is caught only to the extent the operating system refuses
+  a rename onto an existing directory; this residual validation-to-publish
+  interval is a **non-claim**, exactly as the instruments' own write guards state
+  their validation-to-write TOCTOU non-claim.
+- **Residual (hard kill).** A hard kill (or power loss) mid-run may leave an
+  **unpublished staging directory** behind; the final directory is either fully
+  absent or fully published, but the staging directory is not guaranteed to be
+  cleaned up on an uncatchable termination (see §3.8 for handled-failure
+  cleanup). The runner claims **no stronger cross-platform atomicity or
+  power-loss durability** than a single same-directory directory rename provides
+  — in particular it does not claim atomic multi-file publication on platforms
+  where directory rename semantics are weaker, and it does not claim fsync-level
+  durability.
+
+### 3.7 Determinism and bounds
+
+- **Byte-identical outputs.** The same input log bytes, the same protocol bytes,
+  the same explicit `receipt_config_label`, and the same CLI options must produce
+  **byte-identical** campaign outputs. Each instrument already guarantees
+  sorted-key, fixed-separator, LF-only, timestamp-free, randomness-free,
+  absolute-path-free serialization; the campaign **adds none of these** to any
+  generated artifact and introduces no wall-clock timestamp, random identifier,
+  or absolute path of its own (including in any campaign manifest it writes).
+- **Reuse existing ceilings where their contracts apply**, by name and value:
+  NP1/NP6 reader bounds `max_rows` (default 100 000, ceiling 1 000 000) and
+  `max_line_bytes` (default 65 536, ceiling `MAX_LINE_BYTES_CEILING` =
+  16 777 216); per-artifact serialized ceiling 64 KiB (`ReportTooLargeError` /
+  `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` /
+  `PacketTooLargeError`); NP5 `MAX_INPUT_BYTES` = 1 MiB per JSON artifact and
+  `MAX_SERIES_RECEIPTS` = 256; NP6 `MAX_LAB_CONFIGS` = 8 and `MAX_REPLAY_STEPS`
+  = 2000; NP8 `MAX_INPUT_BYTES` = 1 MiB, `MAX_LOG_BYTES` = 16 MiB,
+  `MAX_PACKET_ARTIFACTS` = 8, output ceiling 64 KiB.
+- **Define any campaign-level ceiling explicitly.** Any bound the campaign layer
+  needs that is not already one of the above — for example a cap on the number of
+  published files, or the size of a campaign manifest — must be declared as an
+  explicit named campaign constant with fail-closed enforcement, **never
+  inherited by implication** from an instrument whose contract does not actually
+  govern it.
+
+### 3.8 CLI and failure contract (proposed, explicit, non-harmonising)
+
+The Nextness family deliberately keeps **four distinct exit-code sets across six
+CLIs** and does not harmonise them (`docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md`).
+The campaign therefore defines **its own** explicit map rather than inheriting or
+normalising any existing one. The map below is the **proposed** v1 contract, to
+be ratified at implementation time under a separate gate.
+
+**Proposed CLI surface** (`nextness_evidence_campaign`):
+
+- **Positional**: `log_path` (the recorded `nextness_runs.jsonl`);
+  `protocol_path` (the operator NP6 protocol).
+- **Required option**: `--receipt-config-label <label>` (exact match to one
+  protocol configuration; §3.3).
+- **Output**: `--output-dir <dir>` — the **final** campaign directory, which must
+  be **absent** before the run, must resolve **outside** the repository `data/`
+  tree, and must not alias either input; staging is created in its parent (§3.6).
+- **Reader-bound options**: `--max-rows` (default 100 000, ceiling 1 000 000) and
+  `--max-line-bytes` (default 65 536, ceiling 16 777 216), applied to the log
+  reads and **echoed** into the manifest for the completeness proof (§3.5).
+- **Success output**: a concise success line naming the published final directory
+  (and, optionally, the packet's self-reported role/link summary); exit 0.
+- **Error output**: exactly **one concise `error:` line** to stderr per expected
+  failure, never a traceback — matching the family's `error:` convention (the
+  campaign introduces no second prefix; it has no metrics-style `safety error:`
+  lane).
+
+**Proposed exit-code map**:
+
+| Code | Category | Meaning |
+|---|---|---|
+| 0 | success | full chain built, all four provenance links `verified`, packet self-validated, published to the (previously absent) final directory |
+| 2 | validation | typed `CampaignInputError`: missing / malformed / oversized / unknown-variant input; missing / unknown / duplicate `receipt_config_label`; a produced or consumed artifact failing its validator or NP8 self-validation; **a provenance link not `verified`**; **a complete-log refusal** (a `max_rows` prefix that is not the whole log, or an oversized-terminal-record truncation) per §3.5 |
+| 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
+| 4 | containment | output-path failure: the final directory already exists; a staging or final path under the repository `data/` tree; a path outside the operator workspace; or a path aliasing either input (resolved-path + `os.path.samefile`, fail-closed identity) |
+| 5 | ceiling | a produced artifact over its 64 KiB serialized ceiling, a JSON input over `MAX_INPUT_BYTES` (1 MiB), or the log over `MAX_LOG_BYTES` (16 MiB) |
+| 6 | staging | staging-directory build failure (create / write inside the unique staging directory) |
+| 7 | publication | publication failure: the final directory appeared between the absence check and promotion, or the staging → final rename failed |
+
+**Which exceptions remain loud internal failures.** Mirroring all six family
+`main()` clauses, the campaign `main()` catches **only** its documented typed
+classes (`CampaignInputError` and the instrument exceptions it deliberately
+surfaces — `InsufficientHistoryError`, the `*TooLargeError` ceiling family, the
+containment/output classes, and the proposed staging/publication classes). It
+**never** broadly catches plain `ValueError`; a plain `ValueError`, a
+`RuntimeError` (including the NP8 self-validation re-raise), a `MemoryError`, or
+any exception outside the documented catch set **propagates loudly** rather than
+masquerading as a concise input failure. Argparse usage errors exit 2 via
+argparse's own `SystemExit(2)` with its multi-line `usage:` output, outside this
+map — the standard family carve-out.
+
+### 3.9 Future test plan (synthetic fixtures only)
+
+The future implementation's tests must use **synthetic `tmp_path` fixtures
+only** — no real Medusa artifact, no network, no engine, no observer/calibration
+execution. The suite must include tests for:
+
+- deterministic **byte identity** (same inputs + label + options → identical
+  published bytes across two runs);
+- **explicit configuration selection** (the named label's configuration drives
+  the single checkpoint receipt);
+- **missing, unknown, and duplicate** `receipt_config_label` (each a fail-closed
+  refusal);
+- **all configurations retained by NP6** (every protocol configuration present in
+  the lab report, operator order, no winner/score field);
+- **all four NP8 provenance links `verified`** on a well-formed campaign;
+- **complete-log enforcement** (the full physical log accepted, or refusal);
+- **oversized-row and excess-row refusal** (oversized terminal record; a log
+  longer than `max_rows`);
+- **metrics absent from v1** (no metrics role or metrics artifact in the packet
+  or the published directory);
+- **input byte preservation** (both inputs byte-identical after every path,
+  including refusals);
+- **absent-final-directory requirement** (refusal when the final directory
+  pre-exists);
+- **no overwrite** of an existing final directory;
+- **staging cleanup on a handled failure** (a handled mid-run failure removes its
+  staging directory);
+- **honest hard-kill staging residual** (an uncatchable termination may leave a
+  staging directory — asserted as a documented residual, not a guarantee of
+  cleanup);
+- **no output under repository `data/`**;
+- **no engine, observer-execution, network, model, orchestration or tuning
+  imports** (static import audit of the runner module).
+
+### 3.10 Non-claims and future implementation boundary
+
+**Load-bearing non-claims (must be stated prominently in any future runner and
+its outputs):**
+
+- **Design-only**: this document authorises **no runner implementation**.
+- No real Medusa artifact is read or processed; no snapshot, observer, or
+  calibration execution occurs.
+- No engine, tuning, recommendation, or control path; no configuration is ranked,
+  selected as best, recommended, or applied.
+- No network, HTTP, ZMQ, or model invocation.
+- No consciousness, awareness, phenomenology, or biological-equivalence claim —
+  the campaign is bookkeeping over recorded counting-model artifacts, nothing
+  more (every instrument already embeds this non-claim; the campaign preserves
+  them unchanged).
+
+**Maximum anticipated implementation boundary** (only after a **separate Jack
+audit and a fresh Kev authorisation** — nothing below is authorised by this PR):
+
+- a new `scripts/nextness_evidence_campaign.py`;
+- a new `tests/test_nextness_evidence_campaign.py`;
+- **one factual update** to `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md` — adding a
+  single new row (and, if a genuinely new semantic is introduced, a short prose
+  note) for the campaign CLI to that document's existing six-map table, in
+  keeping with its descriptive, non-harmonising structure.
+
+**No existing producer, validator, artifact schema, observer, calibration,
+metrics, or any other file is implicitly authorised to change.** In particular
+the NP1–NP9 modules, their schemas, their tests, and the NP7 contract guard
+remain untouched; the campaign is purely additive and composes them as-is.
+
+## 4. Consistency with the merged interfaces
+
+These v1 decisions **coexist with the current-`main` contracts** — the reason
+this contract can be frozen without proposing any interface change:
+
+- The six packet roles, the four provenance links, and the per-role
+  schema/byte/SHA-256 records are exactly those `nextness-evidence-packet-v1`
+  already emits and verifies; the campaign supplies all six roles so all four
+  links are checkable.
+- The single-checkpoint-plus-all-configurations split is exactly the existing
+  NP2 (one deterministic receipt per configuration) and NP6 (all configurations,
+  descriptive) division of labour; "no implicit winner" restates NP5/NP6's
+  existing no-ranking / no-recommendation guarantees.
+- The complete-log obligation is stricter than NP1's silent-prefix default but
+  is the **discipline metrics already enforces**; it adds a campaign-level proof
+  and contradicts no instrument.
+- The staging/atomic-ish publication is **new** (no current CLI stages or renames
+  — metrics writes directly, non-atomically), so the campaign defines it
+  explicitly and, crucially, **claims no atomicity the mechanism cannot deliver**,
+  consistent with the family's standing write-lane and TOCTOU non-claims.
+- The exit-code map is the campaign's **own** explicit set, respecting the
+  family's deliberate non-harmonisation; the only documentation touch a future
+  implementation would make is a single additive factual row.
+
+If a future reader finds any of these decisions has drifted out of consistency
+with the merged contracts, the correct action is to **revise this contract under
+its own gate** — never to silently reconcile it against changed source.

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -624,9 +624,9 @@ execution. The suite must include tests for:
 - **protocol-input ceiling** — a protocol over NP6 `MAX_PROTOCOL_BYTES` (64 KiB)
   is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
   lane;
-- **`LabInputError` caught directly, at every raise site that can reach the
-  campaign** — **four** cases, each asserting campaign **exit 2**, exactly
-  **one concise `error:` line** on stderr and **no traceback**:
+- **`LabInputError` caught directly** — **four** required handled
+  `LabInputError` **failure families**, each asserting campaign **exit 2**,
+  exactly **one concise `error:` line** on stderr and **no traceback**:
   - a **malformed operator protocol** (bad schema key, unknown `model`,
     out-of-range `smoothing` / `holdout_fraction`, malformed configuration,
     over-long or duplicate label) → direct `LabInputError` catch → **exit 2**;
@@ -642,6 +642,10 @@ execution. The suite must include tests for:
     is reached only after the protocol has already loaded → the **same** direct
     campaign **exit 2** lane. It bounds a **step count** on operator-supplied
     input, not a serialized byte size, so the exit-5 ceiling lane never applies;
+- **Scope of those four (a bound on the claim, not a further test)** — they
+  cover the named semantic **failure families** at the campaign boundary, and
+  are **not** a one-to-one test of every literal `raise LabInputError`
+  statement in NP6, nor of every invocation of `load_protocol`;
 - **plain-`ValueError` negative control** — a **separate** case, deliberately
   **not** one of the four direct-catch cases above and **not** asserting
   campaign exit 2: a **sentinel plain `ValueError` raised at the NP6 call seam

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -625,8 +625,8 @@ execution. The suite must include tests for:
   is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
   lane;
 - **`LabInputError` caught directly, at every raise site that can reach the
-  campaign** — four cases, each asserting **exit 2**, exactly **one concise
-  `error:` line** on stderr and **no traceback**:
+  campaign** — **three** cases, each asserting campaign **exit 2**, exactly
+  **one concise `error:` line** on stderr and **no traceback**:
   - a **malformed operator protocol** (bad schema key, unknown `model`,
     out-of-range `smoothing` / `holdout_fraction`, malformed configuration,
     over-long or duplicate label) → direct `LabInputError` catch → **exit 2**;
@@ -637,9 +637,14 @@ execution. The suite must include tests for:
     `max_line_bytes` at the reader call inside `build_lab_report`) → direct
     campaign **exit 2**, with NP6's message and `__cause__` intact and **no**
     re-typing into `CampaignInputError`;
-  - a **sentinel plain `ValueError` raised at the NP6 call seam propagates** and
-    is not swallowed — proving the campaign catches the exact `LabInputError`
-    subclass and not its `ValueError` base;
+- **plain-`ValueError` negative control** — a **separate** case, deliberately
+  **not** one of the three direct-catch cases above and **not** asserting
+  campaign exit 2: a **sentinel plain `ValueError` raised at the NP6 call seam
+  propagates** and is not swallowed, proving the campaign catches the exact
+  `LabInputError` subclass and not its `ValueError` base. Because it propagates
+  rather than being handled, this case asserts **propagation** and **explicitly
+  expects neither** campaign exit 2, **nor** a single concise `error:` line,
+  **nor** the absence of a traceback;
 - **metrics absent** from the eight-file set;
 - **input byte preservation** (originals byte-identical after every path);
 - **absent-final-directory requirement** and **no-overwrite at validation time**;

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -26,6 +26,25 @@ exit-code map — is **newly proposed here** and exists only as this design. The
 prose marks these as *(existing at `main`)* or *(proposed, new)* wherever
 confusion is possible.
 
+**How the campaign uses the instruments (read this second).** The proposed
+runner is a **module-level composition**: it calls each instrument's existing
+public builders, loaders and canonical serializers in-process — `build_report`;
+`observations_from_log` + `build_receipt`; `build_evaluation`; `load_protocol` +
+`build_lab_report`; `build_packet`; each with its own `serialize_*`
+*(existing at `main`)*. It does **not** shell out to the six standalone CLIs, and
+**no obligation in this document may be read as requiring an artifact to be
+reproducible through a standalone CLI invocation.** The distinction is
+load-bearing, not stylistic: **NP2's CLI exposes only `log_path`, `--model`,
+`--smoothing` and `--holdout-fraction`** *(existing at `main`,
+`scripts/nextness_monitor.py`)* — no labelled `MonitorConfig`, no
+`min_history` / `window` / threshold values, and no reader-bound options — so a
+labelled-configuration receipt under campaign-selected bounds has **no CLI
+invocation that produces it**, while NP2's module-level
+`observations_from_log(..., max_rows=..., max_line_bytes=..., window=...)` and
+`build_receipt(..., config=MonitorConfig(...))` accept exactly those inputs.
+Composing the modules **adds nothing to, and changes nothing in,** any
+instrument's semantics, schema, validators or exit map.
+
 ## 1. What a "campaign" is — and is not
 
 A **campaign** is the deterministic, offline processing of **one
@@ -98,9 +117,11 @@ instrument interface.
   A path failing containment is a fail-closed refusal (§3.9, exit 4).
 - **Authoritative staged snapshot.** Before running **any** instrument, the
   runner copies the log and the protocol **byte-for-byte** into the unique
-  staging directory. **Every NP1 / NP2 / NP5 / NP6 / NP8 operation reads those
-  staged copies** (and the artifacts it writes into staging); it **never reopens
-  the original source paths** after the copy.
+  staging directory. **Every NP1 / NP2 / NP5 / NP6 / NP8 module-level call is
+  given those staged paths** (and the artifact paths written into staging); the
+  runner **never reopens the original source paths** after the copy. The §3.6
+  completeness preflight and the §3.9 size preflight likewise read staged bytes
+  only.
 - **Honest input-mutation statement.** The runner **never mutates the
   originals**. It does not, however, freeze the operator's filesystem: a
   concurrent actor that mutates or replaces a source **while its copy is being
@@ -112,12 +133,19 @@ instrument interface.
 ### 3.2 Exact output chain and the eight-file publication set
 
 From the staged inputs, the proposed v1 runner produces, in dependency order,
-each the **byte-identical** output of the existing instrument run on the staged
-copies:
+each the **byte-identical canonical output of that instrument's own
+module-level builder and serializer** applied to the staged copies — never a
+re-implementation, and never a standalone-CLI invocation (see *How the campaign
+uses the instruments*):
 
 1. **NP1 predictor report** (`nextness-predictor-v1`) over the staged log;
 2. **NP2 checkpoint receipt** (`nextness-monitor-v1`) for the single monitor
-   configuration selected by the exact `receipt_config_label` (§3.4, §3.5);
+   configuration selected by the exact `receipt_config_label` (§3.4, §3.5),
+   built through NP2's module-level `observations_from_log` +
+   `build_receipt(config=...)` + `serialize_receipt`, because NP2's CLI can
+   express neither a labelled configuration nor campaign reader bounds; the
+   emitted bytes are exactly NP2's own canonical receipt, and NP2's semantics and
+   schema are untouched;
 3. **NP5 evaluation** (`nextness-evaluation-v1`) over the report and that
    receipt;
 4. **NP6 replay-lab report** (`nextness-replay-lab-v1`) over the staged log and
@@ -151,10 +179,18 @@ filenames only**, and its own explicit named ceiling `MAX_CAMPAIGN_MANIFEST_BYTE
   protocol);
 - the campaign reader bounds (`max_rows`, `max_line_bytes`) actually applied;
 - the exact `receipt_config_label` and its configuration correspondence (§3.4);
-- the completeness evidence (§3.6);
+- the completeness evidence (§3.6) — the campaign bounds applied, the physical
+  record count the preflight observed (at most `max_rows`), and the *no record
+  beyond `max_rows`* / *no oversized record* outcomes it established; the
+  preflight is the campaign's **completeness witness** and this record is where
+  its evidence is published;
 - each **produced artifact's** relative filename, byte size and SHA-256 (the NP1
   report, NP2 receipt, NP5 evaluation, NP6 lab report and NP8 packet — the
   packet's hash being the inward pointer of *Direction of trust* below);
+- the **cross-artifact coherence outcome** (§3.4) exactly as NP5 recorded it:
+  for each of `ece_match` and `surprise_nll_match`, the envelope status and —
+  when `computed` — the verdicts present, so a reader can see that publication
+  was permitted because no verdict was `contradicted`;
 - the **four NP8 link statuses** (§3.3), copied for auditability.
 
 Together the two input records and the five produced-artifact records cover the
@@ -198,21 +234,45 @@ individual instruments do not cross-check:
 - The protocol's **`smoothing`** and **`holdout_fraction`** drive **NP1**.
 - The protocol's **`model`**, **`smoothing`** and **`holdout_fraction`**,
   together with the configuration identified by the exact `receipt_config_label`,
-  drive **NP2**.
-- **NP1, NP2 and NP6 use identical campaign `max_rows` and `max_line_bytes`.**
+  drive **NP2**. Because NP2's observation bridge and its receipt take the window
+  by separate arguments, the labelled configuration's **`window` must be passed
+  to `observations_from_log` as well as to `build_receipt`'s `MonitorConfig`**;
+  NP2's own bridge documents that requirement *(existing at `main`)*, nothing
+  downstream detects a mismatch, so the campaign owns it.
+- **NP1, NP2 and NP6 use identical campaign `max_rows` and `max_line_bytes`**,
+  passed to `build_report`, `observations_from_log` and `build_lab_report`
+  respectively. For NP2 this is reachable **only** through its module-level
+  interface — its CLI has no reader-bound options — which is why the campaign
+  composes modules rather than CLIs.
 - **NP6 retains every protocol configuration in operator order** (its existing
   descriptive guarantee, unchanged).
 - The manifest **records the selected label and its exact configuration
   correspondence**, because an **NP2 receipt records the configuration's *values*
   but not the protocol *label*** — without the manifest, the receipt could not be
   tied back to a named protocol configuration.
-- **Cross-artifact coherence gate.** If NP5 produces a **`computed`
-  cross-artifact contradiction** — a genuine disagreement the evaluator was able
-  to compute — where the campaign's same-source construction *should* have made
-  agreement possible, the runner **refuses publication** (§3.9, exit 2). A
-  legitimate **`not_computable`** result (for example `no_covering_receipt`, or
-  any typed absent-evidence reason) is an **evidence outcome, not a failure**:
-  the campaign still publishes, and the manifest carries it forward as recorded.
+- **Cross-artifact coherence gate (verdict-level).** NP5 reports each of its
+  cross-artifact checks (`ece_match`, `surprise_nll_match`) in the standard
+  **envelope** — `computed` or `not_computable` — and, inside a `computed`
+  envelope, carries **per-model results whose `verdict` is one of the three fixed
+  values `consistent` / `contradicted` / `unverifiable`** *(existing at `main`:
+  `nextness_evaluator.VERDICTS`)*. The gate is defined at the **verdict** level,
+  never at the envelope level:
+  - a `computed` result carrying a verdict of exactly **`contradicted`** — a
+    genuine disagreement the evaluator was able to compute, where the campaign's
+    same-source construction *should* have made agreement possible — **refuses
+    publication** (§3.9, exit 2);
+  - **`consistent`** permits publication;
+  - **`unverifiable`** — NP5's recorded-surprise-floor lane, where the comparison
+    cannot be decided in either direction — is an **evidence outcome**: it
+    permits publication and is **never** silently recast as `contradicted` or as
+    `not_computable`;
+  - **`not_computable`** (for example `no_covering_receipt`, or any typed
+    absent-evidence reason) is likewise an **evidence outcome, not a failure**.
+  In every permitting case the campaign publishes and the manifest carries the
+  outcome forward **exactly as NP5 recorded it** — envelope status and verdicts
+  unchanged. The campaign **invents no verdict, adds no verdict value and alters
+  no NP5 schema**; it only decides, from values NP5 already emits, whether to
+  publish.
 
 ### 3.5 No implicit winner
 
@@ -249,11 +309,41 @@ prefix — stated precisely:
   not fail the campaign; a fully-traversed log with rejected rows is still
   complete.
 - The **completeness preflight runs against the staged log** (the authoritative
-  captured bytes), under the campaign `max_rows` / `max_line_bytes`.
-- The runner **refuses** (§3.9, exit 2 — *complete-log refusal*) if the physical
-  record count would exceed `max_rows` (a prefix that is not the whole log) **or**
-  if an **oversized record** (content over `max_line_bytes`) terminated ingestion
-  — **before** treating the campaign as complete. NP1 on its own would silently
+  captured bytes), under the campaign `max_rows` / `max_line_bytes`, **before any
+  instrument is invoked**.
+- **Mechanism — campaign-owned, streaming, byte-level.** The preflight opens the
+  staged log in **binary** and frames records exactly as NP1's reader frames them
+  *(existing at `main`, `scripts/nextness_predictor.py`)*: records are
+  **LF-delimited** and read with bounded `readline(max_line_bytes + 2)` calls; a
+  record's **content** is the returned chunk with a trailing CRLF (two bytes) or
+  LF (one byte) removed, and a chunk that reached the read limit without a
+  terminator is content in full; a record whose **content** exceeds
+  `max_line_bytes` is the **oversized record** that terminates NP1 ingestion.
+  **Every physical record counts** — accepted, rejected and blank alike —
+  matching NP1's `rows_read` accounting. The preflight stops as soon as the
+  question is answered: it reads **at most `max_rows + 1` records**, so its work
+  is bounded by `(max_rows + 1) * (max_line_bytes + 2)` bytes.
+- **Why it is campaign-owned rather than an extra reader call.** It must work at
+  **every permitted bound, including `max_rows = MAX_ROWS_CEILING` = 1 000 000**.
+  NP1's reader cannot be asked to read `max_rows + 1` records there: a `max_rows`
+  above `MAX_ROWS_CEILING` is a typed `PredictorInputError` *(existing at
+  `main`)*, and the reader stops at `max_rows` without probing further, so
+  "exactly `max_rows` records" and "more than `max_rows` records" are
+  indistinguishable in its return value. The preflight is therefore the
+  campaign's own bounded scan — and it re-implements **no NP1 row semantics**,
+  only NP1's record framing.
+- **What the preflight must not do.** It performs **no JSON parsing, no rejection
+  classification, no model inference and no accepted-row judgement**. It answers
+  exactly two byte-level questions — *is there a physical record beyond
+  `max_rows`?* and *is there a record whose content exceeds `max_line_bytes`?*
+  Deciding whether a row is valid, and the **12 NP1 `REJECT_REASONS`**, remain
+  **entirely NP1's** *(existing at `main`)*; the preflight neither duplicates nor
+  reinterprets them and classifies nothing.
+- The runner **refuses** (§3.9, exit 2 — *complete-log refusal*) when the
+  preflight finds a **physical record beyond `max_rows`** (a prefix that is not
+  the whole log) **or** a **record whose content exceeds the campaign
+  `max_line_bytes`** (the oversized record that would terminate NP1 ingestion) —
+  **before** treating the campaign as complete, and before any instrument runs. NP1 on its own would silently
   read a `max_rows` prefix and emit an exit-0 report; the campaign adopts the
   stricter, metrics-style "complete run" discipline instead.
 - **NP8's `log`-role manifest entry is not the campaign completeness witness.**
@@ -285,8 +375,10 @@ prefix — stated precisely:
 - Publication happens **only after** every produced artifact validates through its
   own validator, the NP8 packet passes its **self-validation**, **all four
   provenance checks are `verified`**, and the cross-artifact coherence gate (§3.4)
-  is satisfied. A failure at any of these gates leaves the final directory
-  uncreated.
+  is satisfied — that gate being satisfied exactly when **no `computed`
+  cross-artifact result carries a `contradicted` verdict**, with `consistent`,
+  `unverifiable` and `not_computable` all permitting publication. A failure at
+  any of these gates leaves the final directory uncreated.
 - **No output — staging or final — is created under the repository `data/`
   tree** (guaranteed by the workspace containment of §3.1).
 - **Residuals (retained non-claims).** A hard kill (or power loss) mid-run may
@@ -313,13 +405,32 @@ prefix — stated precisely:
   `MAX_LINE_BYTES_CEILING` = 16 777 216); per-artifact serialized ceiling 64 KiB
   (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` /
   `LabReportTooLargeError` / `PacketTooLargeError`); NP5 `MAX_INPUT_BYTES` = 1 MiB
-  and `MAX_SERIES_RECEIPTS` = 256; NP6 `MAX_LAB_CONFIGS` = 8 and
-  `MAX_REPLAY_STEPS` = 2000; NP8 `MAX_INPUT_BYTES` = 1 MiB, `MAX_LOG_BYTES`
+  and `MAX_SERIES_RECEIPTS` = 256; NP6 `MAX_PROTOCOL_BYTES` = 64 KiB (the
+  protocol **input** ceiling, enforced pre-parse by NP6's own loader),
+  `MAX_LAB_CONFIGS` = 8 and `MAX_REPLAY_STEPS` = 2000; NP8 `MAX_INPUT_BYTES` = 1 MiB, `MAX_LOG_BYTES`
   = 16 MiB, `MAX_PACKET_ARTIFACTS` = 8, output ceiling 64 KiB.
 - **Declare campaign-level bounds explicitly** *(proposed, new)*, never inherited
   by implication: the manifest ceiling `MAX_CAMPAIGN_MANIFEST_BYTES` = 64 KiB
   (fail-closed), and the **fixed eight-file publication set** itself (an exact
   set, neither extended nor reduced).
+- **Four named ceiling families — never conflated** *(families 1-3 existing at
+  `main`; family 4 proposed, new)*:
+  1. **Generated-artifact serialization ceilings** — 64 KiB each, on what an
+     instrument *emits*: `ReportTooLargeError` / `ReceiptTooLargeError` /
+     `EvaluationTooLargeError` / `LabReportTooLargeError` /
+     `PacketTooLargeError`, each raised by that instrument itself → campaign
+     **exit 5**.
+  2. **JSON-artifact and staged-log input ceilings** — NP5 / NP8
+     `MAX_INPUT_BYTES` = 1 MiB and NP8 `MAX_LOG_BYTES` = 16 MiB → campaign
+     **exit 5**, established by the campaign's **own size preflight** (§3.9),
+     never by interpreting a typed loader exception.
+  3. **NP6's protocol *input* ceiling `MAX_PROTOCOL_BYTES` = 64 KiB** — the same
+     number as family 1 but a different lane: it bounds an **operator-supplied
+     external input**, is enforced pre-parse by NP6's own loader and raises
+     `LabInputError`, so it is a **malformed / out-of-bounds external input →
+     campaign exit 2**, *not* the exit-5 ceiling lane.
+  4. **The campaign manifest's own serialized ceiling**
+     `MAX_CAMPAIGN_MANIFEST_BYTES` = 64 KiB → campaign **exit 5**.
 
 ### 3.9 CLI and failure contract (proposed, explicit, non-harmonising)
 
@@ -340,12 +451,33 @@ implementation time under a separate gate.
   the run, inside the workspace, staging created in its parent).
 - **Reader-bound options**: `--max-rows` (default 100 000, ceiling 1 000 000) and
   `--max-line-bytes` (default 65 536, ceiling 16 777 216), applied identically to
-  NP1/NP2/NP6 and echoed into the manifest for the completeness evidence.
+  NP1/NP2/NP6 **through their module-level interfaces** (NP2's CLI has no
+  reader-bound options, so this is module-level by necessity — see *How the
+  campaign uses the instruments*), used by the §3.6 completeness preflight, and
+  echoed into the manifest for the completeness evidence.
 - **Success output**: one concise line naming the published final directory;
   exit 0.
 - **Error output**: exactly **one concise `error:` line** to stderr per expected
   failure, never a traceback (the campaign introduces no second prefix; it has no
   metrics-style `safety error:` lane).
+
+**Campaign-owned size preflight** *(proposed, new — how the input half of the
+exit-5 lane is decided)*. NP5's `load_json_artifact` and NP8's bounded JSON
+loader raise `EvaluatorInputError` / `PacketInputError` for an **oversize**
+artifact and for **malformed** content alike, and NP8's staged-log ceiling raises
+`PacketInputError` as well *(existing at `main`)* — one typed class per module
+covering both lanes. The campaign therefore **never infers a ceiling breach from
+an instrument exception, and never parses exception-message text**. Instead,
+**before invoking each affected loader**, it performs its own bounded **size
+preflight** over the staged file using the **existing named ceilings** (§3.8):
+NP5 / NP8 `MAX_INPUT_BYTES` = 1 MiB for each JSON artifact it is about to hand
+over, and NP8 `MAX_LOG_BYTES` = 16 MiB for the staged log. A breach the preflight
+**confirms** is the campaign's **exit 5**. Anything the preflight passes goes to
+the existing typed loader or validator **unchanged**, and **malformed** content
+surfaces there as that module's own typed error → campaign **exit 2**. No NP5 or
+NP8 exception class, message, contract or exit code is changed, weakened or
+reinterpreted; the preflight only decides which *campaign* lane a *campaign*
+failure lands in.
 
 **Proposed exit-code map** *(new; the family's non-harmonisation is respected —
 this is a fifth distinct set, not a normalisation of the others)*:
@@ -353,26 +485,34 @@ this is a fifth distinct set, not a normalisation of the others)*:
 | Code | Category | Meaning |
 |---|---|---|
 | 0 | success | eight-file set built, all four provenance checks `verified`, packet self-validated, coherence gate satisfied, published to the (previously absent) final directory |
-| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed external input** (the log or protocol; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (excess physical rows, or an oversized-record ingestion termination — §3.6); **NP5 computed cross-artifact contradiction** refusal (§3.4) |
+| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed or out-of-bounds external input** (the log or protocol — including a protocol over NP6's pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, which is NP6's `LabInputError` lane and **not** the exit-5 ceiling lane, §3.8; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (a physical record beyond `max_rows`, or a record whose content exceeds the campaign `max_line_bytes` — established by the §3.6 preflight); **NP5 `computed` cross-artifact `contradicted` verdict** refusal (§3.4) |
 | 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
 | 4 | containment | `--workspace-dir` is not an existing directory; the final directory already exists at validation time; a staging or final path outside the workspace, under the repository `data/` tree, or aliasing an input (resolved-path + `os.path.samefile`, fail-closed identity) |
-| 5 | ceiling (named) | a **serialized-byte ceiling** breach only: a produced instrument artifact over its **64 KiB** ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB); or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB) |
+| 5 | ceiling (named) | a **named byte-ceiling** breach only, from the source that owns it: a produced instrument artifact over its **64 KiB** serialization ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`, each raised by the instrument itself); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); or — **as confirmed by the campaign's own size preflight above, never by catching a loader's typed input error** — a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB) or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB). NP6's protocol **input** ceiling (`MAX_PROTOCOL_BYTES`, 64 KiB) is **not** in this lane — it is exit 2 (§3.8) |
 | 6 | staging | failure to create the unique staging directory, to **copy the log/protocol into it**, or to write a produced artifact inside it |
 | 7 | publication | the staging → final rename fails, or the OS **reports** a destination collision because the final directory appeared between the absence check and the rename (§3.7) |
 
-**"Oversized" disambiguated.** The word covers two **distinct** lanes that map to
-**different** codes: an **oversized record** (content over `max_line_bytes`, which
-terminates NP1 ingestion) is a **complete-log refusal → exit 2**; a
-**serialized-byte ceiling** breach (64 KiB artifact/manifest, 1 MiB input, 16 MiB
-log) is the **ceiling lane → exit 5**. No lane is described by the bare word
-"oversized" alone.
+**"Oversized" disambiguated.** The word covers **three** distinct lanes mapping
+to **different** codes: an **oversized record** (content over the campaign
+`max_line_bytes`, which terminates NP1 ingestion) is a **complete-log refusal →
+exit 2**, established by the §3.6 preflight; an **oversize protocol** (over NP6's
+pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, raising `LabInputError`) is a
+**malformed / out-of-bounds external input → exit 2**; and a **named
+byte-ceiling** breach (64 KiB generated artifact or campaign manifest, 1 MiB JSON
+input, 16 MiB staged log) is the **ceiling lane → exit 5**, its input half
+established by the campaign's own size preflight. No lane is described by the
+bare word "oversized" alone.
 
 **Which failures stay loud internal failures (propagate, not exit 2).** Mirroring
 all six family `main()` clauses, the campaign `main()` catches **only** its
 documented typed classes (`CampaignInputError` and the instrument exceptions it
-deliberately surfaces — `InsufficientHistoryError`, the `*TooLargeError` ceiling
-family, the containment/output classes, and the proposed staging/publication
-classes). Outside that set:
+deliberately surfaces — `InsufficientHistoryError`, the five `*TooLargeError`
+serialization classes, the containment/output classes, and the proposed
+staging/publication classes). The typed catch set is therefore **not** how the
+**input** half of exit 5 is decided: NP5's `EvaluatorInputError` and NP8's
+`PacketInputError` are deliberately **not** in it, precisely because each covers
+oversize and malformed alike — the size preflight above settles that lane before
+those loaders are ever called. Outside the catch set:
 
 - **NP8's emitted-packet self-validation failure** is the **existing loud
   internal `RuntimeError`** *(existing at `main`)* and is **not** reclassified as
@@ -405,10 +545,24 @@ execution. The suite must include tests for:
 - **all configurations retained by NP6** (every protocol configuration present,
   operator order, no winner/score field);
 - **all four NP8 provenance checks `verified`** on a well-formed campaign;
-- **complete-log enforcement** (staged log fully traversed under the bounds, or
-  refusal);
-- **oversized-record and excess-row refusal** (an oversized terminal record; a
-  log longer than `max_rows`);
+- **complete-log enforcement** (the §3.6 preflight confirms the staged log is
+  fully traversed under the campaign bounds, or refuses);
+- **oversized-record and excess-row refusal** (a record whose content exceeds the
+  campaign `max_line_bytes`; a log with a physical record beyond `max_rows`),
+  **including a case with `max_rows` set to `MAX_ROWS_CEILING`** — proving the
+  preflight is not itself bounded by NP1's `max_rows` parameter range;
+- **preflight framing fidelity** — LF-terminated, CRLF-terminated, final
+  unterminated and blank records all counted as physical records exactly as NP1
+  counts `rows_read`, with **no** JSON parsing, rejection classification or
+  accepted-row judgement performed by the preflight (malformed rows still reach
+  NP1 and still land in its 12 `REJECT_REASONS`);
+- **size-preflight lane separation** (§3.9) — an oversize JSON artifact and an
+  oversize staged log yield **exit 5** through the campaign preflight, while a
+  **malformed** artifact of legal size yields **exit 2** from the existing typed
+  loader, with no exception-message parsing anywhere;
+- **protocol-input ceiling** — a protocol over NP6 `MAX_PROTOCOL_BYTES` (64 KiB)
+  is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
+  lane;
 - **metrics absent** from the eight-file set;
 - **input byte preservation** (originals byte-identical after every path);
 - **absent-final-directory requirement** and **no-overwrite at validation time**;
@@ -433,8 +587,10 @@ execution. The suite must include tests for:
   protocol configuration;
 - **NP8 default-bound exception** — the NP8 `log` entry uses NP1 default bounds
   and is not the completeness witness;
-- **computed cross-check contradiction refusal** — a `computed` NP5 contradiction
-  refuses publication, while a `not_computable` outcome publishes;
+- **verdict-level coherence gate** — a `computed` cross-artifact result carrying
+  a **`contradicted`** verdict refuses publication, while **`consistent`**,
+  **`unverifiable`** and **`not_computable`** outcomes each publish and are
+  carried into the manifest unchanged;
 - **destination-race semantics** — a concurrently created destination yields a
   reported publication failure or a permitted empty-directory replacement, with
   the unobservable-replacement non-claim respected.
@@ -481,6 +637,12 @@ untouched; the campaign is purely additive and composes them as-is.
 These v1 decisions **coexist with the current-`main` contracts** — the reason
 this contract can be frozen without proposing any instrument change:
 
+- The campaign touches the instruments **only through their existing public
+  module-level entry points** — builders, loaders and canonical serializers — so
+  every artifact it publishes is that instrument's own canonical output. No
+  instrument CLI is extended, and none is invoked: NP2's CLI could not express a
+  labelled configuration or campaign reader bounds even if it were used, which is
+  why the composition is at module level.
 - The six packet roles and the four provenance checks are exactly those
   `nextness-evidence-packet-v1` already emits and verifies; the campaign supplies
   all six roles from staged copies so all four checks are checkable, and it adds
@@ -494,7 +656,10 @@ this contract can be frozen without proposing any instrument change:
 - The same-log / same-options coherence the NP8 hash links do **not** by
   themselves guarantee is supplied by the campaign construction and recorded in
   the manifest (§3.4) — an additive invariant, not a change to NP8.
-- The complete-log obligation is stricter than NP1's silent-prefix default but is
+- The complete-log obligation is proved by a campaign-owned byte-level preflight
+  (§3.6) that mirrors NP1's record framing while re-implementing none of its row
+  semantics, and it works at every permitted bound including
+  `max_rows = MAX_ROWS_CEILING`. It is stricter than NP1's silent-prefix default but is
   the discipline metrics already enforces; it is expressed as "fully traversed
   under the selected bounds" and runs against the staged log — it adds a
   campaign-level proof and contradicts no instrument.

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -473,11 +473,27 @@ preflight** over the staged file using the **existing named ceilings** (§3.8):
 NP5 / NP8 `MAX_INPUT_BYTES` = 1 MiB for each JSON artifact it is about to hand
 over, and NP8 `MAX_LOG_BYTES` = 16 MiB for the staged log. A breach the preflight
 **confirms** is the campaign's **exit 5**. Anything the preflight passes goes to
-the existing typed loader or validator **unchanged**, and **malformed** content
-surfaces there as that module's own typed error → campaign **exit 2**. No NP5 or
-NP8 exception class, message, contract or exit code is changed, weakened or
-reinterpreted; the preflight only decides which *campaign* lane a *campaign*
-failure lands in.
+the existing typed loader or validator **unchanged**. No NP5 or NP8 exception
+class, message, contract or exit code is changed, weakened or reinterpreted; the
+preflight only decides which *campaign* lane a *campaign* failure lands in, and
+it never widens the catch set.
+
+**What a passed preflight does *not* buy — external input vs campaign-generated
+artifact.** The JSON artifacts handed to NP5 and NP8 (the NP1 report, the NP2
+receipt, the NP5 evaluation, the NP6 lab report) are artifacts the **campaign
+itself generated** from already-accepted staged inputs — they are **not**
+operator-supplied artifact inputs. Once the size preflight has passed, an
+`EvaluatorInputError` or `PacketInputError` raised while consuming one of them is
+therefore **not malformed external input**: it is a **loud internal invariant
+failure**. It is **not** translated into `CampaignInputError`, **not** admitted to
+the campaign's expected-failure catch set, and **never** exit 2 — it propagates
+(see *Which failures stay loud internal failures* below). **Campaign exit 2 stays
+reserved for genuinely external inputs** — the recorded log and the operator
+protocol, each through its own applicable typed boundary (NP1's reader and the
+§3.6 completeness preflight for the log; NP6's `load_protocol` →
+`LabInputError` for the protocol, including its 64 KiB `MAX_PROTOCOL_BYTES`
+ceiling) — **and for the expressly named campaign refusals** listed in the
+exit-2 row.
 
 **Proposed exit-code map** *(new; the family's non-harmonisation is respected —
 this is a fifth distinct set, not a normalisation of the others)*:
@@ -485,7 +501,7 @@ this is a fifth distinct set, not a normalisation of the others)*:
 | Code | Category | Meaning |
 |---|---|---|
 | 0 | success | eight-file set built, all four provenance checks `verified`, packet self-validated, coherence gate satisfied, published to the (previously absent) final directory |
-| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed or out-of-bounds external input** (the log or protocol — including a protocol over NP6's pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, which is NP6's `LabInputError` lane and **not** the exit-5 ceiling lane, §3.8; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (a physical record beyond `max_rows`, or a record whose content exceeds the campaign `max_line_bytes` — established by the §3.6 preflight); **NP5 `computed` cross-artifact `contradicted` verdict** refusal (§3.4) |
+| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed or out-of-bounds external input** (the log or protocol — including a protocol over NP6's pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, which is NP6's `LabInputError` lane and **not** the exit-5 ceiling lane, §3.8; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (a physical record beyond `max_rows`, or a record whose content exceeds the campaign `max_line_bytes` — established by the §3.6 preflight); **NP5 `computed` cross-artifact `contradicted` verdict** refusal (§3.4). **Never a campaign-*generated* artifact**: an `EvaluatorInputError` / `PacketInputError` raised while NP5 or NP8 consumes an artifact the runner itself produced — after that artifact's size preflight passed — is a loud internal invariant failure, not this lane |
 | 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
 | 4 | containment | `--workspace-dir` is not an existing directory; the final directory already exists at validation time; a staging or final path outside the workspace, under the repository `data/` tree, or aliasing an input (resolved-path + `os.path.samefile`, fail-closed identity) |
 | 5 | ceiling (named) | a **named byte-ceiling** breach only, from the source that owns it: a produced instrument artifact over its **64 KiB** serialization ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`, each raised by the instrument itself); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); or — **as confirmed by the campaign's own size preflight above, never by catching a loader's typed input error** — a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB) or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB). NP6's protocol **input** ceiling (`MAX_PROTOCOL_BYTES`, 64 KiB) is **not** in this lane — it is exit 2 (§3.8) |
@@ -520,9 +536,15 @@ those loaders are ever called. Outside the catch set:
 - **Structural invalidity of a campaign-*generated* artifact** (an artifact the
   runner produced from already-validated staged inputs failing its validator) is
   likewise an **internal programming / contract failure, not malformed operator
-  input** — it propagates loudly, never exit 2. (Exit 2's validation lane is for
-  malformed **external** inputs and the explicit campaign refusals above, not for
-  the campaign's own generated output.)
+  input** — it propagates loudly, never exit 2. This **explicitly includes an
+  `EvaluatorInputError` or `PacketInputError` raised while NP5 or NP8 consumes a
+  campaign-generated artifact after that artifact's §3.9 size preflight has
+  passed**: the artifact came from the campaign, not from the operator, so a parse
+  or structure failure there is an internal invariant breach. It is **not** retyped
+  as `CampaignInputError` and **not** added to the catch set. (Exit 2's validation
+  lane is for malformed or out-of-bounds **external** inputs — the recorded log and
+  the operator protocol through their own typed boundaries — and the explicit
+  campaign refusals above, not for the campaign's own generated output.)
 - Any other exception outside the documented catch set — a plain `ValueError`, a
   `RuntimeError`, a `MemoryError` — **propagates loudly** rather than masquerading
   as a concise input failure.
@@ -556,10 +578,17 @@ execution. The suite must include tests for:
   counts `rows_read`, with **no** JSON parsing, rejection classification or
   accepted-row judgement performed by the preflight (malformed rows still reach
   NP1 and still land in its 12 `REJECT_REASONS`);
-- **size-preflight lane separation** (§3.9) — an oversize JSON artifact and an
-  oversize staged log yield **exit 5** through the campaign preflight, while a
-  **malformed** artifact of legal size yields **exit 2** from the existing typed
-  loader, with no exception-message parsing anywhere;
+- **size-preflight lane separation** (§3.9), with no exception-message parsing
+  anywhere:
+  - a **confirmed named input-ceiling breach** — an oversize JSON artifact, or a
+    staged log over `MAX_LOG_BYTES` — yields **exit 5** through the campaign
+    preflight;
+  - an **unexpected `EvaluatorInputError` / `PacketInputError` after a passed
+    preflight**, raised while consuming a campaign-**generated** artifact,
+    **propagates loudly** — neither exit 2 nor exit 5, and the catch set is not
+    widened to swallow it;
+  - a **malformed operator protocol** remains the NP6 `LabInputError` → **exit 2**
+    lane;
 - **protocol-input ceiling** — a protocol over NP6 `MAX_PROTOCOL_BYTES` (64 KiB)
   is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
   lane;

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -625,7 +625,7 @@ execution. The suite must include tests for:
   is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
   lane;
 - **`LabInputError` caught directly, at every raise site that can reach the
-  campaign** — **three** cases, each asserting campaign **exit 2**, exactly
+  campaign** — **four** cases, each asserting campaign **exit 2**, exactly
   **one concise `error:` line** on stderr and **no traceback**:
   - a **malformed operator protocol** (bad schema key, unknown `model`,
     out-of-range `smoothing` / `holdout_fraction`, malformed configuration,
@@ -637,8 +637,13 @@ execution. The suite must include tests for:
     `max_line_bytes` at the reader call inside `build_lab_report`) → direct
     campaign **exit 2**, with NP6's message and `__cause__` intact and **no**
     re-typing into `CampaignInputError`;
+  - a **replay holdout over `MAX_REPLAY_STEPS`** (= 2000) — raised as
+    `LabInputError` by `build_lab_report` itself, not by `load_protocol`, so it
+    is reached only after the protocol has already loaded → the **same** direct
+    campaign **exit 2** lane. It bounds a **step count** on operator-supplied
+    input, not a serialized byte size, so the exit-5 ceiling lane never applies;
 - **plain-`ValueError` negative control** — a **separate** case, deliberately
-  **not** one of the three direct-catch cases above and **not** asserting
+  **not** one of the four direct-catch cases above and **not** asserting
   campaign exit 2: a **sentinel plain `ValueError` raised at the NP6 call seam
   propagates** and is not swallowed, proving the campaign catches the exact
   `LabInputError` subclass and not its `ValueError` base. Because it propagates

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -147,19 +147,26 @@ separators, LF-only, no timestamp / random id / absolute path), **relative
 filenames only**, and its own explicit named ceiling `MAX_CAMPAIGN_MANIFEST_BYTES`
 = **64 KiB** (fail-closed; §3.9 exit 5). It records:
 
-- each input's byte size and SHA-256 (the **staged** log and protocol);
+- each **staged input's** relative filename, byte size and SHA-256 (the log and
+  protocol);
 - the campaign reader bounds (`max_rows`, `max_line_bytes`) actually applied;
 - the exact `receipt_config_label` and its configuration correspondence (§3.4);
 - the completeness evidence (§3.6);
-- every published artifact's relative filename, byte size and SHA-256;
-- the NP8 packet's SHA-256;
+- each **produced artifact's** relative filename, byte size and SHA-256 (the NP1
+  report, NP2 receipt, NP5 evaluation, NP6 lab report and NP8 packet — the
+  packet's hash being the inward pointer of *Direction of trust* below);
 - the **four NP8 link statuses** (§3.3), copied for auditability.
+
+Together the two input records and the five produced-artifact records cover the
+**seven non-manifest files**. The manifest, being a file, **does not and cannot
+record its own SHA-256** — it is the outermost, unhashed-within-itself layer.
 
 **Direction of trust.** The manifest **points inward** to the NP8 packet (it
 records the packet's hash and echoes the packet's link statuses). **NP8 does not
 authenticate or provenance-link the campaign manifest** — the manifest is the
 outermost layer, verified by nothing above it; a consumer that re-verifies the
-chain re-hashes the eight files against the manifest itself.
+chain re-hashes the **seven non-manifest files** against the manifest's records
+and takes the manifest itself as given.
 
 ### 3.3 The four NP8 provenance checks (existing at `main`)
 
@@ -346,7 +353,7 @@ this is a fifth distinct set, not a normalisation of the others)*:
 | Code | Category | Meaning |
 |---|---|---|
 | 0 | success | eight-file set built, all four provenance checks `verified`, packet self-validated, coherence gate satisfied, published to the (previously absent) final directory |
-| 2 | validation / campaign refusal | typed `CampaignInputError`: **malformed external input** (log / protocol / workspace) that arrives malformed; missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (excess physical rows, or an oversized-record ingestion termination — §3.6); **NP5 computed cross-artifact contradiction** refusal (§3.4) |
+| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed external input** (the log or protocol; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (excess physical rows, or an oversized-record ingestion termination — §3.6); **NP5 computed cross-artifact contradiction** refusal (§3.4) |
 | 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
 | 4 | containment | `--workspace-dir` is not an existing directory; the final directory already exists at validation time; a staging or final path outside the workspace, under the repository `data/` tree, or aliasing an input (resolved-path + `os.path.samefile`, fail-closed identity) |
 | 5 | ceiling (named) | a **serialized-byte ceiling** breach only: a produced instrument artifact over its **64 KiB** ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB); or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB) |

--- a/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
+++ b/docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md
@@ -501,7 +501,7 @@ this is a fifth distinct set, not a normalisation of the others)*:
 | Code | Category | Meaning |
 |---|---|---|
 | 0 | success | eight-file set built, all four provenance checks `verified`, packet self-validated, coherence gate satisfied, published to the (previously absent) final directory |
-| 2 | validation / campaign refusal | typed `CampaignInputError`: a **malformed or out-of-bounds external input** (the log or protocol — including a protocol over NP6's pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, which is NP6's `LabInputError` lane and **not** the exit-5 ceiling lane, §3.8; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (a physical record beyond `max_rows`, or a record whose content exceeds the campaign `max_line_bytes` — established by the §3.6 preflight); **NP5 `computed` cross-artifact `contradicted` verdict** refusal (§3.4). **Never a campaign-*generated* artifact**: an `EvaluatorInputError` / `PacketInputError` raised while NP5 or NP8 consumes an artifact the runner itself produced — after that artifact's size preflight passed — is a loud internal invariant failure, not this lane |
+| 2 | validation / campaign refusal | **two typed classes, both caught directly**: the campaign's own `CampaignInputError` for its own validation and refusal lanes, **and NP6's `LabInputError` — caught directly, never translated** — for malformed or out-of-bounds **operator-protocol** input and any other NP6 typed external-input failure surfaced by `build_lab_report` (see *The campaign's expected-failure catch set* below). The lane covers a **malformed or out-of-bounds external input** (the log or protocol — including a protocol over NP6's pre-parse `MAX_PROTOCOL_BYTES` = 64 KiB, which is NP6's `LabInputError` lane and **not** the exit-5 ceiling lane, §3.8; a `--workspace-dir` or path *existence / containment* failure is exit 4, not here); missing / unknown / duplicate `receipt_config_label`; **provenance-not-verified**; **complete-log refusal** (a physical record beyond `max_rows`, or a record whose content exceeds the campaign `max_line_bytes` — established by the §3.6 preflight); **NP5 `computed` cross-artifact `contradicted` verdict** refusal (§3.4). **Never a campaign-*generated* artifact**: an `EvaluatorInputError` / `PacketInputError` raised while NP5 or NP8 consumes an artifact the runner itself produced — after that artifact's size preflight passed — is a loud internal invariant failure, not this lane |
 | 3 | insufficient-history | `InsufficientHistoryError` surfaced from NP1 / NP2 / NP6 (the family's insufficiency semantics; never re-typed) |
 | 4 | containment | `--workspace-dir` is not an existing directory; the final directory already exists at validation time; a staging or final path outside the workspace, under the repository `data/` tree, or aliasing an input (resolved-path + `os.path.samefile`, fail-closed identity) |
 | 5 | ceiling (named) | a **named byte-ceiling** breach only, from the source that owns it: a produced instrument artifact over its **64 KiB** serialization ceiling (`ReportTooLargeError` / `ReceiptTooLargeError` / `EvaluationTooLargeError` / `LabReportTooLargeError` / `PacketTooLargeError`, each raised by the instrument itself); the **campaign manifest** over `MAX_CAMPAIGN_MANIFEST_BYTES` (64 KiB); or — **as confirmed by the campaign's own size preflight above, never by catching a loader's typed input error** — a JSON artifact over NP5/NP8 `MAX_INPUT_BYTES` (1 MiB) or the staged log over NP8 `MAX_LOG_BYTES` (16 MiB). NP6's protocol **input** ceiling (`MAX_PROTOCOL_BYTES`, 64 KiB) is **not** in this lane — it is exit 2 (§3.8) |
@@ -519,16 +519,48 @@ input, 16 MiB staged log) is the **ceiling lane → exit 5**, its input half
 established by the campaign's own size preflight. No lane is described by the
 bare word "oversized" alone.
 
-**Which failures stay loud internal failures (propagate, not exit 2).** Mirroring
-all six family `main()` clauses, the campaign `main()` catches **only** its
-documented typed classes (`CampaignInputError` and the instrument exceptions it
-deliberately surfaces — `InsufficientHistoryError`, the five `*TooLargeError`
-serialization classes, the containment/output classes, and the proposed
-staging/publication classes). The typed catch set is therefore **not** how the
-**input** half of exit 5 is decided: NP5's `EvaluatorInputError` and NP8's
-`PacketInputError` are deliberately **not** in it, precisely because each covers
-oversize and malformed alike — the size preflight above settles that lane before
-those loaders are ever called. Outside the catch set:
+**The campaign's expected-failure catch set.** Mirroring all six family `main()`
+clauses, the campaign `main()` catches **only** its documented typed classes —
+its own `CampaignInputError` plus the instrument exceptions it deliberately
+surfaces:
+
+- **`CampaignInputError`** *(proposed, new)* — the campaign's own validation and
+  refusal lanes → **exit 2**.
+- **`LabInputError`** *(existing at `main`, NP6)* → **exit 2**, **caught
+  directly and never translated into `CampaignInputError`**: its message and its
+  `__cause__` remain exactly what NP6 supplied. `LabInputError` is already NP6's
+  exact typed external-input boundary, so the campaign surfaces it rather than
+  wrapping it. Catching the **class**, not one call site, is deliberate — NP6
+  raises it from `load_protocol` (protocol over `MAX_PROTOCOL_BYTES`, invalid
+  UTF-8/JSON, duplicate JSON key, parser-depth, schema keys, `model` allowlist,
+  `smoothing` / `holdout_fraction` bounds, configuration shape, label length,
+  duplicate label, and `MonitorConfig.validate` failures) **and** from
+  `build_lab_report`, which calls `load_protocol` itself, translates NP1's
+  reader-bound `PredictorInputError` into `LabInputError` (message
+  byte-identical, cause preserved) and raises `LabInputError` when the replay
+  holdout exceeds `MAX_REPLAY_STEPS`. Catching only the campaign's own explicit
+  protocol load would leave those later raises uncovered and the promised
+  operator-protocol exit-2 lane unimplementable.
+- **`InsufficientHistoryError`** → exit 3.
+- The five **`*TooLargeError`** serialization classes → exit 5.
+- The containment/output classes → exit 4.
+- The proposed staging/publication classes → exits 6 and 7.
+
+**Deliberately excluded from the catch set:** NP5's `EvaluatorInputError` and
+NP8's `PacketInputError`. The typed catch set is therefore **not** how the
+**input** half of exit 5 is decided — each of those classes covers oversize and
+malformed alike, the size preflight above settles that lane before those loaders
+are ever called, and after a passed preflight such an error on a
+campaign-generated artifact is a loud internal invariant failure. Adding
+`LabInputError` **does not** relax that exclusion.
+
+**Nor does it broaden base-`ValueError` handling.** `LabInputError` is a
+`ValueError` **subclass** *(existing at `main`)*, and **only that exact subclass
+is caught** — a plain `ValueError` raised at the NP6 call seam still propagates,
+exactly as in all six family clauses.
+
+**Which failures stay loud internal failures (propagate, not exit 2).** Outside
+the catch set:
 
 - **NP8's emitted-packet self-validation failure** is the **existing loud
   internal `RuntimeError`** *(existing at `main`)* and is **not** reclassified as
@@ -588,10 +620,26 @@ execution. The suite must include tests for:
     **propagates loudly** — neither exit 2 nor exit 5, and the catch set is not
     widened to swallow it;
   - a **malformed operator protocol** remains the NP6 `LabInputError` → **exit 2**
-    lane;
+    lane (proved in detail by the direct-catch tests below);
 - **protocol-input ceiling** — a protocol over NP6 `MAX_PROTOCOL_BYTES` (64 KiB)
   is refused on the **exit-2** lane (`LabInputError`), never the exit-5 ceiling
   lane;
+- **`LabInputError` caught directly, at every raise site that can reach the
+  campaign** — four cases, each asserting **exit 2**, exactly **one concise
+  `error:` line** on stderr and **no traceback**:
+  - a **malformed operator protocol** (bad schema key, unknown `model`,
+    out-of-range `smoothing` / `holdout_fraction`, malformed configuration,
+    over-long or duplicate label) → direct `LabInputError` catch → **exit 2**;
+  - a **protocol over `MAX_PROTOCOL_BYTES`** → the **same** direct exit-2 lane,
+    never the exit-5 ceiling lane;
+  - an **NP6 reader-bound failure translated internally** from NP1's
+    `PredictorInputError` into `LabInputError` (an out-of-bounds `max_rows` /
+    `max_line_bytes` at the reader call inside `build_lab_report`) → direct
+    campaign **exit 2**, with NP6's message and `__cause__` intact and **no**
+    re-typing into `CampaignInputError`;
+  - a **sentinel plain `ValueError` raised at the NP6 call seam propagates** and
+    is not swallowed — proving the campaign catches the exact `LabInputError`
+    subclass and not its `ValueError` base;
 - **metrics absent** from the eight-file set;
 - **input byte preservation** (originals byte-identical after every path);
 - **absent-final-directory requirement** and **no-overwrite at validation time**;
@@ -653,8 +701,11 @@ audit and a fresh Kev authorisation** — nothing below is authorised by this PR
   six-map table, **plus** the mechanical corrections that the addition forces —
   the map **count** ("four distinct code sets across six CLIs" → "five … across
   seven"), the affected **headings/summary** wording, and the
-  **catch-set / unexpected-error-propagation list** (adding the campaign's typed
-  catch classes). No other file's content is implied.
+  **catch-set / unexpected-error-propagation list** — adding the campaign's own
+  typed catch class **and the instrument classes it deliberately surfaces**,
+  `LabInputError` among them (caught directly, not translated), while recording
+  that `EvaluatorInputError` and `PacketInputError` are deliberately excluded and
+  that plain `ValueError` still propagates. No other file's content is implied.
 
 **No existing producer, validator, artifact schema, observer, calibration,
 metrics, or any other file is authorised to change** by this contract. The


### PR DESCRIPTION
## Design-only Nextness offline evidence-campaign contract

**Status: DESIGN ONLY — independent Jack audit PASSED at head `6c91a32ff0cc4338c64eb3b2790d3ac46e290930`; Kev separately authorized the ready transition and ordinary protected squash merge. This PR authorizes no implementation.** A single new document is added; no code, test, schema, or existing file is changed.

This adds `docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md`, freezing the v1 contract for a **future** deterministic, offline **evidence-campaign runner** that would turn **one already-recorded** `nextness_runs.jsonl` plus **one operator-authored NP6 protocol** into a single provenance-checked **NP1 → NP2 → NP5 → NP6 → NP8** artifact chain, published — with an outer campaign manifest — as one fixed set of files. "Campaign" is defined narrowly as **recorded-log artifact processing only** — never snapshot collection, observer execution, `process_snapshot()`, calibration experimentation, or any Medusa runtime activity.

### One-file boundary and commit receipts
- **New file (only):** `docs/NEXTNESS_EVIDENCE_CAMPAIGN_CONTRACT.md` — **#420's own one-file boundary is verified**: exactly one added file, **+774 / −0** vs `main` `c8aacbf054269f1e4115292f7c0bb703f1b704e4` (774 lines, 52305 bytes, `sha256 4090c8e27dac4034b663d8cad48029e7bc4daec16f9d98624aeeaebcdedc84ba`), `git diff --check` clean, LF-only committed blob, no other file touched (`AGENT_HANDOFF.md` included).
- **Commits (all ordinary — no amend, force-push or rebase; one merge-from-main):**
  - `65c080c8bf4f74d373d61f064b08c9e1c70ac6e7` — `docs(nextness): define offline evidence campaign contract` (+386/−0)
  - `d3e731ac8b3ef5a7488b56d60477f90adb8637cc` — `docs(nextness): close campaign contract seams` (+383/−261)
  - `8ca0440da680c16704e5bc5d73bacafe81e94a7b` — `docs(nextness): fix manifest self-hash and workspace exit-lane` (+12/−5)
  - `a855516b37d8b02f17ee23d4ce8794253ab7ba7f` — `docs(nextness): ground campaign contract in module-level composition` (+209/−44)
  - `793389a49ee0e9bdd86784473d31b217f030b01e` — `docs(nextness): resolve contradictory malformed-artifact lane (CC-6)` (+42/−13)
  - `792ac0d73430c81fbe0d40ea52652921b6dcb41c` — `docs(nextness): catch NP6 LabInputError directly on campaign exit 2 (CC-7)` (+65/−14)
  - `b998e53ca72cf5dcf60eb650f034223c84726609` — `Merge branch 'main' into docs/nextness-evidence-campaign-contract` — the **one two-parent** commit; parents `792ac0d73430c81fbe0d40ea52652921b6dcb41c` (branch) and `c8aacbf054269f1e4115292f7c0bb703f1b704e4` (`main`). It adds **no change of its own** and leaves this PR's diff untouched: the contract document is byte-identical **before and after the merge** (`sha256 3040334b…` at both `792ac0d` and `b998e53`; the file does not exist on `main` at all), and the 31 files `main`'s 17 incoming commits bring onto the branch are all under `scripts/`, `tests/` and `vis/` — disjoint from this PR's one file.
  - `1f3f110603e8a7b33687492bef7f0e7f62cc0c8a` — `docs(nextness): separate the plain-ValueError negative control from the exit-2 cases (CC-7)` (+10/−5)
  - `a37c79f0aca38bd130f0180a629687e079af7204` — `docs(nextness): add the MAX_REPLAY_STEPS handled case to the direct-catch tests` (+7/−2)
  - `6c91a32ff0cc4338c64eb3b2790d3ac46e290930` — `docs(nextness): bound the direct-catch coverage claim to failure families` (+7/−3)
- **Topology:** `6c91a32 → a37c79f → 1f3f110 → b998e53`, where `b998e53` is the single merge commit with parents `792ac0d` (branch) and `c8aacbf0` (`main`); the branch line continues `792ac0d → 793389a → a855516 → 8ca0440 → d3e731a → 65c080c → 2d6ba881c8fd030e07db985f6fbcbaefc2e9a363` (the original cut point, then `main`). Head = `6c91a32ff0cc4338c64eb3b2790d3ac46e290930`, parent = `a37c79f0aca38bd130f0180a629687e079af7204`, base = current `main` `c8aacbf054269f1e4115292f7c0bb703f1b704e4`. **10 commits: 9 single-parent and one two-parent merge.** No amend, rebase, force-push or history rewrite at any point.

### Correction pass 4 (commit `a855516`) — five audit-raised candidates resolved
An independent source-grounding audit of this PR against current `main` raised five correction candidates. All five were re-verified against source and resolved **in the document only** — no source, test, schema, validator, instrument or CLI-failure doc was touched, and no implementation is authorised:
- **CC-1 module-level composition** — the runner composes the instruments through their existing public builders / loaders / canonical serializers, never through their standalone CLIs, and no obligation may be read as requiring an artifact to be reproducible through a CLI. NP2's CLI exposes only `log_path` / `--model` / `--smoothing` / `--holdout-fraction`, so a labelled `MonitorConfig` and campaign reader bounds are reachable **only** via `observations_from_log` + `build_receipt`; the emitted receipt is still NP2's own canonical byte output and NP2's semantics and schema are unchanged.
- **CC-2 campaign-owned size preflight** — NP5's and NP8's loaders raise one typed class each for **oversize and malformed input alike**, so the input half of exit 5 is decided by a bounded campaign preflight over the staged files using the existing named ceilings — never by catching an ambiguous loader exception, never by parsing message text. No NP5/NP8 exception contract is weakened. **Superseded in part by CC-6 below:** this pass originally also said a legal-size malformed artifact reaching the loader becomes exit 2, which contradicted the document's own loud-internal-failure rule; that claim has been removed.
- **CC-3 verdict-level coherence gate** — `computed` / `not_computable` remain **envelope** outcomes; inside a `computed` envelope publication is refused exactly on a **`contradicted`** verdict, **`consistent`** permits, and **`unverifiable`** remains an evidence outcome that is never recast. No NP5 verdict is invented and no NP5 schema changes.
- **CC-4 complete-log preflight** — a campaign-owned **streaming byte-level** scan of the staged log framing records exactly as NP1's reader does (LF-delimited, bounded `readline(max_line_bytes + 2)`, CRLF/LF terminator excluded from the content bound, every physical record counted), reading at most `max_rows + 1` records. It **works at `max_rows = MAX_ROWS_CEILING`**, where asking NP1's reader for `max_rows + 1` is a typed `PredictorInputError` and the reader cannot distinguish "exactly `max_rows`" from "more than `max_rows`". It parses no JSON and classifies nothing — the 12 `REJECT_REASONS` remain NP1's — and it is the completeness witness recorded in the manifest.
- **CC-5 protocol-input ceiling** — NP6 `MAX_PROTOCOL_BYTES` = 64 KiB added to the named-ceiling inventory as an **operator-supplied input** ceiling (`LabInputError` → campaign **exit 2**), disambiguated from the five 64 KiB generated-artifact serialization ceilings, NP5/NP8's 1 MiB input ceilings, NP8's 16 MiB staged-log ceiling and the manifest's own 64 KiB ceiling.

**Preserved unchanged by the correction pass:** the exact eight-file publication set; the manifest's seven non-manifest hash records and its self-hash prohibition; authoritative staged input bytes; identical campaign reader bounds across NP1/NP2/NP6; selected-label recording in the manifest rather than the NP2 receipt; NP8's three artifact-byte hash links plus one accepted-sequence-representation link; the hash-verification vs campaign-level-coherence distinction; design-only status and every standing non-claim.

**Known cosmetic residual (no semantic effect, disclosed rather than fixed):** two paragraph lines in the corrected document run to 109 and 101 characters, past the file's ~80-column soft-wrap convention, where new text joins retained text in §3.6 and §3.8. Markdown rendering is unaffected; still uncorrected after CC-6, CC-7 and the three correction passes since, none of which was scoped to authorise a cosmetic-only change. No pass since has introduced a further over-long line — the lines added by `1f3f110`, `a37c79f` and `6c91a32` are all within the ~80-column convention (widest new line: 80 characters).

### Correction pass 5 (commit `793389a`) — CC-6, contradictory malformed-artifact lane
Jack's independent review passed CC-1, CC-3, CC-4 and CC-5 and found **one** load-bearing contradiction in CC-2's contractual resolution. Three requirements could not hold at once: (a) the size-preflight paragraph said a legal-size malformed NP5/NP8 artifact reaches the existing typed loader and becomes campaign **exit 2**; (b) the catch-set paragraph deliberately **excludes** `EvaluatorInputError` and `PacketInputError`, so outside that set they propagate; (c) the generated-artifact structural-invalidity paragraph says an invalid campaign-generated artifact propagates **loudly and is never exit 2**. A future-test bullet repeated (a).

The ruling applied preserves the **safer existing loud-failure rule**. The JSON artifacts handed to NP5 and NP8 — the NP1 report, NP2 receipt, NP5 evaluation and NP6 lab report — are generated by the campaign itself from already-accepted staged inputs; they are **not** operator-supplied artifact inputs. Therefore:
- a campaign-owned size preflight may establish a **named input-ceiling breach** before an affected loader and map that **confirmed** breach to **exit 5**;
- after that preflight passes, an `EvaluatorInputError` or `PacketInputError` arising while consuming a **campaign-generated** artifact is a **loud internal invariant failure** — not translated to `CampaignInputError`, not admitted to the expected-failure catch set, and **never exit 2**;
- **campaign exit 2 remains** for malformed or out-of-bounds **genuinely external** inputs (the recorded log and the operator protocol through their own applicable typed boundaries, NP6's `load_protocol` → `LabInputError` included) and for the expressly named campaign refusals;
- the catch set is **not** broadened and **no exception-message text is parsed**.

Four edits: the size-preflight paragraph (stale exit-2 claim removed, explicit *external input vs campaign-generated artifact* paragraph added); the exit-2 map row (states the lane is **never** a campaign-generated artifact); the loud-internal-failure bullet (names both typed classes for that case); and the affected future-test bullet (rewritten into three outcomes — confirmed ceiling breach → exit 5; unexpected typed input error after a passed preflight → propagates loudly; malformed operator protocol → NP6 `LabInputError` → exit 2). Every other exit-2 statement in the document was audited and is correct as written; both stale occurrences are gone. CC-1, CC-3, CC-4 and CC-5 are preserved verbatim in substance, as is every item in the preservation set above.

**Open point raised by this pass — now RESOLVED by CC-7 below.** CC-6 flagged that the documented campaign catch set omitted `LabInputError` while the operator-protocol lane promised campaign exit 2 through it. Jack's independent review confirmed the seam and ruled on it; see *Correction pass 6 (CC-7)*.

### Correction pass 6 (commit `792ac0d`) — CC-7, `LabInputError` omitted from the campaign catch set
Jack's independent review **passed CC-6** (exit map, loud-failure discussion and test plan now agree) and ruled on the open point CC-6 raised. The contract promised that malformed or out-of-bounds **operator-protocol** input — including a protocol over NP6 `MAX_PROTOCOL_BYTES` — reaches campaign **exit 2** through NP6's `LabInputError`, while the documented catch set listed only `CampaignInputError`, `InsufficientHistoryError`, the five `*TooLargeError` classes, the containment/output classes and the proposed staging/publication classes. With `LabInputError` absent, that lane was **unimplementable as written**.

**Scope of the omission, re-verified against current `main`** (`scripts/nextness_replay_lab.py`): `load_protocol` raises `LabInputError` for protocol size, invalid UTF-8/JSON, duplicate JSON key, parser depth, schema keys, `model` allowlist, `smoothing` / `holdout_fraction` bounds, configuration shape, label length, duplicate label and `MonitorConfig.validate` failures (`:273–355`); `build_lab_report` calls `load_protocol` itself (`:533`), translates NP1's reader-bound `PredictorInputError` into `LabInputError` with the cause preserved (`:545–546`), and raises `LabInputError` when the replay holdout exceeds `MAX_REPLAY_STEPS` (`:556–558`). Translating only the campaign's first explicit protocol load would therefore have left three of the four reachable raise paths uncovered.

**The ruling applied:** the campaign `main()` catches NP6's **`LabInputError` directly** and maps it to campaign **exit 2**. It is **not** translated into `CampaignInputError` — its message and `__cause__` remain exactly what NP6 supplied. `LabInputError` is already NP6's exact typed external-input boundary, so direct catching preserves provenance, avoids a wrapper, covers every raise site that can reach the campaign, and matches the family pattern of a composing CLI deliberately surfacing instrument-specific typed expected failures.

Four edits: the **exit-2 map row** now names **two typed classes caught directly** rather than implying every exit-2 input failure is a `CampaignInputError`; the **catch set** is restated as an explicit list with `LabInputError` included and its raise sites enumerated; a new paragraph records that `LabInputError` is a **`ValueError` subclass** and that **only that exact subclass is caught**, so a plain `ValueError` at the NP6 call seam still propagates (as do `RuntimeError`, `MemoryError` and everything else outside the named set); and the **future test plan** gains four direct-catch cases — malformed protocol; protocol over `MAX_PROTOCOL_BYTES`; a reader-bound `PredictorInputError` translated internally to `LabInputError`; and a sentinel plain `ValueError` at the NP6 seam that must propagate — each asserting exit 2 with exactly one concise `error:` line and no traceback. **Superseded in part by the three correction commits since (`1f3f110`, `a37c79f` and `6c91a32`):** the fourth of those cases — a sentinel plain `ValueError` that must **propagate** — could not also assert campaign exit 2, exactly one concise `error:` line and no traceback. That bullet now lists **four required handled `LabInputError` failure families**, each asserting campaign **exit 2**, exactly one concise `error:` line and no traceback — bounded explicitly as semantic families at the campaign boundary rather than as one-to-one coverage of every raise site — **plus a separate propagating plain-`ValueError` negative control** that asserts **propagation** and **explicitly does not expect** campaign exit 2. The future `NEXTNESS_CLI_FAILURE_CONTRACTS.md` catch-set update is reworded to name the surfaced instrument classes and the deliberate exclusions.

**Preserved:** the deliberate exclusion of `EvaluatorInputError` and `PacketInputError` (including CC-6's statement that the catch set is *not* how the input half of exit 5 is decided) is unchanged, and adding `LabInputError` does not relax it. CC-1 through CC-6 are preserved unchanged in substance, as is every item in the preservation set above.

### Correction passes 7 and 8 (commits `1f3f110` and `a37c79f`) — the direct-catch case list: contradiction removed, fourth family added
Two further bounded passes were authorised on the §3.10 future-test bullet CC-7 introduced. Both are documentation-only and touch the one file.

**`1f3f110` — the contradiction.** Jack's independent review of CC-7 found that the bullet introduced **four** cases as "each asserting exit 2, exactly one concise `error:` line and no traceback", then listed as its fourth sub-case a sentinel plain `ValueError` that must **propagate**. A propagating exception can assert none of those three things. The three genuine `LabInputError` direct-catch cases kept the assertions; the sentinel was promoted out of the sub-list to a **separate** top-level negative control asserting **propagation** and explicitly expecting neither campaign exit 2, nor a single concise `error:` line, nor the absence of a traceback (+10/−5).

**`a37c79f` — the coverage gap that removing the contradiction exposed.** With the sentinel no longer padding the list to four, the bullet's lead-in claim of coverage "at every raise site that can reach the campaign" stood against only **three** cases, while §3.9's own catch-set discussion names a **fourth** `LabInputError` raise site: `build_lab_report` raising when the replay holdout exceeds `MAX_REPLAY_STEPS` (= 2000). That site is reached only after the protocol has loaded, so no protocol-loading case exercises it. The gap was **pre-existing** — at CC-7's head the fourth slot was occupied by the sentinel, which is not a `LabInputError` raise site at all, so raise-site coverage was identical; removing the contradiction merely removed the 4-vs-4 numeric coincidence that had masked it. It was reported as an open residual in the previous pass's handback, and Jack's follow-up authorisation ruled that it be closed. This pass adds the fourth **handled** case, asserting campaign **exit 2**, exactly one concise `error:` line and no traceback, and notes that the bound is a **step count** on operator-supplied input rather than a serialized byte size, so the exit-5 ceiling lane never applies to it. The separate propagating plain-`ValueError` negative control is retained unchanged in substance, and the "three direct-catch cases" wording in its text is updated to "four" (+7/−2).

**Preserved:** every earlier pass's description of what *that* commit contained is deliberately left unrewritten; only the forward-looking annotations inside those sections — the CC-7 supersession note and the cosmetic-residual note — are brought up to date. No source, test, schema, validator, instrument or other document is touched by either pass, and the exit-code map, the deliberate `EvaluatorInputError` / `PacketInputError` exclusion and the design-only non-claims are unchanged.

### Correction pass 9 (commit `6c91a32`) — the coverage claim bounded to failure families
Jack's re-audit found that pass 8 left an **over-claim** standing. The bullet's lead-in still read "`LabInputError` caught directly, **at every raise site that can reach the campaign**", and the pass-8 handback asserted that this claim had thereby become true. **It had not, and that assertion was wrong.** Four test cases cannot be one-to-one with every literal `raise LabInputError` statement: `load_protocol` raises the class across the many distinct failure conditions §3.9 enumerates (protocol size, invalid UTF-8/JSON, duplicate key, parser depth, schema keys, `model` allowlist, `smoothing` / `holdout_fraction` bounds, configuration shape, label length, duplicate label, `MonitorConfig.validate`), and `build_lab_report` invokes `load_protocol` a second time itself. Adding a fourth case closed a *family* gap, not a per-statement one.

**The ruling applied — two edits, both in §3.10.** The lead-in now reads "**`LabInputError` caught directly** — **four** required handled `LabInputError` **failure families**", dropping the raise-site claim entirely; and a new bullet bounds what the four do assert: they cover the named semantic families at the campaign boundary, and are **not** a one-to-one test of every literal `raise LabInputError` statement in NP6, nor of every invocation of `load_protocol`. It is labelled as a bound on the claim rather than a further test, so it is not itself a required test case (+7/−3).

**Preserved unchanged in substance:** all four handled families, including the `MAX_REPLAY_STEPS` family added by `a37c79f`; and the separate propagating plain-`ValueError` negative control, whose "four direct-catch cases" reference remains correct. **Deliberately untouched:** §3.9's statement that the *implementation* catches the **class**, not one call site — that is a claim about the catch, as is this body's own CC-7 description of the ruling above; it remains true, and this pass bounds only the **test plan's** coverage claim. Earlier sections' "raise site" wording denotes NP6 raise paths at §3.9's granularity, not literal `raise` statements. **Also corrected in this body, in its own voice:** the passes 7 and 8 heading's closing summary now reads "fourth family added" in place of "then completed", which carried the same over-claim, and the CC-7 supersession note now names three correction commits. Earlier passes' prose descriptions of what those commits contained are left unrewritten.

### Source files / contracts audited (read-only, none modified)
The document is source-grounded against, and proposes no change to, the current-`main` interfaces:
- `scripts/nextness_predictor.py` — `nextness-predictor-v1` — `docs/NEXTNESS_PREDICTION_BASELINE.md`
- `scripts/nextness_monitor.py` — `nextness-monitor-v1` — `docs/NEXTNESS_MONITOR_CONTRACT.md`
- `scripts/nextness_evaluator.py` — `nextness-evaluation-v1` — `docs/NEXTNESS_EVALUATOR_CONTRACT.md`
- `scripts/nextness_replay_lab.py` — `nextness-replay-lab-v1` / `nextness-replay-protocol-v1` — `docs/NEXTNESS_REPLAY_LAB_CONTRACT.md`
- `scripts/nextness_evidence_packet.py` — `nextness-evidence-packet-v1` — `docs/NEXTNESS_EVIDENCE_PACKET_CONTRACT.md`
- `scripts/nextness_artifact_validation.py` (NP9 validators) — `docs/NEXTNESS_ARTIFACT_VALIDATION_CONTRACT.md`
- `tests/test_nextness_contracts.py` (NP7 guard) — `docs/NEXTNESS_CONTRACT_GUARD.md`
- `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md` (cross-CLI exit-code facts)
- `scripts/nextness_metrics.py`, `scripts/nextness_calibration.py`, `scripts/nextness_observer.py` (+ tests) — parked / out-of-scope boundaries.

The document explicitly separates **existing-at-`main` facts** (instrument schemas, bounds, per-CLI exit codes, the four NP8 checks) from **newly proposed campaign facts** (the `nextness-evidence-campaign-v1` manifest, the eight-file set, the `--workspace-dir` staging model, and the campaign exit-code map). It also states up front that the runner is a **module-level composition** of the existing instruments' builders / loaders / serializers — never a standalone-CLI invocation — because NP2's CLI can express neither a labelled `MonitorConfig` nor campaign reader bounds.

### The ten frozen contract areas (post-correction)
1. **Inputs, workspace & authoritative staged snapshot** — one recorded log + one operator NP6 protocol; **required `--workspace-dir <existing-dir>`** with resolved-path containment; log / protocol / staging-parent / final-dir all inside the workspace and **outside repo `data/`**; the log and protocol are **copied byte-for-byte into staging before any instrument**, and every NP1/NP2/NP5/NP6/NP8 op reads the **staged copies** (originals never mutated; concurrent replacement *during copy* is an honest residual; the **authoritative inputs are the captured staged bytes**).
2. **Exact output chain & eight-file set** — NP1 report → NP2 checkpoint receipt → NP5 evaluation → NP6 lab (all configs) → NP8 packet (six roles); published as **exactly eight files** (`nextness_runs.jsonl`, `nextness_replay_protocol.json`, `nextness_predictor_report.json`, `nextness_monitor_receipt.json`, `nextness_evaluation.json`, `nextness_replay_lab.json`, `nextness_evidence_packet.json`, `nextness_evidence_campaign.json`). The last is the **outer manifest `nextness-evidence-campaign-v1` — not an NP8 role** — with an exact schema, canonical serialization, a named 64 KiB ceiling, relative filenames only, recording the **seven non-manifest files'** relative filename/size/SHA-256 (two staged inputs + five produced artifacts — **never the manifest's own hash**), reader bounds, the exact `receipt_config_label`, completeness evidence, and the four NP8 link statuses; it **points inward** to the packet, and **NP8 does not authenticate the manifest**.
3. **Provenance checks (existing at `main`)** — the four NP8 checks are **three artifact-byte hash links** (`evaluation_report_sha256`, `evaluation_receipts_sha256`, `lab_protocol_sha256`) **plus one accepted-sequence-representation hash link** (`lab_sequence_sha256`); **all four `verified`** before publication; these verify **hashes only**, not same-log/same-options coherence.
4. **Semantic lineage** — protocol `smoothing`/`holdout_fraction` drive NP1; protocol `model`/`smoothing`/`holdout_fraction` + the labelled config drive NP2; **identical campaign `max_rows`/`max_line_bytes` across NP1/NP2/NP6**; the selected label + config correspondence is recorded in the manifest (an NP2 receipt records values, not the label); the campaign construction + manifest supply the same-log/same-options coherence the NP8 hash links do not; the coherence gate is **verdict-level** — inside a `computed` envelope a **`contradicted`** verdict refuses publication, while **`consistent`**, **`unverifiable`** and **`not_computable`** all remain evidence outcomes that publish (NP5's fixed `VERDICTS` vocabulary, unchanged); and the labelled configuration's `window` must reach `observations_from_log` as well as the receipt's `MonitorConfig`.
5. **No implicit winner** — mandatory `receipt_config_label` matching **exactly one** protocol configuration; never the first implicitly; never rank/search/recommend/infer/apply a **configuration**. NP5's descriptive **model** ranking (empirical_prior/persistence/first_order) is existing behaviour and is **retained** — the prohibition is configuration selection, not model ranking. NP6 still retains all configurations descriptively.
6. **Complete-log semantics (exact)** — the staged log must be **fully traversed under the selected bounds** (not "every physical row accepted"; ordinary malformed-row rejections stay NP1 behaviour); the completeness preflight is a **campaign-owned streaming byte-level scan** of the staged log that frames records exactly as NP1's reader does, reads at most `max_rows + 1` records, **works at `max_rows = MAX_ROWS_CEILING`**, and **parses no JSON and classifies no rejection** (the 12 `REJECT_REASONS` stay NP1's); excess physical rows or an oversized-record ingestion termination **refuse** before "complete"; NP8's `log`-role entry uses NP1 **default** reader bounds and is **not** the completeness witness (only its `lab_sequence` link uses the lab's recorded bounds).
7. **Publication** — unique staging dir sharing the final dir's parent; **refusal when the final dir exists at validation time**; **no portable absolute no-overwrite guarantee across the validation-to-rename race** — a concurrently created destination yields a **reported publication failure (exit 7 when the OS reports the collision/rename failure)** or a permitted empty-dir replacement, with **unobservable replacement an explicit non-claim**; publish only after all artifacts validate, NP8 self-validation passes, all four links verify, and the coherence gate holds; **no output under `data/`**; hard-kill staging residual and power-loss durability remain non-claims; **no atomicity beyond a single directory rename**.
8. **Determinism & bounds** — byte-identical eight-file output (incl. manifest); no added timestamp/random-id/absolute-path; existing instrument ceilings reused by name — now including NP6 `MAX_PROTOCOL_BYTES` = 64 KiB — sorted into **four named ceiling families** that are never conflated; **explicit** campaign ceilings (manifest 64 KiB `MAX_CAMPAIGN_MANIFEST_BYTES`; the fixed eight-file set).
9. **CLI & failure contract** — a full proposed CLI (positional log/protocol; required `--workspace-dir`, `--receipt-config-label`, `--output-dir`; reader-bound options; success line) with its **own explicit, non-harmonising** exit map — a **fifth** distinct set on a **seventh** CLI: `0` success · `2` malformed **or out-of-bounds** external input only — the log or operator protocol, including a protocol over NP6 `MAX_PROTOCOL_BYTES` (**not** exit 5) and **never** a campaign-*generated* artifact, whose typed input error after a passed size preflight propagates loudly instead; **exit 2 catches two typed classes directly** — the campaign's own `CampaignInputError` and NP6's **`LabInputError`, caught directly and never translated**, which is what makes the operator-protocol lane implementable (its raise sites include `load_protocol`, the internal `PredictorInputError`→`LabInputError` translation and the `MAX_REPLAY_STEPS` bound inside `build_lab_report`) **and** explicit campaign refusals (label errors, **provenance-not-verified**, **complete-log refusal**, **`contradicted` cross-check verdict**) · `3` insufficient-history · `4` containment · `5` **named byte ceilings** (64 KiB generated artifact / manifest, raised by the owning instrument; 1 MiB JSON input and 16 MiB staged log, established by the **campaign-owned size preflight** — never by interpreting NP5/NP8's shared typed input exception) · `6` staging · `7` publication. **NP8 self-validation failure and generated-artifact structural invalidity stay loud internal failures (not exit 2)**; a plain `ValueError`/`RuntimeError`/`MemoryError` outside the typed catch set propagates; the **oversized-record refusal (exit 2)** is disambiguated from the **ceiling lane (exit 5)**.
10. **Non-claims & future implementation boundary** — design-only; no runner authorised; no real-artifact/snapshot/observer/calibration/engine/model/network activity; no consciousness/phenomenology claim. After a **separate Jack audit and fresh Kev authorisation**, the maximum anticipated implementation is a new `scripts/nextness_evidence_campaign.py`, a new `tests/test_nextness_evidence_campaign.py`, and **factual updates** to `docs/NEXTNESS_CLI_FAILURE_CONTRACTS.md` — the new CLI **row plus** the map-count, heading, and catch-set-list corrections a seventh CLI with a fifth distinct map forces — nothing else.

### No implementation or real-artifact execution
No runner is written and none is authorised by this PR. Nothing here reads or processes a real Medusa artifact, runs the observer or calibration, calls `process_snapshot()`, or touches the engine, tuning, orchestrator, API, network, or any model.

### Fences held / non-actions
- Base = current `main` `c8aacbf054269f1e4115292f7c0bb703f1b704e4`. The branch was cut from exact `main` at `2d6ba881c8fd030e07db985f6fbcbaefc2e9a363` and later synchronized by **one ordinary two-parent merge-from-main** (`b998e53c`); every other commit is ordinary and single-parent. No amend, rebase, force-push or history rewrite.
- **#420's own one-file boundary is verified** (exactly one added file, +774/−0). **#419 remained an opaque identity-only fence** — inspected only at the identity level (number/title/author/draft/head/base) and never for its patch, files, body, checks, comments, reviews, or threads; **no cross-PR file-disjointness is certified**.
- No `AGENT_HANDOFF.md` edit; **no #414 thread action**; no `scripts/agent_backends/**`; no `data/` / NPZ / snapshot / external Medusa-evidence read; no `process_snapshot()` / calibration run / observer-semantic change; no engine / `continuous_evolution_ca.py` / Lane-A / Swarm-Hunter / tuning / orchestrator / API / network / model execution.
- Commits 1–3 were authored in the **Kev-only Opus 4.8 seat**; the correction passes `a855516`, `793389a`, `792ac0d`, `1f3f110`, `a37c79f` and `6c91a32`, and the synchronization merge `b998e53`, were authored in the **Kev-only Opus 5 seat** — each under Kev's explicit per-task authorisation.

_Independent Jack audit passed at head `6c91a32ff0cc4338c64eb3b2790d3ac46e290930`; Kev separately authorized the ready transition and ordinary protected squash merge. This merge lands the design contract only and authorizes no implementation._
