### PR TITLE
fix(geometry-daemon): close snapshot .npz archives at the extraction boundary

### DIFF
--- a/scripts/geometry_daemon.py
+++ b/scripts/geometry_daemon.py
@@ -40,6 +40,42 @@ EXPORT_INTERVAL = 3600    # export geometry at most once per hour
 
 
 # ---------------------------------------------------------------------------
+# Snapshot loading
+# ---------------------------------------------------------------------------
+
+def _load_snapshot(path):
+    """Return (state, memory_grid, generation) with the archive already closed.
+
+    Both load sites previously did `snap = np.load(...)` and then kept the
+    returned `NpzFile` referenced in the calling frame — through the whole
+    export stage in the daemon, and until process teardown in `--once`. The
+    archive's underlying file handle therefore stayed open far longer than the
+    extraction needed, which on Windows can block cleanup, rotation or
+    replacement of that snapshot.
+
+    The `with` block bounds the archive's lifetime to the extraction itself:
+    the three values are materialised as real in-memory objects while the
+    archive is open, and it is closed before this function returns — so the
+    potentially long-running exporters never hold the input handle. Closure is
+    explicit, not left to garbage collection or interpreter shutdown.
+
+    Extraction failures are NOT caught, translated or suppressed: a missing key
+    or a failing `int()` conversion propagates exactly as before, and the `with`
+    block still closes the archive on the way out.
+
+    `allow_pickle=True` and the `str(path)` conversion are preserved verbatim;
+    changing that policy is out of scope. The claim here is archive resource
+    lifetime only — not snapshot validation, archive security, deterministic
+    export or atomic output.
+    """
+    with np.load(str(path), allow_pickle=True) as snap:
+        state = snap["lattice"]
+        memory_grid = snap["memory_grid"]
+        generation = int(snap["generation"])
+    return state, memory_grid, generation
+
+
+# ---------------------------------------------------------------------------
 # Exporters
 # ---------------------------------------------------------------------------
 
@@ -228,11 +264,9 @@ def run_daemon():
 
             print(f"\n  [GEO] New snapshot: {latest.name}")
 
-            # Load snapshot
-            snap = np.load(str(latest), allow_pickle=True)
-            state = snap["lattice"]
-            mg = snap["memory_grid"]
-            gen = int(snap["generation"])
+            # Load snapshot. The archive is closed inside the helper, so it is
+            # already released before any exporter below runs.
+            state, mg, gen = _load_snapshot(latest)
 
             # Export geometry
             t0 = time.time()
@@ -287,10 +321,7 @@ if __name__ == "__main__":
             reverse=True,
         )
         if snapshots:
-            snap = np.load(str(snapshots[0]), allow_pickle=True)
-            state = snap["lattice"]
-            mg = snap["memory_grid"]
-            gen = int(snap["generation"])
+            state, mg, gen = _load_snapshot(snapshots[0])
 
             print(f"Exporting geometry for gen {gen:,}...")
 

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -1,0 +1,449 @@
+"""Tests for `scripts/geometry_daemon.py` snapshot-archive resource lifetime.
+
+Both snapshot load sites previously did `snap = np.load(..., allow_pickle=True)`
+and then left the returned `NpzFile` referenced in the calling frame: through the
+entire export stage in `run_daemon()`, and until process teardown on the
+`--once` path. The archive's underlying file handle therefore stayed open far
+longer than the extraction required, which on Windows can block cleanup,
+rotation or replacement of that snapshot.
+
+`_load_snapshot()` now bounds the archive's lifetime to the extraction itself and
+closes it explicitly before returning — before any exporter runs.
+
+Nothing here touches a real snapshot, engine, printer, STL generation or
+long-running daemon: `np.load` is replaced at the module boundary with a fake
+archive that records context entry/exit and closure, the three exporters are
+recorders, and the clock is deterministic. No `.npz`, CSV, JSON, STL or PNG is
+written anywhere, and the module's import-time `GEO_DIR.mkdir(...)` is isolated
+so the repository's real `data/geometry` directory is never created or modified.
+
+Scope is `.npz` archive resource lifetime only — not snapshot validation, archive
+security, deterministic export, atomic output or whole-daemon correctness.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# `scripts/geometry_daemon.py` runs `GEO_DIR.mkdir(parents=True, exist_ok=True)`
+# at module scope. Patching Path.mkdir for the duration of the import keeps that
+# side effect out of the repository; production directory configuration is
+# unchanged.
+with mock.patch.object(Path, "mkdir"):
+    from scripts import geometry_daemon
+
+
+class Boom(Exception):
+    """Distinct extraction failure, so propagation can be asserted exactly."""
+
+
+class _ExplodingInt:
+    """Materialises as a `generation` value whose int() conversion fails."""
+
+    def __int__(self):
+        raise Boom("generation conversion failed")
+
+
+class _IntLike:
+    """Proves the existing int(...) conversion is still applied."""
+
+    def __int__(self):
+        return 42
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` that `np.load` returns.
+
+    Records context entry/exit, explicit closure and key lookups. Deliberately
+    defines **no** `__del__`, so a recorded closure can never have come from
+    garbage collection or finalisation.
+    """
+
+    def __init__(self, contents=None, raise_on=None):
+        self.contents = {} if contents is None else contents
+        self.raise_on = raise_on
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.lookups = []
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress an extraction failure
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.lookups.append(key)
+        if self.raise_on == key:
+            raise KeyError(key)
+        return self.contents[key]
+
+
+def _good_contents(generation=7):
+    return {
+        "lattice": object(),
+        "memory_grid": object(),
+        "generation": generation,
+    }
+
+
+def _load_with(archive, path="/fake/v070_gen0001000.npz"):
+    """Run the real `_load_snapshot` against `archive`; return the load mock."""
+    loader = mock.Mock(return_value=archive)
+    with mock.patch.object(geometry_daemon.np, "load", loader):
+        result = geometry_daemon._load_snapshot(path)
+    return result, loader
+
+
+# -- helper contract ----------------------------------------------------------
+
+
+def test_helper_returns_the_exact_extracted_objects():
+    contents = _good_contents(generation=7)
+    archive = _FakeArchive(contents)
+    (state, memory_grid, generation), _ = _load_with(archive)
+    assert state is contents["lattice"]
+    assert memory_grid is contents["memory_grid"]
+    assert generation == 7
+    assert type(generation) is int
+
+
+def test_helper_preserves_the_int_generation_conversion():
+    archive = _FakeArchive(_good_contents(generation=_IntLike()))
+    (_, _, generation), _ = _load_with(archive)
+    assert generation == 42
+    assert type(generation) is int
+
+
+def test_helper_calls_np_load_with_the_same_path_conversion_and_allow_pickle():
+    archive = _FakeArchive(_good_contents())
+    _, loader = _load_with(archive, path=Path("/fake/dir/v070_gen42.npz"))
+    assert loader.call_count == 1
+    args, kwargs = loader.call_args
+    assert args == (str(Path("/fake/dir/v070_gen42.npz")),)
+    assert type(args[0]) is str
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_helper_enters_the_archive_context_exactly_once():
+    archive = _FakeArchive(_good_contents())
+    _load_with(archive)
+    assert archive.entered == 1
+
+
+def test_helper_closes_the_archive_exactly_once_on_success():
+    archive = _FakeArchive(_good_contents())
+    _load_with(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_is_already_closed_when_the_helper_returns():
+    """The assertion runs immediately after the return, while this frame still
+    holds a live reference to the archive — so closure was explicit."""
+    archive = _FakeArchive(_good_contents())
+    (state, memory_grid, generation), _ = _load_with(archive)
+    assert archive.closed == 1
+    assert state is not None and generation == 7
+
+
+def test_closure_does_not_depend_on_finalisation():
+    """No `__del__` exists on the fake and the reference stays alive, so a
+    recorded closure cannot have come from garbage collection."""
+    assert not hasattr(_FakeArchive, "__del__")
+    archive = _FakeArchive(_good_contents())
+    _load_with(archive)
+    assert archive.closed == 1
+    assert archive is not None  # still referenced here; nothing was finalised
+
+
+def test_helper_extracts_every_required_key():
+    archive = _FakeArchive(_good_contents())
+    _load_with(archive)
+    assert archive.lookups == ["lattice", "memory_grid", "generation"]
+
+
+# -- closure on every extraction failure --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing_key", ["lattice", "memory_grid", "generation"],
+    ids=["lattice", "memory_grid", "generation"],
+)
+def test_archive_closes_when_a_key_lookup_raises(missing_key):
+    archive = _FakeArchive(_good_contents(), raise_on=missing_key)
+    with pytest.raises(KeyError):
+        _load_with(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_closes_when_the_generation_conversion_raises():
+    archive = _FakeArchive(_good_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom):
+        _load_with(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_original_extraction_exception_propagates_unchanged():
+    """Extraction failures are neither caught, translated nor suppressed."""
+    archive = _FakeArchive(_good_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom) as exc:
+        _load_with(archive)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.closed == 1
+
+    missing = _FakeArchive(_good_contents(), raise_on="lattice")
+    with pytest.raises(KeyError) as exc2:
+        _load_with(missing)
+    assert type(exc2.value) is KeyError
+    assert missing.closed == 1
+
+
+# -- one controlled daemon cycle ----------------------------------------------
+
+
+class _FakeStat:
+    def __init__(self, size, mtime):
+        self.st_size = size
+        self.st_mtime = mtime
+
+
+class _FakeSnapshotPath:
+    def __init__(self, name="v070_gen0001000.npz", size=2_000_000, mtime=100.0):
+        self.name = name
+        self._stat = _FakeStat(size, mtime)
+
+    def stat(self):
+        return self._stat
+
+    def __str__(self):
+        return f"/fake/{self.name}"
+
+
+class _FakeDataDir:
+    def __init__(self, paths):
+        self.paths = list(paths)
+        self.globs = []
+
+    def glob(self, pattern):
+        self.globs.append(pattern)
+        return list(self.paths)
+
+
+class _FakeClock:
+    """Deterministic clock whose sleep ends the daemon loop."""
+
+    def __init__(self, stop_after_sleeps=1, now=10_000.0):
+        self.stop_after = stop_after_sleeps
+        self.now = now
+        self.sleeps = []
+
+    def time(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        if len(self.sleeps) >= self.stop_after:
+            raise KeyboardInterrupt
+
+
+def _run_one_daemon_cycle(archive, tmp_path):
+    """Drive the real `run_daemon()` for one cycle; return the recorded calls.
+
+    Every exporter records the archive's closure count at the moment it is
+    invoked, which is what makes the ordering guarantee observable.
+    """
+    calls = []
+
+    def _recorder(name):
+        def _record(*args):
+            calls.append({"exporter": name, "closed_at_call": archive.closed,
+                          "args": args})
+            return None
+        return _record
+
+    snapshot = _FakeSnapshotPath()
+    data_dir = _FakeDataDir([snapshot])
+    clock = _FakeClock(stop_after_sleeps=1)
+    loader = mock.Mock(return_value=archive)
+
+    with mock.patch.object(geometry_daemon.np, "load", loader), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time", clock), \
+         mock.patch.object(geometry_daemon, "export_sage_pointcloud",
+                           _recorder("csv")), \
+         mock.patch.object(geometry_daemon, "export_voxel_summary",
+                           _recorder("json")), \
+         mock.patch.object(geometry_daemon, "export_stl", _recorder("stl")):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass  # the trailing sleep sits outside the loop's try block
+    return calls, loader, snapshot
+
+
+def test_daemon_cycle_closes_the_archive_before_the_first_exporter(tmp_path):
+    """Central witness. Pre-fix the archive was still open here: every exporter
+    saw closed == 0, because the handle was held for the whole export stage."""
+    contents = _good_contents(generation=1000)
+    archive = _FakeArchive(contents)
+    calls, _, _ = _run_one_daemon_cycle(archive, tmp_path)
+    assert [c["exporter"] for c in calls] == ["csv", "json", "stl"]
+    assert calls[0]["closed_at_call"] == 1, "archive must be closed before export"
+    for call in calls:
+        assert call["closed_at_call"] == 1
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_daemon_cycle_preserves_exporter_order(tmp_path):
+    archive = _FakeArchive(_good_contents(generation=1000))
+    calls, _, _ = _run_one_daemon_cycle(archive, tmp_path)
+    assert [c["exporter"] for c in calls] == ["csv", "json", "stl"]
+
+
+def test_daemon_cycle_passes_the_same_objects_to_every_exporter(tmp_path):
+    contents = _good_contents(generation=1000)
+    archive = _FakeArchive(contents)
+    calls, _, _ = _run_one_daemon_cycle(archive, tmp_path)
+    by_name = {c["exporter"]: c["args"] for c in calls}
+    # export_sage_pointcloud(state, memory_grid, gen, output_dir)
+    assert by_name["csv"][0] is contents["lattice"]
+    assert by_name["csv"][1] is contents["memory_grid"]
+    assert by_name["csv"][2] == 1000
+    assert by_name["csv"][3] == tmp_path
+    # export_voxel_summary(state, memory_grid, gen, output_dir)
+    assert by_name["json"][:3] == by_name["csv"][:3]
+    # export_stl(state, gen, output_dir)
+    assert by_name["stl"][0] is contents["lattice"]
+    assert by_name["stl"][1] == 1000
+    assert by_name["stl"][2] == tmp_path
+
+
+def test_daemon_cycle_loads_with_the_preserved_call_shape(tmp_path):
+    archive = _FakeArchive(_good_contents(generation=1000))
+    _, loader, snapshot = _run_one_daemon_cycle(archive, tmp_path)
+    assert loader.call_count == 1
+    args, kwargs = loader.call_args
+    assert args == (str(snapshot),)
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_daemon_cycle_keeps_the_snapshot_glob_pattern(tmp_path):
+    archive = _FakeArchive(_good_contents(generation=1000))
+    snapshot = _FakeSnapshotPath()
+    data_dir = _FakeDataDir([snapshot])
+    clock = _FakeClock(stop_after_sleeps=1)
+    with mock.patch.object(geometry_daemon.np, "load",
+                           mock.Mock(return_value=archive)), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time", clock), \
+         mock.patch.object(geometry_daemon, "export_sage_pointcloud",
+                           lambda *a: None), \
+         mock.patch.object(geometry_daemon, "export_voxel_summary",
+                           lambda *a: None), \
+         mock.patch.object(geometry_daemon, "export_stl", lambda *a: None):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass
+    assert data_dir.globs == ["v070_gen*.npz"]
+
+
+def test_daemon_skips_tiny_snapshot_without_loading(tmp_path):
+    """The established tiny-file threshold still short-circuits before any load."""
+    archive = _FakeArchive(_good_contents())
+    loader = mock.Mock(return_value=archive)
+    data_dir = _FakeDataDir([_FakeSnapshotPath(size=999_999)])
+    with mock.patch.object(geometry_daemon.np, "load", loader), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time", _FakeClock(stop_after_sleeps=1)):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass
+    assert loader.call_count == 0
+    assert archive.entered == 0
+
+
+# -- both load sites use the helper -------------------------------------------
+
+
+def _module_tree():
+    source = Path(geometry_daemon.__file__).read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _np_load_calls(node):
+    found = []
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        if (isinstance(func, ast.Attribute) and func.attr == "load"
+                and isinstance(func.value, ast.Name) and func.value.id == "np"):
+            found.append(sub)
+    return found
+
+
+def _helper_calls(node):
+    return [
+        sub for sub in ast.walk(node)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+        and sub.func.id == "_load_snapshot"
+    ]
+
+
+def test_module_has_exactly_one_np_load_and_it_is_inside_the_helper():
+    """No second direct archive open survives anywhere in the module."""
+    tree = _module_tree()
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_load_snapshot"
+    )
+    assert len(_np_load_calls(helper)) == 1
+    assert len(_np_load_calls(tree)) == 1  # module-wide: only the helper's
+
+
+def test_daemon_path_uses_the_helper():
+    tree = _module_tree()
+    daemon = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "run_daemon"
+    )
+    assert len(_helper_calls(daemon)) == 1
+    assert _np_load_calls(daemon) == []
+
+
+def test_once_path_uses_the_helper():
+    """The `--once` production path calls the closing helper, not a second load."""
+    tree = _module_tree()
+    main_blocks = [
+        node for node in tree.body
+        if isinstance(node, ast.If) and any(
+            isinstance(sub, ast.Name) and sub.id == "__name__"
+            for sub in ast.walk(node.test)
+        )
+    ]
+    assert len(main_blocks) == 1
+    main_block = main_blocks[0]
+    assert len(_helper_calls(main_block)) == 1
+    assert _np_load_calls(main_block) == []


