### PR TITLE
fix(observatory): close NPZ snapshot archives at the extraction boundary

### DIFF
--- a/tests/test_observatory_loader.py
+++ b/tests/test_observatory_loader.py
@@ -1,0 +1,484 @@
+"""Focused tests for `vis/observatory/loader.py` NPZ archive resource lifetime.
+
+`load_npz()` used to keep the `NpzFile` returned by `np.load` referenced through
+legacy-grid migration (which imports the engine and can be expensive), the
+fallback zero-padding, both `.astype()` conversions, the metadata lookups and the
+return — released only by eventual object destruction. `load_snapshot_series()`
+calls it once per file, so every series member inherited that behaviour. On
+Windows a retained handle can interfere with deleting, rotating or replacing a
+snapshot.
+
+All five values are now materialised while the archive is open and it closes
+deterministically before any of that later work begins.
+
+Deliberately separate from the rendering-heavy `tests/test_observatory.py`, which
+is untouched: this module needs no matplotlib, loads no real Medusa snapshot and
+runs no visualization. Archive lifecycle is exercised with a closure-recording
+fake, and the legacy-migration path is driven through a controlled stand-in at
+the exact import seam. Nothing is written inside the repository.
+
+Scope is archive resource lifetime relative to extraction — not an indefinitely
+accumulating descriptor leak, not snapshot validation, not migration policy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+
+def _import_loader():
+    """Return the genuine `vis.observatory.loader` module.
+
+    `vis/__init__.py` eagerly imports the matplotlib-backed plotting modules, so
+    a plain import would fail wherever matplotlib is absent — but the loader
+    contract under test needs only NumPy, and this module must not be skipped for
+    a rendering dependency it does not use. Where the plotting stack is present
+    (as in maintained CI) the ordinary import is used and nothing is stubbed.
+    Otherwise minimal namespace packages stand in for `vis` / `vis.observatory`
+    just long enough to load the real `loader.py` from disk, and `sys.modules` is
+    restored afterwards so no later test sees a half-initialised `vis`.
+    """
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        return importlib.import_module("vis.observatory.loader")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    added = []
+    for name, directory in (
+        ("vis", repo_root / "vis"),
+        ("vis.observatory", repo_root / "vis" / "observatory"),
+    ):
+        if name not in sys.modules:
+            package = types.ModuleType(name)
+            package.__path__ = [str(directory)]
+            sys.modules[name] = package
+            added.append(name)
+    try:
+        module = importlib.import_module("vis.observatory.loader")
+    finally:
+        for name in added:
+            sys.modules.pop(name, None)
+        sys.modules.pop("vis.observatory.constants", None)
+        sys.modules.pop("vis.observatory.loader", None)
+    return module
+
+
+loader = _import_loader()
+NUM_CHANNELS = loader.NUM_CHANNELS
+MIGRATION_MODULE = "scripts.continuous_evolution_ca"
+
+
+class Boom(Exception):
+    """Distinct extraction failure, so propagation can be asserted exactly."""
+
+
+class _ExplodingInt:
+    def __int__(self):
+        raise Boom("generation conversion failed")
+
+
+class _ExplodingFloat:
+    def __float__(self):
+        raise Boom("fitness conversion failed")
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` that `np.load` returns.
+
+    Records context entry/exit, explicit closure, key lookups and `.get()` calls.
+    Defines **no** `__del__`, so a recorded closure can never have come from
+    garbage collection or finalisation.
+    """
+
+    def __init__(self, contents=None, raise_on=None, raise_on_get=None):
+        self.contents = {} if contents is None else contents
+        self.raise_on = raise_on
+        self.raise_on_get = raise_on_get
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.lookups = []
+        self.gets = []
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress an extraction failure
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.lookups.append(key)
+        if self.raise_on == key:
+            raise KeyError(key)
+        return self.contents[key]
+
+    def get(self, key, default=None):
+        self.gets.append(key)
+        if self.raise_on_get == key:
+            raise KeyError(key)
+        return self.contents.get(key, default)
+
+
+def _lattice(size=2):
+    return np.arange(size ** 3, dtype=np.uint8).reshape(size, size, size)
+
+
+def _grid(channels=NUM_CHANNELS, size=2):
+    return np.arange(channels * size ** 3, dtype=np.float32).reshape(
+        (channels, size, size, size)
+    )
+
+
+def _contents(**overrides):
+    base = {
+        "lattice": _lattice(),
+        "memory_grid": _grid(),
+        "generation": 1234,
+        "ca_step": 99,
+        "best_fitness": 0.75,
+    }
+    base.update(overrides)
+    return base
+
+
+def _load(archive, path="/fake/v070_gen1.npz"):
+    """Run the real `load_npz` against `archive`; return (snapshot, load mock)."""
+    load_mock = mock.Mock(return_value=archive)
+    with mock.patch.object(loader.np, "load", load_mock):
+        snapshot = loader.load_npz(path)
+    return snapshot, load_mock
+
+
+# -- successful load ----------------------------------------------------------
+
+
+def test_successful_load_returns_the_same_values():
+    contents = _contents()
+    archive = _FakeArchive(contents)
+    snapshot, _ = _load(archive, path="/fake/dir/v070_gen1234.npz")
+    np.testing.assert_array_equal(snapshot.lattice, contents["lattice"])
+    np.testing.assert_array_equal(snapshot.memory_grid, contents["memory_grid"])
+    assert snapshot.generation == 1234
+    assert snapshot.ca_step == 99
+    assert snapshot.best_fitness == 0.75
+    assert snapshot.source_path == str(Path("/fake/dir/v070_gen1234.npz"))
+
+
+def test_dtype_conversions_are_preserved():
+    archive = _FakeArchive(_contents(lattice=_lattice().astype(np.int32),
+                                    memory_grid=_grid().astype(np.float64)))
+    snapshot, _ = _load(archive)
+    assert snapshot.lattice.dtype == np.uint8
+    assert snapshot.memory_grid.dtype == np.float32
+
+
+def test_np_load_receives_str_path_and_allow_pickle():
+    archive = _FakeArchive(_contents())
+    _, load_mock = _load(archive, path=Path("/fake/dir/v070_gen7.npz"))
+    assert load_mock.call_count == 1
+    args, kwargs = load_mock.call_args
+    assert args == (str(Path("/fake/dir/v070_gen7.npz")),)
+    assert type(args[0]) is str
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_metadata_defaults_are_preserved_when_keys_are_absent():
+    archive = _FakeArchive({"lattice": _lattice(), "memory_grid": _grid()})
+    snapshot, _ = _load(archive)
+    assert snapshot.generation == 0
+    assert snapshot.ca_step == 0
+    assert snapshot.best_fitness == 0.0
+    assert type(snapshot.generation) is int
+    assert type(snapshot.ca_step) is int
+    assert type(snapshot.best_fitness) is float
+
+
+def test_metadata_conversions_are_applied():
+    archive = _FakeArchive(_contents(generation=np.int64(5), ca_step=np.int64(6),
+                                     best_fitness=np.float32(0.5)))
+    snapshot, _ = _load(archive)
+    assert type(snapshot.generation) is int and snapshot.generation == 5
+    assert type(snapshot.ca_step) is int and snapshot.ca_step == 6
+    assert type(snapshot.best_fitness) is float and snapshot.best_fitness == 0.5
+
+
+# -- closure on success -------------------------------------------------------
+
+
+def test_archive_context_entered_exactly_once():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.entered == 1
+
+
+def test_archive_closed_exactly_once_on_success():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_already_closed_when_load_npz_returns():
+    """Asserted immediately after the return, while this frame still holds a
+    live reference — so closure was explicit."""
+    archive = _FakeArchive(_contents())
+    snapshot, _ = _load(archive)
+    assert archive.closed == 1
+    assert snapshot.generation == 1234
+
+
+def test_closure_does_not_depend_on_finalisation():
+    """No `__del__` on the fake and the reference stays alive, so the recorded
+    closure cannot have come from reference-count timing or a gc pass. No test
+    here calls gc.collect()."""
+    assert not hasattr(_FakeArchive, "__del__")
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.closed == 1
+    assert archive is not None
+
+
+def test_all_five_values_are_read_while_the_archive_is_open():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.lookups == ["lattice", "memory_grid"]
+    assert archive.gets == ["generation", "ca_step", "best_fitness"]
+
+
+# -- closure on every extraction failure --------------------------------------
+
+
+@pytest.mark.parametrize("missing", ["lattice", "memory_grid"],
+                         ids=["lattice", "memory_grid"])
+def test_archive_closes_when_a_required_lookup_raises(missing):
+    archive = _FakeArchive(_contents(), raise_on=missing)
+    with pytest.raises(KeyError):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize("key", ["generation", "ca_step", "best_fitness"],
+                         ids=["generation", "ca_step", "best_fitness"])
+def test_archive_closes_when_a_metadata_lookup_raises(key):
+    archive = _FakeArchive(_contents(), raise_on_get=key)
+    with pytest.raises(KeyError):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"generation": _ExplodingInt()},
+        {"ca_step": _ExplodingInt()},
+        {"best_fitness": _ExplodingFloat()},
+    ],
+    ids=["generation_int", "ca_step_int", "best_fitness_float"],
+)
+def test_archive_closes_when_a_metadata_conversion_raises(overrides):
+    archive = _FakeArchive(_contents(**overrides))
+    with pytest.raises(Boom):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_original_extraction_exception_propagates_unchanged():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom) as exc:
+        _load(archive)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.closed == 1
+
+    missing = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError) as exc2:
+        _load(missing)
+    assert type(exc2.value) is KeyError
+    assert missing.closed == 1
+
+
+# -- legacy-grid migration ordering (central witness) -------------------------
+
+
+def _legacy_load(archive, migrate=None, import_error=False):
+    """Load a legacy-grid snapshot, driving the migration import seam.
+
+    The engine is never imported or executed: a controlled module stand-in is
+    installed at `scripts.continuous_evolution_ca` for the duration.
+    """
+    calls = []
+
+    def _default_migrate(grid, shape):
+        calls.append({"closed": archive.closed, "grid": grid, "shape": shape})
+        return np.zeros((NUM_CHANNELS,) + tuple(shape), dtype=np.float32)
+
+    migrate_fn = migrate or _default_migrate
+    if import_error:
+        patched = {MIGRATION_MODULE: None}  # `import` of a None entry -> ImportError
+    else:
+        stub = types.ModuleType(MIGRATION_MODULE)
+        stub._migrate_memory_grid = migrate_fn
+        patched = {MIGRATION_MODULE: stub}
+
+    load_mock = mock.Mock(return_value=archive)
+    with mock.patch.dict(sys.modules, patched), \
+         mock.patch.object(loader.np, "load", load_mock):
+        snapshot = loader.load_npz("/fake/legacy.npz")
+    return snapshot, calls
+
+
+def test_archive_is_closed_before_legacy_migration_begins():
+    """Central witness. Pre-fix the archive was still open here: migration was
+    entered with the handle retained (recorded closed == 0)."""
+    archive = _FakeArchive(_contents(memory_grid=_grid(channels=3)))
+    snapshot, calls = _legacy_load(archive)
+    assert len(calls) == 1, "migration seam must have been reached"
+    assert calls[0]["closed"] == 1, "archive must be closed before migration"
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+    assert snapshot.memory_grid.shape == (NUM_CHANNELS, 2, 2, 2)
+
+
+def test_legacy_migration_receives_the_extracted_grid_and_lattice_shape():
+    legacy = _grid(channels=3)
+    archive = _FakeArchive(_contents(memory_grid=legacy))
+    _, calls = _legacy_load(archive)
+    np.testing.assert_array_equal(calls[0]["grid"], legacy)
+    assert tuple(calls[0]["shape"]) == (2, 2, 2)
+
+
+def test_migrated_device_array_result_still_gets_converted_to_numpy():
+    class _FakeDeviceArray:
+        def __init__(self, array):
+            self._array = array
+            self.get_calls = 0
+
+        def get(self):
+            self.get_calls += 1
+            return self._array
+
+    migrated = np.ones((NUM_CHANNELS, 2, 2, 2), dtype=np.float32)
+    device = _FakeDeviceArray(migrated)
+    archive = _FakeArchive(_contents(memory_grid=_grid(channels=5)))
+    snapshot, _ = _legacy_load(archive, migrate=lambda grid, shape: device)
+    assert device.get_calls == 1
+    assert isinstance(snapshot.memory_grid, np.ndarray)
+    assert snapshot.memory_grid.dtype == np.float32
+    np.testing.assert_array_equal(snapshot.memory_grid, migrated)
+    assert archive.closed == 1
+
+
+def test_import_error_fallback_zero_pads_to_eight_channels():
+    legacy = _grid(channels=3)
+    archive = _FakeArchive(_contents(memory_grid=legacy))
+    snapshot, calls = _legacy_load(archive, import_error=True)
+    assert calls == []  # migration never ran
+    assert snapshot.memory_grid.shape == (NUM_CHANNELS, 2, 2, 2)
+    assert snapshot.memory_grid.dtype == np.float32
+    np.testing.assert_array_equal(snapshot.memory_grid[:3], legacy)
+    np.testing.assert_array_equal(
+        snapshot.memory_grid[3:],
+        np.zeros((NUM_CHANNELS - 3, 2, 2, 2), dtype=np.float32),
+    )
+    assert archive.closed == 1
+
+
+def test_eight_channel_grid_skips_migration_entirely():
+    archive = _FakeArchive(_contents())
+    snapshot, calls = _legacy_load(archive)
+    assert calls == []
+    assert snapshot.memory_grid.shape == (NUM_CHANNELS, 2, 2, 2)
+
+
+# -- load_snapshot delegation -------------------------------------------------
+
+
+def test_load_snapshot_delegates_npz_to_the_closing_loader():
+    """Not a patched-away delegation check: the real `load_npz` runs, so the
+    archive closure is observed through `load_snapshot`."""
+    archive = _FakeArchive(_contents())
+    load_mock = mock.Mock(return_value=archive)
+    with mock.patch.object(loader.np, "load", load_mock):
+        snapshot = loader.load_snapshot(Path("/fake/v070_gen1.npz"))
+    assert load_mock.call_count == 1
+    assert archive.closed == 1
+    assert snapshot.generation == 1234
+
+
+# -- load_snapshot_series per-file closure ------------------------------------
+
+
+def _series_dir(tmp_path, names):
+    for name in names:
+        (tmp_path / name).write_bytes(b"")  # np.load is mocked; contents unused
+    return tmp_path
+
+
+def test_series_closes_each_archive_before_the_next_load(tmp_path):
+    directory = _series_dir(tmp_path, ["v070_gen1.npz", "v070_gen2.npz",
+                                       "v070_gen10.npz"])
+    archives = [_FakeArchive(_contents(generation=n)) for n in (1, 2, 10)]
+    issued = []
+    closure_states = []
+
+    def _next_archive(*args, **kwargs):
+        closure_states.append([a.closed for a in issued])
+        archive = archives[len(issued)]
+        issued.append(archive)
+        return archive
+
+    with mock.patch.object(loader.np, "load", side_effect=_next_archive):
+        snapshots = loader.load_snapshot_series(directory)
+
+    assert len(snapshots) == 3
+    # Every previously issued archive was already closed when the next load began.
+    assert closure_states == [[], [1], [1, 1]]
+    assert [a.closed for a in archives] == [1, 1, 1]
+    assert [a.exited for a in archives] == [1, 1, 1]
+    # Established natural ordering is untouched: gen2 before gen10.
+    assert [s.generation for s in snapshots] == [1, 2, 10]
+
+
+def test_series_load_failure_closes_the_failing_archive_and_propagates(tmp_path):
+    directory = _series_dir(tmp_path, ["v070_gen1.npz", "v070_gen2.npz"])
+    first = _FakeArchive(_contents(generation=1))
+    second = _FakeArchive(_contents(), raise_on="lattice")
+    with mock.patch.object(loader.np, "load", side_effect=[first, second]):
+        with pytest.raises(KeyError) as exc:
+            loader.load_snapshot_series(directory)
+    assert type(exc.value) is KeyError
+    assert first.closed == 1
+    assert second.exited == 1
+    assert second.closed == 1
+
+
+def test_series_respects_max_count_without_loading_extra_archives(tmp_path):
+    directory = _series_dir(tmp_path, ["v070_gen1.npz", "v070_gen2.npz",
+                                       "v070_gen3.npz"])
+    archives = [_FakeArchive(_contents(generation=n)) for n in (1, 2)]
+    load_mock = mock.Mock(side_effect=archives)
+    with mock.patch.object(loader.np, "load", load_mock):
+        snapshots = loader.load_snapshot_series(directory, max_count=2)
+    assert len(snapshots) == 2
+    assert load_mock.call_count == 2
+    assert [a.closed for a in archives] == [1, 1]

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -70,13 +70,37 @@ def load_npz(path: str | Path) -> ObservatorySnapshot:
 
     NPZ files contain: lattice, memory_grid, generation, ca_step, best_fitness.
     Auto-migrates old 3-channel or 5-channel memory grids to 8 channels.
