### PR TITLE
fix(dandelion): derive QR payload and metadata from one read

### DIFF
--- a/scripts/dandelion.py
+++ b/scripts/dandelion.py
@@ -29,7 +29,7 @@ import os
 import sys
 import zlib
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import numpy as np
 
@@ -69,10 +69,32 @@ class DandelionGenomeError(ValueError):
 # Seed 1: QR Code Generator
 # ---------------------------------------------------------------------------
 
-def genome_to_compressed_bytes(genome_path: str) -> bytes:
-    """Load a genome JSON, strip epigenetic data, minify, and zlib compress."""
+class _GenomeCapture(NamedTuple):
+    """One authoritative genome read and everything derived from that text.
+
+    ``source_text`` is exactly what the single read returned; ``minified_bytes``
+    are the canonical, ``epigenetic_snapshot``-stripped minified UTF-8 bytes;
+    ``compressed`` is the zlib payload built from those exact bytes. Every QR
+    size reported to a caller therefore describes one genome version.
+    """
+
+    source_text: str
+    minified_bytes: bytes
+    compressed: bytes
+
+
+def _capture_genome(genome_path: str) -> _GenomeCapture:
+    """Read the genome file ONCE and derive every QR artifact from that text.
+
+    A single read is the whole point: the payload and the reported sizes must
+    describe the same genome version. This is source coherence only — it is not
+    an atomic-snapshot, locking or filesystem-race guarantee, and it makes no
+    claim about what happens to the file after the read returns.
+    """
     with open(genome_path, "r") as f:
-        genome = json.load(f)
+        source_text = f.read()
+
+    genome = json.loads(source_text)
 
     if type(genome) is not dict:
         raise DandelionGenomeError("genome must be a JSON object")
@@ -82,10 +104,16 @@ def genome_to_compressed_bytes(genome_path: str) -> bytes:
 
     # Minify
     minified = json.dumps(genome, separators=(",", ":"), sort_keys=True)
+    minified_bytes = minified.encode("utf-8")
 
     # Compress
-    compressed = zlib.compress(minified.encode("utf-8"), level=9)
-    return compressed
+    compressed = zlib.compress(minified_bytes, level=9)
+    return _GenomeCapture(source_text, minified_bytes, compressed)
+
+
+def genome_to_compressed_bytes(genome_path: str) -> bytes:
+    """Load a genome JSON, strip epigenetic data, minify, and zlib compress."""
+    return _capture_genome(genome_path).compressed
 
 
 def compressed_to_b85(compressed: bytes) -> str:
@@ -102,7 +130,12 @@ def generate_qr(
 ) -> dict:
     """Generate a QR code containing the compressed genome.
 
-    Returns metadata dict with sizes and QR version info.
+    Returns metadata dict with sizes and QR version info. The payload and every
+    reported size come from **one** captured read of the genome file, so
+    ``original_json_bytes`` (the complete captured source text),
+    ``minified_bytes`` (the canonical ``epigenetic_snapshot``-stripped minified
+    bytes that are actually compressed) and ``compressed_bytes`` all describe
+    the same genome version as the QR itself.
     """
     try:
         import qrcode
@@ -125,9 +158,11 @@ def generate_qr(
     }
     ec_level = ec_map.get(error_correction.upper(), ERROR_CORRECT_L)
 
-    # Load, compress, encode
-    compressed = genome_to_compressed_bytes(genome_path)
-    b85_data = compressed_to_b85(compressed)
+    # Load, compress, encode — ONE authoritative read (after the optional
+    # dependency check above). The payload and every size reported below are
+    # derived from this single captured genome version.
+    capture = _capture_genome(genome_path)
+    b85_data = compressed_to_b85(capture.compressed)
 
     # Build QR with header for decoder
     qr_payload = f"UFG1:{b85_data}"  # UFG1 = UtilityFog Genome v1 prefix
