### PR TITLE
fix(nextness-observer): deterministic archive ownership in load_snapshot

### DIFF
--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -1224,41 +1224,63 @@ def load_snapshot(
 
     Raises ``ValueError`` if required keys are missing or shapes are
     inconsistent — defensive against passing the wrong file.
+
+    Archive ownership is deterministic. The ``NpzFile`` is held by a context
+    manager, so it is closed before this function returns on the success path
+    *and* on every failure path after the archive is opened: required-key
+    enumeration or refusal, any required-member access, the ``int()``
+    conversion, either shape validation, optional-member access, and scalar
+    ``.item()`` conversion. Previously the archive was bound to a local with no
+    ``close()``, so release depended on object destruction rather than an
+    explicit ownership boundary, and callers had no contractual guarantee that
+    the input file had been released before Observer processing began.
+
+    Nothing else changes: the pre-load path handling, ``allow_pickle=False``,
+    the required keys, the extraction order, every exception type and message,
+    the narrow skippable-``ValueError`` lane for pickled optional members, the
+    scalar ``.item()`` rule and the returned tuple are all preserved exactly. An
+    exception raised by ``np.load`` itself happens before context entry and
+    propagates unchanged.
+
+    The bounded claim is deterministic archive ownership and close-before-return
+    across this loader's existing contract — not whole-NPZ security, snapshot
+    authenticity, atomic reading, concurrent-writer protection, metadata-schema
+    totality, or any accumulating-descriptor-leak claim.
     """
     snapshot_path = pathlib.Path(snapshot_path)
     if not snapshot_path.is_file():
         raise FileNotFoundError(f"snapshot not found: {snapshot_path}")
-    snap = np.load(str(snapshot_path), allow_pickle=False)
-    keys = set(snap.files)
-    required = {"lattice", "memory_grid", "generation"}
-    missing = required - keys
-    if missing:
-        raise ValueError(
-            f"snapshot {snapshot_path.name} missing keys: {sorted(missing)}"
-        )
-    state = snap["lattice"]
-    memory = snap["memory_grid"]
-    generation = int(snap["generation"])
-    if state.ndim != 3:
-        raise ValueError(
-            f"snapshot {snapshot_path.name}: state must be 3D, got shape {state.shape}"
-        )
-    if memory.ndim != 4 or memory.shape[1:] != state.shape:
-        raise ValueError(
-            f"snapshot {snapshot_path.name}: memory shape {memory.shape} "
-            f"inconsistent with state shape {state.shape}"
-        )
-    # Optional metadata: only include keys that load without pickle.
-    # With allow_pickle=False any key requiring pickle will raise ValueError
-    # at access time; we catch + skip rather than fail the whole load.
-    meta: dict[str, object] = {}
-    for k in keys - required:
-        try:
-            val = snap[k]
-        except ValueError:
-            # Key needs pickle (object dtype); skip silently per §7 #7 spirit.
-            continue
-        meta[k] = val.item() if val.ndim == 0 else val
+    with np.load(str(snapshot_path), allow_pickle=False) as snap:
+        keys = set(snap.files)
+        required = {"lattice", "memory_grid", "generation"}
+        missing = required - keys
+        if missing:
+            raise ValueError(
+                f"snapshot {snapshot_path.name} missing keys: {sorted(missing)}"
+            )
+        state = snap["lattice"]
+        memory = snap["memory_grid"]
+        generation = int(snap["generation"])
+        if state.ndim != 3:
+            raise ValueError(
+                f"snapshot {snapshot_path.name}: state must be 3D, got shape {state.shape}"
+            )
+        if memory.ndim != 4 or memory.shape[1:] != state.shape:
+            raise ValueError(
+                f"snapshot {snapshot_path.name}: memory shape {memory.shape} "
+                f"inconsistent with state shape {state.shape}"
+            )
+        # Optional metadata: only include keys that load without pickle.
+        # With allow_pickle=False any key requiring pickle will raise ValueError
+        # at access time; we catch + skip rather than fail the whole load.
+        meta: dict[str, object] = {}
+        for k in keys - required:
+            try:
+                val = snap[k]
+            except ValueError:
+                # Key needs pickle (object dtype); skip silently per §7 #7 spirit.
+                continue
+            meta[k] = val.item() if val.ndim == 0 else val
     return state, memory, generation, meta
 
 

--- a/tests/test_nextness_observer_snapshot_loader.py
+++ b/tests/test_nextness_observer_snapshot_loader.py
@@ -1,0 +1,909 @@
+"""Focused tests for `nextness_observer.load_snapshot()` archive ownership.
+
+`load_snapshot()` used to bind the `NpzFile` from `np.load` to a local with no
+context manager and no `close()`, then hold it through required-key enumeration,
+all three required-member extractions, the `int()` conversion, both shape
+validations, every optional-metadata traversal and the return. Release depended
+on object destruction rather than an explicit ownership boundary, and callers had
+no contractual proof that the input archive had been released before Observer
+processing began. The same absence applied to every validation and metadata
+failure path.
+
+The loader now owns the archive through a context manager, so it is closed before
+the function returns on the success path and on every failure path after the
+archive is opened.
+
+**Stated precisely:** the defect is the absence of deterministic
+close-before-return across implementations and failure paths. It is *not* a claim
+that `process_snapshot()` certainly retained the archive for a whole
+classification run — in CPython a refcount drop may release it promptly at
+function return — and it is *not* a proven accumulating descriptor leak.
+
+Nothing here runs a Medusa engine, touches the network, imports ZMQ, publishes an
+event, runs GPU code, writes repository data or creates a production log. Real
+`.npz` files are tiny and live in `tmp_path`. `tests/test_nextness_observer.py` is
+untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import pathlib
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from scripts import nextness_observer
+from scripts.nextness_observer import (
+    ObserverConfig,
+    TOKEN_NAMES,
+    load_snapshot,
+    process_snapshot,
+)
+
+
+class Boom(Exception):
+    """Distinct failure, so exception identity can be asserted exactly."""
+
+
+# --------------------------------------------------------------------------- #
+# Closure-recording doubles
+# --------------------------------------------------------------------------- #
+
+
+class _FakeMember:
+    """An archive member with controlled `.ndim`, `.shape` and `.item()`."""
+
+    def __init__(self, ndim=3, shape=(2, 2, 2), item_value=None, item_error=None,
+                 ndim_error=None):
+        self._ndim = ndim
+        self.shape = shape
+        self._item_value = item_value
+        self._item_error = item_error
+        self._ndim_error = ndim_error
+
+    @property
+    def ndim(self):
+        if self._ndim_error is not None:
+            raise self._ndim_error
+        return self._ndim
+
+    def item(self):
+        if self._item_error is not None:
+            raise self._item_error
+        return self._item_value
+
+
+class _FakeArchive:
+    """Stand-in for the `NpzFile` returned by `np.load`.
+
+    Records context entry/exit and explicit closure. Defines **no** `__del__`, so
+    a recorded closure can never have come from finalisation, reference-count
+    timing, garbage collection or interpreter shutdown.
+    """
+
+    def __init__(self, members=None, file_names=None, files_error=None,
+                 access_errors=None):
+        self._members = {} if members is None else members
+        self._file_names = (list(self._members) if file_names is None
+                            else list(file_names))
+        self._files_error = files_error
+        self._access_errors = {} if access_errors is None else access_errors
+        self.entered = 0
+        self.exited = 0
+        self.closed = 0
+        self.accesses = []
+
+    @property
+    def files(self):
+        if self._files_error is not None:
+            raise self._files_error
+        return list(self._file_names)
+
+    def __enter__(self):
+        self.entered += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        self.close()
+        return False  # never suppress
+
+    def close(self):
+        self.closed += 1
+
+    def __getitem__(self, key):
+        self.accesses.append(key)
+        if key in self._access_errors:
+            raise self._access_errors[key]
+        return self._members[key]
+
+
+def _state(shape=(2, 2, 2)):
+    return _FakeMember(ndim=len(shape), shape=shape)
+
+
+def _memory(shape=(4, 2, 2, 2)):
+    return _FakeMember(ndim=len(shape), shape=shape)
+
+
+def _generation(value=1234):
+    return value
+
+
+def _members(**overrides):
+    base = {
+        "lattice": _state(),
+        "memory_grid": _memory(),
+        "generation": _generation(),
+    }
+    base.update(overrides)
+    return base
+
+
+def _snapshot_file(tmp_path, name="v070_gen1234.npz"):
+    """A real file on disk so `is_file()` passes; contents never read."""
+    path = tmp_path / name
+    path.write_bytes(b"")
+    return path
+
+
+def _load(tmp_path, archive, name="v070_gen1234.npz"):
+    """Run the genuine `load_snapshot` against `archive`; return (result, mock)."""
+    path = _snapshot_file(tmp_path, name)
+    load_mock = mock.Mock(return_value=archive)
+    with mock.patch.object(nextness_observer.np, "load", load_mock):
+        result = load_snapshot(path)
+    return result, load_mock
+
+
+def _load_expecting(tmp_path, archive, exc_type, name="v070_gen1234.npz"):
+    path = _snapshot_file(tmp_path, name)
+    load_mock = mock.Mock(return_value=archive)
+    with mock.patch.object(nextness_observer.np, "load", load_mock):
+        with pytest.raises(exc_type) as exc:
+            load_snapshot(path)
+    return exc
+
+
+# --------------------------------------------------------------------------- #
+# Central failing-before witness
+# --------------------------------------------------------------------------- #
+
+
+def test_archive_is_explicitly_closed_before_load_snapshot_returns(tmp_path):
+    """CENTRAL WITNESS.
+
+    Against the pre-fix loader this fails: the function returns while the
+    archive's explicit exit/close count is still zero. The reference below stays
+    live for the whole assertion, `_FakeArchive` defines no `__del__`, and no
+    `gc.collect()` is called anywhere in this module — so a recorded closure can
+    only have come from an explicit ownership boundary.
+    """
+    archive = _FakeArchive(_members())
+    result, _ = _load(tmp_path, archive)
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+    assert result is not None
+    assert archive is not None  # still referenced here; nothing was finalised
+    assert not hasattr(_FakeArchive, "__del__")
+
+
+# --------------------------------------------------------------------------- #
+# Successful materialisation contract
+# --------------------------------------------------------------------------- #
+
+
+def test_successful_return_is_a_four_tuple_in_the_established_order(tmp_path):
+    members = _members()
+    result, _ = _load(tmp_path, _FakeArchive(members))
+    assert isinstance(result, tuple)
+    assert len(result) == 4
+    state, memory, generation, meta = result
+    assert state is members["lattice"]
+    assert memory is members["memory_grid"]
+    assert generation == 1234
+    assert meta == {}
+
+
+def test_state_and_memory_are_returned_by_identity(tmp_path):
+    members = _members()
+    (state, memory, _, _), _ = _load(tmp_path, _FakeArchive(members))
+    assert state is members["lattice"]
+    assert memory is members["memory_grid"]
+
+
+def test_generation_is_an_exact_builtin_int(tmp_path):
+    members = _members(generation=np.int64(77))
+    (_, _, generation, _), _ = _load(tmp_path, _FakeArchive(members))
+    assert type(generation) is int
+    assert generation == 77
+
+
+def test_metadata_is_an_exact_builtin_dict(tmp_path):
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(_members()))
+    assert type(meta) is dict
+
+
+def test_np_load_receives_str_path_and_allow_pickle_false(tmp_path):
+    path = _snapshot_file(tmp_path)
+    load_mock = mock.Mock(return_value=_FakeArchive(_members()))
+    with mock.patch.object(nextness_observer.np, "load", load_mock):
+        load_snapshot(path)
+    args, kwargs = load_mock.call_args
+    assert args == (str(path),)
+    assert type(args[0]) is str
+    assert kwargs == {"allow_pickle": False}
+
+
+def test_required_member_access_order_is_preserved(tmp_path):
+    archive = _FakeArchive(_members())
+    _load(tmp_path, archive)
+    assert archive.accesses[:3] == ["lattice", "memory_grid", "generation"]
+
+
+def test_required_key_enumeration_happens_while_the_archive_is_open(tmp_path):
+    """`snap.files` is read inside the context: a `files` failure is raised with
+    the archive entered and then closed, which can only happen inside it."""
+    archive = _FakeArchive(_members(), files_error=Boom("files exploded"))
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert str(exc.value) == "files exploded"
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+# --------------------------------------------------------------------------- #
+# Pre-load path handling
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_path_raises_the_established_file_not_found(tmp_path):
+    missing = tmp_path / "absent.npz"
+    with pytest.raises(FileNotFoundError) as exc:
+        load_snapshot(missing)
+    assert str(exc.value) == f"snapshot not found: {missing}"
+
+
+def test_missing_path_never_calls_np_load(tmp_path):
+    load_mock = mock.Mock()
+    with mock.patch.object(nextness_observer.np, "load", load_mock):
+        with pytest.raises(FileNotFoundError):
+            load_snapshot(tmp_path / "absent.npz")
+    assert load_mock.call_count == 0
+
+
+def test_np_load_failure_propagates_before_any_context_entry(tmp_path):
+    """An `np.load` failure happens before context entry and is unchanged."""
+    path = _snapshot_file(tmp_path)
+    load_mock = mock.Mock(side_effect=OSError("cannot open"))
+    with mock.patch.object(nextness_observer.np, "load", load_mock):
+        with pytest.raises(OSError) as exc:
+            load_snapshot(path)
+    assert type(exc.value) is OSError
+    assert str(exc.value) == "cannot open"
+
+
+# --------------------------------------------------------------------------- #
+# Required-key refusal
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "present,missing_repr",
+    [
+        (["memory_grid", "generation"], "['lattice']"),
+        (["lattice", "generation"], "['memory_grid']"),
+        (["lattice", "memory_grid"], "['generation']"),
+    ],
+    ids=["no_lattice", "no_memory_grid", "no_generation"],
+)
+def test_one_missing_required_key_preserves_the_refusal(tmp_path, present,
+                                                        missing_repr):
+    archive = _FakeArchive(_members(), file_names=present)
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == f"snapshot v070_gen1234.npz missing keys: {missing_repr}"
+    assert archive.closed == 1
+
+
+def test_multiple_missing_required_keys_are_sorted(tmp_path):
+    archive = _FakeArchive(_members(), file_names=["generation"])
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == (
+        "snapshot v070_gen1234.npz missing keys: ['lattice', 'memory_grid']"
+    )
+    assert archive.closed == 1
+
+
+def test_all_required_keys_missing_is_sorted(tmp_path):
+    archive = _FakeArchive(_members(), file_names=[])
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == (
+        "snapshot v070_gen1234.npz missing keys: "
+        "['generation', 'lattice', 'memory_grid']"
+    )
+    assert archive.closed == 1
+
+
+def test_missing_key_refusal_closes_the_archive(tmp_path):
+    archive = _FakeArchive(_members(), file_names=["lattice"])
+    _load_expecting(tmp_path, archive, ValueError)
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+# --------------------------------------------------------------------------- #
+# Required-member extraction failures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "failing", ["lattice", "memory_grid", "generation"],
+    ids=["lattice", "memory_grid", "generation"],
+)
+def test_required_member_failure_propagates_and_closes(tmp_path, failing):
+    archive = _FakeArchive(_members(), access_errors={failing: Boom(f"{failing} bad")})
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == f"{failing} bad"
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_generation_conversion_failure_preserves_identity_and_closes(tmp_path):
+    class _Unconvertible:
+        def __int__(self):
+            raise Boom("generation conversion failed")
+
+    archive = _FakeArchive(_members(generation=_Unconvertible()))
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "generation conversion failed"
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+# --------------------------------------------------------------------------- #
+# Shape validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("ndim,shape", [(2, (2, 2)), (4, (1, 2, 2, 2)), (1, (8,))],
+                         ids=["two_d", "four_d", "one_d"])
+def test_invalid_state_dimensionality_preserves_the_message_and_closes(
+    tmp_path, ndim, shape
+):
+    archive = _FakeArchive(_members(lattice=_FakeMember(ndim=ndim, shape=shape)))
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == (
+        f"snapshot v070_gen1234.npz: state must be 3D, got shape {shape}"
+    )
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize("ndim,shape", [(3, (2, 2, 2)), (5, (1, 1, 2, 2, 2))],
+                         ids=["three_d", "five_d"])
+def test_wrong_memory_dimensionality_preserves_the_message_and_closes(
+    tmp_path, ndim, shape
+):
+    archive = _FakeArchive(_members(memory_grid=_FakeMember(ndim=ndim, shape=shape)))
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == (
+        f"snapshot v070_gen1234.npz: memory shape {shape} "
+        f"inconsistent with state shape (2, 2, 2)"
+    )
+    assert archive.closed == 1
+
+
+def test_mismatched_memory_spatial_shape_preserves_the_message_and_closes(tmp_path):
+    archive = _FakeArchive(
+        _members(memory_grid=_FakeMember(ndim=4, shape=(4, 3, 3, 3)))
+    )
+    exc = _load_expecting(tmp_path, archive, ValueError)
+    assert str(exc.value) == (
+        "snapshot v070_gen1234.npz: memory shape (4, 3, 3, 3) "
+        "inconsistent with state shape (2, 2, 2)"
+    )
+    assert archive.closed == 1
+
+
+def test_shape_inspection_failure_propagates_unchanged_and_closes(tmp_path):
+    archive = _FakeArchive(
+        _members(lattice=_FakeMember(ndim_error=Boom("ndim exploded")))
+    )
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "ndim exploded"
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+# --------------------------------------------------------------------------- #
+# Optional metadata
+# --------------------------------------------------------------------------- #
+
+
+def test_absent_optional_metadata_returns_an_empty_dict(tmp_path):
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(_members()))
+    assert meta == {}
+    assert type(meta) is dict
+
+
+def test_numeric_scalar_metadata_uses_item(tmp_path):
+    members = _members(seed=_FakeMember(ndim=0, shape=(), item_value=99))
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert meta == {"seed": 99}
+    assert type(meta["seed"]) is int
+
+
+def test_boolean_scalar_metadata_preserves_the_builtin_value(tmp_path):
+    members = _members(flag=_FakeMember(ndim=0, shape=(), item_value=True))
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert meta["flag"] is True
+
+
+def test_string_scalar_metadata_preserves_the_item_result(tmp_path):
+    members = _members(label=_FakeMember(ndim=0, shape=(), item_value="medusa"))
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert meta["label"] == "medusa"
+    assert type(meta["label"]) is str
+
+
+def test_non_scalar_optional_array_is_returned_by_identity(tmp_path):
+    array_member = _FakeMember(ndim=1, shape=(3,))
+    members = _members(history=array_member)
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert meta["history"] is array_member  # not copied, cast or transformed
+
+
+def test_multiple_ordinary_metadata_members_all_survive(tmp_path):
+    members = _members(
+        seed=_FakeMember(ndim=0, shape=(), item_value=1),
+        label=_FakeMember(ndim=0, shape=(), item_value="x"),
+        history=_FakeMember(ndim=2, shape=(2, 2)),
+    )
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert set(meta) == {"seed", "label", "history"}
+    assert meta["seed"] == 1
+    assert meta["label"] == "x"
+    assert meta["history"] is members["history"]
+
+
+def test_optional_member_value_error_skips_only_that_member(tmp_path):
+    """The narrow skippable lane: a pickled member is dropped, others survive."""
+    members = _members(
+        pickled=_FakeMember(),
+        good=_FakeMember(ndim=0, shape=(), item_value=5),
+    )
+    archive = _FakeArchive(
+        members,
+        access_errors={"pickled": ValueError("Object arrays cannot be loaded")},
+    )
+    (_, _, _, meta), _ = _load(tmp_path, archive)
+    assert "pickled" not in meta
+    assert meta == {"good": 5}
+
+
+def test_archive_closes_after_the_expected_skipped_value_error(tmp_path):
+    members = _members(pickled=_FakeMember())
+    archive = _FakeArchive(
+        members,
+        access_errors={"pickled": ValueError("Object arrays cannot be loaded")},
+    )
+    (_, _, _, meta), _ = _load(tmp_path, archive)
+    assert meta == {}
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [RuntimeError("unexpected"), MemoryError("oom"), KeyError("gone"),
+     OSError("io failed")],
+    ids=["runtime_error", "memory_error", "key_error", "os_error"],
+)
+def test_unexpected_optional_failure_propagates_and_closes(tmp_path, error):
+    """Only `ValueError` is skippable; nothing else joins that lane."""
+    members = _members(odd=_FakeMember())
+    archive = _FakeArchive(members, access_errors={"odd": error})
+    exc = _load_expecting(tmp_path, archive, type(error))
+    assert type(exc.value) is type(error)
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_optional_ndim_failure_propagates_and_closes(tmp_path):
+    members = _members(odd=_FakeMember(ndim_error=Boom("ndim exploded")))
+    archive = _FakeArchive(members)
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert str(exc.value) == "ndim exploded"
+    assert archive.closed == 1
+
+
+def test_optional_scalar_item_failure_propagates_with_identity_and_closes(tmp_path):
+    members = _members(
+        odd=_FakeMember(ndim=0, shape=(), item_error=Boom("item exploded"))
+    )
+    archive = _FakeArchive(members)
+    exc = _load_expecting(tmp_path, archive, Boom)
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "item exploded"
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_metadata_values_are_not_copied_cast_or_stringified(tmp_path):
+    """Beyond the established scalar `.item()`, values pass through untouched."""
+    array_member = _FakeMember(ndim=3, shape=(1, 1, 1))
+    members = _members(payload=array_member)
+    (_, _, _, meta), _ = _load(tmp_path, _FakeArchive(members))
+    assert meta["payload"] is array_member
+    assert not isinstance(meta["payload"], str)
+
+
+# --------------------------------------------------------------------------- #
+# Real-NumPy behaviour locks (tiny, tmp_path only)
+# --------------------------------------------------------------------------- #
+
+
+def _write_npz(tmp_path, name="v070_gen0000042.npz", **arrays):
+    path = tmp_path / name
+    np.savez(path, **arrays)
+    return path
+
+
+def _tiny_valid(**extra):
+    arrays = {
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((4, 2, 2, 2), dtype=np.float32),
+        "generation": np.array(42),
+    }
+    arrays.update(extra)
+    return arrays
+
+
+def test_real_npz_round_trip(tmp_path):
+    path = _write_npz(tmp_path, **_tiny_valid())
+    state, memory, generation, meta = load_snapshot(path)
+    assert state.shape == (2, 2, 2)
+    assert state.dtype == np.uint8
+    assert memory.shape == (4, 2, 2, 2)
+    assert memory.dtype == np.float32
+    assert generation == 42
+    assert type(generation) is int
+    assert meta == {}
+
+
+def test_real_npz_optional_numeric_scalar_metadata(tmp_path):
+    path = _write_npz(tmp_path, **_tiny_valid(seed=np.array(7)))
+    _, _, _, meta = load_snapshot(path)
+    assert meta["seed"] == 7
+    assert not isinstance(meta["seed"], np.ndarray)  # .item() applied
+
+
+def test_real_npz_optional_array_metadata(tmp_path):
+    history = np.arange(3, dtype=np.int32)
+    path = _write_npz(tmp_path, **_tiny_valid(history=history))
+    _, _, _, meta = load_snapshot(path)
+    assert isinstance(meta["history"], np.ndarray)
+    np.testing.assert_array_equal(meta["history"], history)
+
+
+def test_real_npz_object_dtype_optional_member_is_skipped(tmp_path):
+    """A harmless object-dtype array: `allow_pickle=False` refuses it, and the
+    established narrow lane skips that member without failing the load."""
+    obj = np.array([{"harmless": 1}], dtype=object)
+    path = _write_npz(tmp_path, **_tiny_valid(notes=obj))
+    state, memory, generation, meta = load_snapshot(path)
+    assert "notes" not in meta
+    assert generation == 42
+    assert state.shape == (2, 2, 2)
+
+
+def test_real_npz_missing_required_member_is_refused(tmp_path):
+    path = _write_npz(
+        tmp_path,
+        lattice=np.zeros((2, 2, 2), dtype=np.uint8),
+        generation=np.array(42),
+    )
+    with pytest.raises(ValueError) as exc:
+        load_snapshot(path)
+    assert "missing keys: ['memory_grid']" in str(exc.value)
+
+
+def test_real_npz_invalid_state_shape_is_refused(tmp_path):
+    path = _write_npz(
+        tmp_path,
+        lattice=np.zeros((2, 2), dtype=np.uint8),
+        memory_grid=np.zeros((4, 2, 2), dtype=np.float32),
+        generation=np.array(42),
+    )
+    with pytest.raises(ValueError) as exc:
+        load_snapshot(path)
+    assert "state must be 3D" in str(exc.value)
+
+
+def test_real_npz_invalid_memory_shape_is_refused(tmp_path):
+    path = _write_npz(
+        tmp_path,
+        lattice=np.zeros((2, 2, 2), dtype=np.uint8),
+        memory_grid=np.zeros((4, 3, 3, 3), dtype=np.float32),
+        generation=np.array(42),
+    )
+    with pytest.raises(ValueError) as exc:
+        load_snapshot(path)
+    assert "inconsistent with state shape" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end process_snapshot ownership ordering
+# --------------------------------------------------------------------------- #
+
+
+class _Seams:
+    def __init__(self, archive):
+        self.archive = archive
+        self.is_medusa_live = []
+        self.compute_safe_stride = []
+        self.iter_patches = []
+        self.classify = []
+        self.warmth = []
+        self.write_log_entry = []
+
+
+def _run_process_snapshot(tmp_path, archive=None, medusa_is_live=None,
+                          classify_error=None, patches=2):
+    """Drive the genuine `process_snapshot()` with controlled downstream seams.
+
+    The real corrected `load_snapshot` runs; `np.load` returns a
+    closure-recording archive; every downstream seam records the archive's
+    closure count at entry. No JSONL is written and no engine runs.
+    """
+    state = np.zeros((2, 2, 2), dtype=np.uint8)
+    memory = np.zeros((4, 2, 2, 2), dtype=np.float32)
+    archive = archive if archive is not None else _FakeArchive(
+        {"lattice": state, "memory_grid": memory, "generation": np.array(1234)}
+    )
+    seams = _Seams(archive)
+    path = _snapshot_file(tmp_path)
+    # A large budget so nothing is timing-sensitive and nothing sleeps.
+    config = dataclasses.replace(
+        ObserverConfig(), log_directory=str(tmp_path / "log"),
+        budget_seconds=3600.0, uniform_grid_stride=8,
+    )
+
+    def _is_medusa_live(check_dir, threshold_minutes=None):
+        seams.is_medusa_live.append({"closed": archive.closed})
+        return False
+
+    def _compute_safe_stride(shape, radius=None, budget_seconds=None,
+                             initial_stride=None):
+        seams.compute_safe_stride.append({"closed": archive.closed,
+                                          "shape": shape})
+        return initial_stride
+
+    def _iter_patches(st, mem, cfg, medusa_is_live=None):
+        seams.iter_patches.append({"closed": archive.closed, "state": st,
+                                   "memory": mem, "live": medusa_is_live})
+        for index in range(patches):
+            yield ("patch", index)
+
+    def _classify_patch(patch):
+        seams.classify.append({"closed": archive.closed, "patch": patch})
+        if classify_error is not None:
+            raise classify_error
+        return TOKEN_NAMES[0]
+
+    def _warmth(mem):
+        seams.warmth.append({"closed": archive.closed, "memory": mem})
+        return 0.0, 0
+
+    def _write_log_entry(log_directory, entry):
+        seams.write_log_entry.append({"closed": archive.closed, "entry": entry})
+        return None
+
+    with mock.patch.object(nextness_observer.np, "load",
+                           mock.Mock(return_value=archive)), \
+         mock.patch.object(nextness_observer, "is_medusa_live", _is_medusa_live), \
+         mock.patch.object(nextness_observer, "compute_safe_stride",
+                           _compute_safe_stride), \
+         mock.patch.object(nextness_observer, "iter_patches", _iter_patches), \
+         mock.patch.object(nextness_observer, "classify_patch", _classify_patch), \
+         mock.patch.object(nextness_observer, "_warmth_diagnostics", _warmth), \
+         mock.patch.object(nextness_observer, "write_log_entry", _write_log_entry):
+        if medusa_is_live is None:
+            entry = process_snapshot(path, config)
+        else:
+            entry = process_snapshot(path, config, medusa_is_live=medusa_is_live)
+    return entry, archive, seams, state, memory
+
+
+def test_liveness_autodetection_begins_after_closure(tmp_path):
+    _, archive, seams, _, _ = _run_process_snapshot(tmp_path)
+    assert len(seams.is_medusa_live) == 1
+    assert seams.is_medusa_live[0]["closed"] == 1
+
+
+def test_supplied_liveness_avoids_the_automatic_call(tmp_path):
+    _, archive, seams, _, _ = _run_process_snapshot(tmp_path, medusa_is_live=False)
+    assert seams.is_medusa_live == []
+    assert archive.closed == 1
+
+
+def test_compute_safe_stride_begins_after_closure(tmp_path):
+    _, _, seams, state, _ = _run_process_snapshot(tmp_path)
+    assert len(seams.compute_safe_stride) == 1
+    assert seams.compute_safe_stride[0]["closed"] == 1
+    assert seams.compute_safe_stride[0]["shape"] == state.shape
+
+
+def test_iter_patches_begins_after_closure(tmp_path):
+    _, _, seams, _, _ = _run_process_snapshot(tmp_path)
+    assert len(seams.iter_patches) == 1
+    assert seams.iter_patches[0]["closed"] == 1
+
+
+def test_first_classification_seam_begins_after_closure(tmp_path):
+    _, _, seams, _, _ = _run_process_snapshot(tmp_path)
+    assert seams.classify, "classification must have run"
+    assert seams.classify[0]["closed"] == 1
+
+
+def test_warmth_diagnostics_begins_after_closure(tmp_path):
+    _, _, seams, _, memory = _run_process_snapshot(tmp_path)
+    assert len(seams.warmth) == 1
+    assert seams.warmth[0]["closed"] == 1
+    assert seams.warmth[0]["memory"] is memory
+
+
+def test_write_log_entry_begins_after_closure(tmp_path):
+    _, _, seams, _, _ = _run_process_snapshot(tmp_path)
+    assert len(seams.write_log_entry) == 1
+    assert seams.write_log_entry[0]["closed"] == 1
+
+
+def test_every_downstream_closure_count_is_exactly_one(tmp_path):
+    _, archive, seams, _, _ = _run_process_snapshot(tmp_path)
+    observed = ([e["closed"] for e in seams.is_medusa_live]
+                + [e["closed"] for e in seams.compute_safe_stride]
+                + [e["closed"] for e in seams.iter_patches]
+                + [e["closed"] for e in seams.classify]
+                + [e["closed"] for e in seams.warmth]
+                + [e["closed"] for e in seams.write_log_entry])
+    assert observed, "seams must have been reached"
+    assert set(observed) == {1}
+
+
+def test_no_downstream_seam_reopens_or_recloses_the_archive(tmp_path):
+    _, archive, _, _, _ = _run_process_snapshot(tmp_path)
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+def test_state_and_memory_reach_the_observer_seams_by_identity(tmp_path):
+    _, _, seams, state, memory = _run_process_snapshot(tmp_path)
+    assert seams.iter_patches[0]["state"] is state
+    assert seams.iter_patches[0]["memory"] is memory
+    assert seams.warmth[0]["memory"] is memory
+
+
+def test_generation_shape_and_channels_reach_the_entry_unchanged(tmp_path):
+    entry, _, _, state, memory = _run_process_snapshot(tmp_path)
+    assert entry["generation"] == 1234
+    assert entry["lattice_shape"] == list(state.shape)
+    assert entry["memory_channels"] == int(memory.shape[0])
+
+
+def test_controlled_token_count_produces_the_established_entry_fields(tmp_path):
+    entry, _, seams, _, _ = _run_process_snapshot(tmp_path, patches=3)
+    assert entry["token_counts"] == {TOKEN_NAMES[0]: 3}
+    assert entry["snapshot_file"] == "v070_gen1234.npz"
+    assert entry["stride_used"] == 8
+    assert entry["stride_backoff_fired"] is False
+    assert entry["medusa_is_live"] is False
+    assert "budget" in entry and "fraction_used" in entry["budget"]
+
+
+def test_process_snapshot_returns_the_dict_passed_to_write_log_entry(tmp_path):
+    entry, _, seams, _, _ = _run_process_snapshot(tmp_path)
+    assert seams.write_log_entry[0]["entry"] is entry
+
+
+def test_downstream_failure_propagates_while_the_archive_stays_closed(tmp_path):
+    archive = _FakeArchive({
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((4, 2, 2, 2), dtype=np.float32),
+        "generation": np.array(1234),
+    })
+    with pytest.raises(Boom) as exc:
+        _run_process_snapshot(tmp_path, archive=archive,
+                              classify_error=Boom("classifier exploded"))
+    assert type(exc.value) is Boom
+    assert str(exc.value) == "classifier exploded"
+    assert archive.entered == 1
+    assert archive.exited == 1
+    assert archive.closed == 1
+
+
+# --------------------------------------------------------------------------- #
+# Structural ownership checks (supplementary, not a substitute)
+# --------------------------------------------------------------------------- #
+
+
+def _module_tree():
+    source = pathlib.Path(nextness_observer.__file__).read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _function(tree, name):
+    return next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _np_load_calls(node):
+    return [
+        sub for sub in ast.walk(node)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+        and sub.func.attr == "load" and isinstance(sub.func.value, ast.Name)
+        and sub.func.value.id == "np"
+    ]
+
+
+def _with_item_calls(node):
+    """Every call that is the context expression of a `with` in `node`."""
+    found = []
+    for sub in ast.walk(node):
+        if isinstance(sub, (ast.With, ast.AsyncWith)):
+            for item in sub.items:
+                if isinstance(item.context_expr, ast.Call):
+                    found.append(item.context_expr)
+    return found
+
+
+def test_load_snapshot_holds_exactly_one_np_load_inside_a_context_manager():
+    tree = _module_tree()
+    loader = _function(tree, "load_snapshot")
+    loads = _np_load_calls(loader)
+    assert len(loads) == 1
+    context_calls = _with_item_calls(loader)
+    assert loads[0] in context_calls  # lexically the `with` expression
+
+
+def test_is_valid_snapshot_npz_retains_its_own_context_managed_load():
+    tree = _module_tree()
+    validator = _function(tree, "_is_valid_snapshot_npz")
+    loads = _np_load_calls(validator)
+    assert len(loads) == 1
+    assert loads[0] in _with_item_calls(validator)
+
+
+def test_process_snapshot_opens_no_archive_of_its_own():
+    tree = _module_tree()
+    processor = _function(tree, "process_snapshot")
+    assert _np_load_calls(processor) == []
+    calls = [
+        sub.func.id for sub in ast.walk(processor)
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
+    ]
+    assert "load_snapshot" in calls  # state comes only through the loader
+
+
+def test_module_has_exactly_two_np_load_call_sites():
+    """The loader and the validator — no other archive-opening path exists."""
+    tree = _module_tree()
+    all_loads = _np_load_calls(tree)
+    assert len(all_loads) == 2
+    owners = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and _np_load_calls(node)
+    }
+    assert owners == {"load_snapshot", "_is_valid_snapshot_npz"}


