### PR TITLE
fix(medusa-api): close the shared snapshot archive at the extraction boundary

### DIFF
--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -74,14 +74,38 @@ def _find_latest_snapshot():
 
 
 def _load_snapshot(path):
-    """Load a snapshot and return (state, memory_grid, gen, fitness)."""
-    snap = np.load(str(path), allow_pickle=True)
-    return (
-        snap["lattice"],
-        snap["memory_grid"],
-        int(snap["generation"]),
-        float(snap["best_fitness"]),
-    )
+    """Load a snapshot and return (state, memory_grid, gen, fitness).
+
+    This helper is shared by ``/api/census``, ``/api/equanimity``,
+    ``/api/acoustic`` (when no saved map is used) and ``/api/geometry/stl``.
+    Previously it returned while the ``NpzFile`` from ``np.load`` was still
+    referenced, so the archive stayed open through whatever the calling endpoint
+    did next — census counting and entropy, equanimity masks and elder sorting,
+    acoustic sector reshaping, geometry sampling and mesh construction — and was
+    released only by eventual object destruction. Every request repeated that.
+    On Windows a retained snapshot handle can interfere with deleting, rotating
+    or replacing that file.
+
+    The four values are now materialised while the archive is open and it is
+    closed before the ``return`` executes, so no endpoint computation holds the
+    input handle. Closure is explicit rather than left to garbage collection.
+
+    Extraction is not guarded: a missing key or a failing ``int()`` / ``float()``
+    conversion propagates exactly as before, and the ``with`` block still closes
+    the archive on the way out. ``str(path)``, ``allow_pickle=True``, the
+    required-key semantics, the extraction order, both conversions and the tuple
+    order are preserved verbatim.
+
+    The claim is archive resource lifetime relative to extraction — not an
+    indefinitely accumulating descriptor leak, not snapshot validation, endpoint
+    totality, API authentication or atomic file access.
+    """
+    with np.load(str(path), allow_pickle=True) as snap:
+        lattice = snap["lattice"]
+        memory_grid = snap["memory_grid"]
+        generation = int(snap["generation"])
+        best_fitness = float(snap["best_fitness"])
+    return (lattice, memory_grid, generation, best_fitness)
 
 
 def _read_engine_log():

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -1,0 +1,428 @@
+"""Focused tests for `scripts/medusa_api._load_snapshot()` archive lifetime.
+
+The shared snapshot helper used to return while the `NpzFile` from `np.load` was
+still referenced, so the archive stayed open through whatever the calling
+endpoint did next — census counting and entropy, equanimity masks and elder
+sorting, acoustic sector reshaping, geometry sampling and mesh construction — and
+was released only by eventual object destruction. Every request repeated that. On
+Windows a retained snapshot handle can interfere with deleting, rotating or
+replacing that file.
+
+The helper now materialises all four values while the archive is open and closes
+it before returning.
+
+Deliberately separate from `tests/test_medusa_api.py`, which is untouched. No
+real snapshot, engine, event bus, socket, network port, Flask server, STL or
+telemetry file is involved: the module is imported inside a scoped
+`MEDUSA_EVENT_BUS_DISABLED=1` override (restored immediately), `np.load` is
+replaced by a closure-recording fake, and the one endpoint witness uses Flask's
+in-process test client.
+
+Scope is archive resource lifetime relative to extraction — not snapshot
+validation, archive security, endpoint totality, API authentication, atomic file
+access or whole-server correctness.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("flask")  # optional dependency for the REST API; CI provisions it
+
+# Record the ambient environment before the scoped import so a test can prove the
+# override restored it exactly — including the originally-absent case.
+_EVENT_BUS_ENV_KEY = "MEDUSA_EVENT_BUS_DISABLED"
+_ENV_BEFORE_IMPORT = os.environ.get(_EVENT_BUS_ENV_KEY)
+
+# Disable the event-bus PUB socket / StateWatcher thread ONLY for the duration of
+# the import, then restore the exact prior environment. `patch.dict` leaks
+# nothing into the rest of the pytest process, so no port is bound and no watcher
+# thread starts.
+with mock.patch.dict(os.environ, {_EVENT_BUS_ENV_KEY: "1"}):
+    from scripts import medusa_api  # noqa: E402  (import inside the scoped override)
+
+_ENV_AFTER_IMPORT = os.environ.get(_EVENT_BUS_ENV_KEY)
+
+
+class Boom(Exception):
+    """Distinct conversion failure, so propagation can be asserted exactly."""
+
+
+class _ExplodingInt:
+    def __int__(self):
+        raise Boom("generation conversion failed")
+
+
+class _ExplodingFloat:
+    def __float__(self):
+        raise Boom("fitness conversion failed")
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` that `np.load` returns.
+
+    Records context entry/exit, explicit closure and key lookups. Defines **no**
+    `__del__`, so a recorded closure can never have come from garbage collection,
+    reference-count timing or interpreter shutdown.
+    """
+
+    def __init__(self, contents=None, raise_on=None):
+        self.contents = {} if contents is None else contents
+        self.raise_on = raise_on
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.lookups = []
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress an extraction failure
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.lookups.append(key)
+        if self.raise_on == key:
+            raise KeyError(key)
+        return self.contents[key]
+
+
+class _FakeSnapshotPath:
+    def __init__(self, name="v070_gen0001000.npz"):
+        self.name = name
+
+    def __str__(self):
+        return f"/fake/data/{self.name}"
+
+
+def _lattice():
+    # A tiny deterministic lattice with several states, so census is meaningful.
+    grid = np.zeros((4, 4, 4), dtype=np.uint8)
+    grid[0, 0, 0] = 1
+    grid[0, 0, 1] = 2
+    grid[0, 0, 2] = 2
+    grid[0, 0, 3] = 3
+    return grid
+
+
+def _memory_grid():
+    return np.zeros((8, 4, 4, 4), dtype=np.float32)
+
+
+def _contents(**overrides):
+    base = {
+        "lattice": _lattice(),
+        "memory_grid": _memory_grid(),
+        "generation": 1234,
+        "best_fitness": 0.875,
+    }
+    base.update(overrides)
+    return base
+
+
+def _load(archive, path=None):
+    """Run the real `_load_snapshot` against `archive`; return (result, mock)."""
+    load_mock = mock.Mock(return_value=archive)
+    target = path if path is not None else _FakeSnapshotPath()
+    with mock.patch.object(medusa_api.np, "load", load_mock):
+        result = medusa_api._load_snapshot(target)
+    return result, load_mock
+
+
+# -- import-time containment --------------------------------------------------
+
+
+def test_event_bus_env_override_was_scoped_to_the_import():
+    """The override must not leak: the ambient value is exactly as before."""
+    assert _ENV_AFTER_IMPORT == _ENV_BEFORE_IMPORT
+    assert os.environ.get(_EVENT_BUS_ENV_KEY) == _ENV_BEFORE_IMPORT
+
+
+def test_no_event_publisher_or_watcher_was_started():
+    """Import under the override binds no PUB socket and starts no thread."""
+    assert getattr(medusa_api, "_event_publisher", None) is None
+    assert getattr(medusa_api, "_state_watcher", None) is None
+
+
+# -- successful helper load ---------------------------------------------------
+
+
+def test_helper_returns_the_exact_objects_and_tuple_order():
+    contents = _contents()
+    archive = _FakeArchive(contents)
+    result, _ = _load(archive)
+    assert isinstance(result, tuple) and len(result) == 4
+    state, memory_grid, generation, fitness = result
+    assert state is contents["lattice"]            # identity, not a copy
+    assert memory_grid is contents["memory_grid"]  # identity, not a copy
+    assert generation == 1234
+    assert fitness == 0.875
+
+
+def test_generation_is_an_exact_builtin_int():
+    archive = _FakeArchive(_contents(generation=np.int64(4242)))
+    (_, _, generation, _), _ = _load(archive)
+    assert type(generation) is int
+    assert generation == 4242
+
+
+def test_fitness_is_an_exact_builtin_float():
+    archive = _FakeArchive(_contents(best_fitness=np.float32(0.5)))
+    (_, _, _, fitness), _ = _load(archive)
+    assert type(fitness) is float
+    assert fitness == 0.5
+
+
+def test_extraction_order_is_preserved():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.lookups == ["lattice", "memory_grid", "generation", "best_fitness"]
+
+
+def test_np_load_receives_str_path_and_allow_pickle():
+    archive = _FakeArchive(_contents())
+    path = _FakeSnapshotPath("v070_gen42.npz")
+    _, load_mock = _load(archive, path=path)
+    assert load_mock.call_count == 1
+    args, kwargs = load_mock.call_args
+    assert args == (str(path),)
+    assert type(args[0]) is str
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_returned_arrays_keep_their_dtypes():
+    contents = _contents()
+    archive = _FakeArchive(contents)
+    (state, memory_grid, _, _), _ = _load(archive)
+    assert state.dtype == np.uint8
+    assert memory_grid.dtype == np.float32
+
+
+# -- closure on success -------------------------------------------------------
+
+
+def test_archive_context_entered_exactly_once():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.entered == 1
+
+
+def test_archive_exits_and_closes_exactly_once_on_success():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_already_closed_when_helper_returns():
+    """Asserted immediately after the return, while this frame still holds a live
+    reference to the archive — so closure was explicit."""
+    archive = _FakeArchive(_contents())
+    result, _ = _load(archive)
+    assert archive.closed == 1
+    assert result[2] == 1234
+
+
+def test_closure_does_not_depend_on_finalisation():
+    """No `__del__` on the fake and the reference stays alive, so the recorded
+    closure cannot come from reference-count timing, a gc pass or interpreter
+    shutdown. No test here calls gc.collect()."""
+    assert not hasattr(_FakeArchive, "__del__")
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.closed == 1
+    assert archive is not None
+
+
+# -- closure on every extraction / conversion failure -------------------------
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["lattice", "memory_grid", "generation", "best_fitness"],
+    ids=["lattice", "memory_grid", "generation", "best_fitness"],
+)
+def test_archive_closes_when_a_key_lookup_raises(missing):
+    archive = _FakeArchive(_contents(), raise_on=missing)
+    with pytest.raises(KeyError):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"generation": _ExplodingInt()}, {"best_fitness": _ExplodingFloat()}],
+    ids=["generation_int", "best_fitness_float"],
+)
+def test_archive_closes_when_a_conversion_raises(overrides):
+    archive = _FakeArchive(_contents(**overrides))
+    with pytest.raises(Boom):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_original_extraction_exception_propagates_unchanged():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom) as exc:
+        _load(archive)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.closed == 1
+
+    fitness_bad = _FakeArchive(_contents(best_fitness=_ExplodingFloat()))
+    with pytest.raises(Boom) as exc2:
+        _load(fitness_bad)
+    assert str(exc2.value) == "fitness conversion failed"
+    assert fitness_bad.closed == 1
+
+    missing = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError) as exc3:
+        _load(missing)
+    assert type(exc3.value) is KeyError
+    assert missing.closed == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("archive read failed"), RuntimeError("boom"), MemoryError("oom"),
+     ValueError("bad zip")],
+    ids=["os_error", "runtime_error", "memory_error", "value_error"],
+)
+def test_unrelated_load_failure_is_not_converted_into_a_lifetime_refusal(error):
+    """No blanket except was added: an `np.load` failure of any kind propagates
+    unchanged rather than becoming a snapshot-lifetime error."""
+    load_mock = mock.Mock(side_effect=error)
+    with mock.patch.object(medusa_api.np, "load", load_mock):
+        with pytest.raises(type(error)) as exc:
+            medusa_api._load_snapshot(_FakeSnapshotPath())
+    assert type(exc.value) is type(error)
+    assert str(exc.value) == str(error)
+
+
+# -- endpoint witness: closure precedes downstream computation ----------------
+
+
+def test_census_request_sees_the_archive_closed_before_first_numpy_work():
+    """Central witness. `/api/census`'s first downstream NumPy computation is
+    `np.unique(state, ...)`; pre-fix the archive was still open at that point,
+    because the helper returned it unclosed."""
+    contents = _contents()
+    archive = _FakeArchive(contents)
+    snapshot = _FakeSnapshotPath()
+    real_unique = np.unique
+    closure_at_first_unique = []
+
+    def _recording_unique(*args, **kwargs):
+        closure_at_first_unique.append(archive.closed)
+        return real_unique(*args, **kwargs)
+
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: snapshot), \
+         mock.patch.object(medusa_api.np, "load", mock.Mock(return_value=archive)), \
+         mock.patch.object(medusa_api.np, "unique", _recording_unique):
+        response = client.get("/api/census")
+
+    assert response.status_code == 200
+    assert closure_at_first_unique, "downstream NumPy work must have been reached"
+    assert closure_at_first_unique[0] == 1, "archive must be closed before census work"
+    assert all(count == 1 for count in closure_at_first_unique)
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_census_response_body_is_unchanged():
+    """The valid response is computed from the extracted arrays exactly as before."""
+    archive = _FakeArchive(_contents())
+    snapshot = _FakeSnapshotPath("v070_gen0001000.npz")
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: snapshot), \
+         mock.patch.object(medusa_api.np, "load", mock.Mock(return_value=archive)):
+        response = client.get("/api/census")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["generation"] == 1234
+    assert payload["lattice_size"] == 4
+    assert payload["total_cells"] == 64
+    assert payload["non_void"] == 4
+    assert payload["states"] == {"VOID": 60, "STRUCTURAL": 1, "COMPUTE": 2, "ENERGY": 1}
+    assert payload["fitness"] == 0.875
+    assert payload["snapshot"] == "v070_gen0001000.npz"
+    assert archive.closed == 1
+
+
+def test_census_without_a_snapshot_still_returns_404_without_loading():
+    load_mock = mock.Mock()
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: None), \
+         mock.patch.object(medusa_api.np, "load", load_mock):
+        response = client.get("/api/census")
+    assert response.status_code == 404
+    assert load_mock.call_count == 0
+
+
+# -- the helper remains the shared path --------------------------------------
+
+
+def _module_tree():
+    source = Path(medusa_api.__file__).read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _calls_named(node, name):
+    return [
+        sub for sub in ast.walk(node)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+        and sub.func.id == name
+    ]
+
+
+def _np_load_calls(node):
+    return [
+        sub for sub in ast.walk(node)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+        and sub.func.attr == "load" and isinstance(sub.func.value, ast.Name)
+        and sub.func.value.id == "np"
+    ]
+
+
+def test_module_has_exactly_one_np_load_and_it_is_inside_the_helper():
+    tree = _module_tree()
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_load_snapshot"
+    )
+    assert len(_np_load_calls(helper)) == 1
+    assert len(_np_load_calls(tree)) == 1  # no second direct archive open anywhere
+
+
+def test_all_four_endpoints_still_use_the_shared_helper():
+    """census, equanimity, acoustic and geometry_stl remain the only callers."""
+    tree = _module_tree()
+    callers = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and _calls_named(node, "_load_snapshot")
+    }
+    assert callers == {"census", "equanimity", "acoustic", "geometry_stl"}
+    for name in callers:
+        function = next(
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == name
+        )
+        assert _np_load_calls(function) == []  # each goes through the helper only