### PR DESCRIPTION
## Geometry daemon: close snapshot `.npz` archives at the extraction boundary

Bounded Ian-seat package. Both snapshot load sites kept the loaded `NpzFile`
referenced long after extraction — through the whole export stage in the daemon,
and until process teardown on `--once`. **Draft — do NOT merge.** Merge authority
is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `26572c0365678416311c440519d519f25a4278f4`
- **head:** `fix/geometry-snapshot-archive-lifetime` @ `743dd300332d7e8f9208c22ddefb343c026e7996`
- **parent of head:** `26572c0365678416311c440519d519f25a4278f4` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- `scripts/geometry_daemon.py` last touched by `20d232a` (**2026-04-08**, Phase 16); nothing imports it. `tests/test_geometry_daemon.py` did not exist on live `main` and is created here. Both direct `np.load(...)` sites were independently confirmed present at gate time (lines 232 and 290).

### Files & diffstat (exactly two permitted files)
```
 scripts/geometry_daemon.py    |  49 ++++-      (+40/-9)
 tests/test_geometry_daemon.py | 449 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 489 insertions(+), 9 deletions(-)
```

### Independently reproduced failing-before lifetime behaviour
Driving the **genuine pre-fix `run_daemon()`** load path with a fake archive that
records closure (no real snapshot, engine, printer or export):

