### PR TITLE
fix(acoustic-map): close the diagnostic's snapshot archive at the extraction boundary

### DIFF
--- a/scripts/acoustic_map.py
+++ b/scripts/acoustic_map.py
@@ -314,14 +314,40 @@ class AcousticMap:
 # Standalone diagnostic: run on a snapshot
 # ---------------------------------------------------------------------------
 def run_acoustic_diagnostic(snapshot_path: str, num_steps: int = 200):
-    """Run acoustic analysis on a snapshot by simulating N steps."""
+    """Run acoustic analysis on a snapshot by simulating N steps.
+
+    The snapshot archive's lifetime is bounded to extraction. Previously the
+    ``NpzFile`` from ``np.load`` stayed referenced for the whole diagnostic —
+    lattice-size inspection, legacy memory-grid expansion, rule-spec loading,
+    RNG and inactivity construction, ``AcousticMap`` construction, every
+    simulated step, the summaries, the final report and the heatmap save — so a
+    default CLI run held the input handle across 100 steps (200 when the
+    function default is used), and callers may ask for more. Release depended on
+    eventual object destruction. On Windows a retained snapshot handle can
+    interfere with deleting, rotating or replacing that file.
+
+    The three values are now materialised while the archive is open and it is
+    closed before any post-extraction work begins — including the ``N =
+    lattice.shape[0]`` inspection. Closure is explicit, not left to garbage
+    collection.
+
+    Extraction is not guarded: a missing key or a failing ``int()`` conversion
+    propagates exactly as before, and the ``with`` block still closes the archive
+    on the way out. The ``snapshot_path`` argument is passed to ``np.load``
+    unchanged (no path conversion is introduced) and ``allow_pickle=True`` is
+    preserved verbatim.
+
+    The claim is archive resource lifetime relative to extraction — not an
+    indefinitely accumulating descriptor leak, not snapshot validation, and
+    nothing about the acoustic mathematics.
+    """
     from scripts.continuous_evolution_ca import step_ca_lattice, load_rule_spec, init_memory_grid
 
     print(f"Loading snapshot: {snapshot_path}")
-    snap = np.load(snapshot_path, allow_pickle=True)
-    lattice = snap["lattice"]
-    memory_grid = snap["memory_grid"]
-    gen = int(snap["generation"])
+    with np.load(snapshot_path, allow_pickle=True) as snap:
+        lattice = snap["lattice"]
+        memory_grid = snap["memory_grid"]
+        gen = int(snap["generation"])
     N = lattice.shape[0]
 
     if memory_grid.shape[0] < 8:

--- a/tests/test_acoustic_map_snapshot_loader.py
+++ b/tests/test_acoustic_map_snapshot_loader.py
@@ -1,0 +1,457 @@
+"""Focused tests for `scripts/acoustic_map.run_acoustic_diagnostic()` archive lifetime.
+
+The diagnostic used to keep the `NpzFile` from `np.load` referenced for its whole
+run — lattice-size inspection, legacy memory-grid expansion, rule-spec loading,
+RNG and inactivity construction, `AcousticMap` construction, every simulated
+step, the summaries, the final report and the heatmap save. A default CLI run
+therefore held the input handle across 100 steps (200 via the function default),
+and callers may request more; release depended on eventual object destruction. On
+Windows a retained snapshot handle can interfere with deleting, rotating or
+replacing that file.
+
+The three values are now materialised while the archive is open and it closes
+before any post-extraction work begins.
+
+No real simulation, engine, GPU kernel, snapshot or heatmap is involved: the
+engine's lazy import is served by a scoped `sys.modules` stand-in (restored
+afterwards), `AcousticMap` is replaced by a recorder, and `np.load` returns a
+closure-recording fake. Nothing is written anywhere.
+
+Scope is archive resource lifetime relative to extraction — not snapshot
+validation, archive security, the acoustic mathematics or whole-diagnostic
+correctness.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+# The module's GPU probe is fully try/except ImportError guarded, so importing it
+# needs only NumPy — no CuPy, no engine, and no module-level skip.
+from scripts import acoustic_map
+
+_ENGINE_MODULE = "scripts.continuous_evolution_ca"
+
+
+class Boom(Exception):
+    """Distinct conversion failure, so propagation can be asserted exactly."""
+
+
+class _ExplodingInt:
+    def __int__(self):
+        raise Boom("generation conversion failed")
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` that `np.load` returns.
+
+    Records context entry/exit, explicit closure and key lookups. Defines **no**
+    `__del__`, so a recorded closure can never have come from garbage collection,
+    reference-count timing or interpreter shutdown.
+    """
+
+    def __init__(self, contents=None, raise_on=None):
+        self.contents = {} if contents is None else contents
+        self.raise_on = raise_on
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.lookups = []
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress an extraction failure
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.lookups.append(key)
+        if self.raise_on == key:
+            raise KeyError(key)
+        return self.contents[key]
+
+
+def _lattice(size=2):
+    return np.zeros((size, size, size), dtype=np.uint8)
+
+
+def _grid(channels=8, size=2):
+    return np.zeros((channels, size, size, size), dtype=np.float32)
+
+
+def _contents(**overrides):
+    base = {"lattice": _lattice(), "memory_grid": _grid(), "generation": 1000}
+    base.update(overrides)
+    return base
+
+
+class _Recorder:
+    """Collects, for every post-extraction seam, the archive's closure count at
+    the moment that seam was entered."""
+
+    def __init__(self, archive):
+        self.archive = archive
+        self.init_memory_grid = []
+        self.load_rule_spec = []
+        self.acoustic_map_init = []
+        self.steps = []
+        self.updates = []
+        self.summaries = 0
+        self.save_heatmap = []
+
+
+def _run(contents=None, archive=None, num_steps=0, snapshot_path=None,
+         raise_on=None, load_error=None):
+    """Drive the genuine `run_acoustic_diagnostic()` with every seam controlled.
+
+    Returns (result, archive, recorder, load_mock). Raised exceptions are left to
+    the caller so propagation can be asserted.
+    """
+    archive = archive if archive is not None else _FakeArchive(
+        _contents() if contents is None else contents, raise_on=raise_on
+    )
+    rec = _Recorder(archive)
+    archive.rec = rec  # reachable after a propagated exception
+    path = snapshot_path if snapshot_path is not None else Path("/fake/v070_gen1000.npz")
+
+    def _init_memory_grid(shape):
+        rec.init_memory_grid.append({"closed": archive.closed, "shape": tuple(shape)})
+        return _grid(channels=8, size=shape[0])
+
+    def _load_rule_spec(rule_path):
+        rec.load_rule_spec.append({"closed": archive.closed, "path": rule_path})
+        return {"rule": "stub"}
+
+    def _step_ca_lattice(lattice, rule_spec, rng, inactivity, memory_grid, generation):
+        rec.steps.append({
+            "closed": archive.closed, "lattice": lattice, "rule_spec": rule_spec,
+            "rng": rng, "inactivity": inactivity, "memory_grid": memory_grid,
+            "generation": generation,
+        })
+        stepped = lattice + 1  # a distinct new array, so `update` can be checked
+        return stepped, inactivity, memory_grid, {"metric": len(rec.steps)}
+
+    engine_stub = types.ModuleType(_ENGINE_MODULE)
+    engine_stub.step_ca_lattice = _step_ca_lattice
+    engine_stub.load_rule_spec = _load_rule_spec
+    engine_stub.init_memory_grid = _init_memory_grid
+
+    class _RecordingAcousticMap:
+        def __init__(self, lattice_size=None, config=None):
+            rec.acoustic_map_init.append({
+                "closed": archive.closed, "lattice_size": lattice_size,
+                "config": config,
+            })
+            self.lattice_size = lattice_size
+            self.config = config
+
+        def update(self, current, previous):
+            rec.updates.append({"closed": archive.closed, "current": current,
+                                "previous": previous})
+
+        def print_summary(self):
+            rec.summaries += 1
+
+        def save_heatmap(self):
+            rec.save_heatmap.append({"closed": archive.closed})
+            return Path("/fake/heatmap.png")  # never written
+
+    load_mock = mock.Mock(side_effect=load_error) if load_error is not None \
+        else mock.Mock(return_value=archive)
+
+    with mock.patch.dict(sys.modules, {_ENGINE_MODULE: engine_stub}), \
+         mock.patch.object(acoustic_map.np, "load", load_mock), \
+         mock.patch.object(acoustic_map, "AcousticMap", _RecordingAcousticMap):
+        result = acoustic_map.run_acoustic_diagnostic(path, num_steps)
+    return result, archive, rec, load_mock
+
+
+def _run_expecting(exception_type, **kwargs):
+    with pytest.raises(exception_type) as exc:
+        _run(**kwargs)
+    return exc
+
+
+# -- extraction identity and conversions --------------------------------------
+
+
+def test_lattice_is_extracted_by_identity():
+    contents = _contents()
+    _, archive, rec, _ = _run(contents=contents, num_steps=1)
+    assert rec.steps[0]["lattice"] is contents["lattice"]
+
+
+def test_memory_grid_is_extracted_by_identity_when_already_eight_channel():
+    contents = _contents()
+    _, archive, rec, _ = _run(contents=contents, num_steps=1)
+    assert rec.steps[0]["memory_grid"] is contents["memory_grid"]
+    assert rec.init_memory_grid == []  # no legacy expansion for an 8-channel grid
+
+
+def test_generation_is_an_exact_builtin_int():
+    contents = _contents(generation=np.int64(4242))
+    _, _, rec, _ = _run(contents=contents, num_steps=1)
+    generation = rec.steps[0]["generation"]
+    assert type(generation) is int
+    assert generation == 4242
+
+
+def test_np_load_receives_the_original_path_and_allow_pickle():
+    """No path conversion is introduced: the very object passed in is forwarded."""
+    path = Path("/fake/dir/v070_gen7.npz")
+    _, _, _, load_mock = _run(num_steps=0, snapshot_path=path)
+    assert load_mock.call_count == 1
+    args, kwargs = load_mock.call_args
+    assert args == (path,)
+    assert args[0] is path  # not str(path), not a re-wrapped Path
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_extraction_order_is_preserved():
+    _, archive, _, _ = _run(num_steps=0)
+    assert archive.lookups == ["lattice", "memory_grid", "generation"]
+
+
+# -- closure on success -------------------------------------------------------
+
+
+def test_archive_context_entered_exactly_once():
+    _, archive, _, _ = _run(num_steps=0)
+    assert archive.entered == 1
+
+
+def test_archive_exits_and_closes_exactly_once_on_success():
+    _, archive, _, _ = _run(num_steps=3)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_closure_does_not_depend_on_finalisation():
+    """No `__del__` on the fake and the reference stays alive, so the recorded
+    closure cannot come from gc, reference-count timing or interpreter shutdown.
+    No test here calls gc.collect()."""
+    assert not hasattr(_FakeArchive, "__del__")
+    _, archive, _, _ = _run(num_steps=0)
+    assert archive.closed == 1
+    assert archive is not None
+
+
+# -- closure precedes every post-extraction seam ------------------------------
+
+
+def test_archive_closed_before_load_rule_spec_for_an_eight_channel_grid():
+    """Central witness (8-channel path). Pre-fix `load_rule_spec` was entered
+    with the archive still open."""
+    _, archive, rec, _ = _run(num_steps=0)
+    assert len(rec.load_rule_spec) == 1
+    assert rec.load_rule_spec[0]["closed"] == 1
+    assert rec.load_rule_spec[0]["path"].endswith("example.toml")
+
+
+def test_archive_closed_before_init_memory_grid_for_a_legacy_grid():
+    """Central witness (legacy path). Pre-fix `init_memory_grid` was entered with
+    the archive still open."""
+    contents = _contents(memory_grid=_grid(channels=3))
+    _, archive, rec, _ = _run(contents=contents, num_steps=0)
+    assert len(rec.init_memory_grid) == 1
+    assert rec.init_memory_grid[0]["closed"] == 1
+    assert rec.init_memory_grid[0]["shape"] == (2, 2, 2)
+    assert rec.load_rule_spec[0]["closed"] == 1
+
+
+def test_archive_closed_before_acoustic_map_construction():
+    _, archive, rec, _ = _run(num_steps=0)
+    assert len(rec.acoustic_map_init) == 1
+    assert rec.acoustic_map_init[0]["closed"] == 1
+    assert rec.acoustic_map_init[0]["lattice_size"] == 2
+
+
+def test_archive_closed_before_the_first_step_and_every_step():
+    _, archive, rec, _ = _run(num_steps=3)
+    assert len(rec.steps) == 3
+    assert rec.steps[0]["closed"] == 1
+    assert all(step["closed"] == 1 for step in rec.steps)
+
+
+def test_archive_closed_before_every_update_and_the_save():
+    _, archive, rec, _ = _run(num_steps=2)
+    assert all(entry["closed"] == 1 for entry in rec.updates)
+    assert len(rec.save_heatmap) == 1
+    assert rec.save_heatmap[0]["closed"] == 1
+
+
+# -- closure on every extraction / conversion failure -------------------------
+
+
+@pytest.mark.parametrize(
+    "missing", ["lattice", "memory_grid", "generation"],
+    ids=["lattice", "memory_grid", "generation"],
+)
+def test_archive_closes_when_a_key_lookup_raises(missing):
+    archive = _FakeArchive(_contents(), raise_on=missing)
+    with pytest.raises(KeyError):
+        _run(archive=archive, num_steps=0)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_closes_when_the_generation_conversion_raises():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom):
+        _run(archive=archive, num_steps=0)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_original_extraction_exception_propagates_unchanged():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom) as exc:
+        _run(archive=archive, num_steps=0)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.closed == 1
+
+    missing = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError) as exc2:
+        _run(archive=missing, num_steps=0)
+    assert type(exc2.value) is KeyError
+    assert missing.closed == 1
+
+
+def test_a_failure_before_extraction_reaches_no_diagnostic_seam():
+    """An extraction failure closes the archive and runs nothing downstream."""
+    archive = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError):
+        _run(archive=archive, num_steps=3)
+    rec = archive.rec
+    assert rec.init_memory_grid == []
+    assert rec.load_rule_spec == []
+    assert rec.acoustic_map_init == []
+    assert rec.steps == []
+    assert rec.updates == []
+    assert rec.save_heatmap == []
+    assert rec.summaries == 0
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("archive read failed"), RuntimeError("boom"), MemoryError("oom"),
+     ValueError("bad zip")],
+    ids=["os_error", "runtime_error", "memory_error", "value_error"],
+)
+def test_np_load_failure_propagates_unchanged(error):
+    """No blanket except was added: an `np.load` failure of any kind propagates
+    with its exact type and message, and no archive was ever entered."""
+    with pytest.raises(type(error)) as exc:
+        _run(num_steps=0, load_error=error)
+    assert type(exc.value) is type(error)
+    assert str(exc.value) == str(error)
+
+
+# -- established diagnostic behaviour ----------------------------------------
+
+
+def test_zero_steps_performs_no_ca_step_but_still_reports_and_saves():
+    result, archive, rec, _ = _run(num_steps=0)
+    assert rec.steps == []
+    assert rec.updates == []
+    assert rec.summaries == 1          # the final report only
+    assert len(rec.save_heatmap) == 1  # heatmap still saved
+    assert result is not None
+
+
+def test_generation_progression_is_gen_plus_index():
+    contents = _contents(generation=500)
+    _, _, rec, _ = _run(contents=contents, num_steps=4)
+    assert [step["generation"] for step in rec.steps] == [500, 501, 502, 503]
+
+
+def test_step_seam_receives_the_established_values():
+    contents = _contents()
+    _, _, rec, _ = _run(contents=contents, num_steps=2)
+    first, second = rec.steps
+    # First step gets the extracted lattice and grid, the loaded rule spec, an
+    # RNG and an int16 inactivity grid shaped like the lattice.
+    assert first["lattice"] is contents["lattice"]
+    assert first["memory_grid"] is contents["memory_grid"]
+    assert first["rule_spec"] == {"rule": "stub"}
+    assert isinstance(first["rng"], np.random.Generator)
+    assert first["inactivity"].dtype == np.int16
+    assert first["inactivity"].shape == contents["lattice"].shape
+    # The loop feeds the previous step's outputs forward.
+    assert second["rng"] is first["rng"]
+    assert second["inactivity"] is first["inactivity"]
+    assert second["rule_spec"] is first["rule_spec"]
+    np.testing.assert_array_equal(second["lattice"], first["lattice"] + 1)
+
+
+def test_rng_is_seeded_deterministically():
+    """Seed 42 is preserved: two runs draw identical values from the RNG."""
+    draws = []
+    for _ in range(2):
+        _, _, rec, _ = _run(num_steps=1)
+        draws.append(rec.steps[0]["rng"].random())
+    assert draws[0] == draws[1]
+    assert draws[0] == np.random.default_rng(42).random()
+
+
+def test_update_receives_the_stepped_lattice_and_previous_state():
+    contents = _contents()
+    _, _, rec, _ = _run(contents=contents, num_steps=1)
+    assert len(rec.updates) == 1
+    current = rec.updates[0]["current"]
+    previous = rec.updates[0]["previous"]
+    # `current` is the array the step returned; `previous` is the pre-step state.
+    np.testing.assert_array_equal(current, contents["lattice"] + 1)
+    np.testing.assert_array_equal(previous, contents["lattice"])
+    if acoustic_map.GPU_AVAILABLE:
+        assert previous is contents["lattice"]      # no copy on the GPU path
+    else:
+        assert previous is not contents["lattice"]  # established .copy()
+
+
+def test_legacy_grid_expansion_semantics_are_preserved():
+    legacy = _grid(channels=3)
+    legacy[:] = 7.0
+    contents = _contents(memory_grid=legacy)
+    _, _, rec, _ = _run(contents=contents, num_steps=1)
+    expanded = rec.steps[0]["memory_grid"]
+    assert expanded.shape[0] == 8
+    np.testing.assert_array_equal(expanded[:3], legacy)
+    np.testing.assert_array_equal(expanded[3:], np.zeros((5, 2, 2, 2), np.float32))
+
+
+def test_function_returns_the_acoustic_map_object():
+    result, _, rec, _ = _run(num_steps=1)
+    assert result is not None
+    assert result.lattice_size == 2
+    assert hasattr(result, "save_heatmap")
+
+
+def test_no_real_engine_acoustic_map_or_output_was_used():
+    """Every seam was a stand-in: no real AcousticMap was built and no file written."""
+    result, _, rec, _ = _run(num_steps=1)
+    assert type(result).__name__ == "_RecordingAcousticMap"
+    # Outside the patch context this attribute is the genuine class again.
+    assert type(result) is not acoustic_map.AcousticMap
+    assert rec.save_heatmap == [{"closed": 1}]
+    assert not Path("/fake/heatmap.png").exists()
+
+
+def test_engine_module_stub_was_scoped_and_restored():
+    before = sys.modules.get(_ENGINE_MODULE)
+    _run(num_steps=0)
+    assert sys.modules.get(_ENGINE_MODULE) is before