### PR DESCRIPTION
## Medusa REST API: close the shared snapshot archive at the extraction boundary

Bounded Ian-seat package. `_load_snapshot()` returned while the loaded `NpzFile`
was still referenced, so the archive stayed open through whatever the calling
endpoint did next — for all four of its live callers, on every request.
**Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `26572c0365678416311c440519d519f25a4278f4`
- **head:** `fix/medusa-api-npz-archive-lifetime` @ `28d7e180057b3ddee04c8900b4f45e83343a341f`
- **parent of head:** `26572c0365678416311c440519d519f25a4278f4` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- The direct `np.load(...)` without closure was independently confirmed at `medusa_api.py:78` at gate time. `tests/test_medusa_api_snapshot_loader.py` did not exist and is created here.

### Files & diffstat (exactly two permitted files)
```
 scripts/medusa_api.py                    |  40 ++-   (+32/-8)
 tests/test_medusa_api_snapshot_loader.py | 428 ++++++++++++++++++++++++++++++
 2 files changed, 460 insertions(+), 8 deletions(-)
```
The production correction is inside `_load_snapshot()` only.

### Production caller inventory (independently confirmed on live `main`)
| Endpoint | Call site | Downstream work that used to hold the handle |
|---|---|---|
| `/api/census` | line 172 | census counting + entropy |
| `/api/equanimity` | line 210 | masks, sorting, elder construction |
| `/api/acoustic` | line 271 | sector reshaping (when no saved map is used) |
| `/api/geometry/stl` | line 317 | coordinate sampling + mesh creation |

