### PR TITLE
fix(dandelion): load snapshot lattices without pickle

### DIFF
--- a/scripts/dandelion.py
+++ b/scripts/dandelion.py
@@ -210,6 +210,26 @@ def decode_qr_payload(payload: str) -> dict:
 # Seed 2: 3D Print Export (STL + 3MF + Voxel Slices)
 # ---------------------------------------------------------------------------
 
+def _load_snapshot_lattice(snapshot_path: str) -> np.ndarray:
+    """Retrieve the ``lattice`` member from an NPZ snapshot, safely.
+
+    Two properties the public ``stl`` / ``glb`` / ``slices`` commands rely on:
+
+    * ``allow_pickle=False`` — an object-dtype member is refused by NumPy rather
+      than unpickled, and a file that is not a valid NPZ is never handed to the
+      unpickler. This is an object-array refusal, NOT whole-archive validation:
+      no claim is made about archive size, entry names or ZIP-bomb resistance.
+    * the archive is a context manager, so the handle is released before the
+      lattice is returned — on success, on a missing member, and on any other
+      exception raised while accessing it.
+
+    The retrieved array is returned as NumPy produced it: no dtype conversion,
+    copy, reshape or validation.
+    """
+    with np.load(snapshot_path, allow_pickle=False) as snapshot:
+        return snapshot["lattice"]
+
+
 def lattice_to_stl(
     lattice: np.ndarray,
     output_path: str = "organism.stl",
@@ -719,16 +739,16 @@ def main(argv=None):
             print(f"  QR codes needed:        {n_codes}")
 
     elif args.command == "stl":
-        snap = np.load(args.snapshot, allow_pickle=True)
-        lattice_to_stl(snap["lattice"], args.output)
+        lattice = _load_snapshot_lattice(args.snapshot)
+        lattice_to_stl(lattice, args.output)
 
     elif args.command == "glb":
-        snap = np.load(args.snapshot, allow_pickle=True)
-        lattice_to_glb(snap["lattice"], args.output)
+        lattice = _load_snapshot_lattice(args.snapshot)
+        lattice_to_glb(lattice, args.output)
 
     elif args.command == "slices":
-        snap = np.load(args.snapshot, allow_pickle=True)
-        lattice_to_voxel_slices(snap["lattice"], args.output_dir, scale=args.scale)
+        lattice = _load_snapshot_lattice(args.snapshot)
+        lattice_to_voxel_slices(lattice, args.output_dir, scale=args.scale)
 
     elif args.command == "wasm":
         print_wasm_guide()

--- a/tests/test_dandelion_snapshot_loading.py
+++ b/tests/test_dandelion_snapshot_loading.py
@@ -1,0 +1,376 @@
+"""Tests for the snapshot-archive loading boundary shared by ``stl``/``glb``/``slices``.
+
+Scope: ONLY how the public Dandelion CLI extracts the ``lattice`` member from an
+NPZ snapshot. Two properties are pinned:
+
+* **no pickle** — the archive is opened with ``allow_pickle=False``, so an
+  object-dtype ``lattice`` is refused by NumPy instead of being unpickled and
+  handed to an exporter;
+* **deterministic archive lifetime** — the NPZ archive is opened as a context
+  manager and is already closed before the selected exporter is invoked, on the
+  success path and on every failure path.
+
+Ordinary numeric-lattice behaviour is unchanged and is locked here.
+
+This is deliberately NOT whole-NPZ validation, archive-size control, ZIP-bomb
+resistance, lattice-shape or state validation, path containment, atomic-file
+handling or snapshot-schema enforcement. No claim is made that a hostile archive
+is safe to load — only that object arrays are refused and the handle is closed.
+
+Every test uses synthetic arrays, temporary NPZ files and monkeypatched
+exporters. No real marching cubes, trimesh, Pillow, Medusa artifact, network,
+engine, observer or calibration run is touched, and no malicious pickle is ever
+constructed or executed — the object-array test uses a harmless payload and
+proves *refusal*, not exploitability.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import scripts.dandelion as dandelion
+
+#: (command, exporter attribute, extra argv, kwargs the exporter receives)
+COMMANDS = [
+    pytest.param("stl", "lattice_to_stl", ["--output"], id="stl"),
+    pytest.param("glb", "lattice_to_glb", ["--output"], id="glb"),
+    pytest.param("slices", "lattice_to_voxel_slices", ["--output-dir"], id="slices"),
+]
+
+
+def _write_npz(path, **members):
+    np.savez(path, **members)
+    return str(path)
+
+
+def _numeric_lattice():
+    return np.arange(27, dtype=np.int8).reshape(3, 3, 3)
+
+
+def _argv(command, snapshot, flag, target):
+    return [command, snapshot, flag, str(target)]
+
+
+# ---------------------------------------------------------------------------
+# 1. All three commands disable pickle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command, exporter, flags", COMMANDS)
+def test_every_snapshot_command_disables_pickle(
+    tmp_path, monkeypatch, command, exporter, flags
+):
+    snapshot = _write_npz(tmp_path / "snap.npz", lattice=_numeric_lattice())
+    calls: list = []
+    real_load = np.load
+
+    def recording_load(file, *args, **kwargs):
+        calls.append({"file": str(file), "args": args, "kwargs": dict(kwargs)})
+        return real_load(file, *args, **kwargs)
+
+    monkeypatch.setattr(dandelion.np, "load", recording_load)
+    monkeypatch.setattr(dandelion, exporter, lambda *a, **k: None)
+
+    dandelion.main(_argv(command, snapshot, flags[0], tmp_path / "out"))
+
+    assert len(calls) == 1, f"expected exactly one np.load, got {len(calls)}"
+    assert calls[0]["kwargs"].get("allow_pickle") is False, (
+        f"expected allow_pickle=False, got {calls[0]['kwargs'].get('allow_pickle')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Controlled fake archive used by the lifetime tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeArchive:
+    """Records the exact order of enter / member access / exit."""
+
+    def __init__(self, log, member, raise_on_access=None):
+        self._log = log
+        self._member = member
+        self._raise = raise_on_access
+        self.closed = False
+        self.entered = False
+
+    def __enter__(self):
+        self.entered = True
+        self._log.append("enter")
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+        self._log.append("exit")
+        return False
+
+    def __getitem__(self, key):
+        self._log.append(f"access:{key}")
+        if self._raise is not None:
+            raise self._raise
+        if key != "lattice":
+            raise KeyError(f"{key} is not a file in the archive")
+        return self._member
+
+    def close(self):
+        self.closed = True
+        self._log.append("close")
+
+
+@pytest.fixture
+def fake_archive(monkeypatch):
+    """Install a fake ``np.load`` returning a controlled archive; return state."""
+
+    def install(member=None, raise_on_access=None):
+        state = {"log": [], "archive": None, "exporter_saw_closed": None}
+
+        def fake_load(file, *args, **kwargs):
+            state["log"].append("load")
+            state["kwargs"] = dict(kwargs)
+            arc = _FakeArchive(state["log"], member, raise_on_access)
+            state["archive"] = arc
+            return arc
+
+        monkeypatch.setattr(dandelion.np, "load", fake_load)
+        return state
+
+    return install
+
+
+# ---------------------------------------------------------------------------
+# 2. The archive closes BEFORE the exporter is invoked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command, exporter, flags", COMMANDS)
+def test_archive_is_closed_before_exporter_runs(
+    tmp_path, monkeypatch, fake_archive, command, exporter, flags
+):
+    lattice = _numeric_lattice()
+    state = fake_archive(member=lattice)
+
+    def recording_exporter(*args, **kwargs):
+        # The exporter itself asserts the handle is already gone.
+        assert state["archive"].closed, "archive was still open when the exporter ran"
+        state["exporter_saw_closed"] = True
+        state["log"].append("exporter")
+        return "out"
+
+    monkeypatch.setattr(dandelion, exporter, recording_exporter)
+    dandelion.main(_argv(command, str(tmp_path / "snap.npz"), flags[0], tmp_path / "out"))
+
+    assert state["log"] == ["load", "enter", "access:lattice", "exit", "exporter"], (
+        f"unexpected ordering: {state['log']}"
+    )
+    assert state["exporter_saw_closed"] is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Numeric lattice and exporter arguments are preserved exactly
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_lattice_and_arguments_reach_stl_unchanged(
+    tmp_path, monkeypatch, fake_archive
+):
+    lattice = _numeric_lattice()
+    fake_archive(member=lattice)
+    seen: list = []
+    monkeypatch.setattr(dandelion, "lattice_to_stl", lambda *a, **k: seen.append((a, k)))
+
+    out = tmp_path / "organism.stl"
+    dandelion.main(["stl", str(tmp_path / "s.npz"), "--output", str(out)])
+
+    assert len(seen) == 1
+    args, kwargs = seen[0]
+    assert args[0] is lattice          # the very same object, no copy or cast
+    assert args[1] == str(out)
+    assert kwargs == {}
+
+
+def test_numeric_lattice_and_arguments_reach_glb_unchanged(
+    tmp_path, monkeypatch, fake_archive
+):
+    lattice = _numeric_lattice()
+    fake_archive(member=lattice)
+    seen: list = []
+    monkeypatch.setattr(dandelion, "lattice_to_glb", lambda *a, **k: seen.append((a, k)))
+
+    out = tmp_path / "organism.glb"
+    dandelion.main(["glb", str(tmp_path / "s.npz"), "--output", str(out)])
+
+    assert len(seen) == 1
+    args, kwargs = seen[0]
+    assert args[0] is lattice
+    assert args[1] == str(out)
+    assert kwargs == {}
+
+
+def test_numeric_lattice_and_arguments_reach_slices_unchanged(
+    tmp_path, monkeypatch, fake_archive
+):
+    lattice = _numeric_lattice()
+    fake_archive(member=lattice)
+    seen: list = []
+    monkeypatch.setattr(
+        dandelion, "lattice_to_voxel_slices", lambda *a, **k: seen.append((a, k))
+    )
+
+    out_dir = tmp_path / "slices_out"
+    dandelion.main(
+        ["slices", str(tmp_path / "s.npz"), "--output-dir", str(out_dir), "--scale", "3"]
+    )
+
+    assert len(seen) == 1
+    args, kwargs = seen[0]
+    assert args[0] is lattice
+    assert args[1] == str(out_dir)
+    assert kwargs == {"scale": 3}
+
+
+def test_slices_scale_default_is_preserved(tmp_path, monkeypatch, fake_archive):
+    fake_archive(member=_numeric_lattice())
+    seen: list = []
+    monkeypatch.setattr(
+        dandelion, "lattice_to_voxel_slices", lambda *a, **k: seen.append((a, k))
+    )
+    dandelion.main(["slices", str(tmp_path / "s.npz")])
+    assert seen[0][1] == {"scale": 1}
+
+
+# ---------------------------------------------------------------------------
+# 4. Object-dtype lattice is refused — real NPZ, harmless payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command, exporter, flags", COMMANDS)
+def test_object_dtype_lattice_is_refused(
+    tmp_path, monkeypatch, capsys, command, exporter, flags
+):
+    # A harmless object array. This proves object arrays are REFUSED; it is not
+    # a malicious pickle and nothing hostile is ever constructed or executed.
+    harmless = np.array([{"note": "harmless"}, None, "text"], dtype=object)
+    snapshot = _write_npz(tmp_path / "obj.npz", lattice=harmless)
+    out = tmp_path / "out"
+    called: list = []
+    monkeypatch.setattr(dandelion, exporter, lambda *a, **k: called.append(1) or "x")
+
+    with pytest.raises(ValueError) as excinfo:
+        dandelion.main(_argv(command, snapshot, flags[0], out))
+
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert called == [], "exporter must never see an object-dtype lattice"
+    assert not out.exists()
+    captured = capsys.readouterr()
+    for leaked in ("STL exported:", "GLB exported:", "Slices exported"):
+        assert leaked not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# 5. Missing member: archive closes, KeyError propagates, no argparse exit 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command, exporter, flags", COMMANDS)
+def test_missing_lattice_member_closes_and_propagates(
+    tmp_path, monkeypatch, command, exporter, flags
+):
+    snapshot = _write_npz(tmp_path / "nolattice.npz", other=np.zeros(3))
+    called: list = []
+    monkeypatch.setattr(dandelion, exporter, lambda *a, **k: called.append(1))
+
+    with pytest.raises(KeyError):
+        dandelion.main(_argv(command, snapshot, flags[0], tmp_path / "out"))
+
+    assert called == []
+
+
+def test_missing_member_closes_the_archive(tmp_path, monkeypatch):
+    """A REAL NpzFile lacking the member: KeyError propagates, handle released."""
+    calls: list = []
+    archives: list = []
+    real_load = np.load  # captured before any patching
+    snapshot = _write_npz(tmp_path / "nolattice.npz", other=np.zeros(3))
+
+    def tracking_load(file, *args, **kwargs):
+        arc = real_load(file, *args, **kwargs)
+        archives.append(arc)
+        return arc
+
+    monkeypatch.setattr(dandelion.np, "load", tracking_load)
+    monkeypatch.setattr(dandelion, "lattice_to_stl", lambda *a, **k: calls.append(1))
+
+    with pytest.raises(KeyError):
+        dandelion.main(["stl", snapshot, "--output", str(tmp_path / "o.stl")])
+
+    assert calls == []
+    assert archives, "np.load was never called"
+    # NpzFile.close() releases the underlying handle and sets fid to None.
+    assert archives[0].fid is None or getattr(archives[0].fid, "closed", True)
+
+
+# ---------------------------------------------------------------------------
+# 6. Member-access failure: archive still closes, sentinel propagates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sentinel", [RuntimeError("boom"), MemoryError("oom")],
+                         ids=["runtime-error", "memory-error"])
+def test_member_access_failure_closes_archive_and_propagates(
+    tmp_path, monkeypatch, fake_archive, sentinel
+):
+    state = fake_archive(raise_on_access=sentinel)
+    called: list = []
+    monkeypatch.setattr(dandelion, "lattice_to_stl", lambda *a, **k: called.append(1))
+
+    with pytest.raises(type(sentinel)) as excinfo:
+        dandelion.main(["stl", str(tmp_path / "s.npz"), "--output", str(tmp_path / "o")])
+
+    assert excinfo.value is sentinel
+    assert state["archive"].closed, "archive must close even when access raises"
+    assert state["log"] == ["load", "enter", "access:lattice", "exit"]
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Load failure stays loud — no catch, no argparse translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command, exporter, flags", COMMANDS)
+def test_load_failure_propagates_untranslated(
+    tmp_path, monkeypatch, command, exporter, flags
+):
+    sentinel = OSError("synthetic archive/filesystem failure")
+
+    def failing_load(*args, **kwargs):
+        raise sentinel
+
+    monkeypatch.setattr(dandelion.np, "load", failing_load)
+    called: list = []
+    monkeypatch.setattr(dandelion, exporter, lambda *a, **k: called.append(1))
+
+    with pytest.raises(OSError) as excinfo:
+        dandelion.main(_argv(command, str(tmp_path / "s.npz"), flags[0], tmp_path / "o"))
+
+    assert excinfo.value is sentinel
+    assert not isinstance(excinfo.value, SystemExit)
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Direct exporters do not load snapshot files themselves (smoke guard)
+# ---------------------------------------------------------------------------
+
+
+def test_direct_exporters_do_not_load_snapshots(monkeypatch):
+    """Smoke guard — the full exporter contracts live in their own suites."""
+    loads: list = []
+    monkeypatch.setattr(dandelion.np, "load", lambda *a, **k: loads.append(1))
+
+    # Each exporter takes an in-memory lattice; none should reach np.load.
+    with pytest.raises(Exception):
+        dandelion.lattice_to_stl(np.zeros((2, 2, 2), dtype=np.int8), "unused.stl",
+                                 states_to_include=[])
+    assert loads == []


### PR DESCRIPTION
## Load snapshot lattices without pickle, and close the archive

**Status: DRAFT — no ready transition and no merge is requested by this PR.** Left as a draft for Jack's independent review.

### The pre-fix three-branch seam
The public `stl`, `glb` and `slices` commands each ran the same two lines independently:

```python
elif args.command == "stl":
    snap = np.load(args.snapshot, allow_pickle=True)
    lattice_to_stl(snap["lattice"], args.output)
```

No context manager. No `close()`. `allow_pickle=True` on all three.

### Defect 1 — pickle-enabled loading accepts object arrays
Measured on unmodified `main` with a **harmless** synthetic object array:

```
OBS-5  object-dtype lattice REACHED exporter: True  dtype= object
OBS-5b allow_pickle=False refuses with ValueError: Object arrays cannot be loaded when allow_pickle=False
```

The same loader also hands a file that isn't a valid NPZ to the **unpickler** — a corrupt archive raised `UnpicklingError` on unmodified `main`, i.e. the unpickler running on unvalidated input.

### Defect 2 — nondeterministic archive lifetime
The NPZ handle was never released. It outlived the loading step and was still open while the exporter ran — on success and on every failure path.

### The correction
One small private helper beside the 3D-export section:

```python
def _load_snapshot_lattice(snapshot_path: str) -> np.ndarray:
    with np.load(snapshot_path, allow_pickle=False) as snapshot:
        return snapshot["lattice"]
```

`np.load` once · `allow_pickle=False` explicitly · context manager · exactly the `"lattice"` member · returned as NumPy produced it (no dtype conversion, copy, reshape or validation). Because the value is produced **inside** the `with`, the context-manager exit completes before the caller receives the lattice — so **the archive is already closed when the exporter is invoked**, and it closes equally on missing-member `KeyError`, on object-array refusal, and on any other exception raised during member access.

Each CLI branch becomes one helper call plus the same exporter call with the same remaining arguments. **No CLI catch added, no new exception class, no message parsing.**

### Exact two-file boundary
| File | Change |
|---|---|
| `scripts/dandelion.py` | **+26 / −6** — helper added, three branches rewired |
| `tests/test_dandelion_snapshot_loading.py` | **+376 / −0** — new focused test file |

Total **+402 / −6**, one ordinary single-parent commit on `main` `0fcaf469bce094b29bfb6abcf28aaeb9976d15cf`.

**Untouched:** `lattice_to_stl`, `lattice_to_glb`, `lattice_to_voxel_slices`, `_GenomeCapture`, `_capture_genome`, the QR and `info` paths, WASM, ATL, the stale empty-GLB docstring sentence, and all four existing dandelion test files.

### Failing-first evidence
Against **unmodified** live `main` — **12 failed, 11 passed**, with these distinct reasons:

```
E  AssertionError: expected allow_pickle=False, got True
E  AssertionError: archive was still open when the exporter ran
E  AssertionError: archive must close even when access raises
E  Failed: DID NOT RAISE <class 'ValueError'>     (object-dtype lattice reached the exporter)
E  Failed: DID NOT RAISE <class 'KeyError'>
```

After the correction: **23 passed**. The eleven that passed beforehand are the numeric-preservation locks, the `scale` default, missing-member propagation, load-failure propagation and the direct-exporter smoke guard — reported honestly as behaviour locks, not evidence of the defect.

**One test of mine was itself faulty** and is disclosed rather than buried: `test_missing_member_closes_the_archive` patched `np.load` twice, so it captured the fake instead of the real loader. Corrected **before commit**, and the failing-first result re-confirmed by stashing only the source change (12 failed / 11 passed again).

### Behaviour preservation
Parser definitions, arguments and defaults; `args.output` / `args.output_dir` / `args.scale` forwarding; the retrieved array itself — tests assert the exporter receives *the very same object* (`args[0] is lattice`); exporter call count and ordering; missing-member `KeyError`; archive and filesystem failures; and no argparse exit-code translation for any snapshot-loading failure.

**One consequence disclosed:** a file that is not a valid NPZ now raises `ValueError` from `np.load` instead of `UnpicklingError`, because the loader no longer attempts to unpickle it. That is a direct result of disabling pickle, it is **not** a caught or translated difference, and no exporter runs in either case.

### Receipts
- `tests/test_dandelion_snapshot_loading.py`: **23 passed**.
- `test_dandelion.py` + `test_dandelion_glb.py` + `test_dandelion_qr_metadata.py` + `test_dandelion_info_coherence.py` (all unmodified): **46 passed**.
- `python -m py_compile` on both changed files: OK.
- `git diff --check`: no whitespace errors; both blobs LF-only with trailing newline.
- Maintained suite: **2166 passed, 48 skipped, 0 failed** — the previous 2143 plus exactly the 23 new tests, no regressions. Skips are environment-gated and unrelated: 24 need the unbuilt Rust `uft_ca` extension, ~22 are Windows symlink / POSIX permission semantics, 1 is an absent `evolution_engine`.

### Scope and non-claims
- One narrow **loading boundary**: object arrays refused, handle deterministically closed, numeric behaviour unchanged.
- **No whole-NPZ-security claim.** Not archive-size control, **not** ZIP-bomb resistance, not entry-name validation, not lattice-shape/state/schema validation, not path containment, not atomic-file handling. No claim that an arbitrary hostile archive is safe to open.
- No malicious pickle was constructed or executed anywhere; the object-array test proves **refusal**, not exploitability.
- No exporter, QR, `info`, WASM or ATL behaviour change.
- Green checks are execution evidence only, **not** semantic proof.
- No cross-PR file-disjointness is certified. **#420 remained parked and untouched**; **#419 was not inspected at any level**.

_Left **draft and unmerged** for Jack's independent review._