### PR DESCRIPTION
## Nextness Observer: deterministic archive ownership in `load_snapshot()`

Bounded Ian-seat package. `load_snapshot()` bound the `NpzFile` to a local with no
context manager and no `close()`, so archive lifetime was never deterministically
bounded to snapshot materialisation. **Draft — do NOT merge.** Merge authority is
Kev's later explicit word only.

### Base / head / lineage
- **freshly verified live base:** `main` @ `d11f96a65ad04c8c5a077e7befe11653ae83fb07`
- **final head:** `fix/nextness-observer-snapshot-materialization-boundary` @ `6ea115857169497bf0983c66dba344691504d33d`
- **lineage:** `d11f96a... → 6ea1158...`
- **commit count: 1.** The final head's direct parent is the branch-cut base. Fresh branch from freshly reverified live `main`; ordinary push; **no amend, no rebase, no force-push, no history rewrite.**

### Final file boundary & diffstat (exactly two permitted files)
```
scripts/nextness_observer.py                     +53 / -31
tests/test_nextness_observer_snapshot_loader.py +909 /  -0
TOTAL                                            +962 / -31
```
`tests/test_nextness_observer.py` is **untouched**.

### Independently reproduced failing-before behaviour
Running the **genuine pre-fix `load_snapshot()`** with a live reference to a
closure-recording fake archive:

- the function **returned** with the archive's explicit exit/close count **still zero**;
- `_FakeArchive` defines **no `__del__`**, and no `gc.collect()` is called anywhere in the module;
- the same zero-close result held for **every** post-open failure path: `snap.files`
  failure, required-key refusal, each required-member access failure, the `int()`
  conversion failure, all three shape refusals, the skippable optional `ValueError`,
  and every unexpected optional failure.

**29 of 52 harness checks fail against the pre-fix module — every one an ownership
check**, including the central witness and the structural one. The 23 that pass
pre-fix are exactly the semantic checks.

**Claim precision, as instructed.** The defect is the **absence of deterministic
close-before-return** across implementations and failure paths. It is **not** a
claim that `process_snapshot()` certainly retained the archive for a whole
classification run — in CPython a refcount drop may release it promptly at function
return — and it is **not** a proven accumulating descriptor leak.

### Exact load/materialisation contract
Pre-load handling is untouched: `pathlib.Path(snapshot_path)`, `is_file()`, and the
same `FileNotFoundError(f"snapshot not found: {snapshot_path}")`. Then:

```python
with np.load(str(snapshot_path), allow_pickle=False) as snap:
    ...   # snap.files, required-key calc + refusal, lattice, memory_grid,
          # generation, int(), both shape validations, optional access,
          # scalar .item(), metadata dict construction
return state, memory, generation, meta
```
Every archive-touching operation is inside the context; the tuple is returned after
it exits. An exception raised by `np.load` itself occurs **before** context entry and
propagates unchanged.