### PR DESCRIPTION
## Acoustic Map diagnostic: close the snapshot archive at the extraction boundary

Bounded Ian-seat package. `run_acoustic_diagnostic()` kept the loaded `NpzFile`
referenced for its entire run — including every simulated step — with no explicit
close. **Draft — do NOT merge.** Merge authority is Kev's later explicit word only.

### Base / head / lineage
- **base:** `main` @ `0fcaf469bce094b29bfb6abcf28aaeb9976d15cf`
- **head:** `fix/acoustic-diagnostic-npz-archive-lifetime` @ `eec9198523d1fa5d02117b8078958b01a2e03b38`
- **parent of head:** `0fcaf469bce094b29bfb6abcf28aaeb9976d15cf` (single parent; fresh branch from freshly reverified live `main`; ordinary push, no force)
- Live `main` had advanced via merged **#427**, whose diff (`26572c0..0fcaf46`) is `scripts/dandelion.py` + `tests/test_dandelion_info_coherence.py` — Dandelion only, disjoint, treated purely as history.
- `np.load(...)` without closure independently confirmed at `acoustic_map.py:321` at gate time; `tests/test_acoustic_map_snapshot_loader.py` did not exist and is created here.

### Files & diffstat (exactly two permitted files)
```
 scripts/acoustic_map.py                    |  36 ++-   (+31/-5)
 tests/test_acoustic_map_snapshot_loader.py | 457 ++++++++++++++++++++++++++++++
 2 files changed, 488 insertions(+), 5 deletions(-)
```
The production correction is inside the snapshot-extraction portion of
`run_acoustic_diagnostic()` only — four code lines plus its docstring.

