### PR TITLE
fix(shard-protocol): HaloPacket.from_bytes structural refusal totality

### DIFF
--- a/scripts/shard_protocol.py
+++ b/scripts/shard_protocol.py
@@ -217,6 +217,45 @@ class HaloPacket:
 
     @classmethod
     def from_bytes(cls, buf: bytes) -> "HaloPacket":
+        """Decode a wire frame, refusing every structurally invalid shape.
+
+        The structural refusals below are total over the header and the
+        declared payload length. Each raises `ValueError` with a FIXED,
+        value-free message: no supplied byte sequence, numeric field, type
+        name, representation, conversion result, or exception text is exposed.
+
+          - A frame shorter than `_HEADER_SIZE` is refused BEFORE
+            `struct.unpack` runs. Previously such a frame raised
+            `struct.error` — which is NOT a `ValueError` — straight out of a
+            transport's receive loop.
+          - A magic mismatch is refused ("bad magic ...").
+          - Unsupported dtype codes are refused.
+          - The decoded direction must be an EXACT member of
+            `NEIGHBOR_DIRECTIONS`, so every component is one of -1/0/1 and the
+            non-neighbor `(0, 0, 0)` is refused as well. Previously all 256
+            signed-byte values per component decoded silently, and
+            `_slab_slice` treats every component other than -1 and 0 as +1 —
+            so a corrupt direction wrote a halo into the WRONG face instead of
+            being refused, violating the module's bitwise-reproducibility
+            principle.
+          - The frame length must equal EXACTLY `_HEADER_SIZE` + the declared
+            state element count + 4 * the declared memory element count. This
+            refuses a truncated payload, trailing bytes, and an over-declared
+            shape before either `np.frombuffer` call, so no allocation is
+            attempted for a length the frame cannot satisfy.
+
+        No exception handler is added: `MemoryError` and internal programming
+        failures are never converted into input refusals. A valid frame
+        decodes exactly as before, byte for byte.
+
+        The claim is bounded to structural refusal inside this decoder. It is
+        NOT whole-protocol, transport, packet-authentication, or
+        distributed-execution totality: `source_coord`, `target_coord`, and
+        `generation` are not validated here, and a `HaloPacket` constructed
+        directly — bypassing this decoder — remains unchecked.
+        """
+        if len(buf) < _HEADER_SIZE:
+            raise ValueError("bad halo packet: frame shorter than the fixed header")
         (
             magic,
             sx, sy, sz,
@@ -229,23 +268,28 @@ class HaloPacket:
             msc, msx, msy, msz,
         ) = struct.unpack(_HEADER_FMT, buf[:_HEADER_SIZE])
         if magic != b"SHD1":
-            raise ValueError(f"bad magic {magic!r}; expected b'SHD1'")
+            raise ValueError("bad magic in halo packet header")
         if state_code != 0 or memory_code != 0:
-            raise ValueError(f"unsupported dtype codes state={state_code} memory={memory_code}")
-        offset = _HEADER_SIZE
+            raise ValueError("unsupported dtype codes in halo packet header")
+        direction = (dx, dy, dz)
+        if direction not in NEIGHBOR_DIRECTIONS:
+            raise ValueError("bad halo packet: direction is not a neighbor direction")
         state_size = ssx * ssy * ssz
+        memory_count = msc * msx * msy * msz
+        if len(buf) != _HEADER_SIZE + state_size + 4 * memory_count:
+            raise ValueError("bad halo packet: length does not match the declared shapes")
+        offset = _HEADER_SIZE
         state = np.frombuffer(buf, dtype=np.uint8, count=state_size, offset=offset).reshape(
             (ssx, ssy, ssz)
         ).copy()
         offset += state_size