### Exception-preservation evidence
Verified by diff, not assertion: **exactly one line was removed and not re-added
modulo indentation** — the bare `snap = np.load(str(snapshot_path), allow_pickle=False)`
assignment. Every other line is byte-identical, including all three `ValueError`
messages, the required key set `{"lattice", "memory_grid", "generation"}`, `set(snap.files)`,
the `sorted(missing)` presentation, the extraction order, the narrow
`except ValueError: continue` lane, and `val.item() if val.ndim == 0 else val`.

The skippable lane was **not** broadened: `RuntimeError`, `MemoryError`, `KeyError`
and `OSError` from optional access each propagate with exact type, and failures from
`val.ndim`, `val.item()` or metadata assignment propagate with exact identity and
message — the only difference is that the archive closes on the way out.

### Closure evidence
| Path | Result |
|---|---|
| successful load | `entered == 1`, `exited == 1`, `closed == 1`, closed when the function returns |
| `snap.files` failure | propagates, closed |
| one / two / three missing required keys | established refusal with sorted presentation, closed |
| `lattice` / `memory_grid` / `generation` access failure | propagates with exact identity, closed |
| `int(generation)` failure | exact identity + message, closed |
| state not 3-D (2-D, 4-D, 1-D) | established message, closed |
| memory not 4-D (3-D, 5-D) | established message, closed |
| memory spatial mismatch | established message, closed |
| `val.ndim` failure | propagates, closed |
| skippable optional `ValueError` | member dropped, others survive, closed |
| unexpected optional `RuntimeError`/`MemoryError`/`KeyError`/`OSError` | propagates, closed |
| optional `.item()` failure | exact identity, closed |