| Observation | Pre-fix |
|---|---|
| `export_sage_pointcloud` invoked with archive closed? | **no** — recorded `closed == 0` |
| `export_voxel_summary` invoked with archive closed? | **no** — `closed == 0` |
| `export_stl` invoked with archive closed? | **no** — `closed == 0` |
| archive context entered / exited | never entered as a context; never explicitly closed |
| `_load_snapshot` present | absent |
| direct `np.load` calls in module | **2** (daemon + `--once`) |

So the archive was still open across the entire export stage, and on `--once` it
was released only by eventual destruction or process teardown.

**Claim precision, as instructed:** what is demonstrated is **unbounded resource
lifetime relative to the extraction operation** — one archive held open across
export and later polling. This is **not** a claim of an ever-growing number of
simultaneously open archives. No accumulating descriptor leak was proven and none
is asserted.

### Exact helper contract
```python
def _load_snapshot(path):
    with np.load(str(path), allow_pickle=True) as snap:
        state = snap["lattice"]
        memory_grid = snap["memory_grid"]
        generation = int(snap["generation"])
    return state, memory_grid, generation
```
- Opens the archive with a context manager; closes it **before returning**.
- `str(path)` conversion and `allow_pickle=True` preserved verbatim.
- Materialises `lattice`, `memory_grid` and `int(generation)` while open, returning
  the same three values and types the exporters already received.
