### PR TITLE
fix(watchdog): fail closed when the engine process query fails

### DIFF
--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -38,6 +38,14 @@ MAX_RESTART_ATTEMPTS = 10  # before giving up
 RESTART_COOLDOWN = 30      # seconds to wait before restart after crash
 PROCESS_NAME = "run_v070_engine.py"
 
+# Fixed status lines for a FAILED process query. A query failure means the
+# engine's real state is unknown -- it is never evidence that zero engines are
+# running -- so these are deliberately distinct from "ENGINE DOWN!".
+PROCESS_QUERY_FAILED_MESSAGE = "Process query FAILED: engine status unknown"
+ENGINE_STATUS_UNKNOWN_MESSAGE = (
+    "Engine status UNKNOWN: process query failed; no restart decision this cycle"
+)
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -57,16 +65,44 @@ log = logging.getLogger("watchdog")
 # ---------------------------------------------------------------------------
 
 def find_engine_processes():
-    """Find all running Medusa engine processes. Returns list of (pid, cmdline)."""
+    """Find all running Medusa engine processes.
+
+    Returns a list of ``(pid, cmdline)`` when the query SUCCEEDS — an ordinary
+    empty list when it succeeded and simply matched nothing — and ``None`` when
+    the query itself FAILED, so the engine's real state is unknown.
+
+    That distinction is the whole point: the watchdog restarts the engine when
+    it sees zero processes. Previously every failure — a PowerShell timeout, a
+    launch/OS error, a non-zero exit whose stdout happened to be empty, or
+    output whose PID would not parse — was converted into ``[]``, which the loop
+    read as proof that no engine was running. A monitoring failure could
+    therefore start a duplicate engine or drive a restart storm. ``None`` cannot
+    be mistaken for a successful count of zero.
+
+    Only expected process-query and parsing boundary failures are caught; there
+    is no blanket catch, so unrelated programming errors still surface.
+    """
     try:
         result = subprocess.run(
             ["powershell", "-Command",
              "Get-CimInstance Win32_Process | Where-Object {$_.CommandLine -like '*run_v070_engine*' -and $_.Name -eq 'python.exe'} | Select-Object ProcessId, CommandLine | Format-List"],
             capture_output=True, text=True, timeout=10
         )
-        processes = []
-        current_pid = None
-        current_cmd = None
+    except (subprocess.SubprocessError, OSError):
+        # Timeout, launch failure, or any other OS-level query failure.
+        log.error(PROCESS_QUERY_FAILED_MESSAGE)
+        return None
+
+    # A non-zero exit means the query did not run to completion, so its (often
+    # empty) stdout is NOT evidence that no engine is running.
+    if result.returncode != 0:
+        log.error(PROCESS_QUERY_FAILED_MESSAGE)
+        return None
+
+    processes = []
+    current_pid = None
+    current_cmd = None
+    try:
         for line in result.stdout.strip().split("\n"):
             line = line.strip()
             if line.startswith("ProcessId"):
@@ -77,10 +113,12 @@ def find_engine_processes():
                     processes.append((current_pid, current_cmd))
                 current_pid = None
                 current_cmd = None
-        return processes
-    except Exception as e:
-        log.error(f"Failed to query processes: {e}")
-        return []
+    except ValueError:
+        # A PID that will not parse means the listing cannot be trusted; report
+        # unknown rather than a silently partial count.
+        log.error(PROCESS_QUERY_FAILED_MESSAGE)
+        return None
+    return processes
 
 
 def find_latest_snapshot():
@@ -172,6 +210,17 @@ def run_watchdog():
         try:
             # 1. Find engine processes
             processes = find_engine_processes()
+
+            # 1a. A FAILED query is not proof the engine is down, so no restart
+            # or duplicate-kill decision may be made from it: no snapshot
+            # lookup, no start_engine, no kill_process, and restart_count /
+            # last_restart_time are left exactly as they were. Wait the normal
+            # cadence and re-query on the next cycle.
+            if processes is None:
+                log.error(ENGINE_STATUS_UNKNOWN_MESSAGE)
+                time.sleep(CHECK_INTERVAL)
+                continue
+
             num_engines = len(processes)
 
             # 2. Handle duplicate processes
@@ -241,6 +290,37 @@ def run_watchdog():
         time.sleep(CHECK_INTERVAL)
 
 
