### PR TITLE
fix(lucid-server): ignore non-object JSON frames instead of dropping the client

### DIFF
--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -156,6 +156,17 @@ async def handle_client(websocket):
         async for message in websocket:
             try:
                 event = json.loads(message)
+                # Valid JSON is not necessarily a JSON *object*. `null`, booleans,
+                # numbers, strings and arrays all decode successfully but have no
+                # .get(), so reaching for one raised AttributeError, escaped the
+                # JSONDecodeError guard below, and terminated this client's handler
+                # -- disconnecting the browser instead of ignoring one bad frame.
+                # Accept only an exact built-in dict; every other decoded shape is
+                # ignored silently (no reply, no event action, and nothing about the
+                # supplied value or its type is logged) and the loop keeps reading
+                # later messages from the same client, exactly like malformed JSON.
+                if type(event) is not dict:
+                    continue
                 event_type = event.get('type', '')
 
                 if event_type == 'click':

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -1,0 +1,336 @@
+"""Tests for `scripts/lucid_server.handle_client` top-level JSON-shape handling.
+
+`handle_client` reads browser WebSocket frames, `json.loads` each one, and then
+reaches for `.get('type')`. Valid JSON is not necessarily a JSON *object*:
+`null`, booleans, numbers, strings and arrays all decode successfully but have
+no `.get`, so the attribute access raised `AttributeError`, escaped the
+`json.JSONDecodeError` guard, and terminated that client's handler — the
+browser was disconnected by one malformed frame instead of the frame being
+ignored. Construction now accepts only an exact built-in `dict` and silently
+ignores every other decoded shape, continuing to read later messages exactly
+as it already did for syntactically invalid JSON.
+
+Everything here runs in-process against the real coroutine driven by a
+controlled asynchronous fake socket: no real WebSocket, no browser, no network,
+no snapshot files and no NumPy data.
+
+Scope is top-level JSON shape in `handle_client` only — not whole-server,
+whole-WebSocket, authentication, authorization or payload-schema totality.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+def _optional_dependency_stubs() -> dict:
+    """Test-only stand-ins for `scripts.lucid_server`'s optional imports.
+
+    The module imports NumPy at top level and calls `sys.exit(1)` when
+    `websockets` is missing, so a minimal environment cannot import it at all.
+    Only a genuinely-absent module is stubbed — where the real package is
+    installed it is used untouched — and the substitution is scoped to the
+    import by `patch.dict`, which restores `sys.modules` immediately afterwards.
+    This keeps the malformed-frame contract executing in ordinary maintained CI
+    rather than being skipped away behind an optional dependency, and changes no
+    production dependency behaviour.
+    """
+    stubs: dict = {}
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        stubs["numpy"] = types.ModuleType("numpy")
+    try:
+        import websockets  # noqa: F401
+    except ImportError:
+        websockets_stub = types.ModuleType("websockets")
+        exceptions_stub = types.ModuleType("websockets.exceptions")
+
+        class ConnectionClosed(Exception):
+            """Stand-in for `websockets.exceptions.ConnectionClosed`."""
+
+        exceptions_stub.ConnectionClosed = ConnectionClosed
+        websockets_stub.exceptions = exceptions_stub
+        stubs["websockets"] = websockets_stub
+        stubs["websockets.exceptions"] = exceptions_stub
+    return stubs
+
+
+with mock.patch.dict(sys.modules, _optional_dependency_stubs()):
+    from scripts import lucid_server
+
+# `lucid_server` holds its own references to whatever was bound above, so the
+# handler stays callable after `patch.dict` restores `sys.modules`.
+
+
+PING = json.dumps({"type": "ping"})
+
+
+class FakeWebSocket:
+    """Async-iterable stand-in for one connected browser.
+
+    Records what the handler actually consumed and sent, and samples the
+    registration state at the moment each frame is delivered.
+    """
+
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.sent: list = []
+        self.delivered: list = []
+        self.registered_during: list = []
+        self.remote_address = ("test-client", 0)
+
+    def __aiter__(self):
+        return self._deliver()
+
+    async def _deliver(self):
+        for message in self.messages:
+            self.registered_during.append(self in lucid_server.connected_clients)
+            self.delivered.append(message)
+            yield message
+
+    async def send(self, message):
+        self.sent.append(message)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_client_registry():
+    """`connected_clients` is module state; keep every test independent."""
+    lucid_server.connected_clients.clear()
+    yield
+    lucid_server.connected_clients.clear()
+
+
+def _drive(messages, monkeypatch) -> FakeWebSocket:
+    """Run the real `handle_client` over `messages`; return the fake socket.
+
+    The initial-snapshot send is neutralised so no test depends on the real data
+    directory or on external snapshots; that path is exercised separately by
+    `test_initial_snapshot_frame_still_sent`.
+    """
+    monkeypatch.setattr(lucid_server, "find_latest_snapshot", lambda data_dir: None)
+    websocket = FakeWebSocket(messages)
+    asyncio.run(lucid_server.handle_client(websocket))
+    return websocket
+
+
+def _pongs(websocket) -> list:
+    return [s for s in websocket.sent if json.loads(s).get("type") == "pong"]
+
+
+def _assert_whole_stream_consumed(websocket, expected) -> None:
+    """Anti-vacuity guard.
+
+    The handler must have read EVERY frame, including the trailing ping. If it
+    died on an earlier frame the generator would stop there, so without this a
+    test could 'pass' merely because the stream ended before the follow-up ping.
+    """
+    assert websocket.delivered == list(expected)
+
+
+# -- non-object top-level JSON is ignored, and the client survives ------------
+
+
+_NON_OBJECT_JSON = [
+    "null",
+    "true",
+    "false",
+    "0",
+    "42",
+    "-17",
+    "3.14",
+    '""',
+    '"text"',
+    '"{\\"type\\": \\"ping\\"}"',
+    "[]",
+    "[1, 2, 3]",
+    '[{"type": "ping"}]',
+]
+_NON_OBJECT_IDS = [
+    "null",
+    "true",
+    "false",
+    "zero",
+    "int",
+    "negative_int",
+    "float",
+    "empty_string",
+    "string",
+    "string_looking_like_an_event",
+    "empty_array",
+    "array",
+    "array_of_events",
+]
+
+
+@pytest.mark.parametrize("payload", _NON_OBJECT_JSON, ids=_NON_OBJECT_IDS)
+def test_non_object_json_is_ignored_and_client_keeps_reading(payload, monkeypatch):
+    """Pre-fix each of these raised AttributeError out of the handler, so the
+    trailing ping was never read and the client was disconnected."""
+    websocket = _drive([payload, PING], monkeypatch)
+    _assert_whole_stream_consumed(websocket, [payload, PING])
+    assert len(_pongs(websocket)) == 1          # the later valid ping still answered
+    assert len(websocket.sent) == 1             # the non-object frame drew no reply
+    assert websocket not in lucid_server.connected_clients
+
+
+@pytest.mark.parametrize("payload", _NON_OBJECT_JSON, ids=_NON_OBJECT_IDS)
+def test_non_object_json_stays_registered_until_the_stream_ends(payload, monkeypatch):
+    """Registration must survive the ignored frame: both frames are delivered
+    while this client is still in `connected_clients`."""
+    websocket = _drive([payload, PING], monkeypatch)
+    assert websocket.registered_during == [True, True]
+
+
+def test_many_non_object_messages_do_not_end_the_stream(monkeypatch):
+    payloads = ["null", "true", "42", '"s"', "[]", "{not json", "[1]", PING]
+    websocket = _drive(payloads, monkeypatch)
+    _assert_whole_stream_consumed(websocket, payloads)
+    assert len(_pongs(websocket)) == 1
+    assert len(websocket.sent) == 1
+
+
+def test_non_object_json_produces_no_event_output_and_exposes_no_value(
+    monkeypatch, capsys
+):
+    """No reply, no event action, and nothing about the supplied value or its
+    type is printed."""
+    payloads = ['"LEAK-SENTINEL"', '["LEAK-SENTINEL"]', "null", "1234567", PING]
+    websocket = _drive(payloads, monkeypatch)
+    _assert_whole_stream_consumed(websocket, payloads)
+    output = capsys.readouterr().out
+    assert "LEAK-SENTINEL" not in output
+    assert "1234567" not in output
+    for type_name in ("NoneType", "AttributeError", "not a dict", "object has no attribute"):
+        assert type_name not in output
+    for event_marker in ("Click at", "Polish event", "Inject"):
+        assert event_marker not in output
+    assert len(_pongs(websocket)) == 1
+
+
+# -- syntactically invalid JSON keeps its established handling ---------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["{not json", "", "   ", "{'single': 'quotes'}", "[1, 2", '{"unterminated": '],
+    ids=["brace_text", "empty", "whitespace", "single_quotes", "unclosed_array",
+         "unterminated_object"],
+)
+def test_malformed_json_is_still_ignored_without_disconnect(payload, monkeypatch):
+    websocket = _drive([payload, PING], monkeypatch)
+    _assert_whole_stream_consumed(websocket, [payload, PING])
+    assert len(_pongs(websocket)) == 1
+    assert len(websocket.sent) == 1
+
+
+# -- established valid-object behaviour is unchanged -------------------------
+
+
+def test_valid_ping_receives_pong(monkeypatch):
+    websocket = _drive([PING], monkeypatch)
+    assert len(websocket.sent) == 1
+    reply = json.loads(websocket.sent[0])
+    assert reply["type"] == "pong"
+    assert isinstance(reply["time"], float)
+
+
+def test_repeated_pings_each_receive_a_pong(monkeypatch):
+    websocket = _drive([PING, PING, PING], monkeypatch)
+    _assert_whole_stream_consumed(websocket, [PING, PING, PING])
+    assert len(_pongs(websocket)) == 3
+
+
+def test_click_event_still_handled(monkeypatch, capsys):
+    websocket = _drive(
+        [json.dumps({"type": "click", "x": 1, "y": 2, "z": 3}), PING], monkeypatch
+    )
+    assert "Click at (1,2,3)" in capsys.readouterr().out
+    assert len(_pongs(websocket)) == 1
+
+
+def test_polish_event_still_handled(monkeypatch, capsys):
+    websocket = _drive([json.dumps({"type": "polish"}), PING], monkeypatch)
+    assert "Polish event" in capsys.readouterr().out
+    assert len(_pongs(websocket)) == 1
+
+
+def test_inject_event_still_handled(monkeypatch, capsys):
+    websocket = _drive(
+        [json.dumps({"type": "inject", "cell_type": 2, "x": 4, "y": 5, "z": 6}), PING],
+        monkeypatch,
+    )
+    output = capsys.readouterr().out
+    assert "Inject 2 at (4,5,6)" in output
+    assert len(_pongs(websocket)) == 1
+
+
+@pytest.mark.parametrize(
+    "event",
+    [{"type": "nope"}, {"type": ""}, {}, {"a": 1}, {"type": 5}, {"type": None}],
+    ids=["unknown_type", "empty_type", "empty_object", "no_type_key", "numeric_type",
+         "null_type"],
+)
+def test_unknown_object_event_is_ignored_without_reply(event, monkeypatch):
+    payload = json.dumps(event)
+    websocket = _drive([payload, PING], monkeypatch)
+    _assert_whole_stream_consumed(websocket, [payload, PING])
+    assert len(_pongs(websocket)) == 1
+    assert len(websocket.sent) == 1
+
+
+def test_click_with_missing_coordinates_still_uses_defaults(monkeypatch, capsys):
+    """An exact object with absent keys keeps the established `.get` defaults."""
+    websocket = _drive([json.dumps({"type": "click"}), PING], monkeypatch)
+    assert "Click at (0,0,0)" in capsys.readouterr().out
+    assert len(_pongs(websocket)) == 1
+
+
+# -- registration lifecycle ---------------------------------------------------
+
+
+def test_client_is_registered_while_active_and_removed_on_completion(monkeypatch):
+    websocket = _drive([PING, PING], monkeypatch)
+    assert websocket.registered_during == [True, True]
+    assert websocket not in lucid_server.connected_clients
+    assert lucid_server.connected_clients == set()
+
+
+def test_client_removed_even_when_stream_is_empty(monkeypatch):
+    websocket = _drive([], monkeypatch)
+    assert websocket.delivered == []
+    assert websocket not in lucid_server.connected_clients
+
+
+# -- initial snapshot delivery (test-only stand-ins, no real snapshot) --------
+
+
+def test_initial_snapshot_frame_still_sent(monkeypatch):
+    monkeypatch.setattr(lucid_server, "find_latest_snapshot", lambda data_dir: "snap")
+    monkeypatch.setattr(lucid_server, "extract_render_data", lambda path: {"cells": []})
+    websocket = FakeWebSocket([PING])
+    asyncio.run(lucid_server.handle_client(websocket))
+    first = json.loads(websocket.sent[0])
+    assert first["type"] == "frame"
+    assert first["data"] == {"cells": []}
+    assert len(_pongs(websocket)) == 1
+
+
+def test_initial_snapshot_failure_does_not_block_message_handling(monkeypatch):
+    """Established behaviour: a failing initial send is caught and the client
+    still goes on to have its frames handled."""
+    def _boom(path):
+        raise RuntimeError("snapshot unavailable")
+
+    monkeypatch.setattr(lucid_server, "find_latest_snapshot", lambda data_dir: "snap")
+    monkeypatch.setattr(lucid_server, "extract_render_data", _boom)
+    websocket = FakeWebSocket(["null", PING])
+    asyncio.run(lucid_server.handle_client(websocket))
+    assert websocket.delivered == ["null", PING]
+    assert len(_pongs(websocket)) == 1


### PR DESCRIPTION
## Lucid WebSocket handler — non-object JSON frames must be ignored, not fatal

Bounded Ian-seat package. `handle_client` decoded every browser frame and then
reached for `.get('type')` on the result — but valid JSON is not necessarily a
JSON *object*, so one `null`/number/string/array frame killed the client's
handler. **Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `3e1b164574aeed450d82024263e8125dc244175f`
- **head:** `fix/lucid-server-json-object-boundary` @ `d9f7e842cc51acf0b0de6a8d559056c074ab745f`
- **parent of head:** `3e1b164574aeed450d82024263e8125dc244175f` (single parent; branch cut fresh from freshly re-derived live `main`; ordinary push, no force)
- `scripts/lucid_server.py` was last touched by `68ebfa5` (**2026-03-27**, Phase 13) and is reached by no other open or recently merged package. `tests/test_lucid_server.py` did not exist on live `main` and is created here.

### Files & diffstat (exactly two permitted files)
```
 scripts/lucid_server.py    |  11 ++
 tests/test_lucid_server.py | 336 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 347 insertions(+)
```
The production change is confined to `handle_client` — one guard plus its
comment. `extract_render_data`, `find_latest_snapshot`, `broadcast`,
`snapshot_watcher`, `main`, server binding/startup, snapshot selection, sampling,
coordinate/field validation, auth/origin policy, output formatting and every
HTML/frontend file are untouched.

### Network reachability
`handle_client` is the per-connection coroutine registered by the server's
`websockets.serve(...)` loop; each frame it iterates comes straight off a
browser WebSocket connection. A frame is attacker- or bug-supplied text, decoded
by `json.loads` with no shape check before `.get` — so this is reachable by any
client that can open the socket.

### Failing-before (independently reproduced, not taken on description)
Driving the **pre-fix** coroutine with a controlled async fake socket, sending
one non-object frame followed by a valid `{"type":"ping"}`:

| Frame | Pre-fix result | Frames consumed | Pong |
|---|---|---|---|
| `null` | `AttributeError: 'NoneType' object has no attribute 'get'` | 1 of 2 | none |
| `true` / `false` | `AttributeError: 'bool' object has no attribute 'get'` | 1 of 2 | none |
| `42` / `-17` | `AttributeError: 'int' object has no attribute 'get'` | 1 of 2 | none |
| `3.14` | `AttributeError: 'float' object has no attribute 'get'` | 1 of 2 | none |
| `""` / `"text"` | `AttributeError: 'str' object has no attribute 'get'` | 1 of 2 | none |
| `[]` / `[1,2,3]` / `[{"type":"ping"}]` | `AttributeError: 'list' object has no attribute 'get'` | 1 of 2 | none |
| `{not json` | ignored (already correct) | 2 of 2 | ✅ |

The `AttributeError` escapes the inner `except json.JSONDecodeError`, is not
caught by the outer `except websockets.exceptions.ConnectionClosed`, runs the
`finally` (client discarded, "Client disconnected" printed) and propagates out of
`handle_client` — **the connection is dropped and every later frame from that
client is lost**.

### Implemented semantics
Inside `handle_client` only, immediately after a successful `json.loads`:

```python
if type(event) is not dict:
    continue
```

- Accepts only an **exact built-in `dict`** (a real JSON object). `json.loads`
  never produces a `dict` subclass here, so every genuine JSON object is accepted.
- Every other decoded shape is **ignored silently**: no reply is sent, no event
  action runs, and nothing about the supplied value or its type is logged,
  represented or exposed.
- The loop **continues reading later frames from the same client**, exactly as it
  already did for malformed JSON.
- Syntactically invalid JSON keeps its existing `except json.JSONDecodeError: pass`
  handling — untouched.
- **No blanket `except Exception`** was added; no `except` at all was added.
  `MemoryError`, send failures, WebSocket connection failures and unrelated
  programming errors are not converted into input refusals.

### Valid-event preservation
`click`, `polish`, `inject`, `ping`→`pong`, unknown event types, absent-key
`.get` defaults, initial snapshot delivery, and client registration/cleanup all
behave identically. Verified by direct execution: identical handler output
(`Click at (1,2,3)`, `Polish event: …`, `Inject 2 at (4,5,6)`), identical pong
counts, identical `connected_clients` lifecycle before and after the change.

### Tests and anti-vacuity design
`tests/test_lucid_server.py` (new): **16 test functions → 50 collected cases**
(static AST count, parametrisation expanded). All in-process against the real
coroutine driven by a controlled asynchronous fake socket — **no real WebSocket,
no browser, no network, no snapshot files, no NumPy data**.

Covered: `null`, `true`, `false`, `0`, `42`, `-17`, `3.14`, `""`, `"text"`, a
string that *looks* like an event, `[]`, `[1,2,3]`, `[{"type":"ping"}]` — each
followed by a valid ping; six malformed-JSON variants each followed by a ping; a
mixed burst of seven bad frames then a ping; ping/pong (single and repeated);
click, polish, inject, `.get` defaults; six unknown-object events; registration
present while active and removed on completion; empty stream; initial snapshot
frame still delivered; a failing initial send still allowing frame handling; and
a no-exposure test asserting no sentinel value, number, type name or event
marker reaches the output.

**Anti-vacuity:** every case asserts `websocket.delivered == <the whole message
list>` — the handler must have consumed the trailing ping. If it died early the
fake's generator would stop there, so a test cannot pass merely because the
stream ended before the follow-up ping. Each case additionally asserts exactly
one pong and exactly one send.

**Dependency isolation:** `scripts.lucid_server` imports NumPy at module level
and calls `sys.exit(1)` when `websockets` is absent, so a minimal environment
cannot import it. The test module stubs **only genuinely-absent** modules — the
real package is used wherever installed — via `mock.patch.dict(sys.modules, …)`
scoped to the import, mirroring the pattern already used by
`tests/test_medusa_api.py`. **The file is not module-level skipped**, so the
malformed-frame contract executes in ordinary maintained CI. No production
dependency behaviour was changed.

### Local evidence (this seat) — separated from CI
`pytest` is **not installed** on this seat, and no pytest substitute was built or
claimed as equivalent. **No test suite was run locally.** What *was* run:
1. `compile()` clean on both changed files.
2. Static AST check of the new module: 16 functions → 50 cases, and **no
   `parametrize` id/value cardinality mismatch** (which would be a CI collection error).
3. **Direct execution of the real `handle_client`** with fake async sockets over
   the exact payloads the tests use — a 118-check harness run against both the
   pre-fix module (from `origin/main`) and the post-fix module:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `3e1b164` | 118 | **57** |
| post-fix (this head) | 118 | **0** |

Critically, **zero** of the 57 pre-fix failures fall in the malformed-JSON,
valid-event, lifecycle or initial-frame categories — those pass in both states,
evidencing that only the intended behaviour changed.

Scratch probes lived outside the repository and were removed.

### CI / GitHub evidence
See the CI receipt appended below once checks conclude. **CI `verify-python` is
the authoritative gate**; everything in the section above is seat-produced.

### Unavailable / unresolved checks
- No local pytest run, so per-test pass/fail and collection behaviour rest on CI.
- Whether CI provisions `websockets` is unknown to me; the test module is written
  to run either way, which is precisely why the stand-in seam exists.
- No real browser, socket or server-startup path was exercised anywhere.

### Residuals and non-claims
- **Bounded claim:** top-level JSON-shape handling in `handle_client`. **Not**
  whole-server, whole-WebSocket, authentication, authorization or payload-schema
  totality.
- **Field-level payload contents are still unvalidated.** An exact object such as
  `{"type":"click","x":{"nested":"junk"}}` is accepted and its values printed by
  the established handlers — unchanged, and deliberately out of scope.
- `polish` still prints the whole event dict, so an accepted *object* can place
  attacker-supplied content in server logs. Pre-existing valid-object behaviour;
  not touched.
- No origin, authentication or authorization check exists on this socket; this
  package adds none.
- Transport-level failures (`send` errors, connection drops) are unchanged.
- No claim about `sys.exit(1)` on a missing `websockets` import at module load —
  untouched production dependency behaviour.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419** (`fix/tool-result-metadata-shape-totality`, Opus-4.8) and **#422**
  (`fix/halo-packet-wire-decode-totality`, Opus-5) were verified parked (OPEN,
  draft, unmerged) and **neither was modified**. Both file boundaries are disjoint
  from this package's two files, with no shared symbol or import.
- **#420** and **#423** (Kev-seat) were kept **opaque**: bare number, title,
  draft/open identity and branch identity only. No body, patch, files, checks,
  comments, reviews or threads were inspected, and nothing here derives from them.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No merge / auto-merge / ready-for-review
transition / rebase / merge-from-main / history rewrite / repository, workflow,
protection or settings change / manual workflow rerun / branch deletion. No
comment, review, thread reply, resolution, reaction or label. Leave **OPEN, draft,
unmerged** and hand back to Jack for audit.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `d9f7e842cc51acf0b0de6a8d559056c074ab745f`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m25s) | run `30189119430` / job `89758918802` — **2288 passed, 13 skipped, 0 failed** (42.50s) |
| verify-python (push-triggered run) | ✅ pass (1m27s) | run `30189088896` / job `89758833788` |
| Analyze Python (CodeQL) | ✅ pass (1m6s) | run `30189119422` |
| CodeQL | ✅ pass | job `89758996304` |
| agent-safety | ✅ pass (13s) | run `30189119416` |
| tripwire | ✅ pass (6s) | run `30189119443` |
| frontend-quality | ✅ pass (54s / 49s) | runs `30189088896`, `30189119430` |

**The new tests demonstrably ran — they were not skipped.** Baseline
`verify-python` on live `main` `3e1b164` (run `30185095748`) reports
**2238 passed, 13 skipped**. This head reports **2288 passed, 13 skipped**:

- **+50 passed**, exactly matching the 50 statically counted collected cases;
- **skipped unchanged at 13**, so the dependency-isolation seam worked and the
  module was not skipped away behind an optional import;
- **0 failed**, and all 2238 pre-existing cases still pass — no regression.

CI's figures supersede the seat-local evidence as the authoritative gate. PR
remains **OPEN, draft, unmerged** — handing back to Jack for audit; merge
authority is Kev's later explicit word only.