### Independently reproduced failing-before lifetime behaviour
Running the **genuine pre-fix diagnostic** with a closure-recording fake archive
and controlled engine / `AcousticMap` stand-ins:

| Post-extraction seam | Pre-fix closure state when entered |
|---|---|
| `init_memory_grid` (legacy 3-channel grid) | **archive open** — `closed == 0` |
| `load_rule_spec` (8-channel grid) | **archive open** — `closed == 0` |
| `AcousticMap(...)` construction | **archive open** |
| every `step_ca_lattice` call | **archive open** |
| every `amap.update` call | **archive open** |
| `save_heatmap()` | **archive open** |
| any key-lookup or `int()` failure | archive **never closed** |

The archive was also never entered as a context at all (`entered == 0`). **13 of 47
pre-fix checks fail — all of them closure checks**, including both central seam
witnesses.

**Scale, stated precisely:** the CLI default is 100 steps
(`sys.argv[2]` fallback) and the *function* default is `num_steps=200`; callers may
request more. **Claim precision:** what is demonstrated is **resource lifetime
relative to extraction**. No indefinitely accumulating descriptor leak was
demonstrated and none is claimed.

### The correction
```python
with np.load(snapshot_path, allow_pickle=True) as snap:
    lattice = snap["lattice"]
    memory_grid = snap["memory_grid"]
    gen = int(snap["generation"])
N = lattice.shape[0]
```
`N = lattice.shape[0]` now sits **outside** the block, so even the lattice-size
inspection happens after closure. The engine's lazy import already preceded
`np.load` and was not moved.