+def run_once():
+    """One-shot status check for ``--once``. Returns the process exit status.
+
+    A failed process query reports the fixed status-unknown line and exits
+    non-zero: it must never print "Engine NOT running!", which asserts a fact a
+    failed query cannot establish. A successful query keeps its established
+    output for zero, one or many processes and exits 0.
+
+    Split out of the ``__main__`` block only so the query-failure branch has a
+    return status to assert; argument parsing and dispatch are unchanged.
+    """
+    processes = find_engine_processes()
+    if processes is None:
+        print(PROCESS_QUERY_FAILED_MESSAGE)
+        return 1
+    if processes:
+        print(f"Engine running: {len(processes)} process(es)")
+        for pid, cmd in processes:
+            print(f"  PID {pid}: {cmd[:80]}...")
+        healthy, status = check_engine_health(processes)
+        print(f"  Health: {'OK' if healthy else 'WARNING'} — {status}")
+    else:
+        print("Engine NOT running!")
+        snapshot = find_latest_snapshot()
+        if snapshot:
+            print(f"  Latest snapshot: {snapshot.name}")
+        else:
+            print("  No snapshots found!")
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Entry Point
 # ---------------------------------------------------------------------------
@@ -254,19 +334,6 @@ if __name__ == "__main__":
     CHECK_INTERVAL = args.check_interval
 
     if args.once:
-        processes = find_engine_processes()
-        if processes:
-            print(f"Engine running: {len(processes)} process(es)")
-            for pid, cmd in processes:
-                print(f"  PID {pid}: {cmd[:80]}...")
-            healthy, status = check_engine_health(processes)
-            print(f"  Health: {'OK' if healthy else 'WARNING'} — {status}")
-        else:
-            print("Engine NOT running!")
-            snapshot = find_latest_snapshot()
-            if snapshot:
-                print(f"  Latest snapshot: {snapshot.name}")
-            else:
-                print("  No snapshots found!")
+        sys.exit(run_once())
     else:
         run_watchdog()

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,328 @@
+"""Tests for `scripts/watchdog.py` process-query fail-closed behaviour.
+
+`find_engine_processes()` used to convert every failure of the PowerShell
+process query — timeout, launch/OS error, a non-zero exit whose stdout happened
+to be empty, or output whose PID would not parse — into an empty list. The
+watchdog loop reads an empty list as proof that zero engines are running, so a
+*monitoring* failure could send it down the engine-down path: pick a snapshot,
+call `start_engine`, and count a restart. That can create a duplicate engine or
+a restart storm from a state that was never actually observed.
+
+The query now returns `None` on failure, which no caller can mistake for a
+successful count of zero, and the loop makes no restart or duplicate-kill
+decision from it.
+
+Nothing here runs a real process: `subprocess.run` is replaced at the module
+boundary, and the snapshot/start/kill seams are mocked. No real PowerShell,
+taskkill, engine, scheduled task or subprocess is executed, no watchdog log file
+is written, and no test sleeps in real time.
+
+Scope is the "query failed" versus "query succeeded with zero engines"
+distinction only — not whole-watchdog, whole-process-management or
+Windows-service totality.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+# `scripts/watchdog.py` builds `logging.FileHandler(log_path)` as an ARGUMENT to
+# `logging.basicConfig`, so importing it opens `data/watchdog.log` even when
+# basicConfig itself is neutralised. Both are patched for the duration of the
+# import so the suite writes no watchdog log and does not reconfigure root
+# logging; production logging architecture is unchanged.
+with mock.patch("logging.FileHandler"), mock.patch("logging.basicConfig"):
+    from scripts import watchdog
+
+
+VALID_STDOUT = (
+    "ProcessId   : 1234\n"
+    "CommandLine : python.exe -u run_v070_engine.py --resume snap.npz\n"
+    "\n"
+    "ProcessId   : 5678\n"
+    "CommandLine : python.exe -u run_v070_engine.py --resume other.npz\n"
+)
+
+VALID_PROCESSES = [
+    (1234, "python.exe -u run_v070_engine.py --resume snap.npz"),
+    (5678, "python.exe -u run_v070_engine.py --resume other.npz"),
+]
+
+
+class _Completed:
+    """Stand-in for `subprocess.CompletedProcess`."""
+
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+class _FakeTime:
+    """Deterministic clock whose `sleep` ends the loop instead of waiting."""
+
+    def __init__(self, stop_after_sleeps=1):
+        self.stop_after = stop_after_sleeps
+        self.sleeps = []
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        if len(self.sleeps) >= self.stop_after:
+            raise KeyboardInterrupt  # run_watchdog treats this as a clean stop
+
+    def time(self):
+        return 1000.0
+
+
+# Query-failure side effects, exercised through the real `subprocess.run` seam.
+def _timeout():
+    return subprocess.TimeoutExpired(cmd="powershell", timeout=10)
+
+
+QUERY_FAILURES = [
+    ("timeout", _timeout),
+    ("os_error", lambda: OSError("launch failed")),
+    ("nonzero_exit", lambda: _Completed(stdout="", returncode=1)),
+    ("nonzero_exit_with_output", lambda: _Completed(stdout=VALID_STDOUT, returncode=2)),
+    ("malformed_pid", lambda: _Completed(
+        stdout="ProcessId   : not-a-number\nCommandLine : x\n", returncode=0)),
+]
+QUERY_FAILURE_IDS = [name for name, _ in QUERY_FAILURES]
+
+
+def _query(monkeypatch, side_effect):
+    """Call the REAL find_engine_processes with a mocked subprocess boundary."""
+    monkeypatch.setattr(watchdog.subprocess, "run", mock.Mock(side_effect=side_effect))
+    return watchdog.find_engine_processes()
+
+
+class _Seams:
+    """Recorded stand-ins for every side-effecting call the loop can make."""
+
+    def __init__(self, snapshot_name="snap.npz"):
+        self.snapshot_name = snapshot_name
+        self.snapshot_lookups = 0
+        self.started = []
+        self.killed = []
+
+    def find_latest_snapshot(self):
+        self.snapshot_lookups += 1
+        if self.snapshot_name is None:
+            return None
+        return types.SimpleNamespace(name=self.snapshot_name)
+
+    def start_engine(self, snapshot_path):
+        self.started.append(getattr(snapshot_path, "name", snapshot_path))
+        return 4321
+
+    def kill_process(self, pid):
+        self.killed.append(pid)
+        return True
+
+
+def _run_loop(monkeypatch, side_effects, cycles=1, snapshot_name="snap.npz"):
+    """Drive the REAL run_watchdog for `cycles` iterations; return the seams.
+
+    `side_effects` feeds the mocked `subprocess.run`, so each cycle exercises the
+    genuine `find_engine_processes` rather than an injected return value.
+    """
+    seams = _Seams(snapshot_name)
+    monkeypatch.setattr(watchdog.subprocess, "run", mock.Mock(side_effect=side_effects))
+    monkeypatch.setattr(watchdog, "find_latest_snapshot", seams.find_latest_snapshot)
+    monkeypatch.setattr(watchdog, "start_engine", seams.start_engine)
+    monkeypatch.setattr(watchdog, "kill_process", seams.kill_process)
+    monkeypatch.setattr(watchdog, "time", _FakeTime(stop_after_sleeps=cycles))
+    try:
+        watchdog.run_watchdog()
+    except KeyboardInterrupt:
+        pass  # the trailing sleep is outside the loop's try block
+    return seams
+
+
+# -- find_engine_processes: successful queries --------------------------------
+
+
+def test_successful_query_returns_process_tuples(monkeypatch):
+    assert _query(monkeypatch, [_Completed(stdout=VALID_STDOUT)]) == VALID_PROCESSES
+
+
+def test_successful_query_with_no_matches_returns_exact_empty_list(monkeypatch):
+    result = _query(monkeypatch, [_Completed(stdout="", returncode=0)])
+    assert result == []
+    assert type(result) is list  # an ordinary empty list, never the failure signal
+    assert result is not None
+
+
+def test_successful_query_ignores_incomplete_trailing_record(monkeypatch):
+    """Established parsing behaviour: a ProcessId with no CommandLine is skipped."""
+    stdout = VALID_STDOUT + "ProcessId   : 9999\n"
+    assert _query(monkeypatch, [_Completed(stdout=stdout)]) == VALID_PROCESSES
+
+
+# -- find_engine_processes: failures produce the unmistakable signal ----------
+
+
+@pytest.mark.parametrize("name,make", QUERY_FAILURES, ids=QUERY_FAILURE_IDS)
+def test_query_failure_returns_none(name, make, monkeypatch):
+    """Every recognised query failure must be distinguishable from zero engines."""
+    result = _query(monkeypatch, [make()])
+    assert result is None
+    assert result != []  # explicitly NOT a successful empty result
+
+
+@pytest.mark.parametrize("name,make", QUERY_FAILURES, ids=QUERY_FAILURE_IDS)
+def test_query_failure_logs_the_fixed_message(name, make, monkeypatch, caplog):
+    caplog.set_level(logging.ERROR, logger="watchdog")
+    _query(monkeypatch, [make()])
+    assert watchdog.PROCESS_QUERY_FAILED_MESSAGE in caplog.text
+
+
+def test_unrelated_programming_error_is_not_swallowed(monkeypatch):
+    """No blanket catch: an unexpected error still surfaces instead of becoming
+    a query-failure signal."""
+    monkeypatch.setattr(
+        watchdog.subprocess, "run", mock.Mock(side_effect=ZeroDivisionError("bug"))
+    )
+    with pytest.raises(ZeroDivisionError):
+        watchdog.find_engine_processes()
+
+
+# -- run_watchdog: a failed query reaches no restart decision -----------------
+
+
+@pytest.mark.parametrize("name,make", QUERY_FAILURES, ids=QUERY_FAILURE_IDS)
+def test_query_failure_makes_no_restart_or_kill_decision(name, make, monkeypatch):
+    """Pre-fix this returned [], so the loop logged ENGINE DOWN, looked up a
+    snapshot and called start_engine."""
+    seams = _run_loop(monkeypatch, [make()], cycles=1)
+    assert seams.started == []
+    assert seams.killed == []
+    assert seams.snapshot_lookups == 0  # the restart snapshot was never inspected
+
+
+@pytest.mark.parametrize("name,make", QUERY_FAILURES, ids=QUERY_FAILURE_IDS)
+def test_query_failure_is_not_reported_as_engine_down(name, make, monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    _run_loop(monkeypatch, [make()], cycles=1)
+    assert watchdog.ENGINE_STATUS_UNKNOWN_MESSAGE in caplog.text
+    assert "ENGINE DOWN" not in caplog.text
+    assert "Restart #" not in caplog.text
+
+
+def test_repeated_query_failures_never_restart(monkeypatch):
+    seams = _run_loop(monkeypatch, [_timeout() for _ in range(5)], cycles=5)
+    assert seams.started == []
+    assert seams.killed == []
+    assert seams.snapshot_lookups == 0
+
+
+# -- restart accounting is untouched by a failed cycle ------------------------
+
+
+def test_failed_cycle_does_not_consume_restart_accounting(monkeypatch, caplog):
+    """A failure cycle followed by a genuine zero-process cycle must restart,
+    and must be restart #1.
+
+    This witnesses both counters: had the failure cycle set `last_restart_time`
+    the second cycle would be inside the cooldown and skip the restart, and had
+    it incremented `restart_count` the log would read "Restart #2".
+    """
+    caplog.set_level(logging.INFO, logger="watchdog")
+    seams = _run_loop(
+        monkeypatch, [_timeout(), _Completed(stdout="", returncode=0)], cycles=2
+    )
+    assert seams.started == ["snap.npz"]
+    assert "Restart #1 successful" in caplog.text
+    assert "Restart #2" not in caplog.text
+
+
+def test_successful_cycle_after_failure_still_proceeds(monkeypatch):
+    seams = _run_loop(
+        monkeypatch,
+        [_timeout(), _timeout(), _Completed(stdout="", returncode=0)],
+        cycles=3,
+    )
+    assert seams.started == ["snap.npz"]
+    assert seams.snapshot_lookups == 1  # only the successful cycle looked
+
+
+# -- established successful-query behaviour is preserved ----------------------
+
+
+def test_genuine_zero_process_result_still_restarts(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    seams = _run_loop(monkeypatch, [_Completed(stdout="", returncode=0)], cycles=1)
+    assert seams.started == ["snap.npz"]
+    assert seams.snapshot_lookups == 1
+    assert "ENGINE DOWN" in caplog.text
+
+
+def test_genuine_zero_process_result_with_no_snapshot_does_not_start(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    seams = _run_loop(
+        monkeypatch, [_Completed(stdout="", returncode=0)], cycles=1, snapshot_name=None
+    )
+    assert seams.started == []
+    assert seams.snapshot_lookups == 1
+    assert "No snapshot found to resume from!" in caplog.text
+
+
+def test_duplicate_detection_still_kills_the_extra_process(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="watchdog")
+    seams = _run_loop(monkeypatch, [_Completed(stdout=VALID_STDOUT)], cycles=1)
+    assert seams.killed == [5678]      # lowest PID kept, the rest killed
+    assert seams.started == []
+    assert "DUPLICATE DETECTED" in caplog.text
+
+
+def test_single_healthy_process_is_left_alone(monkeypatch):
+    single = "ProcessId   : 1234\nCommandLine : python.exe -u run_v070_engine.py\n"
+    monkeypatch.setattr(watchdog, "check_engine_health", lambda p: (True, "ok"))
+    seams = _run_loop(monkeypatch, [_Completed(stdout=single)], cycles=1)
+    assert seams.started == []
+    assert seams.killed == []
+
+
+# -- --once behaviour ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("name,make", QUERY_FAILURES, ids=QUERY_FAILURE_IDS)
+def test_once_reports_status_unknown_and_exits_non_zero(name, make, monkeypatch, capsys):
+    monkeypatch.setattr(watchdog.subprocess, "run", mock.Mock(side_effect=[make()]))
+    status = watchdog.run_once()
+    output = capsys.readouterr().out
+    assert status != 0
+    assert status == 1
+    assert watchdog.PROCESS_QUERY_FAILED_MESSAGE in output
+    assert "Engine NOT running!" not in output  # the false claim it used to make
+
+
+def test_once_zero_processes_keeps_established_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        watchdog.subprocess, "run", mock.Mock(side_effect=[_Completed(stdout="")])
+    )
+    monkeypatch.setattr(watchdog, "find_latest_snapshot", lambda: None)
+    status = watchdog.run_once()
+    output = capsys.readouterr().out
+    assert status == 0
+    assert "Engine NOT running!" in output
+    assert "No snapshots found!" in output
+
+
+def test_once_running_processes_keep_established_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        watchdog.subprocess, "run", mock.Mock(side_effect=[_Completed(stdout=VALID_STDOUT)])
+    )
+    monkeypatch.setattr(watchdog, "check_engine_health", lambda p: (True, "Latest: x"))
+    status = watchdog.run_once()
+    output = capsys.readouterr().out
+    assert status == 0
+    assert "Engine running: 2 process(es)" in output
+    assert "PID 1234" in output and "PID 5678" in output
+    assert "Health: OK" in output


### PR DESCRIPTION
## Watchdog: fail closed when the engine process query fails

Bounded Ian-seat package. A failed process query was indistinguishable from
"zero engines running", so a **monitoring** failure could restart the engine — or
kill a "duplicate" — from a state that was never observed.
**Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `3e1b164574aeed450d82024263e8125dc244175f`
- **head:** `fix/watchdog-process-query-fail-closed` @ `77d91d6469a54b298ad13e700af46b3fa7df06e7`
- **parent of head:** `3e1b164574aeed450d82024263e8125dc244175f` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- `scripts/watchdog.py` last touched by `57666e7` (**2026-04-02**, Phase 14d); nothing imports it and no open or merged package overlaps it. `tests/test_watchdog.py` did not exist on live `main` and is created here.

### Files & diffstat (exactly two permitted files)
```
 scripts/watchdog.py    | 111 +++++++++++----
 tests/test_watchdog.py | 328 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 417 insertions(+), 22 deletions(-)
```

### Independently reproduced failing-before
Driving the **pre-fix** module with `subprocess.run` mocked at the real boundary
(no PowerShell executed) and every side-effecting seam recorded:

| Query failure | Pre-fix return | Loop consequence |
|---|---|---|
| PowerShell timeout | `[]` | `ENGINE DOWN!` → snapshot lookup → **`start_engine`** → `Restart #1` |
| process-launch / `OSError` | `[]` | same |
| non-zero exit, empty stdout | `[]` | same, and **silently** — no exception was raised, so nothing was even logged |
| malformed PID output | `[]` | same |
| non-zero exit, *parseable* stdout | `[(1234,…),(5678,…)]` | `DUPLICATE DETECTED` → **`kill_process(5678)`** |
| unrelated `ZeroDivisionError` | `[]` | blanket catch swallowed a programming error into a "zero engines" answer |

The last two rows are worse than a restart storm: a failed query could **kill a
process** it never actually observed, and genuine bugs were hidden.

### The successful-empty versus query-failed distinction
`find_engine_processes()` now returns:

- **query SUCCEEDED** → a `list` of `(pid, command_line)`; an ordinary **empty
  list** when it succeeded and matched nothing — the established engine-down
  restart behaviour is retained for that case;
- **query FAILED** → **`None`**, which no caller can mistake for a successful
  count of zero.

`None` was chosen as the minimal design the authorization preferred: it needs no
new type, is impossible to confuse with a count, and makes the two call sites'
handling a single explicit `is None` check.

### Expected failures recognised
| Condition | Detection |
|---|---|
| PowerShell timeout | `except subprocess.SubprocessError` (covers `TimeoutExpired`) |
| process-launch / OS failure | `except OSError` |
| non-zero PowerShell exit | explicit `if result.returncode != 0` |
| malformed PID output | `except ValueError` around the parse loop only |

Only those narrow boundaries are caught. **No blanket catch** — an unrelated
programming error still propagates (asserted by a dedicated test). Both failure
logs are **fixed strings**; no exception text, value or type name is interpolated.

### Watchdog-loop behaviour on unknown state
```python
processes = find_engine_processes()
if processes is None:
    log.error(ENGINE_STATUS_UNKNOWN_MESSAGE)
    time.sleep(CHECK_INTERVAL)
    continue
```
On a failed query the loop reports the fixed status-unknown line and then: does
**not** classify the engine as down, does **not** inspect or select a restart
snapshot, does **not** call `start_engine`, does **not** call `kill_process`,
leaves `restart_count` and `last_restart_time` untouched, and waits the normal
`CHECK_INTERVAL` cadence before re-querying. The `sleep`-then-`continue` shape
matches the loop's existing cooldown/backoff branches.

### `--once` behaviour and exit status
A failed query prints the fixed `Process query FAILED: engine status unknown` and
returns **exit status 1**. It no longer prints `Engine NOT running!`, which
asserts a fact a failed query cannot establish. A successful query keeps its
established output for zero, one or many processes and exits **0**.

The one-shot body moved into `run_once()` **only** so the exit status is
returnable and assertable in-process — testing it otherwise would have required
spawning a real subprocess, which is prohibited. `argparse` and the dispatch are
otherwise unchanged, and every printed line is preserved verbatim.

### Valid behaviour preserved
Successful output parsing (the parse loop is byte-identical), the
`(pid, command_line)` records, true zero-process handling, restart cooldown,
`MAX_RESTART_ATTEMPTS`, snapshot selection, successful engine launch, duplicate
handling after a **successful** query, health and stale-snapshot checks,
heartbeat, kill mechanics, engine command construction, and the logging
architecture (only the two new fixed query-failure lines were added).

### Tests and anti-vacuity evidence
`tests/test_watchdog.py` (new): **18 test functions → 38 collected cases**.

Covered: successful valid output → the existing tuples; successful no-match →
exact `[]`; timeout, OS failure, non-zero exit (empty *and* parseable stdout) and
malformed PID → the failure signal, each with its fixed log line; unrelated error
not swallowed; query failure in `run_watchdog` → no snapshot lookup, no
`start_engine`, no `kill_process`, no `ENGINE DOWN`, no `Restart #`; five
consecutive failures never restart; a failure cycle followed by a genuine
zero-process cycle still restarts **as `Restart #1`**; genuine zero → restart
(and no-snapshot → no start); duplicate detection still kills only the extra PID;
a single healthy process untouched; and `--once` unknown → fixed line + exit 1,
versus zero/one/many → established output + exit 0.

**Anti-vacuity — the central witness is not a sentinel.** Every case mocks
`subprocess.run` at the real boundary and calls the genuine
`find_engine_processes` / `run_watchdog` / `run_once`, so the pre-fix code path
really does turn a mocked query failure into `[]` and really does reach the
restart branch. `test_failed_cycle_does_not_consume_restart_accounting` witnesses
both counters at once: had the failure cycle set `last_restart_time`, the next
cycle would sit inside the 30 s cooldown and skip the restart; had it incremented
`restart_count`, the log would read `Restart #2`.

**Isolation:** no real PowerShell, `taskkill`, engine, scheduled task or
subprocess is executed; no test sleeps in real time (a deterministic fake clock's
`sleep` terminates the loop); and no `watchdog.log` is written — the module builds
`logging.FileHandler(log_path)` as an *argument* to `basicConfig`, so the log file
opens at import even if `basicConfig` alone is patched. Both are patched for the
duration of the import, in the **test only**; production logging is unchanged.

### Local evidence (this seat) — separated from CI
`pytest` is **not installed** here; **no test suite was run locally** and no
pytest substitute was built or claimed equivalent. What ran:
1. `compile()` clean on both changed files.
2. Static AST check of the new module: 18 functions → 38 cases, **no
   `parametrize` id/value cardinality mismatch** (which would be a CI collection error).
3. A direct-execution harness over the same expectations, against both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `3e1b164` | 46 | **25** |
| post-fix `77d91d6` | 62 | **0** |

(The pre-fix run has fewer checks because the `--once` group cannot run: `run_once`
does not exist there.) **Every successful-query check passes in both states** —
valid output, successful empty, incomplete trailing record, genuine-zero restart,
duplicate kill and single-healthy — evidencing that only the intended behaviour changed.

### CI / GitHub evidence
See the CI receipt appended below once checks conclude. **CI `verify-python` is
the authoritative gate**; everything above is seat-produced.

### Residuals and explicit non-claims
- **Bounded claim:** distinguishing "query failed" from "query succeeded with zero
  engines". **Not** whole-watchdog, whole-process-management or Windows-service totality.
- The query remains **Windows/PowerShell-specific**; nothing here makes the
  watchdog portable, and CI never executes it.
- A query that **succeeds but lies** (PowerShell returning 0 with a wrong or
  truncated listing that still parses) is indistinguishable from truth and is
  out of scope. Only *unparseable* PIDs are treated as failure.
- No liveness/PID-reuse verification: a returned PID is trusted as an engine.
- `restart_count` and `last_restart_time` remain locals of `run_watchdog`, so
  they are witnessed indirectly (via cooldown behaviour and the `Restart #n`
  line) rather than read directly.
- `kill_process` and `start_engine` keep their own broad `except Exception`
  handlers; untouched and out of scope.
- The outer `except Exception` in the watchdog loop is unchanged, so an
  unexpected error in a *later* stage of a cycle is still logged and swallowed by
  that pre-existing handler.
- `run_once()` is a new public name in the module; no other file references it.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422** and **#424** were verified parked (OPEN, draft, unmerged,
  0 labels, 0 reviews) and **none was modified**. Their file boundaries
  (`agent_backends/base.py` + `tests/test_agent_backend.py`; `shard_protocol.py` +
  `tests/test_shard_protocol.py`; `lucid_server.py` + `tests/test_lucid_server.py`)
  are disjoint from this package's two files, with no shared symbol or import.
- **#420** and **#423** (Kev-seat) were kept **opaque**: bare number, title,
  branch identity and draft/open identity only. No body, patch, files, checks,
  comments, reviews or threads were inspected, and nothing here derives from them.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real process query, process kill or
engine launch anywhere. No merge / auto-merge / ready-for-review transition /
rebase / merge-from-main / history rewrite / repository, workflow, protection or
settings change / manual workflow rerun / branch deletion. No comment, review,
thread action, reaction or label. Leave **OPEN, draft, unmerged** and hand back to
Jack for audit.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `77d91d6469a54b298ad13e700af46b3fa7df06e7`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m45s) | run `30190625192` / job `89763125089` — **2276 passed, 13 skipped, 0 failed** (40.35s) |
| verify-python (push-triggered run) | ✅ pass (1m34s) | run `30190595501` / job `89763046748` |
| Analyze Python (CodeQL) | ✅ pass (1m1s) | run `30190625188` |
| CodeQL | ✅ pass | job `89763191936` |
| agent-safety | ✅ pass (8s) | run `30190625202` |
| tripwire | ✅ pass (4s) | run `30190625206` |
| frontend-quality | ✅ pass (54s / 55s) | runs `30190595501`, `30190625192` |

**The new tests demonstrably ran — none was skipped.** Baseline `verify-python`
on live `main` `3e1b164` (run `30185095748`) reports **2238 passed, 13 skipped**.
This head reports **2276 passed, 13 skipped**:

- **+38 passed**, exactly matching the 38 statically counted collected cases;
- **skipped unchanged at 13**, so nothing was skipped away behind an optional
  dependency or an import-time side effect;
- **0 failed**, and all 2238 pre-existing cases still pass — no regression, and
  in particular no other suite was disturbed by the import-time logging isolation.

CI's figures supersede the seat-local evidence as the authoritative gate. PR
remains **OPEN, draft, unmerged** — handing back to Jack for audit; merge
authority is Kev's later explicit word only.
