### PR TITLE
fix(gpu-benchmark): close the snapshot archive at the extraction boundary

### DIFF
--- a/scripts/gpu_benchmark.py
+++ b/scripts/gpu_benchmark.py
@@ -76,6 +76,42 @@ def benchmark_component(name: str, fn, warmup: int = 2, iterations: int = 10) ->
     return median
 
 
+def _load_snapshot(snapshot_path):
+    """Return (lattice, memory_grid, generation) with the archive already closed.
+
+    `run_benchmarks` previously did `snap = np.load(...)` inline and kept the
+    returned `NpzFile` referenced for the whole suite: the shape and cell-count
+    calculations, `load_rule_spec`, legacy memory-grid expansion, RNG and
+    inactivity construction, the temporary CPU/GPU global switch, every CPU and
+    optional GPU component benchmark with all its warmups and iterations, every
+    full `step_ca_lattice` step, the timing aggregation and the printed summary.
+    A benchmark run therefore held the input handle across an operator-selected
+    number of steps, released only by eventual object destruction. On Windows a
+    retained snapshot handle can interfere with deleting, rotating or replacing
+    that file.
+
+    The `with` block bounds the archive to extraction: the three values are
+    materialised while it is open and it is closed before this helper returns,
+    so no benchmark work holds the input handle. Closure is explicit, not left
+    to garbage collection.
+
+    Extraction is not guarded: a missing key or a failing `int()` conversion
+    propagates exactly as before, and the `with` block still closes the archive
+    on the way out. The supplied `snapshot_path` object is passed to `np.load`
+    unchanged (no path conversion introduced) and `allow_pickle=True` is
+    preserved verbatim.
+
+    The claim is archive resource lifetime relative to extraction — not an
+    indefinitely accumulating descriptor leak, not snapshot validation, and
+    nothing about the benchmark mathematics or timing methodology.
+    """
+    with np.load(snapshot_path, allow_pickle=True) as snap:
+        lattice = snap["lattice"]
+        memory_grid = snap["memory_grid"]
+        generation = int(snap["generation"])
+    return lattice, memory_grid, generation
+
+
 def run_benchmarks(snapshot_path: str, num_steps: int = 10):
     """Run the full benchmark suite."""
     print("=" * 72)
@@ -93,10 +129,7 @@ def run_benchmarks(snapshot_path: str, num_steps: int = 10):
 
     # Load snapshot
     print(f"  Loading snapshot: {snapshot_path}")
-    snap = np.load(snapshot_path, allow_pickle=True)
-    lattice = snap["lattice"]
-    memory_grid = snap["memory_grid"]
-    generation = int(snap["generation"])
+    lattice, memory_grid, generation = _load_snapshot(snapshot_path)
     shape = lattice.shape
     N = shape[0]
     total_cells = lattice.size

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -34,7 +34,10 @@ from unittest import mock
 import numpy as np
 import pytest
 
+import scripts as _scripts_package
+
 _ENGINE = "scripts.continuous_evolution_ca"
+_ENGINE_ATTR = "continuous_evolution_ca"
 
 
 def _engine_stand_in():
@@ -319,7 +322,15 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
         })
         return lattice, inactivity, memory_grid, {"entropy": 0.5}
 
+    # `run_benchmarks` does `import scripts.continuous_evolution_ca as ca_module`.
+    # For that dotted `import ... as` form CPython resolves the binding via
+    # `getattr(scripts, "continuous_evolution_ca")` and only falls back to
+    # `sys.modules`, so patching `sys.modules` alone is not enough once any other
+    # test module has imported the real engine (which sets that attribute on the
+    # package). Both are patched here, and both are restored on exit, so the real
+    # engine's globals are never read or mutated by these tests.
     with mock.patch.dict(sys.modules, {_ENGINE: engine}), \