-        memory_count = msc * msx * msy * msz
         memory = np.frombuffer(buf, dtype=np.float32, count=memory_count, offset=offset).reshape(
             (msc, msx, msy, msz)
         ).copy()
         return cls(
             source_coord=(sx, sy, sz),
             target_coord=(tx, ty, tz),
-            direction=(dx, dy, dz),
+            direction=direction,
             generation=generation,
             state_slab=state,
             memory_slab=memory,

--- a/tests/test_shard_protocol.py
+++ b/tests/test_shard_protocol.py
@@ -8,6 +8,8 @@ protocol — if it passes, any transport backend that moves the same bytes
 around will produce the same results.
 """
 
+import struct
+
 import numpy as np
 import pytest
 
@@ -17,6 +19,8 @@ from scripts.shard_protocol import (
     NEIGHBOR_DIRECTIONS,
     ShardLayout,
     StepCoordinator,
+    _HEADER_FMT,
+    _HEADER_SIZE,
     assemble_lattice,
     halo_slab,
     interior_boundary_slab,
@@ -176,6 +180,290 @@ def test_halo_packet_rejects_wrong_dtype():
 def test_halo_packet_bad_magic():
     with pytest.raises(ValueError, match="bad magic"):
         HaloPacket.from_bytes(b"XXXX" + b"\x00" * 200)
+
+
+# -- from_bytes structural refusal totality ----------------------------------
+#
+# `from_bytes` decodes frames straight off a transport — scripts/
+# shard_transport_zmq.py calls it bare on socket bytes inside its recv loop —
+# so every structurally invalid frame must become a FIXED, value-free
+# ValueError instead of a struct.error, a silently misread halo face, or a
+# numpy message carrying wire-supplied values.
+#
+# Failing-before, against the pre-fix decoder:
+#   - empty / 1-byte / (_HEADER_SIZE - 1) frames raised `struct.error` — which
+#     is NOT a ValueError — straight out of `struct.unpack`;
+#   - out-of-range direction components and the non-neighbor (0, 0, 0) decoded
+#     silently, and `_slab_slice` maps every component other than -1/0 onto the
+#     +1 face, so a corrupt direction wrote a halo into the WRONG face;
+#   - a short payload surfaced numpy's own "buffer is smaller than requested
+#     size" ValueError, and trailing bytes were accepted outright;
+#   - the magic and dtype-code refusals embedded the supplied values.
+#
+# Every case below pins the EXACT fixed message, so none of them can pass
+# vacuously against the pre-fix decoder. Scope is structural refusal only:
+# source/target coordinates, generation, and directly-constructed HaloPackets
+# are deliberately not covered.
+
+_VALID_STATE_SHAPE = (1, 2, 2)
+_VALID_MEMORY_SHAPE = (8, 1, 2, 2)
+
+
+def _element_count(shape):
+    n = 1
+    for dim in shape:
+        n *= dim
+    return n
+
+
+def _halo_header(
+    *,
+    magic=b"SHD1",
+    source=(0, 0, 0),
+    target=(1, 0, 0),
+    direction=(1, 0, 0),
+    generation=7,
+    state_code=0,
+    memory_code=0,
+    state_shape=_VALID_STATE_SHAPE,
+    memory_shape=_VALID_MEMORY_SHAPE,
+):
+    """Pack a header field-by-field so exactly one field can be made invalid."""
+    return struct.pack(
+        _HEADER_FMT,
+        magic,
+        *source,
+        *target,
+        *direction,
+        generation,
+        state_code,
+        memory_code,
+        *state_shape,
+        *memory_shape,
+    )
+
+
+def _halo_payload(state_shape=_VALID_STATE_SHAPE, memory_shape=_VALID_MEMORY_SHAPE):
+    """Zero payload of exactly the size the declared shapes require."""
+    return bytes(_element_count(state_shape)) + bytes(4 * _element_count(memory_shape))
+
+
+def _valid_frame(**header_kwargs):
+    return _halo_header(**header_kwargs) + _halo_payload()
+
+
+def _refusal_message(frame):
+    """Decode `frame`, requiring an exact ValueError; return its message."""
+    with pytest.raises(ValueError) as exc:
+        HaloPacket.from_bytes(frame)
+    # Exactly ValueError: not struct.error (which is not a ValueError at all),
+    # and not some subclass carrying extra state.
+    assert type(exc.value) is ValueError
+    return str(exc.value)
+
+
+def test_handcrafted_valid_frame_decodes():
+    """Guards every refusal case below: the hand-packed frame really is valid,
+    so a later refusal is caused by the mutated field alone, not the helper."""
+    packet = HaloPacket.from_bytes(_valid_frame())
+    assert packet.source_coord == (0, 0, 0)
+    assert packet.target_coord == (1, 0, 0)
+    assert packet.direction == (1, 0, 0)
+    assert packet.generation == 7
+    assert packet.state_slab.shape == _VALID_STATE_SHAPE
+    assert packet.memory_slab.shape == _VALID_MEMORY_SHAPE
+    assert packet.state_slab.dtype == np.uint8
+    assert packet.memory_slab.dtype == np.float32
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        b"",
+        b"\x00",
+        b"S",
+        b"SHD1",
+        bytes(_HEADER_SIZE - 1),
+        b"SHD1" + bytes(_HEADER_SIZE - 5),
+    ],
+    ids=[
+        "empty",
+        "one_zero_byte",
+        "one_letter",
+        "magic_only",
+        "header_size_minus_one",
+        "valid_magic_short_header",
+    ],
+)
+def test_from_bytes_refuses_frame_shorter_than_header(frame):
+    # Pre-fix these raised struct.error out of struct.unpack.
+    assert len(frame) < _HEADER_SIZE
+    assert _refusal_message(frame) == (
+        "bad halo packet: frame shorter than the fixed header"
+    )
+
+
+@pytest.mark.parametrize(
+    "direction",
+    [
+        (2, 0, 0),
+        (0, 3, 0),
+        (0, 0, 127),
+        (-2, 0, 0),
+        (0, -7, 0),
+        (0, 0, -128),
+        (42, -7, 99),
+        (1, 1, 2),
+        (-1, -1, -2),
+    ],
+    ids=[
+        "pos_x_two",
+        "pos_y_three",
+        "pos_z_max",
+        "neg_x_two",
+        "neg_y_seven",
+        "neg_z_min",
+        "all_out_of_range",
+        "one_component_out_of_range",
+        "one_negative_out_of_range",
+    ],
+)
+def test_from_bytes_refuses_out_of_range_direction(direction):
+    assert direction not in NEIGHBOR_DIRECTIONS
+    assert _refusal_message(_valid_frame(direction=direction)) == (
+        "bad halo packet: direction is not a neighbor direction"
+    )
+
+
+def test_from_bytes_refuses_zero_direction():
+    """(0, 0, 0) packs as a legal signed-byte triple but is NOT a neighbor
+    direction — NEIGHBOR_DIRECTIONS deliberately excludes it, so a frame
+    claiming it must be refused rather than applied to some halo face."""
+    assert (0, 0, 0) not in NEIGHBOR_DIRECTIONS
+    assert _refusal_message(_valid_frame(direction=(0, 0, 0))) == (
+        "bad halo packet: direction is not a neighbor direction"
+    )
+
+
+def test_from_bytes_accepts_every_neighbor_direction():
+    """No over-refusal: all 26 real directions a coordinator emits still decode."""
+    assert len(NEIGHBOR_DIRECTIONS) == 26
+    for direction in NEIGHBOR_DIRECTIONS:
+        packet = HaloPacket.from_bytes(_valid_frame(direction=direction))
+        assert packet.direction == direction
+
+
+@pytest.mark.parametrize(
+    "frame_builder",
+    [
+        lambda: _halo_header(),
+        lambda: _halo_header() + bytes(_element_count(_VALID_STATE_SHAPE)),
+        lambda: _valid_frame()[:-1],
+        lambda: _valid_frame()[: _HEADER_SIZE + 1],
+    ],
+    ids=[
+        "header_only",
+        "state_but_no_memory",
+        "one_byte_short",
+        "one_payload_byte_only",
+    ],
+)
+def test_from_bytes_refuses_payload_shorter_than_declared(frame_builder):
+    assert _refusal_message(frame_builder()) == (
+        "bad halo packet: length does not match the declared shapes"
+    )
+
+
+@pytest.mark.parametrize(
+    "trailer",
+    [b"\x00", b"\x00" * 4, b"trailing junk"],
+    ids=["one_zero_byte", "four_zero_bytes", "junk"],
+)
+def test_from_bytes_refuses_trailing_bytes(trailer):
+    """A frame whose payload is complete but is followed by extra bytes was
+    previously decoded, silently ignoring the trailer."""
+    assert _refusal_message(_valid_frame() + trailer) == (
+        "bad halo packet: length does not match the declared shapes"
+    )
+
+
+@pytest.mark.parametrize(
+    "header_kwargs",
+    [
+        {"state_shape": (4096, 4096, 4096)},
+        {"memory_shape": (8, 4096, 4096, 4096)},
+        {"state_shape": (65535, 65535, 65535)},
+    ],
+    ids=["huge_state", "huge_memory", "enormous_state"],
+)
+def test_from_bytes_refuses_over_declared_shape_before_allocating(header_kwargs):
+    """An over-declared shape is refused on declared length alone, so neither
+    np.frombuffer call is reached and no allocation is attempted."""
+    assert _refusal_message(_halo_header(**header_kwargs) + _halo_payload()) == (
+        "bad halo packet: length does not match the declared shapes"
+    )
+
+
+@pytest.mark.parametrize(
+    "state_code,memory_code",
+    [(1, 0), (0, 1), (1, 1), (255, 0), (0, 255), (7, 9)],
+    ids=["state_one", "memory_one", "both_one", "state_max", "memory_max", "both_unknown"],
+)
+def test_from_bytes_refuses_unsupported_dtype_codes(state_code, memory_code):
+    assert _refusal_message(
+        _valid_frame(state_code=state_code, memory_code=memory_code)
+    ) == "unsupported dtype codes in halo packet header"
+
+
+def test_from_bytes_bad_magic_message_is_fixed():
+    """The established `bad magic` contract is kept, without the value."""
+    message = _refusal_message(_valid_frame(magic=b"XXXX"))
+    assert message == "bad magic in halo packet header"
+    assert "bad magic" in message  # the pre-existing test's contract
+
+
+def test_from_bytes_refusals_are_fixed_and_value_free():
+    """No refusal may echo a supplied byte sequence or numeric field. Every
+    fixed message is digit-free, so no wire number can leak through one."""
+    cases = [
+        (_valid_frame(magic=b"LEAK"), ["LEAK"]),
+        (_valid_frame(direction=(42, -7, 99)), ["42", "-7", "99"]),
+        (_valid_frame(state_code=77, memory_code=88), ["77", "88"]),
+        (_valid_frame() + b"LEAKINGTRAILER", ["LEAKINGTRAILER"]),
+        (_halo_header(state_shape=(3, 5, 7)), ["3", "5", "7"]),
+        (bytes(_HEADER_SIZE - 1), []),
+    ]
+    for frame, forbidden_tokens in cases:
+        message = _refusal_message(frame)
+        assert message == message.strip()
+        assert not any(character.isdigit() for character in message)
+        for token in forbidden_tokens:
+            assert token not in message
+
+
+def test_valid_round_trip_unchanged_by_refusal_hardening():
+    """Valid-packet byte interpretation is untouched: the decoded packet
+    matches the source arrays and re-encodes to the identical frame."""
+    rng = np.random.default_rng(17)
+    state_slab = rng.integers(0, 5, size=(2, 3, 4), dtype=np.uint8)
+    memory_slab = rng.random(size=(8, 2, 3, 4), dtype=np.float32)
+    packet = HaloPacket(
+        source_coord=(1, 2, 3),
+        target_coord=(0, 2, 3),
+        direction=(-1, 0, 0),
+        generation=99,
+        state_slab=state_slab,
+        memory_slab=memory_slab,
+    )
+    frame = packet.to_bytes()
+    restored = HaloPacket.from_bytes(frame)
+    assert restored.source_coord == (1, 2, 3)
+    assert restored.target_coord == (0, 2, 3)
+    assert restored.direction == (-1, 0, 0)
+    assert restored.generation == 99
+    np.testing.assert_array_equal(restored.state_slab, state_slab)
+    np.testing.assert_array_equal(restored.memory_slab, memory_slab)
+    assert restored.to_bytes() == frame
 
 
 # -- end-to-end correctness --------------------------------------------------


### PR DESCRIPTION
## `HaloPacket.from_bytes` — structural refusal totality

Bounded Ian-seat package. `HaloPacket.from_bytes` decodes frames taken straight
off a transport, but validated only the magic and the two dtype codes. This
closes four reachable structural gaps inside that one classmethod.
**Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `2d6ba881c8fd030e07db985f6fbcbaefc2e9a363`
- **head:** `fix/halo-packet-wire-decode-totality` @ `e16c26766255c6af8dc351f399cdec0fcb87398c`
- **parent of head:** `2d6ba881c8fd030e07db985f6fbcbaefc2e9a363` (single parent; branch cut fresh from freshly re-derived live `main`, ordinary push, no force)
- Target files were last touched by **#117 (2026-04-20)** and are reached by no
  other open or recently merged package.

### Files & diffstat (exactly two permitted files)
```
 scripts/shard_protocol.py    |  54 ++++++--
 tests/test_shard_protocol.py | 288 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 337 insertions(+), 5 deletions(-)
```
No other file changed. The production change is confined to
`HaloPacket.from_bytes` (guards + docstring); `to_bytes`, `_slab_slice`,
`interior_boundary_slab`, `halo_slab`, `ShardLayout`, `ShardState`,
`StepCoordinator` and `scripts/shard_transport_zmq.py` are untouched.

### Reachability
`scripts/shard_transport_zmq.py:139` calls `HaloPacket.from_bytes(buf)` **bare**
on bytes returned by a ZMQ PULL socket, inside `recv_all`'s per-step loop. There
is no `try`/`except` at that call site, so whatever the decoder raises escapes
into the step loop.

### Failing-before (measured against the pre-fix module — see limitations)
| Case | Pre-fix behaviour |
|---|---|
| empty / 1-byte / `_HEADER_SIZE - 1` frame | **`struct.error('unpack requires a buffer of 69 bytes')`** — `struct.error` is **not** a `ValueError`, and the message carries the header size |
| direction components out of range (`(2,0,0)`, `(0,0,127)`, `(-2,0,0)`, `(0,0,-128)`, `(42,-7,99)`) | **decoded silently, no refusal** |
| direction `(0, 0, 0)` (not a neighbour) | **decoded silently, no refusal** |
| valid payload followed by trailing bytes | **decoded silently, trailer ignored** |
| truncated payload / over-declared shape | reached `np.frombuffer`, which decided it with **numpy's own** `ValueError` text rather than a module refusal |
| bad magic | `ValueError("bad magic b'XXXX'; expected b'SHD1'")` — **echoes the supplied bytes** |
| unsupported dtype codes | `ValueError('unsupported dtype codes state=77 memory=88')` — **echoes the supplied numbers** |

The direction gap is the sharp one: `_slab_slice` tests only `== -1` and
otherwise falls through to the `+1` face, so `apply_halos` wrote a corrupt
direction's halo into the **wrong face** instead of refusing it — a silent
violation of the module's stated bitwise-reproducibility principle.

### Implemented refusal semantics (all inside `from_bytes`)
Every refusal is a **fixed, value-free, digit-free `ValueError`** (exact type
`ValueError`, no subclass), evaluated in this order:

| Order | Condition | Message |
|---|---|---|
| 1 | `len(buf) < _HEADER_SIZE` — **before `struct.unpack`** | `bad halo packet: frame shorter than the fixed header` |
| 2 | magic != `b"SHD1"` | `bad magic in halo packet header` |
| 3 | `state_code != 0 or memory_code != 0` | `unsupported dtype codes in halo packet header` |
| 4 | `(dx, dy, dz) not in NEIGHBOR_DIRECTIONS` | `bad halo packet: direction is not a neighbor direction` |
| 5 | `len(buf) != _HEADER_SIZE + state_elements + 4 * memory_elements` — **before either `np.frombuffer`** | `bad halo packet: length does not match the declared shapes` |

Check 4 is exact-membership against the existing module constant, so it enforces
"every component ∈ {−1, 0, 1}" **and** refuses the non-neighbour `(0, 0, 0)`
without a second rule. Check 5 uses exact equality, so it refuses truncated
payloads, trailing bytes, and over-declared shapes with one comparison.

No exception handler was added anywhere: `MemoryError` and internal programming
failures are never converted into input refusals, and no blanket `except` exists
in the decoder.

### Valid-packet non-regression
- The `(count, offset)` arithmetic handed to both `np.frombuffer` calls is
  **unchanged**: for the reference frame, `uint8 count=4 offset=69` then
  `float32 count=32 offset=73`, identical pre- and post-fix.
- All **26** members of `NEIGHBOR_DIRECTIONS` still decode (26/26 pre- and
  post-fix) — the membership check introduces no over-refusal.
- The pre-existing `test_halo_packet_bad_magic` contract still holds: its exact
  input still raises `ValueError` whose message matches `bad magic`.
- A round-trip test asserts the decoded packet's fields and arrays match the
  source **and** that re-encoding it reproduces the original frame byte for byte.
- `InProcessHaloExchange` passes packet objects without serialising, so the
  end-to-end sharded-vs-monolithic proof never enters this decoder and is
  unaffected.

### Tests
`tests/test_shard_protocol.py`: **15 → 52 collected cases** (+12 test functions,
+37 cases; static AST count, parametrisation expanded). All in-process against
the pure serializer/decoder — **no ZMQ sockets, no engine execution, no
distributed run, no network**.

Covered: empty, 1-byte, `magic`-only and `_HEADER_SIZE − 1` frames · nine
out-of-range direction triples (positive and negative, single- and
multi-component) · the forbidden `(0, 0, 0)` · header-only, state-without-memory,
one-byte-short and one-payload-byte frames · three trailing-byte variants ·
three over-declared shapes · six unsupported dtype-code pairs · exact
fixed-message equality for every refusal, with a dedicated value-free test
asserting no supplied token survives and that no message contains any digit ·
all 26 valid directions · valid round-trip re-encode equality.

Two deliberate anti-vacuity guards: `test_handcrafted_valid_frame_decodes`
proves the hand-packed frame really is valid (so a later refusal comes from the
mutated field alone), and every refusal assertion pins the **exact** message, so
no case can pass against the pre-fix decoder — including the truncated-payload
cases, which pre-fix raised numpy's differently-worded `ValueError`.

### Local toolchain limitations
This seat (Ian's lounge) has **no `numpy`, no `zmq` and no `pytest`**, and `pip`
is not importable; per standing seat policy **nothing was installed**. Python
3.13.7 (`py`) is present.

**Tests actually run locally: none — there is no pytest here, and no pytest-free
substitute was built or claimed as equivalent.** Local evidence is:
1. `compile()` clean for both changed files.
2. A **stub-instrumented run of the real `from_bytes`**, both pre-fix (from
   `origin/main`) and post-fix, with a minimal `numpy` stub injected into
   `sys.modules`. Every refusal path returns before any numpy function is
   called, so those paths executed the genuine production code and produced the
   pre/post tables above. The valid-frame path was instrumented only to record
   the `(count, offset)` arguments; actual array decoding was **not** verified
   locally.
3. `struct`-level confirmation that `_HEADER_SIZE == 69`, that `struct.error` is
   not a subclass of `ValueError`, and that a `3b` direction accepts all 256
   values per component.

Scratch probes lived outside the repository and were removed. **The
authoritative gate is CI `verify-python`**; a body-only CI receipt is appended
below once checks conclude.

### Residuals and explicit non-claims
- **Bounded claim:** structural refusal inside `HaloPacket.from_bytes` only.
  **Not** whole-protocol, whole-module, transport, packet-authentication, or
  distributed-execution totality.
- `source_coord`, `target_coord` and `generation` are **not** validated — a
  well-formed frame may still address an unexpected shard or generation.
- **A `HaloPacket` constructed directly, bypassing this decoder, remains
  unchecked**; the dataclass has no `__post_init__`. Manual construction is out
  of scope and is stated honestly rather than claimed closed.
- **No allocation-exhaustion / OOM claim.** Check 5 refuses an over-declared
  shape before `np.frombuffer` is reached, but `np.frombuffer` already validated
  `count` against the buffer before allocating, so this is a message-and-locality
  improvement, not a new memory-safety guarantee.
- Transport-level catch/drop/retry policy is untouched: a refusal still
  propagates out of `ZMQHaloExchange.recv_all` as before, now as a `ValueError`
  instead of a `struct.error` for short frames. Deciding whether the transport
  should catch it is deliberately left to a separate package.
- A degenerate frame declaring a zero-sized dimension is length-consistent and
  still decodes, exactly as before; unchanged behaviour, out of scope.
- `_slab_slice`'s `+1` fall-through is described here as the *reason* the
  direction gap mattered, but was **not modified** — it is out of scope.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID
`claude-opus-5`, the "84" seat), under Kev's explicit bounded authorization. No
model crossover during the work.

### Isolation of #419 and #420
- **#419** (`fix/tool-result-metadata-shape-totality`, Opus-4.8 Ian-seat) was
  neither modified nor reopened. Its file boundary
  (`scripts/agent_backends/base.py`, `tests/test_agent_backend.py`) is disjoint
  from this package's two files, with no shared symbol or import.
- **#420** (Kev-seat) was kept **opaque**: only its bare board identity was
  read. Its body, patch, files, checks, comments, reviews and threads were not
  inspected, and nothing here derives from it. Neither of this package's files
  is a Nextness or docs path.
- **#421** was checked at file-boundary level only, for overlap
  (`scripts/dandelion.py`, `tests/test_dandelion_glb.py` — disjoint).

### Fences
Exactly one focused commit; exactly two permitted files; fresh single-parent
branch from live `main`; ordinary push, **no force**. No merge / auto-merge /
ready-for-review transition / rebase / merge-from-main / history rewrite /
protection or settings change / manual workflow rerun / branch deletion. No
review-thread reply or resolution, no reaction, no label, no unrelated comment.
Leave **OPEN, draft, unmerged** and hand back to Jack for audit.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `e16c26766255c6af8dc351f399cdec0fcb87398c`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m27s) | run `30163036676` / job `89691347698` — **2266 passed, 13 skipped, 0 failed** (42.99s) |
| verify-python (push-triggered run) | ✅ pass (1m32s) | run `30162995536` / job `89691243847` — **2266 passed, 13 skipped, 0 failed** (40.60s) |
| Analyze Python (CodeQL) | ✅ pass (1m3s) | run `30163036720` |
| CodeQL | ✅ pass | job `89691421382` |
| agent-safety | ✅ pass (8s) | run `30163036668` |
| tripwire | ✅ pass (4s) | run `30163036665` |
| frontend-quality | ✅ pass (55s / 56s) | runs `30162995536`, `30163036676` |

All registered checks green; zero failures. Both `verify-python` jobs report the
same figures against the same `head_sha`.

**Independent corroboration of the case count:** live `main` `2d6ba88` reports
2229 passed / 13 skipped (2242 collected). This head reports 2266 passed / 13
skipped (2279 collected) — exactly **+37 passed, +37 collected, skips
unchanged**, matching the static AST count of newly added cases. So all 37 new
cases ran, passed, and none was skipped; the `shard_protocol` suite is fully
exercised in CI (numpy present there, absent on the Ian seat).

CI's full-suite figure supersedes the seat-local evidence as the authoritative
gate. PR remains **OPEN, draft, unmerged** — handing back to Jack for audit;
merge authority is Kev's later explicit word only.
