### PR TITLE
fix(event-bus): structural totality for EventSubscriber.recv inbound frames

### DIFF
--- a/scripts/event_bus.py
+++ b/scripts/event_bus.py
@@ -130,6 +130,16 @@ class EventPublisher:
         self.close()
 
 
+# Inbound SUB-side wire boundary. Frames arrive from the network, so their
+# structure is not guaranteed by anything the publisher promises. These refusals
+# are fixed and value-free: none of them may expose a supplied frame count, any
+# frame bytes, a decoding position, or the text of an underlying decode error.
+_WIRE_FRAME_COUNT = 3
+WIRE_FRAME_COUNT_MESSAGE = "event wire message must have exactly three frames"
+TOPIC_DECODE_MESSAGE = "event wire topic frame is not valid UTF-8"
+TIMESTAMP_DECODE_MESSAGE = "event wire timestamp frame is not valid UTF-8"
+
+
 class EventSubscriber:
     """Helper SUB-side wrapper. Primarily used by tests and by future agent
     orchestration code. Production traffic goes through `EventPublisher`
@@ -150,19 +160,69 @@ class EventSubscriber:
         self._closed = False
 
     def recv(self, timeout_ms: int = 1000) -> Optional[tuple[str, str, dict]]:
-        """Return (topic, timestamp, payload) or None on timeout."""
+        """Return (topic, timestamp, payload) or None on timeout.
+
+        The three frames arrive off the network, so their shape is validated
+        here rather than assumed:
+
+        - Exactly `_WIRE_FRAME_COUNT` frames are required. Previously the frame
+          list was tuple-unpacked directly, so a message with zero, one, two or
+          four frames raised Python's own unpacking `ValueError` — whose text
+          reports the supplied frame count — instead of a fixed module refusal.
+        - `topic` and `timestamp` are decoded as strict UTF-8 *before* the
+          payload guard. Previously they were decoded in the `return` expression,
+          outside every guard, so invalid UTF-8 in either metadata frame raised
+          `UnicodeDecodeError` at the caller.
+        - The returned payload is always an exact built-in `dict`. Valid JSON
+          whose top-level value is an array, string, number, boolean or `null`
+          used to be returned as that value, contradicting the declared
+          `tuple[str, str, dict]` contract.
+
+        Metadata refusals are fixed, value-free `ValueError`s raised with
+        `from None`, so no frame bytes, decoding position or underlying
+        `UnicodeDecodeError` text reaches the caller. The `_raw` payload
+        fallback is deliberately unchanged: it is existing observability
+        behaviour, built from the decoded payload TEXT (never from a
+        representation of a decoded Python value).
+
+        No blanket `except` is used, so `MemoryError`, unexpected socket
+        failures and unrelated programming errors still propagate. The claim is
+        bounded to this method's frame structure, metadata UTF-8, and exact-dict
+        payload return shape.
+        """
         if self._closed:
             raise RuntimeError("subscriber is closed")
         self.sock.setsockopt(zmq.RCVTIMEO, timeout_ms)
         try:
-            topic_b, ts_b, data_b = self.sock.recv_multipart()
+            frames = self.sock.recv_multipart()
         except zmq.Again:
             return None
+        if len(frames) != _WIRE_FRAME_COUNT:
+            raise ValueError(WIRE_FRAME_COUNT_MESSAGE)
+        topic_b, ts_b, data_b = frames
         try:
-            payload = json.loads(data_b.decode("utf-8"))
-        except (ValueError, UnicodeDecodeError):
+            topic = topic_b.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(TOPIC_DECODE_MESSAGE) from None
+        try:
+            timestamp = ts_b.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(TIMESTAMP_DECODE_MESSAGE) from None
+        try:
+            payload_text = data_b.decode("utf-8")
+        except UnicodeDecodeError:
             payload = {"_raw": data_b.decode("utf-8", errors="replace")}
-        return topic_b.decode("utf-8"), ts_b.decode("utf-8"), payload
+        else:
+            try:
+                decoded = json.loads(payload_text)
+            except ValueError:
+                payload = {"_raw": payload_text}
+            else:
+                # Only an exact JSON object can satisfy the declared dict
+                # contract; every other valid-JSON shape takes the established
+                # _raw form, built from the already-decoded text.
+                payload = decoded if type(decoded) is dict else {"_raw": payload_text}
+        return topic, timestamp, payload
 
     def close(self) -> None:
         if not self._closed:

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -26,10 +26,13 @@ except ImportError:
     pytest.skip("pyzmq not installed", allow_module_level=True)
 
 from scripts.event_bus import (
+    TIMESTAMP_DECODE_MESSAGE,
+    TOPIC_DECODE_MESSAGE,
     TOPIC_TELEMETRY_5MIN,
     TOPIC_TUNING_COMMITTED,
     TOPIC_TUNING_REJECTED,
     TOPIC_TUNING_ROLLED_BACK,
+    WIRE_FRAME_COUNT_MESSAGE,
     EventPublisher,
     EventSubscriber,
     StateWatcher,
@@ -439,3 +442,256 @@ def test_tuning_state_without_publisher_works(tmp_path):
     )
     entry = state.commit(proposal_id=prop["proposal_id"], approver="human:kevin")
     assert entry["effective_after"]["signal_interval"] == 15
+
+
+# -- EventSubscriber.recv inbound wire-shape totality ------------------------
+#
+# recv() decodes frames that arrive off the network, so their structure is not
+# guaranteed by anything the publisher promises. Before this package it
+# tuple-unpacked the frame list directly, decoded topic/timestamp in the return
+# expression outside every guard, and returned whatever json.loads produced:
+#
+#   - zero, one, two or four frames raised Python's own unpacking ValueError,
+#     whose text reports the SUPPLIED frame count ("expected 3, got 2") rather
+#     than a fixed module refusal;
+#   - invalid UTF-8 in the topic or timestamp frame raised UnicodeDecodeError
+#     carrying the offending byte and its position;
+#   - valid JSON whose top-level value was an array, string, number, boolean or
+#     null was returned as that value, contradicting the declared
+#     Optional[tuple[str, str, dict]].
+#
+# Every case below drives the genuine recv() through a controlled fake socket:
+# no ZMQ context, no socket, no endpoint, no port and no network. The existing
+# in-process PUB/SUB round trips above are untouched and still cover the real
+# transport.
+
+
+class _FakeSocket:
+    """Controlled stand-in for the SUB socket."""
+
+    def __init__(self, frames=None, error=None):
+        self.frames = frames
+        self.error = error
+        self.sockopts = []
+
+    def setsockopt(self, opt, value):
+        self.sockopts.append((opt, value))
+
+    def recv_multipart(self):
+        if self.error is not None:
+            raise self.error
+        return self.frames
+
+
+def _wire_subscriber(frames=None, error=None, closed=False) -> EventSubscriber:
+    """A real EventSubscriber wired to a fake socket.
+
+    Built with `object.__new__` so no context is created, no socket opened and
+    no endpoint connected -- the method under test is the genuine `recv()`, never
+    a replacement.
+    """
+    subscriber = object.__new__(EventSubscriber)
+    subscriber.sock = _FakeSocket(frames=frames, error=error)
+    subscriber._closed = closed
+    return subscriber
+
+
+_WIRE_TOPIC = b"tuning.committed"
+_WIRE_TS = b"2026-07-26T06:00:00Z"
+
+
+def _wire_recv(frames=None, error=None, closed=False):
+    return _wire_subscriber(frames, error, closed).recv()
+
+
+# -- preserved outcomes -------------------------------------------------------
+
+
+def test_wire_valid_three_frame_message_is_unchanged():
+    assert _wire_recv([_WIRE_TOPIC, _WIRE_TS, b'{"a": 1, "b": [2, 3]}']) == (
+        "tuning.committed",
+        "2026-07-26T06:00:00Z",
+        {"a": 1, "b": [2, 3]},
+    )
+
+
+def test_wire_topic_and_timestamp_are_exact_str():
+    topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, b"{}"])
+    assert type(topic) is str and type(timestamp) is str
+    assert topic == "tuning.committed"
+    assert timestamp == "2026-07-26T06:00:00Z"
+
+
+def test_wire_valid_non_ascii_utf8_metadata_is_accepted():
+    """No over-refusal: strict UTF-8 still accepts non-ASCII metadata."""
+    topic, timestamp, payload = _wire_recv(
+        ["tuning.check".encode("utf-8"), "2026-07-26T06:00:00Z✓".encode("utf-8"), b"{}"]
+    )
+    assert topic == "tuning.check"
+    assert timestamp == "2026-07-26T06:00:00Z✓"
+
+
+def test_wire_timeout_still_returns_none():
+    assert _wire_recv(error=zmq.Again()) is None
+
+
+def test_wire_closed_subscriber_still_raises_runtime_error():
+    with pytest.raises(RuntimeError, match="subscriber is closed"):
+        _wire_recv([_WIRE_TOPIC, _WIRE_TS, b"{}"], closed=True)
+
+
+def test_wire_recv_still_applies_the_receive_timeout():
+    subscriber = _wire_subscriber([_WIRE_TOPIC, _WIRE_TS, b"{}"])
+    subscriber.recv(timeout_ms=250)
+    assert (zmq.RCVTIMEO, 250) in subscriber.sock.sockopts
+
+
+@pytest.mark.parametrize(
+    "error",
+    [zmq.ZMQError(), RuntimeError("boom"), OSError("boom"), MemoryError("oom")],
+    ids=["zmq_error", "runtime_error", "os_error", "memory_error"],
+)
+def test_wire_unexpected_socket_error_still_propagates(error):
+    """Only zmq.Again is absorbed; no blanket except was added."""
+    with pytest.raises(type(error)):
+        _wire_recv(error=error)
+
+
+# -- multipart structure ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "frames",
+    [
+        [],
+        [_WIRE_TOPIC],
+        [_WIRE_TOPIC, _WIRE_TS],
+        [_WIRE_TOPIC, _WIRE_TS, b"{}", b"extra"],
+        [_WIRE_TOPIC, _WIRE_TS, b"{}", b"x", b"y"],
+    ],
+    ids=["zero_frames", "one_frame", "two_frames", "four_frames", "five_frames"],
+)
+def test_wire_frame_count_other_than_three_is_refused(frames):
+    with pytest.raises(ValueError) as exc:
+        _wire_recv(frames)
+    assert type(exc.value) is ValueError
+    assert str(exc.value) == WIRE_FRAME_COUNT_MESSAGE
+
+
+def test_wire_frame_count_refusal_names_no_number():
+    """The supplied frame count must not appear -- the fixed message has no digits."""
+    assert not any(character.isdigit() for character in WIRE_FRAME_COUNT_MESSAGE)
+
+
+# -- metadata UTF-8 -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "topic_bytes",
+    [b"\xff", b"\xff\xfe", b"valid\xffinvalid", b"\x80\x81\x82"],
+    ids=["single_bad_byte", "bom_like", "mid_string", "continuation_bytes"],
+)
+def test_wire_invalid_utf8_topic_is_refused(topic_bytes):
+    with pytest.raises(ValueError) as exc:
+        _wire_recv([topic_bytes, _WIRE_TS, b"{}"])
+    assert type(exc.value) is ValueError
+    assert str(exc.value) == TOPIC_DECODE_MESSAGE
+
+
+@pytest.mark.parametrize(
+    "ts_bytes",
+    [b"\xff", b"\xff\xfe", b"2026\xff07", b"\x80\x81\x82"],
+    ids=["single_bad_byte", "bom_like", "mid_string", "continuation_bytes"],
+)
+def test_wire_invalid_utf8_timestamp_is_refused(ts_bytes):
+    with pytest.raises(ValueError) as exc:
+        _wire_recv([_WIRE_TOPIC, ts_bytes, b"{}"])
+    assert type(exc.value) is ValueError
+    assert str(exc.value) == TIMESTAMP_DECODE_MESSAGE
+
+
+def test_wire_metadata_refusals_expose_nothing_supplied():
+    """No frame bytes, frame count, decoding position, representation or
+    underlying UnicodeDecodeError text may reach the caller."""
+    cases = [
+        ([_WIRE_TOPIC, _WIRE_TS], WIRE_FRAME_COUNT_MESSAGE),
+        ([_WIRE_TOPIC, _WIRE_TS, b"{}", b"LEAKFRAME"], WIRE_FRAME_COUNT_MESSAGE),
+        ([b"\xffLEAKTOPIC", _WIRE_TS, b"{}"], TOPIC_DECODE_MESSAGE),
+        ([_WIRE_TOPIC, b"\xffLEAKSTAMP", b"{}"], TIMESTAMP_DECODE_MESSAGE),
+    ]
+    for frames, expected in cases:
+        with pytest.raises(ValueError) as exc:
+            _wire_recv(frames)
+        message = str(exc.value)
+        assert message == expected
+        for token in ("LEAK", "0xff", "0x80", "position", "codec", "unpack",
+                      "expected 3", "invalid start byte"):
+            assert token not in message
+        # The underlying decode error must not be chained into the traceback.
+        assert exc.value.__cause__ is None
+        assert exc.value.__context__ is None or exc.value.__suppress_context__
+
+
+# -- payload result shape is always an exact dict -----------------------------
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        (b'{"a": 1}', {"a": 1}),
+        (b"{}", {}),
+        (b'{"a": {"b": [1, 2]}, "c": null}', {"a": {"b": [1, 2]}, "c": None}),
+    ],
+    ids=["object", "empty_object", "nested_object"],
+)
+def test_wire_json_object_payload_is_returned_unchanged(body, expected):
+    topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, body])
+    assert type(payload) is dict
+    assert payload == expected
+
+
+@pytest.mark.parametrize(
+    "body",
+    [b"[1, 2, 3]", b"[]", b'"text"', b'""', b"42", b"-7", b"3.14", b"0.0",
+     b"true", b"false", b"null"],
+    ids=["array", "empty_array", "string", "empty_string", "integer",
+         "negative_integer", "float", "zero_float", "true", "false", "null"],
+)
+def test_wire_valid_non_object_json_becomes_an_exact_raw_dict(body):
+    """Pre-fix these were returned as list/str/int/float/bool/None."""
+    topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, body])
+    assert type(payload) is dict
+    # Built from the decoded payload TEXT, never a representation of the decoded
+    # Python value: a JSON string keeps its quotes.
+    assert payload == {"_raw": body.decode("utf-8")}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [b"{not json", b"", b"   ", b"{'single': 1}", b"[1,", b'{"a": }'],
+    ids=["brace_text", "empty", "whitespace", "single_quotes", "unclosed_array",
+         "bad_value"],
+)
+def test_wire_malformed_json_preserves_the_raw_fallback(body):
+    topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, body])
+    assert type(payload) is dict
+    assert payload == {"_raw": body.decode("utf-8")}
+
+
+def test_wire_invalid_utf8_payload_preserves_the_replacement_raw_fallback():
+    body = b"\xff\xfe\x00"
+    topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, body])
+    assert type(payload) is dict
+    assert payload == {"_raw": body.decode("utf-8", errors="replace")}
+
+
+def test_wire_every_payload_category_returns_an_exact_dict():
+    """One sweep proving the declared dict contract holds for every shape."""
+    bodies = [
+        b'{"a": 1}', b"{}", b'{"n": {"d": 1}}',
+        b"[1, 2]", b"[]", b'"s"', b"1", b"1.5", b"true", b"false", b"null",
+        b"{not json", b"", b"\xff\xfe",
+    ]
+    for body in bodies:
+        topic, timestamp, payload = _wire_recv([_WIRE_TOPIC, _WIRE_TS, body])
+        assert type(payload) is dict, body


### PR DESCRIPTION
## Event Bus: structural totality for `EventSubscriber.recv()` inbound frames

Bounded Ian-seat package. `recv()` advertises `Optional[tuple[str, str, dict]]`
over a documented three-frame wire layout but validated none of it: it
tuple-unpacked the frame list, decoded metadata outside every guard, and returned
whatever `json.loads` produced. **Draft — do NOT merge.** Merge authority is
Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `26572c0365678416311c440519d519f25a4278f4`
- **head:** `fix/event-subscriber-wire-shape-totality` @ `29f5fe13ceb88dbbe8043744e9e585ca777f8fd4`
- **parent of head:** `26572c0365678416311c440519d519f25a4278f4` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- Live `main` had advanced past my previous handback via merged **#423**, whose diff (`3e1b164..26572c0`) is `scripts/dandelion.py` + `tests/test_dandelion_qr_metadata.py` — Dandelion only, disjoint from this package. It is treated purely as live-main history; no Dandelion work is derived from it.
- `scripts/event_bus.py` was last touched by `dbc6cf0` (#415), which reworked **`StateWatcher`** accounting — not `EventSubscriber`. No open or merged work overlaps either authorized file or already corrects this behaviour.

### Files & diffstat (exactly two permitted files)
```
 scripts/event_bus.py    |  70 +++++++++++-   (+65/-5)
 tests/test_event_bus.py | 256 ++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 321 insertions(+), 5 deletions(-)
```
The production change is confined to `EventSubscriber.recv()` plus three fixed
module message constants and `_WIRE_FRAME_COUNT`.

### Independently reproduced failing-before
Driving the **genuine pre-fix `recv()`** with a controlled fake socket — no ZMQ
context, socket, endpoint, port or network:

| Input | Pre-fix behaviour |
|---|---|
| 0 frames | `ValueError: not enough values to unpack (expected 3, got 0)` |
| 1 frame | `… (expected 3, got 1)` |
| 2 frames | `… (expected 3, got 2)` — **leaks the supplied frame count** |
| 4 / 5 frames | `ValueError: too many values to unpack (expected 3)` |
| topic `b"\xff\xfe"` | `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` |
| timestamp `b"\xff\xfe"` | the same `UnicodeDecodeError` |
| payload `[1,2,3]` | returned as `list` |
| payload `"LEAKSTRING"` | returned as `str` |
| payload `42` / `3.14` | returned as `int` / `float` |
| payload `true` / `false` | returned as `bool` |
| payload `null` | returned as `None` |

None of the frame-count cases produced a fixed module refusal — Python's own
unpacking exceptions escaped, and their text reports the supplied count.

### Exact frame-count rule
`len(frames) != _WIRE_FRAME_COUNT` (3) → refusal, evaluated **before** any
unpacking. Tuple-unpacking is no longer the validator; `topic_b, ts_b, data_b =
frames` runs only after the length is proven.

### Exact fixed refusal messages
| Constant | Message | Exception |
|---|---|---|
| `WIRE_FRAME_COUNT_MESSAGE` | `event wire message must have exactly three frames` | exact `ValueError` |
| `TOPIC_DECODE_MESSAGE` | `event wire topic frame is not valid UTF-8` | exact `ValueError` |
| `TIMESTAMP_DECODE_MESSAGE` | `event wire timestamp frame is not valid UTF-8` | exact `ValueError` |

All three are fixed module constants. The frame-count message **contains no digit
at all**, so no supplied count can appear in it. Both metadata refusals are
raised `from None`, so `__cause__` is `None` and the context is suppressed — the
offending bytes, the decoding position and the original `UnicodeDecodeError` text
never reach the caller.

### Exact-dict payload guarantee
The returned payload is now always an exact built-in `dict`:

- valid JSON **object** → returned unchanged (including `{}` and nested objects);
- **invalid UTF-8** payload bytes → `{"_raw": data.decode("utf-8", errors="replace")}`, unchanged;
- **invalid JSON** → `{"_raw": <decoded text>}`, unchanged;
- **valid JSON that is not an object** → the same `_raw` form, built from the
  already-decoded payload **text**, never from a representation of the decoded
  Python value. A JSON string therefore keeps its quotes: `b'"text"'` →
  `{"_raw": '"text"'}`.

### Preserved `_raw` semantics and other established outcomes
`_raw` is existing intentional observability behaviour and is deliberately exempt
from the value-free metadata rule. The payload is decoded once, so the two
pre-existing `_raw` cases are byte-identical to before. Also preserved verbatim:
`RuntimeError("subscriber is closed")` on a closed subscriber; `zmq.Again` →
`None`; a valid three-frame message returning the same `(topic, timestamp, dict)`;
and the `RCVTIMEO` timeout configuration (verified: `setsockopt(zmq.RCVTIMEO, 250)`
still applied). Non-ASCII but valid UTF-8 metadata is still accepted — no
over-refusal.

### Exception policy
No blanket `except` was added. Only `zmq.Again` is absorbed (unchanged), plus the
explicitly authorized `UnicodeDecodeError` boundaries for topic/timestamp and the
pre-existing payload guard. `MemoryError`, `zmq.ZMQError`, `OSError` and unrelated
programming defects all still propagate — asserted by a dedicated test.

### Tests, failing-first and passing-after
`tests/test_event_bus.py`: **+17 test functions → +47 collected cases** (33
functions / 63 cases total; static AST count, parametrisation expanded, **no
`parametrize` id/value cardinality mismatch**). Appended below the existing
suite; the module-level `pyzmq` gate is retained unchanged.

Covered: valid three-frame exact-dict message; exact-`str` metadata; non-ASCII
UTF-8 metadata accepted; timeout → `None`; closed → established `RuntimeError`;
`RCVTIMEO` still applied; four unexpected socket errors still propagating; zero,
one, two, four and five frames; four invalid-UTF-8 topic byte patterns; four
invalid-UTF-8 timestamp patterns; a hygiene test asserting exact messages with no
leaked token and no chained cause; three JSON-object payloads unchanged; eleven
valid non-object JSON shapes → exact `_raw` dicts; six malformed-JSON bodies →
`_raw` preserved; invalid-UTF-8 payload → replacement `_raw`; and a sweep proving
all fourteen payload categories return an exact `dict`.

**Failing-first is against the real implementation, not a sentinel:** every case
builds the subscriber with `object.__new__` and a fake socket, so the method
exercised is the genuine `recv()`.

### Local evidence (this seat) — separated from CI
**`pyzmq` and `pytest` are both absent on this seat, stated plainly: no test
suite was run locally**, and no pytest substitute was built or claimed
equivalent. Because `scripts/event_bus.py` imports `zmq` at module level, local
probes injected a minimal `zmq` stand-in (only the constants and `Again` the
module actually touches) into `sys.modules` — the `recv()` body itself is genuine
production code. What ran:
1. `compile()` clean on both changed files.
2. Static AST check of the test module (counts + parametrize cardinality above).
3. A direct-invocation harness over the same expectations, both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `26572c0` | 81 | **42** |
| post-fix `29f5fe1` | 81 | **0** |

**Every preserved-behaviour check passes in both states** — valid three-frame
message, exact-`str` metadata, non-ASCII metadata, timeout, closed-subscriber
`RuntimeError`, `RCVTIMEO`, all four error-propagation cases, JSON-object
payloads, malformed-JSON `_raw` and invalid-UTF-8 `_raw` — evidencing that only
the intended behaviour changed.

Scratch probes lived outside the repository and were removed.

### CI / GitHub evidence
See the CI receipt appended below once checks conclude. **CI `verify-python` is
the authoritative gate** (it provisions `pyzmq`); everything above is
seat-produced.

### Residuals and explicit non-claims
- **Bounded claim:** `recv()` multipart structure, metadata UTF-8 and exact-dict
  payload return shape. **Not** whole-module, publisher, `StateWatcher`,
  protocol, authentication, authorization, encryption or payload-schema totality.
- **Topic membership and timestamp ISO syntax are deliberately NOT validated** —
  only wire shape and UTF-8 decoding were authorized. A well-formed frame may
  still carry an unknown topic or a nonsense timestamp.
- **Payload field contents are unvalidated.** An exact JSON object is returned as
  decoded; nested values are arbitrary.
- The `_raw` fallback is lossy by design and can carry attacker-supplied text to
  a consumer — pre-existing intentional observability behaviour, unchanged.
- A caller cannot distinguish "publisher genuinely sent `_raw`-shaped data" from
  "payload was unparseable or non-object". That ambiguity pre-exists and was not
  in scope to change.
- No fourth frame, no protocol redesign, no signing or authenticity check: a
  structurally valid frame is still trusted as to origin.
- `EventPublisher` still serializes with `default=str`, so it can emit a payload
  whose JSON is a non-object only if a caller passes one; publisher behaviour was
  out of scope.
- `zmq.Again` remains the only absorbed socket condition; a genuinely dead socket
  surfaces to the caller exactly as before.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424** and **#425** were verified parked (OPEN, draft,
  unmerged, 0 labels, 0 reviews) and **none was modified**. Their file boundaries
  are disjoint from `scripts/event_bus.py` + `tests/test_event_bus.py`.
- **#420** (Kev-seat) was kept **opaque**: bare number, title, branch identity
  and draft/open identity only. No body, patch, files, checks, comments, reviews
  or threads were inspected.
- **#423** is merged and was used only as live-`main` history; its file list was
  read solely to confirm disjointness.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real external network, no public TCP port
bound. No merge / auto-merge / ready-for-review transition / rebase /
merge-from-main / history rewrite / repository, workflow, protection or settings
change / manual workflow rerun / branch deletion. No comment, review, thread
action, reaction or label. Leave **OPEN, draft, unmerged** and hand back to Jack.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `29f5fe13ceb88dbbe8043744e9e585ca777f8fd4`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m42s) | run `30192462559` / job `89768067739` — **2298 passed, 13 skipped, 0 failed** (45.42s) |
| verify-python (push-triggered run) | ✅ pass (1m35s) | run `30192426358` / job `89767976824` |
| Analyze Python (CodeQL) | ✅ pass (1m2s) | run `30192462570` |
| CodeQL | ✅ pass | job `89768139631` |
| agent-safety | ✅ pass (6s) | run `30192462587` |
| tripwire | ✅ pass (5s) | run `30192462557` |
| frontend-quality | ✅ pass (56s / 54s) | runs `30192426358`, `30192462559` |

**The new tests demonstrably ran, and the pyzmq gate did not skip them.**
Baseline `verify-python` on live `main` `26572c0` (run `30191010631`) reports
**2251 passed, 13 skipped**. This head reports **2298 passed, 13 skipped**:

- **+47 passed**, exactly matching the 47 statically counted new cases;
- **skipped unchanged at 13** — had `pyzmq` been absent in CI the whole module
  would have skipped and the +47 could not have appeared, so this figure is
  positive proof the contract executes in ordinary maintained CI;
- **0 failed**, and all 2251 pre-existing cases still pass — the existing
  `inproc://` PUB/SUB round trips and `StateWatcher` tests are unaffected.

CI's figures supersede the seat-local evidence as the authoritative gate. PR
remains **OPEN, draft, unmerged** — handing back to Jack for audit; merge
authority is Kev's later explicit word only.