- Extraction failures are **not** caught, translated or suppressed.

### Success and exceptional closure evidence
| Case | Result |
|---|---|
| successful extraction | `entered == 1`, `exited == 1`, `closed == 1` |
| `lattice` lookup raises | `KeyError` propagates, `closed == 1` |
| `memory_grid` lookup raises | `KeyError` propagates, `closed == 1` |
| `generation` lookup raises | `KeyError` propagates, `closed == 1` |
| `int(generation)` raises | original `Boom` propagates with its exact message, `closed == 1` |

Exception identity is asserted (`type(exc) is Boom`, exact message), so nothing is
translated. Closure is **explicit, not finalisation-dependent**: the fake archive
defines no `__del__` and the asserting frame still holds a live reference when
`closed == 1` is observed.

### Proof that closure precedes every exporter
One controlled daemon cycle records the archive's closure count *at the moment
each exporter is invoked*. Post-fix all three record `closed == 1`; the first
exporter's check is the central witness and fails against the pre-fix module.
Export order is asserted as **CSV → JSON → STL**.

### Proof both load sites use the helper
Structural, over the real parsed module (not a text grep):
- the module contains **exactly one** `np.load` call, and it is inside `_load_snapshot`;
- `run_daemon` contains exactly one `_load_snapshot` call and **zero** `np.load` calls;
- the `if __name__ == "__main__"` block contains exactly one `_load_snapshot` call
  and **zero** `np.load` calls.

The `--once` path lives inside `__main__`, so its use of the helper is proven
structurally rather than by execution; the *behaviour* it now shares is proven by
the helper tests, since it is literally the same function. No `run_once()`
extraction or CLI refactor was performed.

### Valid behaviour preserved
Snapshot glob pattern (asserted: `v070_gen*.npz`), latest-file selection, mtime
ordering, the tiny-file threshold (asserted: a 999 999-byte snapshot is skipped
**without any load**), export cadence, `last_snapshot` / `last_export_time` logic,
exporter call order and arguments (asserted: all three receive the same state and
memory-grid objects by identity and the same integer generation), CSV/JSON/STL
contents, sampling, generation conversion, `allow_pickle=True`, daemon exception
reporting, CLI arguments and defaults, no-snapshot output, output directories, and
every exporter implementation — all untouched.

### Local evidence (this seat) — separated from CI
**`pytest` and `numpy` are both absent on this seat: no test suite was run
locally**, and no pytest substitute was built or claimed equivalent. Probes
injected a minimal `numpy` stand-in whose `load` is replaced by a fake in every
case, so the executed code is the genuine module; `Path.mkdir` was patched during
import so no geometry directory was created. What ran:
1. `compile()` clean on both changed files.
2. Static AST check of the test module: 20 functions → 22 collected cases, **no
   `parametrize` id/value cardinality mismatch**.