+         mock.patch.object(_scripts_package, _ENGINE_ATTR, engine, create=True), \
          mock.patch.object(gpu_benchmark.np, "load",
                            mock.Mock(return_value=archive)), \
          mock.patch.object(gpu_benchmark, "load_rule_spec", _load_rule_spec), \

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -1,0 +1,485 @@
+"""Focused tests for `scripts/gpu_benchmark` snapshot-archive resource lifetime.
+
+`run_benchmarks()` used to do `snap = np.load(...)` inline and keep the returned
+`NpzFile` referenced for the whole suite — shape and cell-count calculations,
+`load_rule_spec`, legacy memory-grid expansion, RNG and inactivity construction,
+the temporary CPU/GPU global switch, every component benchmark with all its
+warmups and iterations, every full `step_ca_lattice` step, the timing
+aggregation and the printed summary. A run therefore held the input handle
+across an operator-selected number of steps, released only by eventual object
+destruction. On Windows a retained snapshot handle can interfere with deleting,
+rotating or replacing that file.
+
+`_load_snapshot()` now bounds the archive to extraction and closes it before
+returning.
+
+No real benchmark, engine, GPU kernel, snapshot or persistent output is used:
+`scripts.continuous_evolution_ca` is replaced by a scoped stand-in (the
+production module imports it at load time), `benchmark_component` is a
+deterministic recorder rather than a timing loop, arrays are 2x2x2, and
+`np.load` returns a closure-recording fake. Nothing is written anywhere.
+
+Scope is archive resource lifetime relative to extraction — not snapshot
+validation, benchmark mathematics, timing methodology, or the separate question
+of exception-safe restoration of the temporary engine globals.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+_ENGINE = "scripts.continuous_evolution_ca"
+
+
+def _engine_stand_in():
+    """A stand-in for the engine module the benchmark imports at load time."""
+    module = types.ModuleType(_ENGINE)
+    module.step_ca_lattice = lambda *a, **k: None
+    module.count_neighbors_3d = lambda *a, **k: None
+    module.load_rule_spec = lambda *a, **k: None
+    module.init_memory_grid = lambda *a, **k: None
+    module._separable_box_filter_3d = lambda *a, **k: None
+    module._max_neighbor_value = lambda *a, **k: None
+    module.GPU_AVAILABLE = False
+    module._xp = np
+    return module
+
+
+# The production module does a top-level `from scripts.continuous_evolution_ca
+# import ...`, so the engine is replaced for the duration of the import and
+# `sys.modules` is restored immediately afterwards. The real engine is never
+# imported or executed by this file.
+with mock.patch.dict(sys.modules, {_ENGINE: _engine_stand_in()}):
+    from scripts import gpu_benchmark
+
+
+class Boom(Exception):
+    """Distinct conversion failure, so propagation can be asserted exactly."""
+
+
+class _ExplodingInt:
+    def __int__(self):
+        raise Boom("generation conversion failed")
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` that `np.load` returns.
+
+    Records context entry/exit, explicit closure and key lookups. Defines **no**
+    `__del__`, so a recorded closure can never have come from garbage
+    collection, reference-count timing or interpreter shutdown.
+    """
+
+    def __init__(self, contents=None, raise_on=None):
+        self.contents = {} if contents is None else contents
+        self.raise_on = raise_on
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.lookups = []
+        self.rec = None  # reachable after a propagated exception
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress an extraction failure
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.lookups.append(key)
+        if self.raise_on == key:
+            raise KeyError(key)
+        return self.contents[key]
+
+
+def _lattice(size=2):
+    return np.zeros((size, size, size), dtype=np.uint8)
+
+
+def _grid(channels=8, size=2):
+    return np.zeros((channels, size, size, size), dtype=np.float32)
+
+
+def _contents(**overrides):
+    base = {"lattice": _lattice(), "memory_grid": _grid(), "generation": 1000}
+    base.update(overrides)
+    return base
+
+
+def _load(archive, path=None):
+    """Run the real `_load_snapshot` against `archive`; return (result, mock)."""
+    load_mock = mock.Mock(return_value=archive)
+    target = path if path is not None else Path("/fake/v070_gen1000.npz")
+    with mock.patch.object(gpu_benchmark.np, "load", load_mock):
+        result = gpu_benchmark._load_snapshot(target)
+    return result, load_mock
+
+
+# -- helper contract ----------------------------------------------------------
+
+
+def test_helper_returns_the_exact_objects_in_order():
+    contents = _contents()
+    archive = _FakeArchive(contents)
+    result, _ = _load(archive)
+    assert isinstance(result, tuple) and len(result) == 3
+    lattice, memory_grid, generation = result
+    assert lattice is contents["lattice"]            # identity, not a copy
+    assert memory_grid is contents["memory_grid"]    # identity, not a copy
+    assert generation == 1000
+
+
+def test_generation_is_an_exact_builtin_int():
+    archive = _FakeArchive(_contents(generation=np.int64(4242)))
+    (_, _, generation), _ = _load(archive)
+    assert type(generation) is int
+    assert generation == 4242
+
+
+def test_np_load_receives_the_original_path_object_and_allow_pickle():
+    """No path conversion is introduced: the very object passed in is forwarded."""
+    path = Path("/fake/dir/v070_gen7.npz")
+    _, load_mock = _load(_FakeArchive(_contents()), path=path)
+    assert load_mock.call_count == 1
+    args, kwargs = load_mock.call_args
+    assert args == (path,)
+    assert args[0] is path
+    assert kwargs == {"allow_pickle": True}
+
+
+def test_extraction_order_is_preserved():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.lookups == ["lattice", "memory_grid", "generation"]
+
+
+# -- closure on success -------------------------------------------------------
+
+
+def test_archive_context_entered_exactly_once():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.entered == 1
+
+
+def test_archive_exits_and_closes_exactly_once_on_success():
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_already_closed_when_the_helper_returns():
+    """Asserted immediately after the return, while this frame still holds a
+    live reference to the archive — so closure was explicit."""
+    archive = _FakeArchive(_contents())
+    result, _ = _load(archive)
+    assert archive.closed == 1
+    assert result[2] == 1000
+
+
+def test_closure_does_not_depend_on_finalisation():
+    """No `__del__` on the fake and the reference stays alive, so the recorded
+    closure cannot come from gc, reference-count timing or interpreter
+    shutdown. No test here calls gc.collect()."""
+    assert not hasattr(_FakeArchive, "__del__")
+    archive = _FakeArchive(_contents())
+    _load(archive)
+    assert archive.closed == 1
+    assert archive is not None
+
+
+# -- closure on every extraction / conversion failure -------------------------
+
+
+@pytest.mark.parametrize(
+    "missing", ["lattice", "memory_grid", "generation"],
+    ids=["lattice", "memory_grid", "generation"],
+)
+def test_archive_closes_when_a_key_lookup_raises(missing):
+    archive = _FakeArchive(_contents(), raise_on=missing)
+    with pytest.raises(KeyError):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_archive_closes_when_the_generation_conversion_raises():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom):
+        _load(archive)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_original_extraction_exception_propagates_unchanged():
+    archive = _FakeArchive(_contents(generation=_ExplodingInt()))
+    with pytest.raises(Boom) as exc:
+        _load(archive)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.closed == 1
+
+    missing = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError) as exc2:
+        _load(missing)
+    assert type(exc2.value) is KeyError
+    assert missing.closed == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("archive read failed"), RuntimeError("boom"), MemoryError("oom"),
+     ValueError("bad zip")],
+    ids=["os_error", "runtime_error", "memory_error", "value_error"],
+)
+def test_np_load_failure_propagates_unchanged(error):
+    """No blanket except was added, and no archive was ever entered."""
+    load_mock = mock.Mock(side_effect=error)
+    with mock.patch.object(gpu_benchmark.np, "load", load_mock):
+        with pytest.raises(type(error)) as exc:
+            gpu_benchmark._load_snapshot(Path("/fake/x.npz"))
+    assert type(exc.value) is type(error)
+    assert str(exc.value) == str(error)
+
+
+# -- controlled run_benchmarks() ----------------------------------------------
+
+
+class _Recorder:
+    def __init__(self, archive):
+        self.archive = archive
+        self.load_rule_spec = []
+        self.init_memory_grid = []
+        self.components = []
+        self.steps = []
+        self.measured = []  # what the measured callables actually received
+
+
+def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
+    """Drive the genuine `run_benchmarks()` with every seam controlled.
+
+    Returns (archive, recorder). Nothing real is benchmarked: the engine is a
+    scoped stand-in, `benchmark_component` is a deterministic recorder rather
+    than a timing loop, and the arrays are 2x2x2.
+    """
+    archive = archive if archive is not None else _FakeArchive(
+        _contents() if contents is None else contents, raise_on=raise_on
+    )
+    rec = _Recorder(archive)
+    archive.rec = rec
+    engine = _engine_stand_in()
+    sentinel_xp = object()
+    engine.GPU_AVAILABLE = True      # a distinctive prior value...
+    engine._xp = sentinel_xp         # ...so restoration is observable
+
+    def _load_rule_spec(rule_path):
+        rec.load_rule_spec.append({"closed": archive.closed, "path": rule_path,
+                                   "gpu": engine.GPU_AVAILABLE})
+        return {"rule": "stub"}
+
+    def _init_memory_grid(shape):
+        rec.init_memory_grid.append({"closed": archive.closed, "shape": tuple(shape)})
+        return _grid(channels=8, size=shape[0])
+
+    def _benchmark_component(name, fn, warmup=2, iterations=10):
+        rec.components.append({
+            "closed": archive.closed, "name": name, "warmup": warmup,
+            "iterations": iterations, "gpu": engine.GPU_AVAILABLE,
+            "xp_is_numpy": engine._xp is np,
+        })
+        fn()  # exactly once — deterministic, no warmup/iteration timing loop
+        return 1.0
+
+    def _measured(label):
+        def _record(arg, *rest, **kwargs):
+            rec.measured.append({"label": label, "arg": arg,
+                                 "closed": archive.closed})
+            return arg
+        return _record
+
+    def _step_ca_lattice(lattice, rule_spec, rng, inactivity, memory_grid,
+                         current_gen=None):
+        rec.steps.append({
+            "closed": archive.closed, "lattice": lattice, "rule_spec": rule_spec,
+            "rng": rng, "inactivity": inactivity, "memory_grid": memory_grid,
+            "current_gen": current_gen,
+        })
+        return lattice, inactivity, memory_grid, {"entropy": 0.5}
+
+    with mock.patch.dict(sys.modules, {_ENGINE: engine}), \
+         mock.patch.object(gpu_benchmark.np, "load",
+                           mock.Mock(return_value=archive)), \
+         mock.patch.object(gpu_benchmark, "load_rule_spec", _load_rule_spec), \
+         mock.patch.object(gpu_benchmark, "init_memory_grid", _init_memory_grid), \
+         mock.patch.object(gpu_benchmark, "benchmark_component", _benchmark_component), \
+         mock.patch.object(gpu_benchmark, "step_ca_lattice", _step_ca_lattice), \
+         mock.patch.object(gpu_benchmark, "count_neighbors_3d",
+                           _measured("count_neighbors_3d")), \
+         mock.patch.object(gpu_benchmark, "_separable_box_filter_3d",
+                           _measured("box_filter")), \
+         mock.patch.object(gpu_benchmark, "_max_neighbor_value",
+                           _measured("max_neighbor")), \
+         mock.patch.object(gpu_benchmark, "GPU_AVAILABLE", False):
+        gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", num_steps)
+
+    # The engine stand-in is discarded with the scope; assert the temporary
+    # switch was restored on it before that happened.
+    rec.engine_after = {"gpu": engine.GPU_AVAILABLE,
+                        "xp_is_sentinel": engine._xp is sentinel_xp}
+    return archive, rec
+
+
+def test_run_benchmarks_closes_the_archive_before_load_rule_spec(capsys):
+    """Central witness. Pre-fix `load_rule_spec` was entered with the archive
+    still open, because the inline `np.load` result stayed referenced."""
+    archive, rec = _run_benchmarks(num_steps=1)
+    assert len(rec.load_rule_spec) == 1
+    assert rec.load_rule_spec[0]["closed"] == 1
+    assert rec.load_rule_spec[0]["path"].endswith("example.toml")
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_run_benchmarks_closes_the_archive_before_init_memory_grid(capsys):
+    """Central witness on the legacy path."""
+    archive, rec = _run_benchmarks(
+        contents=_contents(memory_grid=_grid(channels=3)), num_steps=1
+    )
+    assert len(rec.init_memory_grid) == 1
+    assert rec.init_memory_grid[0]["closed"] == 1
+    assert rec.init_memory_grid[0]["shape"] == (2, 2, 2)
+
+
+def test_first_component_benchmark_observes_a_closed_archive(capsys):
+    archive, rec = _run_benchmarks(num_steps=1)
+    assert rec.components, "component benchmarks must have run"
+    assert rec.components[0]["closed"] == 1
+    assert all(entry["closed"] == 1 for entry in rec.components)
+
+
+def test_first_full_step_observes_a_closed_archive(capsys):
+    archive, rec = _run_benchmarks(num_steps=3)
+    assert len(rec.steps) == 3
+    assert rec.steps[0]["closed"] == 1
+    assert all(step["closed"] == 1 for step in rec.steps)
+
+
+def test_every_post_extraction_seam_observes_exactly_one_closure(capsys):
+    archive, rec = _run_benchmarks(num_steps=2)
+    observed = ([entry["closed"] for entry in rec.load_rule_spec]
+                + [entry["closed"] for entry in rec.components]
+                + [step["closed"] for step in rec.steps])
+    assert observed, "seams must have been reached"
+    assert set(observed) == {1}
+    assert archive.closed == 1
+
+
+# -- established benchmark behaviour -----------------------------------------
+
+
+def test_extracted_lattice_reaches_the_component_seam_by_identity(capsys):
+    """With no legacy expansion, the component benchmark measures the extracted
+    lattice object itself — asserted at the seam that actually receives it."""
+    contents = _contents()
+    archive, rec = _run_benchmarks(contents=contents, num_steps=1)
+    measured = {entry["label"]: entry for entry in rec.measured}
+    assert measured["count_neighbors_3d"]["arg"] is contents["lattice"]
+    assert all(entry["closed"] == 1 for entry in rec.measured)
+
+
+def test_full_step_seam_receives_the_established_copies(capsys):
+    """The established loop benchmarks copies, not the extracted arrays."""
+    contents = _contents()
+    archive, rec = _run_benchmarks(contents=contents, num_steps=1)
+    step = rec.steps[0]
+    np.testing.assert_array_equal(step["lattice"], contents["lattice"])
+    np.testing.assert_array_equal(step["memory_grid"], contents["memory_grid"])
+    assert step["lattice"] is not contents["lattice"]        # established .copy()
+    assert step["memory_grid"] is not contents["memory_grid"]
+    assert step["rule_spec"] == {"rule": "stub"}
+
+
+def test_legacy_memory_grid_expansion_is_unchanged(capsys):
+    legacy = _grid(channels=3)
+    legacy[:] = 7.0
+    archive, rec = _run_benchmarks(contents=_contents(memory_grid=legacy),
+                                   num_steps=1)
+    expanded = rec.steps[0]["memory_grid"]
+    assert expanded.shape[0] == 8
+    np.testing.assert_array_equal(expanded[:3], legacy)
+    np.testing.assert_array_equal(expanded[3:], np.zeros((5, 2, 2, 2), np.float32))
+
+
+def test_generation_progression_is_generation_plus_index(capsys):
+    archive, rec = _run_benchmarks(contents=_contents(generation=500), num_steps=4)
+    assert [step["current_gen"] for step in rec.steps] == [500, 501, 502, 503]
+
+
+def test_rng_seed_and_inactivity_dtype_are_unchanged(capsys):
+    archive, rec = _run_benchmarks(num_steps=2)
+    first = rec.steps[0]
+    assert isinstance(first["rng"], np.random.Generator)
+    assert first["rng"].random() == np.random.default_rng(seed=42).random()
+    assert first["inactivity"].dtype == np.int16
+    assert first["inactivity"].shape == (2, 2, 2)
+    assert rec.steps[1]["rng"] is first["rng"]
+
+
+def test_temporary_cpu_mode_switch_and_restoration_are_unchanged(capsys):
+    """During the CPU component section the engine globals are forced to CPU;
+    afterwards the prior values are restored on the successful path."""
+    archive, rec = _run_benchmarks(num_steps=1)
+    assert rec.components, "component benchmarks must have run"
+    assert all(entry["gpu"] is False for entry in rec.components)
+    assert all(entry["xp_is_numpy"] for entry in rec.components)
+    assert rec.engine_after["gpu"] is True          # restored
+    assert rec.engine_after["xp_is_sentinel"] is True  # restored
+
+
+def test_component_warmup_and_iteration_counts_are_unchanged(capsys):
+    archive, rec = _run_benchmarks(num_steps=1)
+    names = [entry["name"] for entry in rec.components]
+    assert names == [
+        "count_neighbors_3d (CPU)",
+        "box_filter_3d R=12 (CPU)",
+        "max_neighbor_value (CPU)",
+    ]
+    assert all(entry["warmup"] == 1 and entry["iterations"] == 5
+               for entry in rec.components)
+
+
+def test_an_extraction_failure_reaches_no_benchmark_seam(capsys):
+    archive = _FakeArchive(_contents(), raise_on="lattice")
+    with pytest.raises(KeyError):
+        _run_benchmarks(archive=archive, num_steps=3)
+    rec = archive.rec
+    assert rec.load_rule_spec == []
+    assert rec.init_memory_grid == []
+    assert rec.components == []
+    assert rec.steps == []
+    assert archive.closed == 1
+
+
+def test_no_real_engine_gpu_or_benchmark_was_executed(capsys):
+    """Every seam was a stand-in and the engine stub is scoped, not resident."""
+    before = sys.modules.get(_ENGINE)
+    archive, rec = _run_benchmarks(num_steps=1)
+    assert sys.modules.get(_ENGINE) is before
+    # Only the three CPU components ran: the GPU branch was never entered.
+    assert all(entry["name"].endswith("(CPU)") for entry in rec.components)
+    assert not any("(GPU)" in entry["name"] for entry in rec.components)
+    assert len(rec.measured) == 3  # each measured callable invoked exactly once