### Successful and exceptional closure evidence
| Case | Result |
|---|---|
| success | `entered == 1`, `exited == 1`, `closed == 1` |
| `lattice` / `memory_grid` / `generation` lookup raises | `KeyError` propagates, `closed == 1`, **and no diagnostic seam ran** |
| `int(generation)` raises | original `Boom` propagates ("generation conversion failed"), `closed == 1` |
| `np.load` itself raises `OSError` / `RuntimeError` / `MemoryError` / `ValueError` | propagates with exact type **and** message; archive never entered (`entered == 0`) |

Exception identity is asserted, so nothing is caught, translated or suppressed.
**Closure is explicit, not finalisation-dependent:** the fake defines no `__del__`,
asserting frames hold live references when `closed == 1` is observed, and no test
calls `gc.collect()`.

### Proof closure precedes every tested post-extraction seam
Each seam records the archive's closure count **at the moment it is entered**.
Post-fix all record `1`: `init_memory_grid` (legacy path), `load_rule_spec`
(8-channel path), `AcousticMap` construction, the first and every
`step_ca_lattice`, every `amap.update`, and `save_heatmap`. The two marked
**CENTRAL** are the witnesses that fail against the pre-fix module.

### Identity and conversion preservation
`lattice` and `memory_grid` reach the step seam **by identity** (not copies) when
the grid is already 8-channel; `generation` is an exact built-in `int` (asserted
with an `np.int64` input); extraction order asserted
`["lattice", "memory_grid", "generation"]`; and **`np.load` receives the original
`snapshot_path` object itself** — a `Path` is asserted with `args[0] is path`,
proving no `str()` or re-wrapping was introduced — plus `allow_pickle=True`.