+
+    The archive's lifetime is bounded to extraction. Previously the `NpzFile`
+    returned by `np.load` stayed referenced through legacy-grid migration (which
+    imports the engine and can be expensive), the fallback zero-padding, both
+    `.astype()` conversions, the metadata lookups and the return — released only
+    by eventual object destruction. `load_snapshot_series()` calls this function
+    once per file, so every series member inherits that behaviour. A retained
+    handle can interfere with deleting, rotating or replacing a snapshot on
+    Windows.
+
+    All five values are now materialised while the archive is open and it is
+    closed deterministically before any of that later work begins. Extraction
+    failures are not caught, translated or suppressed: a missing key or a failing
+    metadata conversion propagates exactly as before, and the `with` block still
+    closes the archive on the way out. `str(path)`, `allow_pickle=True`, the
+    `0` / `0` / `0.0` metadata defaults and the `int()` / `float()` conversions
+    are preserved verbatim.
+
+    The claim is archive resource lifetime relative to extraction — not an
+    indefinitely accumulating descriptor leak, and not snapshot validation.
     """
     path = Path(path)
-    snap = np.load(str(path), allow_pickle=True)
-    lattice = snap["lattice"]
-    memory_grid = snap["memory_grid"]
+    with np.load(str(path), allow_pickle=True) as snap:
+        lattice = snap["lattice"]
+        memory_grid = snap["memory_grid"]
+        generation = int(snap.get("generation", 0))
+        ca_step = int(snap.get("ca_step", 0))
+        best_fitness = float(snap.get("best_fitness", 0.0))
 
-    # Auto-migrate old memory grid formats
+    # Auto-migrate old memory grid formats. The archive is already closed here,
+    # so neither the engine import nor the migration retains the file handle.
     if memory_grid.shape[0] != NUM_CHANNELS:
         try:
             from scripts.continuous_evolution_ca import _migrate_memory_grid
@@ -96,9 +120,9 @@ def load_npz(path: str | Path) -> ObservatorySnapshot:
     return ObservatorySnapshot(
         lattice=lattice.astype(np.uint8),
         memory_grid=memory_grid.astype(np.float32),
-        generation=int(snap.get("generation", 0)),
-        ca_step=int(snap.get("ca_step", 0)),
-        best_fitness=float(snap.get("best_fitness", 0.0)),
+        generation=generation,
+        ca_step=ca_step,
+        best_fitness=best_fitness,
         source_path=str(path),
     )
 


### PR DESCRIPTION
## Observatory loader: close NPZ snapshot archives at the extraction boundary

Bounded Ian-seat package. `load_npz()` held the loaded `NpzFile` through legacy
migration, the engine import, the fallback zero-padding, both dtype conversions,
the metadata lookups and the return — with no explicit close.
**Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `26572c0365678416311c440519d519f25a4278f4`
- **head:** `fix/observatory-npz-archive-lifetime` @ `dbb2ba150f084db2ce72db5da16eeb5d4be4d6f1`
- **parent of head:** `26572c0365678416311c440519d519f25a4278f4` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- `vis/observatory/loader.py` last touched by `7085b98` (#302, 2026-07-08). `tests/test_observatory_loader.py` did not exist and is created here. The direct `np.load(...)` without closure was independently confirmed present at gate time (line 75).

### Files & diffstat (exactly two permitted files)
```
 vis/observatory/loader.py        |  40 +++-   (+32/-8)
 tests/test_observatory_loader.py | 484 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 516 insertions(+), 8 deletions(-)
```
The production correction is inside `load_npz()` only.

### Independently reproduced failing-before behaviour
Running the **genuine pre-fix `load_npz()`** with a closure-recording fake archive
and a controlled stand-in at the `scripts.continuous_evolution_ca` import seam
(the engine is never imported or executed):

| Path | Pre-fix |
|---|---|
| legacy-grid migration entered | **archive still open** — recorded `closed == 0` |
| successful load | never entered as a context; never explicitly closed |
| `lattice` / `memory_grid` lookup raises | exception propagates, archive **not** closed |
| `generation` / `ca_step` / `best_fitness` lookup raises | same |
| `int()` / `float()` conversion raises | same |
| device-array migration path | archive **not** closed |
| ImportError zero-pad fallback | archive **not** closed |
| `load_snapshot` → `.npz` | archive **not** closed |
| `load_snapshot_series` (3 files) | **no** archive closed before the next load began |

**19 of 42 pre-fix checks fail**, including the central migration-ordering witness.

**Claim precision, as instructed:** what is demonstrated is **resource lifetime
relative to extraction**. No indefinitely accumulating descriptor leak was
demonstrated and none is claimed.

### The correction
```python
with np.load(str(path), allow_pickle=True) as snap:
    lattice = snap["lattice"]
    memory_grid = snap["memory_grid"]
    generation = int(snap.get("generation", 0))
    ca_step = int(snap.get("ca_step", 0))
    best_fitness = float(snap.get("best_fitness", 0.0))
```
The three metadata reads moved out of the `ObservatorySnapshot(...)` call — where
they previously forced the archive to stay open past migration and both
`.astype()` calls — into the `with` block. Their values, defaults and conversions
are unchanged.

### Successful and exceptional closure evidence
| Case | Result |
|---|---|
| success | `entered == 1`, `exited == 1`, `closed == 1`, closed when `load_npz` returns |
| `lattice` lookup raises | `KeyError` propagates, `closed == 1` |
| `memory_grid` lookup raises | `KeyError` propagates, `closed == 1` |
| `generation` / `ca_step` / `best_fitness` lookup raises | `KeyError` propagates, `closed == 1` |
| `int(generation)` / `int(ca_step)` / `float(best_fitness)` raises | original `Boom` propagates with exact message, `closed == 1` |
| device-array migration | `closed == 1`, `.get()` called once |
| ImportError fallback | `closed == 1` |

Exception identity is asserted (`type(exc) is Boom`, exact message text), so
nothing is caught, translated or suppressed. **Closure is explicit, not
finalisation-dependent:** the fake archive defines no `__del__`, the asserting
frame holds a live reference when `closed == 1` is observed, and no test calls
`gc.collect()`.

### Proof closure precedes legacy migration and dtype conversion
The migration stand-in records the archive's closure count **at the moment it is
invoked**; post-fix it records `closed == 1`, and that is the check that fails
against the pre-fix module. Both `.astype()` conversions and the
`ObservatorySnapshot` construction happen after the `with` block has exited, and
the `.astype` calls are asserted (`lattice → uint8`, `memory_grid → float32`).

### Metadata-default preservation
Absent keys still yield `generation == 0`, `ca_step == 0`, `best_fitness == 0.0`
with types `int`, `int`, `float`; present keys still pass through `int()`/`float()`
(asserted with `np.int64` / `np.float32` inputs); `source_path == str(path)`.

### Migration and series-load preservation
- Legacy 3-channel and 5-channel grids still reach `_migrate_memory_grid` with the
  extracted grid and `lattice.shape`.
- A migration result that is not an `ndarray` still receives `.get()` and becomes
  NumPy `float32`.
- The ImportError fallback still produces the established eight-channel
  zero-padded grid with the legacy channels copied and the remainder zero.
- An eight-channel grid still skips migration entirely.
- `load_snapshot()` still routes `.npz` to this loader — asserted through the
  **real** `load_npz`, so the closure is observed via `load_snapshot`.
- `load_snapshot_series()` is **not modified**; it inherits per-file closure.
  Asserted: with three files, every previously issued archive was already closed
  when the next load began (`[[], [1], [1, 1]]`), all closed exactly once, and the
  established natural ordering (`gen2` before `gen10`) is intact. A mid-series
  failure closes both the failing and the earlier archive and propagates the
  original `KeyError`. `max_count` still stops further loads.

### Tests
`tests/test_observatory_loader.py` (new, focused): **23 test functions → 28
collected cases** (static AST count; **no `parametrize` id/value cardinality
mismatch**). Deliberately separate from the rendering-heavy
`tests/test_observatory.py`, which is **not modified**.

**Not module-level skipped for matplotlib.** `vis/__init__.py` eagerly imports the
matplotlib-backed plotting modules, so a plain import would fail wherever that
stack is absent — but this loader contract needs only NumPy. Where matplotlib is
present (as in CI) the **ordinary import** is used and nothing is stubbed;
otherwise minimal namespace stand-ins for `vis` / `vis.observatory` load the real
`loader.py` from disk and `sys.modules` is restored afterwards, so no later test
sees a half-initialised `vis`.

No real Medusa snapshot, engine or visualization runs; the engine is replaced at
its exact import seam via scoped `mock.patch.dict(sys.modules, ...)`; nothing is
written inside the repository (series tests use `tmp_path`).

### Local evidence (this seat) — separated from CI
**`pytest` and `numpy` are both absent on this seat: no test suite was run
locally**, and no pytest substitute was built or claimed equivalent. Probes
injected a minimal `numpy` stand-in serving the array operations `load_npz`
performs (`.shape`, `.astype`, `zeros`, `isinstance(..., ndarray)`) with `load`
replaced per case, so the executed code is the genuine loader. What ran:
1. `compile()` clean on both changed files.
2. Static AST check: 23 functions → 28 cases, no `parametrize` mismatch.
3. A direct-execution harness over the same expectations, both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `26572c0` | 42 | **19** (incl. the central witness) |
| post-fix `dbb2ba1` | 42 | **0** |

**Every preserved-behaviour check passes in both states** — returned values,
`source_path`, dtype conversions, `np.load` call shape, metadata defaults and
conversions, exception identity, migration inputs, device-array `.get()`,
ImportError fallback, eight-channel skip, series ordering and series failure
propagation — evidencing that only resource lifetime changed.

Scratch probes lived outside the repository and were removed.

### CI / GitHub evidence
See the CI receipt appended below once checks conclude. **CI `verify-python` is
the authoritative gate**; everything above is seat-produced.

### Residuals and explicit non-claims
- **Bounded claim:** NPZ archive resource lifetime relative to extraction. **Not**
  snapshot validation, archive security, migration policy, deterministic export or
  whole-Observatory correctness.
- **No accumulating-descriptor-leak claim** (see above).
- `allow_pickle=True` is preserved deliberately and unexamined — a hostile `.npz`
  can still execute pickle payloads. Explicitly out of scope.
- Extracted arrays remain real in-memory objects after close, so **memory** use is
  unchanged; this shortens a *handle* lifetime, not a footprint.
- No schema validation: a missing `lattice`/`memory_grid` still raises `KeyError`
  with unchanged message contents.
- `load_genome` (JSON path) is untouched and has no archive to close.
- `load_snapshot_series` still loads eagerly into a list; nothing about its memory
  profile or ordering changed.
- The Windows consequence (blocked delete/rotate/replace) is stated as the
  *motivation*; it was **not** reproduced against a real Windows file lock.
- The `numpy` stand-in means real `NpzFile.__exit__` semantics were exercised only
  in CI; locally the context-manager protocol was driven by a fake.
- The focused module's namespace-stub import path engages only where matplotlib is
  absent; in CI it is not exercised.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424**, **#425**, **#426** and **#428** were verified parked
  (OPEN, draft, unmerged) and **none was modified**. Their file boundaries are
  disjoint from `vis/observatory/loader.py` + `tests/test_observatory_loader.py`.
- **#420** and **#427** (Kev-seat) kept **opaque**: bare number, title, branch
  identity and draft/open identity only — no body, patch, files, checks, comments,
  reviews or threads inspected, and nothing here derives from them.
- **#423** merged, used only as live-`main` history.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real Medusa snapshot, engine or
visualization execution; nothing written inside the repository. No merge /
auto-merge / ready-for-review transition / rebase / merge-from-main / history
rewrite / repository, workflow, protection or settings change / manual workflow
rerun / branch deletion. No comment, review, thread action, reaction or label. The
existing Observatory tests are untouched. Leave **OPEN, draft, unmerged** and hand
back to Jack.

---

### CI receipt (body-only append; all registered checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `dbb2ba150f084db2ce72db5da16eeb5d4be4d6f1`. No workflow was manually rerun.

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m22s) | run `30196440697` / job `89778703314` — **2279 passed, 13 skipped, 0 failed** (41.19s) |
| verify-python (push-triggered run) | ✅ pass (1m26s) | run `30196411090` / job `89778627181` |
| agent-safety | ✅ pass (7s) | run `30196440705` |
| tripwire | ✅ pass (5s) | run `30196440708` |
| frontend-quality | ✅ pass (55s ×2) | runs `30196411090`, `30196440697` |

**Reported precisely: the status rollup contains 6 entries, all `COMPLETED /
SUCCESS`, none pending.** Unlike #428, **`CodeQL` / `Analyze Python` did not
register on this PR** — that is an observed fact about which checks were
triggered for this file set (`vis/**` + `tests/**`), not a failure and not a
skipped requirement. I did not inspect the workflow definitions to determine
why, since workflow files are outside this package's boundary. Flagging it for
Jack rather than drawing a conclusion.

**The new tests demonstrably ran — none was skipped.** Baseline `verify-python`
on live `main` `26572c0` (run `30191010631`) reports **2251 passed, 13 skipped**.
This head reports **2279 passed, 13 skipped**:

- **+28 passed**, exactly matching the 28 statically counted collected cases;
- **skipped unchanged at 13** — positive proof the focused module was **not**
  module-level skipped for matplotlib, and that its import path did not disturb
  the existing matplotlib-gated `tests/test_observatory.py`;
- **0 failed**, and all 2251 pre-existing cases still pass.

CI's figures supersede the seat-local evidence as the authoritative gate. PR
remains **OPEN, draft, unmerged** — handing back to Jack for audit; merge
authority is Kev's later explicit word only.