### PR DESCRIPTION
## GPU benchmark: close the snapshot archive at the extraction boundary

Bounded Ian-seat package. `run_benchmarks()` kept the loaded `NpzFile` referenced
for the entire benchmark suite — every warmup, every component iteration and every
full step — with no explicit close. **Draft — do NOT merge.** Merge authority is
Kev's later explicit word only.

### Base / head / lineage
- **branch-cut base:** `main` @ `0fcaf469bce094b29bfb6abcf28aaeb9976d15cf`
- **first implementation commit:** `6dea60fe6f2da4d791f95be2c0d97b025ad0427f` — production change plus the initial tests
- **final head:** `fdbc1268b0ca3597ac6e39aeeb62a8f2ee87f9eb` — **test-file only**, repairing the CI-exposed test-isolation defect
- **exact lineage:** `0fcaf469... → 6dea60f... → fdbc126...`
- **Two ordinary commits.** The final head's direct parent is the **first commit** `6dea60f`, *not* the branch-cut base. The branch was cut fresh from freshly reverified live `main`; both commits were ordinary pushes. **No amend, no rebase, no force-push, no history rewrite.**
- Inline `np.load(...)` without closure independently confirmed at `gpu_benchmark.py:96` at gate time, with the archive referenced through all later benchmark work. `tests/test_gpu_benchmark_snapshot_loader.py` did not exist and is created here.