3. A direct-execution harness over the same expectations, both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `26572c0` | 15 | **8** (incl. the central witness) |
| post-fix `743dd30` | 28 | **0** |

The pre-fix run executes fewer checks because the helper does not exist there. The
**7 checks that pass pre-fix are exactly the preserved-behaviour ones** — exporter
order, exporter arguments, load call shape, glob pattern and tiny-file skip —
evidencing that only resource lifetime changed.

Scratch probes lived outside the repository and were removed.

### CI / GitHub evidence
See the CI receipt appended below once checks conclude. **CI `verify-python` is the
authoritative gate**; everything above is seat-produced.

### Residuals and explicit non-claims
- **Bounded claim:** `.npz` archive resource lifetime at the extraction boundary.
  **Not** snapshot validation, archive security, deterministic export, atomic
  output or whole-daemon correctness.
- **No accumulating-descriptor-leak claim** (see above) — only lifetime relative
  to extraction.
- `allow_pickle=True` is preserved deliberately and unexamined; a hostile `.npz`
  can still execute pickle payloads. Changing that policy was explicitly out of scope.
- No snapshot schema or content validation: a missing key still raises `KeyError`
  and is reported by the daemon's existing broad `except Exception` handler, whose
  message contents are unchanged.
- The extracted arrays are real in-memory objects after close, so **memory** use
  is unchanged; this package shortens a *handle* lifetime, not a memory footprint.
- The exporters' own file writes are unchanged and remain non-atomic.
- The daemon's own `except Exception` swallow-and-continue behaviour is untouched.
- `--once` closure is proven structurally plus by the shared helper's behavioural
  tests, not by executing the `__main__` block (which would need a real subprocess).
- The Windows-specific consequence (blocked cleanup/rotation/replacement) is stated
  as the *motivation*; it was not reproduced against a real Windows file lock.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424**, **#425** and **#426** were verified parked (OPEN,
  draft, unmerged) and **none was modified**. Their file boundaries are disjoint
  from `scripts/geometry_daemon.py` + `tests/test_geometry_daemon.py`.
- **#420** (Kev-seat) kept **opaque**: bare number, title, branch identity and
  draft/open identity only — no body, patch, files, checks, comments, reviews or
  threads inspected.
- **#423** merged, used only as live-`main` history.
- **#427** appeared on the board during this package; its file boundary was
  checked at identity level only for overlap (`scripts/dandelion.py`,
  `tests/test_dandelion_info_coherence.py` — disjoint), and nothing derives from it.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real Medusa snapshot, engine execution or
geometry export; nothing written inside the repository. No merge / auto-merge /
ready-for-review transition / rebase / merge-from-main / history rewrite /
repository, workflow, protection or settings change / manual workflow rerun /
branch deletion. No comment, review, thread action, reaction or label. No new
dependency. Leave **OPEN, draft, unmerged** and hand back to Jack.

---

### CI receipt (body-only append; all checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `743dd300332d7e8f9208c22ddefb343c026e7996`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m27s) | run `30193976067` / job `89772087447` — **2273 passed, 13 skipped, 0 failed** (43.60s) |
| verify-python (push-triggered run) | ✅ pass (1m39s) | run `30193942108` / job `89771996065` |
| Analyze Python (CodeQL) | ✅ pass (58s) | run `30193976066` |
| CodeQL | ✅ pass | job `89772159700` |
| agent-safety | ✅ pass (10s) | run `30193976087` |
| tripwire | ✅ pass (5s) | run `30193976078` |
| frontend-quality | ✅ pass (1m0s / 51s) | runs `30193942108`, `30193976067` |

**The new tests demonstrably ran — none was skipped.** Baseline `verify-python` on
live `main` `26572c0` (run `30191010631`) reports **2251 passed, 13 skipped**. This
head reports **2273 passed, 13 skipped**:

- **+22 passed**, exactly matching the 22 statically counted collected cases;
- **skipped unchanged at 13**, so nothing was gated away by an optional dependency
  or an import-time side effect;
- **0 failed**, and all 2251 pre-existing cases still pass — the import-time
  `Path.mkdir` isolation disturbed no other suite.

CI's figures supersede the seat-local evidence as the authoritative gate. PR remains
**OPEN, draft, unmerged** — handing back to Jack for audit; merge authority is Kev's
later explicit word only.