**No closure claim rests on `__del__`, reference counting, garbage collection,
`gc.collect()`, interpreter shutdown or process exit.** The fake defines no
finaliser, references stay live across the assertions, and no test forces a GC.

### Real-NumPy behaviour locks (tiny, `tmp_path` only)
Seven real `.npz` tests: ordinary valid round trip (shapes, dtypes, exact `int`
generation, empty meta); optional numeric scalar via `.item()`; optional numeric
array by value; a **harmless object-dtype** optional member refused by
`allow_pickle=False` and skipped while the load still succeeds; missing-required-member
refusal; invalid state-shape refusal; invalid memory-shape refusal. No malicious
pickle is constructed or executed. Lattices are 2×2×2.

### Closure before every tested `process_snapshot()` seam
The genuine `process_snapshot()` runs with the corrected real `load_snapshot()`, a
closure-recording archive, tiny arrays and controlled downstream seams. Each seam
records the archive's closure count at entry; all record **1**:

`is_medusa_live` (auto-detect path) · `compute_safe_stride` · `iter_patches` · the
first `classify_patch` · `_warmth_diagnostics` · `write_log_entry`.

Also asserted: the union of every observed count is exactly `{1}`; a supplied
`medusa_is_live=False` avoids the automatic liveness call entirely; state and memory
reach `iter_patches` and `_warmth_diagnostics` **by identity**; `generation`,
`lattice_shape` and `memory_channels` reach the entry unchanged; a controlled token
count reproduces the established entry fields; the function returns the **same dict
object** passed to `write_log_entry`; a downstream classifier failure propagates with
exact identity while the archive stays closed; and no seam re-enters or re-closes it
(`entered == exited == closed == 1`).