### Final file boundary & diffstat (exactly two permitted files)
Measured against the branch-cut base `0fcaf46` at the final head `fdbc126`:
```
scripts/gpu_benchmark.py                    +37 / -4
tests/test_gpu_benchmark_snapshot_loader.py +496 / -0
TOTAL                                       +533 / -4
```
*First-head historical figure, superseded:* commit `6dea60f` alone was
`+522 / -4` with a 485-line test file; the follow-up commit `fdbc126` added
**11 test lines only**, giving the final `+533 / -4` above.

### Current-`main` relationship (separate from branch-cut history)
- Live `main` has since advanced to **`d11f96a65ad04c8c5a077e7befe11653ae83fb07`** through merged **#432**.
- That intervening package is **Dandelion-only and file-disjoint** from #433 (`scripts/gpu_benchmark.py`, `tests/test_gpu_benchmark_snapshot_loader.py`).
- #433 is presently **two commits ahead on its own branch and one commit behind current `main`**.
- **No synchronization, rebase or merge-from-`main` was performed or authorised.** #432 is used only as merged live-`main` history; no Dandelion work is derived or assigned from it.

### Independently reproduced failing-before lifetime behaviour
Driving the **genuine pre-fix `run_benchmarks()`** with a closure-recording fake
archive and controlled engine/benchmark seams:

| Post-extraction seam | Pre-fix closure state when entered |
|---|---|
| `load_rule_spec` | **archive open** — `closed == 0` |
| `init_memory_grid` (legacy 3-channel grid) | **archive open** |
| first CPU component benchmark | **archive open** |
| every measured callable (`count_neighbors_3d`, box filter, max-neighbour) | **archive open** |
| first and every full `step_ca_lattice` | **archive open** |
| any key-lookup or `int()` failure | archive **never closed** |

The archive was never entered as a context at all. **12 of 28 pre-fix checks fail**
— every one a closure or helper-existence check.

**Claim precision:** what is demonstrated is **resource lifetime relative to
extraction**. No indefinitely accumulating descriptor leak was demonstrated and
none is claimed.

### Helper contract
```python
def _load_snapshot(snapshot_path):
    with np.load(snapshot_path, allow_pickle=True) as snap:
        lattice = snap["lattice"]
        memory_grid = snap["memory_grid"]
        generation = int(snap["generation"])
    return lattice, memory_grid, generation
```
Opens with a context manager; materialises all three while open; closes **before
returning**; returns the same three values in the same order. `snapshot_path` is
forwarded unchanged and `allow_pickle=True` preserved. Called once from
`run_benchmarks()`.

### Successful and exceptional closure evidence
| Case | Result |
|---|---|
| success | `entered == 1`, `exited == 1`, `closed == 1`, closed when the helper returns |
| `lattice` / `memory_grid` / `generation` lookup raises | `KeyError` propagates, `closed == 1` |
| `int(generation)` raises | original `Boom` propagates ("generation conversion failed"), `closed == 1` |
| `np.load` raises `OSError` / `RuntimeError` / `MemoryError` / `ValueError` | propagates with exact type **and** message; archive never entered |
| extraction failure inside a full run | closes, and **no benchmark seam runs at all** (rule spec, expansion, components, steps all empty) |