All four remain the *only* callers, and none opens its own archive — asserted
structurally over the parsed module.

### Independently reproduced failing-before behaviour
Running the **genuine pre-fix `_load_snapshot()`** with a closure-recording fake
archive:

| Case | Pre-fix |
|---|---|
| successful extraction | helper **returned with the archive unclosed** — `entered/exited/closed` all `0` |
| `lattice` lookup raises | propagates, archive **not** closed |
| `memory_grid` lookup raises | propagates, archive **not** closed |
| `generation` lookup raises | propagates, archive **not** closed |
| `best_fitness` lookup raises | propagates, archive **not** closed |
| `int(generation)` raises | propagates, archive **not** closed |
| `float(best_fitness)` raises | propagates, archive **not** closed |

**9 of 32 pre-fix checks fail — all of them closure checks.**

**Claim precision, as instructed:** what is demonstrated is **resource lifetime
relative to extraction**. No indefinitely accumulating descriptor leak was
demonstrated and none is claimed.

### The correction
```python
with np.load(str(path), allow_pickle=True) as snap:
    lattice = snap["lattice"]
    memory_grid = snap["memory_grid"]
    generation = int(snap["generation"])
    best_fitness = float(snap["best_fitness"])
return (lattice, memory_grid, generation, best_fitness)
```
Materialising into locals and returning **outside** the `with` makes the ordering
structural: the archive is provably closed before the `return` statement executes,
rather than relying on `__exit__` firing during a return expression.