### Structural ownership evidence (supplementary)
Over the parsed production module: `load_snapshot` contains exactly one `np.load`
and it **is** the `with` context expression; `_is_valid_snapshot_npz` retains its own
separate context-managed load; `process_snapshot` contains **no** `np.load` and does
call `load_snapshot`; the module has exactly **two** `np.load` sites and their owners
are exactly `{load_snapshot, _is_valid_snapshot_npz}` — so no new archive-opening
path was introduced.

### Tests, filesystem, network and engine isolation
**58 test functions → 68 collected cases** (static AST count; **no `parametrize`
id/value cardinality mismatch**). No Medusa engine, no network, no ZMQ import, no
event publication, no GPU code, no repository write, no production log —
`write_log_entry` is patched. Every real file uses `tmp_path`. A large budget keeps
the tests free of sleeping and wall-clock sensitivity. No test depends on execution
order. The module is **not** module-level skipped.

### Local evidence — separate from CI and CodeQL
**`pytest` and NumPy are both absent on this seat: no maintained-suite run was
performed locally.** The direct harness below is **supporting evidence, not a pytest
substitute and not equivalent to the maintained suite**; it injects a minimal NumPy
stand-in for the module import and replaces `np.load` per case, so the executed
`load_snapshot` body is genuine.

| Tree | Checks | Failed |
|---|---|---|
| pre-fix `d11f96a` | 52 | **29** (all ownership; incl. both central witnesses) |
| post-fix `6ea1158` | 52 | **0** |