### Zero-step and controlled multi-step preservation
- `num_steps=0`: no `step_ca_lattice`, no `amap.update`, **one** final
  `print_summary`, and `save_heatmap` still called — established behaviour intact.
- A 3–4 step run: `gen + i` progression asserted as `[500, 501, 502, 503]`; the RNG,
  inactivity grid and rule spec are carried forward by identity between steps; the
  first step receives the extracted lattice and grid, the loaded rule spec, an
  `np.random.Generator`, and an `int16` inactivity grid shaped like the lattice.
- RNG seed 42 preserved — two runs draw identical values, matching
  `np.random.default_rng(42).random()`.
- `amap.update` receives the **stepped** lattice and the established previous
  state; on the non-GPU path that previous state is the established `.copy()` (not
  the same object), and the test branches on the module's actual `GPU_AVAILABLE`
  rather than hardcoding it.
- Legacy expansion semantics preserved: a 3-channel grid becomes 8 channels with
  the first three copied and the remainder zero.
- The function still returns the Acoustic Map object.

### Import / GPU / engine isolation
The module's GPU probe is fully `try/except ImportError` guarded, so the focused
module needs only NumPy — it is **not** module-level skipped for CuPy or the
engine. The diagnostic's lazy import of `step_ca_lattice` / `load_rule_spec` /
`init_memory_grid` is served by a scoped `mock.patch.dict(sys.modules, ...)`
stand-in, and a dedicated test asserts `sys.modules` holds exactly what it did
before the run. `AcousticMap` is replaced by a recorder, so no real map is
constructed and `save_heatmap` writes nothing — asserted, including that the
returned stub path does not exist on disk.