### Successful and exceptional closure evidence
| Case | Result |
|---|---|
| success | `entered == 1`, `exited == 1`, `closed == 1`, closed when the helper returns |
| `lattice` / `memory_grid` / `generation` / `best_fitness` lookup raises | `KeyError` propagates, `closed == 1` |
| `int(generation)` raises | original `Boom` propagates ("generation conversion failed"), `closed == 1` |
| `float(best_fitness)` raises | original `Boom` propagates ("fitness conversion failed"), `closed == 1` |
| `np.load` itself raises `OSError` / `RuntimeError` / `MemoryError` / `ValueError` | propagates with exact type **and** message — no blanket `except`, nothing converted into a lifetime refusal |

**Closure is explicit, not finalisation-dependent:** the fake defines no `__del__`,
asserting frames hold live references when `closed == 1` is observed, and no test
calls `gc.collect()`.

### Proof closure precedes endpoint computation
A genuine `/api/census` request through Flask's in-process test client wraps
`np.unique` — the endpoint's **first** downstream NumPy computation — and records
the archive's closure count at that moment. Post-fix it records `1`; pre-fix the
archive was still open there, because the helper returned it unclosed. The census
response body is separately asserted unchanged (generation, lattice size, total
cells, non-void, per-state counts, fitness, snapshot name), and the no-snapshot
path still returns 404 **without** loading.