Exception identity asserted, so nothing is caught, translated or suppressed.
**Closure is explicit, not finalisation-dependent:** the fake defines no `__del__`,
asserting frames hold live references when `closed == 1` is observed, and no test
calls `gc.collect()`.

### Proof closure precedes every tested benchmark seam
Each seam records the archive's closure count **at entry**; post-fix all record
`1` — `load_rule_spec`, `init_memory_grid` (legacy path), the first and every
component benchmark, every measured callable, and the first and every
`step_ca_lattice`. A dedicated test asserts the union of all observed values is
exactly `{1}`. The two marked **CENTRAL** are the witnesses that fail against the
pre-fix module.

### Identity, conversion and generation-progression preservation
- `lattice` and `memory_grid` returned **by identity** from the helper.
- With no legacy expansion, the extracted lattice reaches the **component seam by
  identity** — asserted where it is actually received (`count_neighbors_3d`),
  since the full-step loop deliberately benchmarks copies.
- The full-step seam still receives the established `.copy()` values (asserted
  equal but **not** identical).
- `generation` is an exact built-in `int` (asserted with an `np.int64` input).
- **`np.load` receives the original `snapshot_path` object** — a `Path` asserted
  with `args[0] is path`, proving no conversion was introduced — plus
  `allow_pickle=True`.
- Extraction order asserted `["lattice", "memory_grid", "generation"]`.
- Generation progression asserted `[500, 501, 502, 503]` for `generation + i`.
- RNG seed 42 verified against `np.random.default_rng(seed=42).random()`, and the
  same generator instance is carried across steps; inactivity is `int16`, shaped
  like the lattice.
- Component names and warmup/iteration counts unchanged
  (`count_neighbors_3d (CPU)`, `box_filter_3d R=12 (CPU)`,
  `max_neighbor_value (CPU)`, each `warmup=1, iterations=5`).
- Legacy 3→8 channel expansion unchanged: first three channels copied, remainder zero.
- Temporary CPU-mode switching verified: during the component section
  `ca_module.GPU_AVAILABLE` is `False` and `_xp is np`; afterwards the **prior**
  values are restored (asserted against a distinctive sentinel).