### Local evidence (this seat) — separated from CI and CodeQL
**`pytest`, NumPy and CuPy are all absent on this seat: no test suite was run
locally**, and no custom pytest replacement was built or described as equivalent.
Probes served the module's import seams with minimal stand-ins (`numpy`,
`scripts.gpu_accelerator`, the engine module) and replaced `np.load` per case, so
the executed function body is the genuine diagnostic. What ran:
1. `compile()` clean on both changed files.
2. Static AST check of the focused module: 27 functions → 32 cases, **no
   `parametrize` id/value cardinality mismatch**.
3. A direct-execution harness over the genuine diagnostic, both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `0fcaf46` | 47 | **13** (all closure checks, incl. both central witnesses) |
| post-fix `eec9198` | 47 | **0** |

**Every preserved-behaviour check passes in both states** — identity extraction,
the `int()` conversion, extraction order, the unchanged `np.load` path argument and
`allow_pickle`, rule-file selection, `gen + i` progression, RNG seed 42, `int16`
inactivity, zero-step behaviour, carried-forward step values, exception identity,
and the one-`np.load` structure. **Real-NumPy specifics** (actual `int16` dtype,
RNG determinism against `default_rng(42)`, array equality) are exercised only in
CI, since NumPy is absent here.

Scratch probes lived outside the repository and were removed.

### CI / CodeQL evidence
See the receipt appended below once all **registered** checks conclude. This
package touches `scripts/**`, so CodeQL is expected to register per current
repository policy; the receipt records exactly what registered and claims nothing
about checks that did not.

### Residuals and explicit non-claims
- **Bounded claim:** archive resource lifetime relative to extraction. **Not**
  snapshot validation, archive security, the acoustic mathematics, deterministic
  science, output atomicity or whole-diagnostic correctness. **No
  accumulating-descriptor-leak claim.**
- `allow_pickle=True` preserved and unexamined — a hostile `.npz` can still execute
  pickle payloads. Explicitly out of scope.
- Extracted arrays stay in memory after close: a **handle** lifetime shortened, not
  a footprint. A 256³ diagnostic still holds the lattice and an 8-channel grid.