### Tuple and conversion preservation
Returned as a 4-tuple in the same order; `lattice` and `memory_grid` returned **by
identity** (not copies); `generation` an exact built-in `int` (asserted with
`np.int64` input and with a float input to prove `int()` still truncates);
`best_fitness` an exact built-in `float` (asserted with `np.float32` and with an
`int` input); dtypes preserved; extraction order asserted as
`["lattice", "memory_grid", "generation", "best_fitness"]`; `np.load` still
receives `str(path)` plus `allow_pickle=True`.

### Import and event-bus isolation
The module imports Flask, tuning and event-bus components at load and would
otherwise construct a PUB socket on `:8081` and start a `StateWatcher` thread. The
focused module imports it inside a scoped `mock.patch.dict(os.environ,
{"MEDUSA_EVENT_BUS_DISABLED": "1"})` and **asserts** afterwards that the ambient
environment is exactly as before (including the originally-absent case) and that
`_event_publisher` / `_state_watcher` are both `None`. No socket, no port, no
watcher thread, no Flask server, no engine, no repository snapshot or telemetry
read, nothing written inside the repository.

`pytest.importorskip("flask")` is retained as the optional-dependency guard for
minimal environments; the CI counts below prove every new case *ran* rather than
being skipped.

### Local evidence (this seat) — separated from CI and CodeQL
**`pytest`, NumPy and Flask are all absent on this seat: no test suite was run
locally**, and no custom pytest replacement was built or described as equivalent.
Probes stubbed only the import seams (`numpy`, `flask`, `scripts.tuning_api`,
`scripts.event_bus`) with `np.load` replaced per case, so the executed function
body is the real `_load_snapshot`. What ran:
1. `compile()` clean on both changed files.
2. Static AST check of the focused module: 21 functions → 28 cases, **no
   `parametrize` id/value cardinality mismatch**.