**Explicitly not repaired:** exception-safe restoration of those temporary engine
globals is a separate question and was left alone, as instructed.

### GPU / engine / timer isolation
The production module imports the engine at load time, so
`scripts.continuous_evolution_ca` is replaced by a scoped `sys.modules` stand-in
for the import and restored immediately; each test installs a fresh stand-in for
the in-function `import ... as ca_module`, so `GPU_AVAILABLE` / `_xp` cannot leak
between tests — asserted, along with `sys.modules` being unchanged after a run.
`GPU_AVAILABLE` is patched `False` so the GPU section never runs (asserted: no
`(GPU)` component appears). `benchmark_component` is a deterministic recorder that
invokes each measured callable **exactly once** rather than running warmup and
iteration timing loops, so nothing is performance-sensitive. Arrays are 2×2×2. No
CuPy is required and the file is **not** module-level skipped for it.

### Local evidence (this seat) — separated from CI and CodeQL
**`pytest`, NumPy and CuPy are all absent on this seat: no test suite was run
locally**, and no custom pytest replacement was built or described as equivalent.
Probes served the module's import seams and array operations with stand-ins and
replaced `np.load` per case, so the executed bodies are the genuine helper and
`run_benchmarks`. What ran:
1. `compile()` clean on both changed files.
2. Static AST check: 26 functions → 31 collected cases, **no `parametrize`
   id/value cardinality mismatch**.
3. A direct-execution harness over both trees:

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `0fcaf46` | 28 | **12** (incl. both central witnesses) |
| post-fix production, first-head harness | 47 | **0** |
| post-fix production, final harness with the CI condition reproduced (`fdbc126`) | 49 | **0** |

The production change is byte-identical across both post-fix rows — the second
row is the same harness after it was corrected to model CI's import state, plus
two added checks. 

The pre-fix run executes fewer checks because `_load_snapshot` does not exist
there. **Every preserved-behaviour check passes in both states** — rule-file
selection, `gen + i`, RNG seed, `int16` inactivity, component names and counts,
CPU-mode forcing and restoration, component-seam identity, full-step copies, the
absent GPU section, legacy expansion, extraction-failure propagation and engine
stub scoping. Real-NumPy specifics (actual `int16` dtype, RNG determinism, array
equality) are exercised only in CI.

Scratch probes lived outside the repository and were removed.

### CI / CodeQL evidence
See the receipt appended below once every **registered** check is conclusive. This
package touches `scripts/**`, so CodeQL is expected to register per current
repository policy; the receipt records exactly what registered and claims nothing
about checks that did not.

### Residuals and explicit non-claims
- **Bounded claim:** archive resource lifetime relative to extraction. **Not**
  snapshot validation, archive security, benchmark mathematics, timing methodology
  or whole-benchmark correctness. **No accumulating-descriptor-leak claim.**
- `allow_pickle=True` preserved and unexamined — a hostile `.npz` can still execute
  pickle payloads. Out of scope.
- Extracted arrays stay in memory after close: a **handle** lifetime shortened, not
  a footprint — and `run_benchmarks` then makes its own copies for the step loop.
- **Exception-safe restoration of `ca_module.GPU_AVAILABLE` / `_xp` is untouched
  and still absent**: an exception raised inside the CPU component section would
  still leave those globals forced to CPU. Deliberately out of scope here, and
  flagged rather than silently fixed.
- The GPU component branch is never exercised — CI has no CuPy, and the tests
  assert it did not run rather than testing it.
- `num_steps=0` is not exercised: the established code computes
  `np.median([])` and references `first_metrics`, so a zero-step run is a
  pre-existing edge outside this boundary.
- No schema validation; a missing key still raises `KeyError` unchanged and the
  benchmark has no top-level handler.
- The Windows consequence (blocked delete/rotate/replace) is stated as the
  *motivation*; it was **not** reproduced against a real Windows file lock.
- Locally the context-manager protocol was driven by a fake, so real
  `NpzFile.__exit__` semantics were exercised only in CI.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from the other packages
- **#419**, **#422**, **#424**, **#425**, **#426**, **#428**, **#429**, **#430**
  and **#431** were verified parked (OPEN, draft, unmerged) and **none was
  modified**. Their file boundaries are disjoint from `scripts/gpu_benchmark.py` +
  `tests/test_gpu_benchmark_snapshot_loader.py`.
- **#419's computed mergeability indicator was not queried, not reconciled and not
  acted on**, per instruction — only its parked state was confirmed.
- **#420** (Kev-seat) kept **opaque** — bare number, title, branch and open/draft
  identity only; no body, files, checks, comments, reviews or threads inspected or
  discussed, as in every prior round.