- No schema validation: a missing key still raises `KeyError` unchanged, and the
  diagnostic has no top-level handler, so it still propagates to the caller/CLI.
- `save_heatmap`'s own output-file handling is untouched and remains non-atomic.
- The `__main__` block's latest-snapshot selection and `sys.argv` handling are
  unchanged; the `num_steps=200` function default versus the 100-step CLI default is
  pre-existing and deliberately left alone.
- The Windows consequence (blocked delete/rotate/replace) is stated as the
  *motivation*; it was **not** reproduced against a real Windows file lock.
- Locally the context-manager protocol was driven by a fake, so real
  `NpzFile.__exit__` semantics were exercised only in CI.
- The GPU path (`GPU_AVAILABLE == True`, `prev = lattice` without a copy) is asserted
  conditionally rather than exercised — CI runs without CuPy.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424**, **#425**, **#426**, **#428**, **#429** and **#430**
  were verified parked (OPEN, draft, unmerged) and **none was modified**. Their file
  boundaries are disjoint from `scripts/acoustic_map.py` +
  `tests/test_acoustic_map_snapshot_loader.py`.
- **#419's computed mergeability indicator was deliberately not queried, not
  reconciled and not acted on**, per instruction — only its parked state
  (open/draft/unmerged/head) was confirmed.
- **#430** was not synchronized or modified, despite now being based one commit
  behind current `main`.
- **#420** (Kev-seat) kept **opaque**: bare number, title, branch identity and
  draft/open identity only.
- **#423** and **#427** merged, used only as live-`main` history.

### Fences
Exactly two authorized files; one focused commit; fresh single-parent branch from
live `main`; ordinary push, no force. No real Medusa snapshot, engine, GPU
simulation or Acoustic Map output; nothing written inside the repository.
`scripts/continuous_evolution_ca.py`, GPU accelerator modules and rule files
untouched. No merge / auto-merge / ready-for-review transition / rebase /
merge-from-main / history rewrite / repository, workflow, protection or settings
change / manual workflow rerun / branch deletion. No comment, review, thread
action, reaction or label. No new dependency. Leave **OPEN, draft, unmerged** and
hand back to Jack.

---

### CI receipt (body-only append; all registered checks conclusive — GREEN)
Observed read-only to conclusive result on PR head `eec9198523d1fa5d02117b8078958b01a2e03b38`. No workflow was manually rerun.

**The status rollup contains exactly 8 entries, all `SUCCESS`, none pending.** Recorded verbatim, with no claim about checks that did not register:

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m32s) | run `30203422574` / job `89797243341` — **2297 passed, 13 skipped, 0 failed** (44.02s) |
| verify-python (push-triggered run) | ✅ pass (1m25s) | run `30203381098` / job `89797130967` |
| **Analyze Python (CodeQL)** | ✅ pass (52s) | run `30203422599` / job `89797243311` |
| **CodeQL** | ✅ pass | job `89797309685` |
| agent-safety | ✅ pass (9s) | run `30203422610` |
| tripwire | ✅ pass (2s) | run `30203422606` |
| frontend-quality | ✅ pass (1m0s / 55s) | runs `30203381098`, `30203422574` |

CodeQL registered as expected for a `scripts/**` package, consistent with the
stated repository policy.

**Every new case ran; none was skipped.** Baseline `verify-python` on live `main`
`0fcaf46` (run `30202563297`) reports **2265 passed, 13 skipped**. This head
reports **2297 passed, 13 skipped**:

- **+32 passed**, exactly matching the 32 statically counted collected cases;
- **skipped unchanged at 13** — positive proof the focused module was **not**
  module-level skipped for CuPy or the engine, and that its scoped `sys.modules`
  stand-in disturbed no other suite;
- **0 failed**, and all 2265 pre-existing cases still pass.

CI's figures supersede the seat-local evidence as the authoritative gate. PR remains
**OPEN, draft, unmerged** — handing back to Jack for audit; merge authority is Kev's
later explicit word only.