@@ -144,16 +179,10 @@ def generate_qr(
     img = qr.make_image(fill_color="black", back_color="white")
     img.save(output_path)
 
-    # Read back original for size comparison
-    with open(genome_path, "r") as f:
-        original_size = len(f.read().encode("utf-8"))
-
     return {
-        "original_json_bytes": original_size,
-        "minified_bytes": len(json.dumps(
-            json.load(open(genome_path)), separators=(",", ":"), sort_keys=True
-        ).encode("utf-8")),
-        "compressed_bytes": len(compressed),
+        "original_json_bytes": len(capture.source_text.encode("utf-8")),
+        "minified_bytes": len(capture.minified_bytes),
+        "compressed_bytes": len(capture.compressed),
         "b85_encoded_chars": len(b85_data),
         "qr_payload_chars": len(qr_payload),
         "qr_version": qr.version,

--- a/tests/test_dandelion_qr_metadata.py
+++ b/tests/test_dandelion_qr_metadata.py
@@ -1,0 +1,471 @@
+"""Tests for QR payload/metadata source coherence in ``scripts/dandelion.py``.
+
+Scope: ONLY that ``generate_qr()`` derives its QR payload and every reported
+byte count from **one** captured read of **one** genome-file version, and that
+``minified_bytes`` describes the exact canonical, ``epigenetic_snapshot``-
+stripped minified UTF-8 bytes that are actually compressed into the QR.
+
+Two defects are pinned:
+
+* **stable-file defect** — the pre-fix ``minified_bytes`` was computed from a
+  later reread that never removed ``epigenetic_snapshot``, so a snapshot-bearing
+  genome reported a size describing material the QR does not contain;
+* **coherence defect** — the payload came from the first read while the two size
+  fields came from a second and a third read, so a source replaced between them
+  produced metadata describing a different genome version than the payload.
+
+This is deliberately NOT whole-Dandelion totality, filesystem-atomicity,
+QR-capacity policy, QR-decoding totality, genome-schema validation, path
+containment or concurrency work. The public ``info`` path is out of scope and
+keeps its own reads.
+
+Every test uses synthetic ASCII JSON, ``tmp_path`` and a controlled fake
+``qrcode`` module — the maintained suite never requires the real optional
+``qrcode`` package, and no real genome, NPZ, Medusa artifact, network, model,
+engine, observer or calibration run is touched.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import sys
+import types
+import zlib
+from pathlib import Path
+
+import pytest
+
+import scripts.dandelion as dandelion
+from scripts.dandelion import (
+    DandelionGenomeError,
+    decode_qr_payload,
+    generate_qr,
+    genome_to_compressed_bytes,
+)
+
+_SNAPSHOT_MARKER = "SNAPSHOT-ONLY-MARKER"
+
+
+# ---------------------------------------------------------------------------
+# Controlled fake ``qrcode`` stack
+# ---------------------------------------------------------------------------
+
+
+class _QRRecorder:
+    """Everything the fake QR stack observed, for behaviour locks."""
+
+    def __init__(self) -> None:
+        self.construct: dict | None = None
+        self.data: list = []
+        self.make_calls: list = []
+        self.image_calls: list = []
+        self.saves: list = []
+
+
+@pytest.fixture
+def fake_qrcode(monkeypatch):
+    """Install a recording fake ``qrcode`` package; return the installer.
+
+    The installer accepts optional failure injections so a QR-library error can
+    be raised at a chosen seam without touching the genome-reading contract.
+    """
+
+    def install(*, version=7, fail_on_add_data=None, fail_on_make=None):
+        rec = _QRRecorder()
+
+        class _Img:
+            def __init__(self, fill_color, back_color):
+                self.fill_color = fill_color
+                self.back_color = back_color
+
+            def save(self, path):
+                rec.saves.append(str(path))
+                Path(path).write_bytes(b"PNG-fake-bytes")
+
+        class _QRCode:
+            def __init__(self, version=None, error_correction=None, box_size=None,
+                         border=None):
+                rec.construct = {
+                    "version": version,
+                    "error_correction": error_correction,
+                    "box_size": box_size,
+                    "border": border,
+                }
+                self.version = None
+
+            def add_data(self, payload):
+                if fail_on_add_data is not None:
+                    raise fail_on_add_data
+                rec.data.append(payload)
+
+            def make(self, fit=True):
+                if fail_on_make is not None:
+                    raise fail_on_make
+                rec.make_calls.append(fit)
+                self.version = version
+
+            def make_image(self, fill_color=None, back_color=None):
+                rec.image_calls.append((fill_color, back_color))
+                return _Img(fill_color, back_color)
+
+        qrcode_mod = types.ModuleType("qrcode")
+        constants_mod = types.ModuleType("qrcode.constants")
+        constants_mod.ERROR_CORRECT_L = "EC-L"
+        constants_mod.ERROR_CORRECT_M = "EC-M"
+        constants_mod.ERROR_CORRECT_Q = "EC-Q"
+        constants_mod.ERROR_CORRECT_H = "EC-H"
+        qrcode_mod.QRCode = _QRCode
+        qrcode_mod.constants = constants_mod
+
+        monkeypatch.setitem(sys.modules, "qrcode", qrcode_mod)
+        monkeypatch.setitem(sys.modules, "qrcode.constants", constants_mod)
+        return rec
+
+    return install
+
+
+# ---------------------------------------------------------------------------
+# Independent reference helpers (never import the module's own implementation)
+# ---------------------------------------------------------------------------
+
+
+def _canonical_stripped_bytes(genome: dict) -> bytes:
+    """The exact material the QR must carry, computed independently."""
+    stripped = dict(genome)
+    stripped.pop("epigenetic_snapshot", None)
+    return json.dumps(stripped, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _canonical_unstripped_bytes(genome: dict) -> bytes:
+    """The pre-fix (wrong) material, kept to prove the counts really differ."""
+    return json.dumps(genome, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _write_genome(path: Path, genome: dict) -> str:
+    """Write ASCII-only JSON and return the text a text-mode read yields."""
+    path.write_text(json.dumps(genome, indent=2))
+    return path.read_text()
+
+
+def _snapshot_genome() -> dict:
+    return {
+        "organism_id": "synthetic-0001",
+        "rules": [1, 2, 3, 4],
+        "epigenetic_snapshot": {"marker": _SNAPSHOT_MARKER, "blob": "x" * 4000},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Snapshot-stripped metadata truth
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_describes_the_stripped_material(fake_qrcode, tmp_path):
+    rec = fake_qrcode()
+    genome = _snapshot_genome()
+    src = tmp_path / "genome.json"
+    source_text = _write_genome(src, genome)
+    out = tmp_path / "qr.png"
+
+    meta = generate_qr(str(src), output_path=str(out))
+
+    stripped = _canonical_stripped_bytes(genome)
+    unstripped = _canonical_unstripped_bytes(genome)
+
+    # original_json_bytes keeps its existing meaning: the complete captured text.
+    assert meta["original_json_bytes"] == len(source_text.encode("utf-8"))
+    # minified_bytes describes exactly what is compressed into the QR.
+    assert meta["minified_bytes"] == len(stripped)
+    assert meta["compressed_bytes"] == len(zlib.compress(stripped, level=9))
+    # The pre-fix count described different material — prove they really differ.
+    assert len(stripped) != len(unstripped)
+    assert meta["minified_bytes"] != len(unstripped)
+
+    # The payload decodes to the stripped genome, with no snapshot leakage.
+    payload = rec.data[0]
+    assert payload.startswith("UFG1:")
+    decoded = decode_qr_payload(payload)
+    expected = dict(genome)
+    expected.pop("epigenetic_snapshot")
+    assert decoded == expected
+    assert "epigenetic_snapshot" not in decoded
+    assert _SNAPSHOT_MARKER not in payload
+
+
+# ---------------------------------------------------------------------------
+# 2. One-read guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_successful_generate_qr_reads_genome_exactly_once(
+    fake_qrcode, tmp_path, monkeypatch
+):
+    fake_qrcode()
+    src = tmp_path / "genome.json"
+    _write_genome(src, _snapshot_genome())
+    out = tmp_path / "qr.png"
+
+    real_open = builtins.open
+    genome_opens: list = []
+
+    def counting_open(file, mode="r", *args, **kwargs):
+        # Count reads of the GENOME path only; writes to the QR output are not
+        # genome reads and must not be counted.
+        if str(file) == str(src):
+            genome_opens.append(mode)
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+    generate_qr(str(src), output_path=str(out))
+    monkeypatch.undo()
+
+    assert genome_opens == ["r"], f"expected exactly one genome read, got {genome_opens}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Replacement / coherence regression
+# ---------------------------------------------------------------------------
+
+
+def test_replacement_between_reads_cannot_mix_sources(
+    fake_qrcode, tmp_path, monkeypatch
+):
+    """Version A is available first; any second read would expose version B.
+
+    Against the pre-fix implementation the payload came from A while the size
+    fields came from B — the exact incoherence this pins shut.
+    """
+    rec = fake_qrcode()
+    version_a = {"organism_id": "VERSION-A", "epigenetic_snapshot": {"blob": "a" * 64}}
+    version_b = {"organism_id": "VERSION-B-REPLACEMENT", "padding": "b" * 900}
+    text_a = json.dumps(version_a, indent=2)
+    text_b = json.dumps(version_b, indent=2)
+
+    src = tmp_path / "genome.json"
+    src.write_text(text_a)
+    out = tmp_path / "qr.png"
+
+    real_open = builtins.open
+    reads: list = []
+
+    def swapping_open(file, mode="r", *args, **kwargs):
+        if str(file) == str(src) and "r" in mode and "b" not in mode:
+            reads.append(len(reads) + 1)
+            return io.StringIO(text_a if len(reads) == 1 else text_b)
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", swapping_open)
+    meta = generate_qr(str(src), output_path=str(out))
+    monkeypatch.undo()
+
+    # Only version A was ever read.
+    assert reads == [1], f"expected exactly one read, got {len(reads)}"
+
+    stripped_a = _canonical_stripped_bytes(version_a)
+    # Every returned byte-count field describes A.
+    assert meta["original_json_bytes"] == len(text_a.encode("utf-8"))
+    assert meta["minified_bytes"] == len(stripped_a)
+    assert meta["compressed_bytes"] == len(zlib.compress(stripped_a, level=9))
+    # No value from B entered metadata or payload.
+    assert meta["minified_bytes"] != len(_canonical_stripped_bytes(version_b))
+    assert meta["original_json_bytes"] != len(text_b.encode("utf-8"))
+    decoded = decode_qr_payload(rec.data[0])
+    assert decoded == {"organism_id": "VERSION-A"}
+    assert "VERSION-B-REPLACEMENT" not in rec.data[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Direct compression byte lock
+# ---------------------------------------------------------------------------
+
+
+def test_genome_to_compressed_bytes_is_byte_identical_to_reference(tmp_path):
+    genome = _snapshot_genome()
+    src = tmp_path / "genome.json"
+    _write_genome(src, genome)
+
+    produced = genome_to_compressed_bytes(str(src))
+    reference = zlib.compress(_canonical_stripped_bytes(genome), level=9)
+
+    assert produced == reference
+    # And it round-trips to the stripped genome.
+    expected = dict(genome)
+    expected.pop("epigenetic_snapshot")
+    assert json.loads(zlib.decompress(produced).decode("utf-8")) == expected
+
+
+# ---------------------------------------------------------------------------
+# 5. Valid QR behaviour lock
+# ---------------------------------------------------------------------------
+
+
+def test_valid_qr_path_behaviour_is_preserved(fake_qrcode, tmp_path):
+    rec = fake_qrcode(version=11)
+    genome = {"organism_id": "synthetic-lock", "rules": [7]}
+    src = tmp_path / "genome.json"
+    _write_genome(src, genome)
+    out = tmp_path / "nested-name.png"
+
+    meta = generate_qr(
+        str(src), output_path=str(out), box_size=9, border=2, error_correction="q"
+    )
+
+    # Error-correction lookup uses .upper() against the constants map.
+    assert rec.construct["error_correction"] == "EC-Q"
+    assert meta["qr_error_correction"] == "Q"
+    # Construction arguments are passed through unchanged.
+    assert rec.construct["version"] is None
+    assert rec.construct["box_size"] == 9
+    assert rec.construct["border"] == 2
+    # Payload, fit and image colours.
+    expected_payload = "UFG1:" + dandelion.compressed_to_b85(
+        zlib.compress(_canonical_stripped_bytes(genome), level=9)
+    )
+    assert rec.data == [expected_payload]
+    assert rec.make_calls == [True]
+    assert rec.image_calls == [("black", "white")]
+    # Exactly one save, to the requested output path.
+    assert rec.saves == [str(out)]
+    assert out.exists()
+    # Version metadata and single-QR verdict.
+    assert meta["output_path"] == str(out)
+    assert meta["qr_version"] == 11
+    assert meta["fits_single_qr"] is True
+    assert meta["b85_encoded_chars"] == len(expected_payload) - len("UFG1:")
+    assert meta["qr_payload_chars"] == len(expected_payload)
+
+
+def test_unknown_error_correction_falls_back_to_l(fake_qrcode, tmp_path):
+    rec = fake_qrcode()
+    src = tmp_path / "genome.json"
+    _write_genome(src, {"organism_id": "fallback"})
+
+    meta = generate_qr(
+        str(src), output_path=str(tmp_path / "qr.png"), error_correction="z"
+    )
+
+    assert rec.construct["error_correction"] == "EC-L"
+    assert meta["qr_error_correction"] == "Z"
+
+
+# ---------------------------------------------------------------------------
+# 6. Optional-dependency precedence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("genome_state", ["missing", "malformed"])
+def test_missing_qrcode_dependency_precedes_any_genome_read(
+    tmp_path, monkeypatch, genome_state
+):
+    # ``None`` in sys.modules makes the import raise ImportError whether or not
+    # the real optional package is installed on this seat.
+    monkeypatch.setitem(sys.modules, "qrcode", None)
+    monkeypatch.setitem(sys.modules, "qrcode.constants", None)
+
+    src = tmp_path / "genome.json"
+    if genome_state == "malformed":
+        src.write_text("{not valid json")
+
+    real_open = builtins.open
+    genome_opens: list = []
+
+    def counting_open(file, mode="r", *args, **kwargs):
+        if str(file) == str(src):
+            genome_opens.append(mode)
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+    with pytest.raises(ImportError) as excinfo:
+        generate_qr(str(src), output_path=str(tmp_path / "qr.png"))
+    monkeypatch.undo()
+
+    assert not isinstance(excinfo.value, ValueError)
+    assert "qrcode library required" in str(excinfo.value)
+    assert "pip install qrcode[pil]" in str(excinfo.value)
+    # The dependency failure happened before the genome was touched at all.
+    assert genome_opens == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Typed non-object refusal, direct and through the public CLI
+# ---------------------------------------------------------------------------
+
+
+def test_non_object_genome_root_refused_directly(fake_qrcode, tmp_path):
+    fake_qrcode()
+    src = tmp_path / "genome.json"
+    src.write_text(json.dumps([1, 2, 3]))
+    out = tmp_path / "qr.png"
+
+    with pytest.raises(DandelionGenomeError) as excinfo:
+        generate_qr(str(src), output_path=str(out))
+
+    assert str(excinfo.value) == "genome must be a JSON object"
+    assert not out.exists()
+
+
+def test_public_qr_cli_routes_only_the_typed_refusal_to_exit_2(
+    fake_qrcode, tmp_path, capsys
+):
+    fake_qrcode()
+    src = tmp_path / "genome.json"
+    src.write_text(json.dumps("a bare string root"))
+    out = tmp_path / "qr.png"
+
+    with pytest.raises(SystemExit) as excinfo:
+        dandelion.main(["qr", str(src), "--output", str(out)])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "QR Code generated" not in captured.out
+    assert not out.exists()
+
+
+# ---------------------------------------------------------------------------
+# 8. No broad catch
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_json_is_not_caught_by_the_typed_boundary(fake_qrcode, tmp_path):
+    fake_qrcode()
+    src = tmp_path / "genome.json"
+    src.write_text("{ this is not json")
+
+    with pytest.raises(json.JSONDecodeError) as excinfo:
+        generate_qr(str(src), output_path=str(tmp_path / "qr.png"))
+
+    assert not isinstance(excinfo.value, DandelionGenomeError)
+
+
+def test_qr_library_failure_is_not_caught(fake_qrcode, tmp_path):
+    sentinel = RuntimeError("synthetic QR-library failure")
+    fake_qrcode(fail_on_make=sentinel)
+    src = tmp_path / "genome.json"
+    _write_genome(src, {"organism_id": "sentinel"})
+
+    with pytest.raises(RuntimeError) as excinfo:
+        generate_qr(str(src), output_path=str(tmp_path / "qr.png"))
+
+    assert excinfo.value is sentinel
+
+
+def test_cli_does_not_translate_a_plain_valueerror_from_the_qr_library(
+    fake_qrcode, tmp_path
+):
+    """Only ``DandelionGenomeError`` routes to exit 2 — not its ``ValueError`` base.
+
+    A plain ``ValueError`` raised inside the QR library must propagate, proving
+    the CLI catch was not broadened to the base class.
+    """
+    sentinel = ValueError("synthetic QR-library ValueError")
+    fake_qrcode(fail_on_add_data=sentinel)
+    src = tmp_path / "genome.json"
+    _write_genome(src, {"organism_id": "sentinel"})
+
+    with pytest.raises(ValueError) as excinfo:
+        dandelion.main(["qr", str(src), "--output", str(tmp_path / "qr.png")])
+
+    assert excinfo.value is sentinel
+    assert not isinstance(excinfo.value, DandelionGenomeError)


### PR DESCRIPTION
## Derive the QR payload and its metadata from one read

**Status: DRAFT — no ready transition and no merge is requested by this PR.** Left as a draft for Jack's independent review.

`generate_qr()` reported byte counts that did not describe the QR it had just written. This corrects that, and only that.

### The pre-fix three-read seam
On its **successful** path `generate_qr()` reached the genome file **three separate times**:

| # | Site | Used for |
|---|---|---|
| 1 | `genome_to_compressed_bytes(genome_path)` → `open(...)` + `json.load` | the **QR payload** (stripped, canonical, zlib level 9) |
| 2 | `with open(genome_path, "r") as f: ...` | `original_json_bytes` |
| 3 | `json.load(open(genome_path))` inside the return dict | `minified_bytes` — **with no `epigenetic_snapshot` removal** |

Instrumented on unmodified `main`, one successful call opened the genome path `['r', 'r', 'r']`.

### Defect 1 — stable-file `minified_bytes` describes the wrong material
Read 3 never stripped `epigenetic_snapshot`, so for a snapshot-bearing genome the reported size described material the QR does not contain. Measured on a synthetic genome before the fix:

```
reported minified_bytes       : 4116
canonical STRIPPED minified   :   50   <- what is actually compressed into the QR
canonical UNSTRIPPED minified : 4116   <- what was reported
```

No filesystem race is needed for this one: a perfectly stable file reports the wrong number.

### Defect 2 — payload and metadata could describe different versions
The payload came from read 1 while the two size fields came from reads 2 and 3. With a controlled source seam where version A is available first and any later read exposes version B, the pre-fix function produced a QR carrying **A** while `minified_bytes` described **B**.

### The ruling implemented
A private `_capture_genome()` performs **one authoritative read** and returns a `_GenomeCapture` of `(source_text, minified_bytes, compressed)`:
- opens `genome_path` in the same text-mode/encoding manner as before and reads its text **once**;
- parses that captured text (`json.loads`), preserving the exact `type(genome) is dict` guard and the exact `DandelionGenomeError("genome must be a JSON object")` refusal;
- removes `epigenetic_snapshot` exactly as before; canonical `json.dumps(separators=(",", ":"), sort_keys=True)`; UTF-8; `zlib.compress(..., level=9)`.

`genome_to_compressed_bytes()` returns that capture's compressed bytes. `generate_qr()` derives the payload **and all three size fields** from the same capture, and the two later rereads are deleted. **A successful `generate_qr()` now performs exactly one read of `genome_path`.**

Metadata meanings after the correction:
- `original_json_bytes` — UTF-8 length of the **complete captured source text**, snapshot included (existing metric definition preserved);
- `minified_bytes` — UTF-8 length of the **exact canonical snapshot-stripped minified text that was compressed**;
- `compressed_bytes` — length of the **exact bytes encoded into the QR**;
- every other field unchanged in meaning.

No file-stat substitute, no mtime/inode comparison, no exception-message inspection, no locking, retries, temporary copies or filesystem identity checks.

### Exact two-file boundary
| File | Change |
|---|---|
| `scripts/dandelion.py` | **+48 / −19** (private single-read helper + `generate_qr` rewiring) |
| `tests/test_dandelion_qr_metadata.py` | **+471 / −0** — new focused test file |

Total **+519 / −19**, one ordinary single-parent commit on `main` `3e1b164574aeed450d82024263e8125dc244175f`. `tests/test_dandelion.py` and `tests/test_dandelion_glb.py` are **not** modified.

### Failing-first evidence
The tests were written and run against the **unmodified** live-`main` implementation first — **3 failed, 10 passed**:

```
FAILED test_metadata_describes_the_stripped_material          E  assert 4116 == 50
FAILED test_successful_generate_qr_reads_genome_exactly_once  E  expected exactly one genome read, got ['r', 'r', 'r']
FAILED test_replacement_between_reads_cannot_mix_sources      E  expected exactly one read, got 3
```

The ten behaviour-lock tests **already passed before the correction** and still pass — reported honestly, they pin what must *not* change rather than proving the defect. After the correction: **13 passed**. The failing-only state was not committed.

### Preservation
- **Compression bytes unchanged** — pinned byte-for-byte against an independent reference (strip → canonical `json.dumps` → UTF-8 → zlib level 9), plus a decompress round-trip.
- **Optional-dependency precedence unchanged** — the `qrcode` import still runs before any genome read; pinned with a missing **and** a malformed genome, asserting the `ImportError`, its `pip install qrcode[pil]` guidance, and that the genome was opened **zero** times.
- **Typed public refusal unchanged** — `DandelionGenomeError` with its exact message directly, and the public `qr` CLI still routes only that type through argparse to exit 2 with no success output and no QR file.
- **No broadened catch** — invalid JSON still raises `json.JSONDecodeError`; a sentinel QR-library `RuntimeError` propagates; and a plain `ValueError` from the QR library is **not** translated to exit 2 merely for subclassing `ValueError` (the base of `DandelionGenomeError`).
- **Valid QR path locked** — error-correction selection and `ERROR_CORRECT_L` fallback, `box_size`/`border`, the `UFG1:` payload, `make(fit=True)`, black/white image, exactly one save to the requested path, `qr.version`, `fits_single_qr`, `output_path`.
- **`info` untouched** — it keeps its own reads; this package does not attempt to make it single-read.

### Receipts
- `tests/test_dandelion_qr_metadata.py`: **13 passed**.
- `tests/test_dandelion.py` + `tests/test_dandelion_glb.py` (both unmodified): **19 passed**.
- `python -m py_compile` on both changed files: OK.
- `git diff --check`: no whitespace errors; both committed blobs LF-only with a trailing newline.
- Maintained suite on this seat: **2129 passed, 48 skipped, 0 failed** — exactly the previous 2116 plus the 13 new tests, no regressions. Skips are environment-gated and unrelated: 24 need the unbuilt Rust `uft_ca` extension (`maturin develop`), ~22 are Windows symlink / POSIX permission semantics, 1 is an absent `evolution_engine`.

### Scope and non-claims
- One narrow **source-coherence** correction. **No** whole-Dandelion totality, **no** filesystem-atomicity or atomic-snapshot claim, **no** general race prevention, **no** QR-capacity or QR-decoding totality, **no** genome-schema validation, **no** path containment or concurrency work.
- The guarantee is that everything reported derives from one captured read; it makes **no** claim about what happens to the file after that read returns.
- No GLB, STL, slices, `info`, decoder or genome-schema behaviour changes.
- Green checks are execution evidence only, **not** semantic proof.
- No cross-PR file-disjointness is certified. **#420 remained parked and untouched**; **#419 was not inspected at any level**.

_Left **draft and unmerged** for Jack's independent review._