- **#432** was open and opaque at gate time, when only the minimum
  file-disjointness confirmation the authorization carved out was taken — paths
  only (`scripts/dandelion.py`, `tests/test_dandelion_snapshot_loading.py`,
  disjoint). It has **since merged** and is now used only as merged live-`main`
  history; no Dandelion work is derived or assigned from it.
- **#423** and **#427** merged, used only as live-`main` history.

### Fences
Exactly two authorized files across **both** commits; **two ordinary commits** —
one focused implementation commit plus one authorized follow-up, test-file only,
for a concrete CI-exposed defect; branch cut fresh from live `main`; ordinary
pushes, **no amend, no rebase, no force-push, no history rewrite**. No real Medusa
snapshot, engine benchmark or GPU execution; nothing written inside the repository.
`scripts/continuous_evolution_ca.py`, `scripts/gpu_accelerator.py` and rule files
untouched. No merge / auto-merge / ready-for-review transition / rebase /
merge-from-main / history rewrite / repository, workflow, protection or settings
change / manual workflow rerun / branch deletion. No comment, review, thread
action, reaction or label. No new dependency. Leave **OPEN, draft, unmerged** and
hand back to Jack.

---

### CI receipt (body-only append; all registered checks conclusive — GREEN)

**First head `6dea60f` FAILED CI, and the failure was in this package's test
isolation, not in the production change.** Recorded openly:

- `verify-python` on `6dea60f`: **1 failed, 2295 passed, 13 skipped** — the single
  failure was `test_temporary_cpu_mode_switch_and_restoration_are_unchanged`.
- Cause: `run_benchmarks()` does `import scripts.continuous_evolution_ca as
  ca_module`. For that dotted `import ... as` form CPython binds via
  `getattr(scripts, "continuous_evolution_ca")` and only falls back to
  `sys.modules`. Once an earlier test module in the session has imported the **real**
  engine, that attribute exists on the package and wins over a `sys.modules` patch —
  so `ca_module` resolved to the real engine, the stand-in's `GPU_AVAILABLE` was
  never forced to `False`, and the assertion correctly failed. It also meant the
  tests were reading, and `run_benchmarks` was temporarily mutating, the **real**
  engine module's globals — precisely what the isolation requirement forbids.
  Production restores those globals on its successful path, so nothing leaked and the
  other 2295 cases were unaffected.
- Why it passed locally: the attribute never existed on this seat, so the
  `sys.modules` fallback found the stand-in.
- Fix (`fdbc126`, one ordinary follow-up commit, **test file only**, no amend/rebase/
  force): patch the package attribute alongside the `sys.modules` entry, both scoped
  and both restored. The local harness was corrected to reproduce the CI condition
  with a decoy "already-imported real engine" and now also asserts the decoy is never
  mutated and the attribute is restored — 49 checks, 0 failures. **The CI failure was
  the negative control.**
- **The production change was NOT altered after the failure.** `scripts/gpu_benchmark.py`
  is byte-identical between `6dea60f` and the final head `fdbc126`; the follow-up
  diff is `tests/test_gpu_benchmark_snapshot_loader.py +11 / -0` and nothing else.

Final head `fdbc1268b0ca3597ac6e39aeeb62a8f2ee87f9eb`. No workflow was manually rerun.

**The status rollup contains exactly 7 entries, all `SUCCESS`, none pending or queued.** Recorded verbatim, claiming nothing about checks that did not register:

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m28s) | run `30229600638` / job `89865839704` — **2296 passed, 13 skipped, 0 failed** (41.92s) |
| verify-python (push-triggered run) | ✅ pass (1m27s) | run `30229598853` / job `89865835137` |
| **Analyze Python (CodeQL)** | ✅ pass (59s) | run `30229600605` |
| **CodeQL** | ✅ pass | job `89865924296` |
| agent-safety | ✅ pass (9s) | run `30229600652` |
| frontend-quality | ✅ pass (52s ×2) | runs `30229598853`, `30229600638` |

**`tripwire` did not register on the final head.** It registered and passed on the
first head (`6dea60f`), and the follow-up commit touched only
`tests/test_gpu_benchmark_snapshot_loader.py`. That is an observed fact about which
workflows were triggered for that file set — not a failure and not a pending check. I
did not inspect workflow definitions to explain it, and I do **not** claim it green on
this head.

**Every new case ran; none was skipped.** Baseline `verify-python` on live `main`
`0fcaf46` (run `30202563297`) reports **2265 passed, 13 skipped**. This head reports
**2296 passed, 13 skipped**:

- **+31 passed**, exactly matching the 31 statically counted collected cases;
- **skipped unchanged at 13** — the focused module was not skipped for CuPy or a GPU;
- **0 failed**, and all 2265 pre-existing cases still pass.

CI's figures supersede the seat-local evidence as the authoritative gate. PR remains
**OPEN, draft, unmerged** — handing back to Jack for audit; merge authority is Kev's
later explicit word only.