3. A direct-execution harness over the helper, both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `26572c0` | 32 | **9** (all closure checks) |
| post-fix `28d7e18` | 32 | **0** |

**Every preserved-behaviour check passes in both states** — tuple shape, identity
returns, both conversions, extraction order, `np.load` call shape, unrelated-error
propagation, the one-`np.load`-inside-the-helper structure and the four-caller
inventory. The **Flask endpoint witness needs real Flask and real NumPy and was
deliberately left to CI**; it was not attempted locally.

Scratch probes lived outside the repository and were removed.

### CI / CodeQL evidence
See the receipt appended below once all **registered** checks conclude. Per
current repository policy the CodeQL workflow starts only for `scripts/**`,
`src/uft_orch/**` and CodeQL-configuration changes — this package touches
`scripts/**`, so CodeQL is expected to register here; the receipt records exactly
what actually registered and claims nothing about checks that did not.

### Residuals and explicit non-claims
- **Bounded claim:** archive resource lifetime relative to extraction. **Not**
  snapshot validation, archive security, endpoint totality, API authentication,
  atomic file access or whole-server correctness.
- **No accumulating-descriptor-leak claim** (see above).
- `allow_pickle=True` preserved deliberately and unexamined — a hostile `.npz` can
  still execute pickle payloads. Explicitly out of scope.
- Extracted arrays remain real in-memory objects after close, so **memory** use is
  unchanged; this shortens a *handle* lifetime, not a footprint.