Plus `compile()` clean on both files and the diff-level proof that only the
`np.load` binding line changed. **`process_snapshot()` ordering and the real-`.npz`
locks require genuine NumPy and were deliberately left to CI** — they were not
attempted locally.

### CI / CodeQL evidence
See the receipt appended below once every registered check is conclusive. This
package touches `scripts/**`, so CodeQL is expected to register; the receipt will
record exactly what registered and claim nothing about checks that did not.

### Residuals and explicit non-claims
- **Bounded claim:** deterministic archive ownership and close-before-return across
  the existing loader contract. **Not** whole-NPZ security, whole-Observer
  correctness, snapshot authenticity, atomic snapshot reading, concurrent-writer
  protection, metadata-schema totality, evidence-campaign implementation, or an
  accumulating-descriptor-leak claim.
- `allow_pickle=False` is unchanged; no schema field, validation, size limit,
  ZIP-bomb defence or path-containment rule was added or removed.
- Metadata ordering is **not** normalised and metadata names/values are **not**
  validated — the optional-key set is still `keys - required` with its natural
  iteration order, and no ordering contract is asserted anywhere in the tests.
- The extracted arrays remain in memory after close: this bounds a **handle**
  lifetime, not a memory footprint.
- `process_snapshot()` control flow, the entry schema, thresholds, classifier
  precedence, token vocabulary, sampling, budget monitoring, stride calculation,
  snapshot discovery, liveness calculation, transactional log publication, path
  containment, permissions, JSON serialization and timestamp formatting are all
  untouched.
- The Windows motivation for handle hygiene is not reproduced against a real file
  lock; no file-lock test is attempted.
- Locally the context-manager protocol was driven by a fake, so real
  `NpzFile.__exit__` semantics are exercised only in CI.

### Model identity
Implemented from the **Ian seat** by **Claude Opus 5** (model ID `claude-opus-5`,
the "84" seat), under Kev's explicit bounded authorization. No model crossover.

### Isolation from every parked package
- **#419, #422, #424, #425, #426, #428, #429, #430, #431, #433** verified parked
  (OPEN, draft, unmerged) and **none modified**; all file boundaries disjoint from
  `scripts/nextness_observer.py` + `tests/test_nextness_observer_snapshot_loader.py`.
- **#419's computed mergeability was not queried, reconciled or acted on.**
- **#420** (Kev-seat) kept **opaque** — bare number, title, branch and open/draft
  identity only; body, patch, files, checks, comments, reviews and threads neither
  inspected nor discussed. **No evidence-campaign functionality is implemented here.**
- **#423**, **#427** and **#432** merged, used only as live-`main` history.

### Fences
Exactly the two authorized files; one focused commit; fresh single-parent branch
from live `main`; ordinary push, no force. Existing Observer test file unmodified.
No real Medusa snapshot, engine execution, network, event bus, real JSONL
publication or evidence-campaign work. No merge / auto-merge / ready-for-review
transition / rebase / merge-from-`main` / history rewrite / repository, workflow,
protection or settings change / manual workflow rerun / branch deletion. No comment,
review, thread action, reaction or label. No new dependency. Leave **OPEN, draft,
unmerged** and hand back to Jack.

---

### CI receipt (body-only append; all registered checks conclusive — GREEN)
Observed read-only to conclusive result on head `6ea115857169497bf0983c66dba344691504d33d`. **No CI failure occurred on this package — the first head was green**, so there is no red-to-green chronology to record. No workflow was manually rerun, and no follow-up commit was required.

**The status rollup contains exactly 8 entries, all `SUCCESS`, none pending or queued.** Recorded verbatim, claiming nothing about checks that did not register:

| Check | Result | Detail |
|-------|--------|--------|
| **verify-python** (authoritative) | ✅ pass (1m2s) | run `30236290065` / job `89884615114` — **2356 passed, 13 skipped, 0 failed** (29.25s) |
| verify-python (push-triggered run) | ✅ pass (1m31s) | run `30236241536` / job `89884483609` |
| **Analyze Python (CodeQL)** | ✅ pass (50s) | run `30236290031` / job `89884614937` |
| **CodeQL** | ✅ pass | job `89884695612` |
| agent-safety | ✅ pass (10s) | run `30236290028` |
| tripwire | ✅ pass (6s) | run `30236290035` |
| frontend-quality | ✅ pass (51s / 56s) | runs `30236241536`, `30236290065` |

**Every new case ran; none was skipped.** Baseline `verify-python` on live `main`
`d11f96a` (run `30232102865`) reports **2288 passed, 13 skipped**. This head reports
**2356 passed, 13 skipped**:

- **+68 passed**, exactly matching the 68 statically counted collected cases;
- **skipped unchanged at 13** — positive proof the focused module was not
  module-level skipped and that the seven real-`.npz` locks and the fifteen
  `process_snapshot` ordering assertions actually executed under genuine NumPy;
- **0 failed**, and all 2288 pre-existing cases still pass — including the untouched
  `tests/test_nextness_observer.py`.

CI's figures supersede the seat-local evidence as the authoritative gate. PR remains
**OPEN, draft, unmerged** — handing back to Jack for audit; merge authority is Kev's
later explicit word only.