- No schema validation: a missing key still raises `KeyError`, surfacing to Flask
  exactly as before (message contents unchanged).
- `/api/snapshot/latest` streams the file via `send_file` and is untouched — it has
  its own handle lifetime, outside this boundary.
- `_find_latest_snapshot` and snapshot-size filtering are unchanged; a truncated or
  corrupt archive is still detected only by `np.load` failing.
- The Windows consequence (blocked delete/rotate/replace) is stated as the
  *motivation*; it was **not** reproduced against a real Windows file lock.
- Locally the context-manager protocol was driven by a fake, so real
  `NpzFile.__exit__` semantics were exercised only in CI.
- The equanimity, acoustic and geometry endpoints are covered structurally (shared
  helper, no private archive) rather than by their own request witnesses; only
  census has an end-to-end ordering witness.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424**, **#425**, **#426**, **#428** and **#429** were
  verified parked (OPEN, draft, unmerged) and **none was modified**. Their file
  boundaries are disjoint from `scripts/medusa_api.py` +
  `tests/test_medusa_api_snapshot_loader.py`.
- **#419's mergeability was observed read-only and not acted on.** At gate time it
  reported `mergeable=MERGEABLE`, `mergeStateStatus=BEHIND` — recorded as observed;
  no sync, rebase, merge-from-main or correction was attempted or authorized.
- **#420** and **#427** (Kev-seat) kept **opaque**: bare number, title, branch
  identity and draft/open identity only.
- **#423** merged, used only as live-`main` history.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real Medusa snapshot, engine, event-bus
connection or server execution; **no network port bound**; nothing written inside
the repository. `tests/test_medusa_api.py`, `scripts/event_bus.py` and
`scripts/tuning_api.py` untouched. No merge / auto-merge / ready-for-review
transition / rebase / merge-from-main / history rewrite / repository, workflow,
protection or settings change / manual workflow rerun / branch deletion. No
comment, review, thread action, reaction or label. No new dependency. Leave
**OPEN, draft, unmerged** and hand back to Jack.

---

### CI receipt (body-only append; all registered checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `28d7e180057b3ddee04c8900b4f45e83343a341f`. No workflow was manually rerun.

**The status rollup contains exactly 8 entries, all `SUCCESS`, none pending.** Recorded verbatim, with no claim about checks that did not register:

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m21s) | run `30198045507` / job `89783028860` — **2279 passed, 13 skipped, 0 failed** (33.31s) |
| verify-python (push-triggered run) | ✅ pass (1m29s) | run `30198013787` / job `89782935967` |
| **Analyze Python (CodeQL)** | ✅ pass (1m1s) | run `30198045502` / job `89783028713` |
| **CodeQL** | ✅ pass | job `89783097660` |
| agent-safety | ✅ pass (10s) | run `30198045497` |
| tripwire | ✅ pass (2s) | run `30198045524` |
| frontend-quality | ✅ pass (59s / 53s) | runs `30198013787`, `30198045507` |

CodeQL registered here as expected for a `scripts/**` package, consistent with the
stated repository policy — in contrast to #429, whose `vis/**` file set does not
start that workflow.

**Every new case ran; none was skipped.** Baseline `verify-python` on live `main`
`26572c0` (run `30191010631`) reports **2251 passed, 13 skipped**. This head
reports **2279 passed, 13 skipped**:

- **+28 passed**, exactly matching the 28 statically counted collected cases;
- **skipped unchanged at 13** — positive proof the retained
  `pytest.importorskip("flask")` guard did **not** fire in CI, so the whole focused
  module executed;
- **0 failed**, and all 2251 pre-existing cases still pass, including the untouched
  `tests/test_medusa_api.py` — so the scoped event-bus import override disturbed no
  other suite.

CI's figures supersede the seat-local evidence as the authoritative gate. PR
remains **OPEN, draft, unmerged** — handing back to Jack for audit; merge authority
is Kev's later explicit word only.
