### PR TITLE
fix(portable-genome): structural refusal totality for the seven configuration sections

### DIFF
--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -46,17 +46,21 @@ MEMORY_CHANNEL_DEFS = [
 class PortableGenomeError(ValueError):
     """Structural refusal for malformed portable-genome shapes.
 
-    Raised by :func:`import_genome` for the narrow set of top-level and
-    transition-table structural shapes validated in this module: the genome
-    root, ``format``, ``transition_table``, each source-state mapping, and each
-    source/target state name and neighbor-count key. Subclasses
+    Raised by :func:`import_genome` for the narrow set of structural shapes
+    validated in this module: the genome root, ``format``, ``transition_table``,
+    each source-state mapping, each source/target state name and neighbor-count
+    key, and the container shape of the seven configuration sections
+    ``stochastic``, ``contagion``, ``decay``, ``cosmic_garden``,
+    ``experimental``, ``metadata`` and ``topology``. Subclasses
     :class:`ValueError` so existing callers that catch ``ValueError`` keep
     working; the public ``info`` CLI catches this type specifically.
 
-    This does NOT make the whole importer total. Malformed shapes elsewhere in
-    the genome (e.g. non-object ``stochastic``/``contagion``/``metadata`` config
-    sections or the epigenetic snapshot) remain outside this package's scope and
-    still surface as their original exceptions.
+    This does NOT make the whole importer total. Still outside this module's
+    structural boundary, and still surfacing as their original exceptions:
+    individual field values *inside* an otherwise correctly shaped section,
+    ``fitness``, ``memory_layout``, ``epigenetic_snapshot``,
+    :func:`extract_epigenetic_snapshot`, schema completeness, and any
+    semantic or numeric range validation.
     """
 
 
@@ -247,8 +251,35 @@ def export_genome(filepath, rule_spec, generation=0, ca_step=0, best_fitness=0.0
     return filepath
 
 
+def _require_json_object_section(genome: dict, section_name: str) -> dict:
+    """Return ``genome[section_name]`` only when it is a JSON object.
+
+    A missing section yields a fresh empty ``dict`` (the established default).
+    An exact built-in ``dict`` is returned by identity. Every other JSON value
+    -- array, string, number, Boolean, ``null`` -- and every ``dict`` subclass
+    is refused with :class:`PortableGenomeError`.
+
+    The refusal message is built from ``section_name`` alone: the supplied value
+    is never rendered, and none of its methods (``get``, ``__repr__``,
+    ``__str__``, ``__eq__``, ``__hash__``) is invoked while producing it.
+    """
+    section = genome.get(section_name, {})
+    if type(section) is not dict:
+        raise PortableGenomeError(f"{section_name} must be a JSON object")
+    return section
+
+
 def import_genome(filepath):
-    """Import a portable genome and reconstruct the rule_spec and CAConfig."""
+    """Import a portable genome and reconstruct the rule_spec and CAConfig.
+
+    Structural refusals raise :class:`PortableGenomeError` with an exact,
+    value-free message: the genome root, ``format``, the transition table and
+    its source mappings, and the container shape of the seven configuration
+    sections ``stochastic``, ``contagion``, ``decay``, ``cosmic_garden``,
+    ``experimental``, ``metadata`` and ``topology`` -- validated in that order,
+    each at its retrieval site, before any of its keys is read. Field values
+    *within* a correctly shaped section are not validated here.
+    """
     filepath = Path(filepath)
     with open(filepath, "r", encoding="utf-8") as f:
         genome = json.load(f)
@@ -273,13 +304,13 @@ def import_genome(filepath):
         for count_str, target_name in mappings.items():
             transitions[src_name][count_str] = target_name
 
-    stoch_section = genome.get("stochastic", {})
-    contagion_section = genome.get("contagion", {})
-    decay_section = genome.get("decay", {})
-    cosmic_section = genome.get("cosmic_garden", {})
-    exp_section = genome.get("experimental", {})
-    meta = genome.get("metadata", {})
-    topo = genome.get("topology", {})
+    stoch_section = _require_json_object_section(genome, "stochastic")
+    contagion_section = _require_json_object_section(genome, "contagion")
+    decay_section = _require_json_object_section(genome, "decay")
+    cosmic_section = _require_json_object_section(genome, "cosmic_garden")
+    exp_section = _require_json_object_section(genome, "experimental")
+    meta = _require_json_object_section(genome, "metadata")
+    topo = _require_json_object_section(genome, "topology")
 
     rule_spec = {
         "rule": {

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1,0 +1,1195 @@
+"""Structural refusal totality for the seven configuration sections of
+``scripts.portable_genome.import_genome()``.
+
+Scope: this module tests ONLY the *container shape* of ``stochastic``,
+``contagion``, ``decay``, ``cosmic_garden``, ``experimental``, ``metadata`` and
+``topology``. It deliberately does NOT assert whole-importer totality — field
+values inside a correctly shaped section, ``fitness``, ``memory_layout``,
+``epigenetic_snapshot``, ``extract_epigenetic_snapshot()``, schema completeness
+and semantic/range validation all remain out of scope and are not exercised
+here.
+
+Before this package each of those seven values was fetched with
+``genome.get(<name>, {})`` and then had ``.get()`` invoked on it directly, so a
+genome whose section parsed as an array, string, number, Boolean or ``null``
+raised an ambient ``AttributeError`` instead of the importer's
+``PortableGenomeError``. The public ``info`` CLI catches ``PortableGenomeError``
+specifically, so those shapes bypassed argparse's exit-2 lane and produced a
+traceback.
+
+Reachability is checked on two separate surfaces:
+  * DIRECT — ``import_genome()`` raises ``PortableGenomeError`` with an exact,
+    value-free, section-anchored message.
+  * PUBLIC — ``python -m scripts.portable_genome info <file>`` exits 2 through
+    argparse with that message on stderr, no traceback, and no leak of the
+    offending value.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import scripts.portable_genome as pg
+from scripts.portable_genome import (
+    STATE_NAME_TO_ID,
+    PortableGenomeError,
+    import_genome,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_VALID_FMT = {"format_id": "utilityfog-portable-genome"}
+
+#: The exact authorized section set, in the importer's established order. The
+#: order is load-bearing: it decides which refusal wins when several sections
+#: are malformed at once.
+_SECTIONS = (
+    "stochastic",
+    "contagion",
+    "decay",
+    "cosmic_garden",
+    "experimental",
+    "metadata",
+    "topology",
+)
+
+#: Every ordinary non-object JSON shape, each carrying a recognisable payload
+#: where the shape allows one, so a message leak would be detectable.
+_LEAK_MARKER = "ZZ-SECRET-SECTION-VALUE-ZZ"
+_NON_OBJECT_SHAPES = (
+    ("array", [_LEAK_MARKER]),
+    ("string", _LEAK_MARKER),
+    ("integer", 987654321),
+    ("float", 1234.5678),
+    ("true", True),
+    ("false", False),
+    ("null", None),
+)
+
+#: Every configuration constructor ``import_genome`` reaches *after* the seven
+#: sections have been retrieved and validated.
+_CONSTRUCTOR_NAMES = (
+    "StochasticConfig",
+    "ContagionConfig",
+    "DecayConfig",
+    "CosmicGardenConfig",
+    "ExperimentalConfig",
+    "DensityPhaseDetectorConfig",
+    "VoxelMemoryParams",
+    "CAConfig",
+)
+
+_SHAPE_IDS = [
+    f"{section}-{shape_id}"
+    for section in _SECTIONS
+    for shape_id, _value in _NON_OBJECT_SHAPES
+]
+_SHAPE_CASES = [
+    (section, value)
+    for section in _SECTIONS
+    for _shape_id, value in _NON_OBJECT_SHAPES
+]
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _base_genome() -> dict:
+    """A small genome that imports cleanly; tests malform one section of it."""
+    return {
+        "format": dict(_VALID_FMT),
+        "transition_table": {"VOID": {"3": "STRUCTURAL"}},
+    }
+
+
+def _write(tmp_path: Path, obj, name: str = "genome.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def _write_raw(tmp_path: Path, text: str, name: str = "genome.json") -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _info(genome_path: Path) -> subprocess.CompletedProcess:
+    """Run the PUBLIC ``info`` CLI on a genome path and capture the result."""
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.portable_genome", "info", str(genome_path)],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _forbid_constructors(monkeypatch) -> list:
+    """Arm every post-retrieval configuration constructor.
+
+    Returns the list the sentinels append to. ``monkeypatch`` restores the real
+    constructors at teardown. See
+    :func:`test_constructor_sentinels_are_actually_reachable` — without that
+    anti-vacuity check these sentinels would prove nothing.
+    """
+    reached: list = []
+
+    for name in _CONSTRUCTOR_NAMES:
+        def sentinel(*_a, _name=name, **_k):
+            reached.append(_name)
+            raise AssertionError("configuration constructor reached: " + _name)
+
+        monkeypatch.setattr(pg, name, sentinel)
+    return reached
+
+
+def _patch_loaded_genome(monkeypatch, genome_obj):
+    """Replace the module's JSON load seam so a non-JSON object can be injected.
+
+    Only ``scripts.portable_genome``'s own ``json`` binding is replaced, so the
+    stdlib module is untouched; ``monkeypatch`` restores the binding.
+    """
+
+    class _JsonSeam:
+        @staticmethod
+        def load(_fp):
+            return genome_obj
+
+    monkeypatch.setattr(pg, "json", _JsonSeam)
+
+
+def _refusal_message(section: str) -> str:
+    return f"{section} must be a JSON object"
+
+
+class _GetRaises:
+    """Not a dict. Its ``.get()`` must never be reached."""
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def get(self, *_a, **_k):
+        self.calls.append("get")
+        raise AssertionError("section .get() was called")
+
+
+class _ReprRaises:
+    """Not a dict. Its ``__repr__`` must never be reached."""
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def __repr__(self):
+        self.calls.append("repr")
+        raise AssertionError("section __repr__ was called")
+
+
+class _StrRaises:
+    """Not a dict. Its ``__str__`` must never be reached."""
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def __str__(self):
+        self.calls.append("str")
+        raise AssertionError("section __str__ was called")
+
+
+class _HostileDictSubclass(dict):
+    """A real ``dict`` instance that is not an exact built-in ``dict``.
+
+    Every hook the refusal path could plausibly touch is armed.
+    """
+
+    def __init__(self, calls):
+        super().__init__()
+        self.calls = calls
+
+    def get(self, *_a, **_k):
+        self.calls.append("get")
+        raise AssertionError("section .get() was called")
+
+    def keys(self):
+        self.calls.append("keys")
+        raise AssertionError("section .keys() was called")
+
+    def items(self):
+        self.calls.append("items")
+        raise AssertionError("section .items() was called")
+
+    def __repr__(self):
+        self.calls.append("repr")
+        raise AssertionError("section __repr__ was called")
+
+    def __str__(self):
+        self.calls.append("str")
+        raise AssertionError("section __str__ was called")
+
+    def __eq__(self, _other):
+        self.calls.append("eq")
+        raise AssertionError("section __eq__ was called")
+
+    def __hash__(self):
+        self.calls.append("hash")
+        raise AssertionError("section __hash__ was called")
+
+
+# --------------------------------------------------------------------------
+# DIRECT refusals — every section x every ordinary non-object JSON shape
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("section,value", _SHAPE_CASES, ids=_SHAPE_IDS)
+def test_non_object_section_is_refused(section, value, tmp_path, monkeypatch):
+    reached = _forbid_constructors(monkeypatch)
+    genome = _base_genome()
+    genome[section] = value
+    p = _write(tmp_path, genome)
+
+    returned = "NOTHING-RETURNED"
+    with pytest.raises(PortableGenomeError) as exc:
+        returned = import_genome(p)
+
+    message = str(exc.value)
+    # 1. exact exception type (not merely a ValueError subclass).
+    assert type(exc.value) is PortableGenomeError
+    # 2. exact, section-anchored message.
+    assert message == _refusal_message(section)
+    # 3. no supplied value reflected in the message.
+    assert _LEAK_MARKER not in message
+    assert "987654321" not in message
+    assert "1234.5678" not in message
+    # 4. no configuration object returned.
+    assert returned == "NOTHING-RETURNED"
+    # 5. no downstream configuration constructor reached.
+    assert reached == []
+
+
+def test_error_type_is_valueerror_subclass():
+    # Backward compatibility: callers catching ValueError keep working.
+    assert issubclass(PortableGenomeError, ValueError)
+
+
+def test_constructor_sentinels_are_actually_reachable(tmp_path, monkeypatch):
+    # Anti-vacuity: the sentinel seam used above must be live, i.e. a genome
+    # that gets past section validation really does reach a constructor.
+    reached = _forbid_constructors(monkeypatch)
+    p = _write(tmp_path, _base_genome())
+    with pytest.raises(AssertionError):
+        import_genome(p)
+    assert reached == [_CONSTRUCTOR_NAMES[0]]
+
+
+# --------------------------------------------------------------------------
+# Hook avoidance — refusal touches none of the section object's own methods
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_section_get_is_never_called(section, tmp_path, monkeypatch):
+    calls: list = []
+    genome = _base_genome()
+    genome[section] = _GetRaises(calls)
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+
+    assert str(exc.value) == _refusal_message(section)
+    assert calls == []
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_section_repr_is_never_called(section, tmp_path, monkeypatch):
+    calls: list = []
+    genome = _base_genome()
+    genome[section] = _ReprRaises(calls)
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+
+    # Only plain strings are compared here — the hostile object is never fed to
+    # pytest's assertion diagnostics.
+    assert str(exc.value) == _refusal_message(section)
+    assert calls == []
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_section_str_is_never_called(section, tmp_path, monkeypatch):
+    calls: list = []
+    genome = _base_genome()
+    genome[section] = _StrRaises(calls)
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+
+    assert str(exc.value) == _refusal_message(section)
+    assert calls == []
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_hostile_dict_subclass_is_refused(section, tmp_path, monkeypatch):
+    # A dict subclass IS a dict instance, but it is not an exact built-in dict,
+    # so the exact-type gate refuses it without touching a single hook.
+    calls: list = []
+    hostile = _HostileDictSubclass(calls)
+    genome = _base_genome()
+    genome[section] = hostile
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+
+    assert isinstance(hostile, dict)
+    assert type(hostile) is not dict
+    assert str(exc.value) == _refusal_message(section)
+    # No hostile hook ran, so none of them could have altered the message.
+    assert calls == []
+
+
+def test_hostile_section_does_not_alter_the_message(tmp_path, monkeypatch):
+    calls: list = []
+    genome = _base_genome()
+    genome["metadata"] = _HostileDictSubclass(calls)
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+
+    assert str(exc.value) == "metadata must be a JSON object"
+    assert calls == []
+
+
+# --------------------------------------------------------------------------
+# Helper contract
+# --------------------------------------------------------------------------
+
+
+def _helper():
+    """Resolve the private section-validation helper by structure, not name."""
+    tree = ast.parse(inspect.getsource(pg))
+    names = _private_error_raising_function_names(tree)
+    assert len(names) == 1
+    return getattr(pg, names[0])
+
+
+def test_helper_returns_a_valid_section_by_identity():
+    section = {"enabled": False}
+    genome = {"stochastic": section}
+    assert _helper()(genome, "stochastic") is section
+
+
+def test_helper_returns_empty_dict_for_missing_section():
+    result = _helper()({}, "stochastic")
+    assert type(result) is dict
+    assert result == {}
+
+
+def test_helper_defaults_are_independent_objects():
+    fn = _helper()
+    first = fn({}, "stochastic")
+    second = fn({}, "contagion")
+    third = fn({}, "stochastic")
+    # No persistent shared mutable default.
+    assert first is not second
+    assert first is not third
+    first["mutated"] = True
+    assert second == {}
+    assert third == {}
+
+
+def test_helper_refuses_every_non_object_shape():
+    fn = _helper()
+    for _shape_id, value in _NON_OBJECT_SHAPES:
+        with pytest.raises(PortableGenomeError) as exc:
+            fn({"decay": value}, "decay")
+        assert str(exc.value) == "decay must be a JSON object"
+
+
+# --------------------------------------------------------------------------
+# Missing and valid-section behavior locks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_missing_section_still_imports(section, tmp_path):
+    # Each authorized section absent on its own (the base genome carries none
+    # of them, so this is exactly "this one is missing").
+    genome = _base_genome()
+    for other in _SECTIONS:
+        if other != section:
+            genome[other] = {}
+    p = _write(tmp_path, genome)
+    rule_spec, ca_config, metadata = import_genome(p)
+    assert isinstance(rule_spec, dict)
+    assert isinstance(metadata, dict)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {
+        3: STATE_NAME_TO_ID["STRUCTURAL"]
+    }
+
+
+def test_all_seven_sections_missing_simultaneously(tmp_path):
+    p = _write(tmp_path, _base_genome())
+    rule_spec, ca_config, metadata = import_genome(p)
+    # Established defaults for absent configuration sections.
+    assert ca_config.stochastic.enabled is True
+    assert ca_config.stochastic.baseline_transition_prob == 0.08
+    assert ca_config.contagion.enabled is True
+    assert ca_config.contagion.energy_neighbor_threshold == 4
+    assert ca_config.decay.enabled is True
+    assert ca_config.decay.structural_inactive_steps_to_decay == 6
+    assert ca_config.cosmic.shield_strength == 0.85
+    assert ca_config.experimental.mamba_d_model == 64
+    assert rule_spec["rule"]["name"] == "imported-genome"
+    assert rule_spec["rule"]["neighborhood"] == "moore-3d"
+    assert rule_spec["rule"]["transition"] == "outer-totalistic"
+    assert metadata["topology"] == {}
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_empty_builtin_dict_section_is_accepted(section, tmp_path):
+    genome = _base_genome()
+    genome[section] = {}
+    p = _write(tmp_path, genome)
+    rule_spec, ca_config, metadata = import_genome(p)
+    assert isinstance(rule_spec, dict)
+    assert isinstance(metadata, dict)
+    assert ca_config.transition_table != {}
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_populated_builtin_dict_section_is_accepted(section, tmp_path):
+    populated = {
+        "stochastic": {"enabled": False},
+        "contagion": {"energy_neighbor_threshold": 9},
+        "decay": {"inactivity_neighbor_threshold": 5},
+        "cosmic_garden": {"shield_strength": 0.11},
+        "experimental": {"mamba_d_model": 128},
+        "metadata": {"name": "populated-organism"},
+        "topology": {"neighborhood": "von-neumann-3d"},
+    }
+    genome = _base_genome()
+    genome[section] = populated[section]
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {
+        3: STATE_NAME_TO_ID["STRUCTURAL"]
+    }
+
+
+def test_minimal_valid_genome_still_imports(tmp_path):
+    p = _write(tmp_path, {"format": dict(_VALID_FMT)})
+    rule_spec, ca_config, metadata = import_genome(p)
+    assert isinstance(rule_spec, dict)
+    assert ca_config.transition_table == {}
+    assert isinstance(metadata, dict)
+
+
+def _fully_populated_genome() -> dict:
+    genome = _base_genome()
+    genome["stochastic"] = {
+        "enabled": False,
+        "baseline_transition_prob": 0.11,
+        "structural_to_energy_prob": 0.12,
+        "structural_to_sensor_prob": 0.13,
+        "compute_to_energy_prob": 0.14,
+        "compute_to_sensor_prob": 0.15,
+        "structural_to_void_decay_prob": 0.16,
+        "energy_to_void_decay_prob": 0.17,
+        "sensor_to_void_decay_prob": 0.18,
+    }
+    genome["contagion"] = {
+        "enabled": False,
+        "energy_neighbor_threshold": 21,
+        "sensor_neighbor_threshold": 22,
+        "structural_energy_conversion_prob": 0.21,
+        "structural_sensor_conversion_prob": 0.22,
+        "compute_energy_conversion_prob": 0.23,
+        "compute_sensor_conversion_prob": 0.24,
+    }
+    genome["decay"] = {
+        "enabled": False,
+        "inactivity_neighbor_threshold": 31,
+        "structural_inactive_steps_to_decay": 32,
+    }
+    genome["cosmic_garden"] = {
+        "cluster_coherence_threshold": 41,
+        "shield_strength": 0.41,
+        "cluster_shield_bonus": 0.42,
+        "halbach_recuperation_rate": 0.43,
+        "temporal_dilation": 0.44,
+        "bamboo_initial_growth": 42,
+        "bamboo_max_length": 43,
+        "bamboo_rebirth_age": 44,
+        "biofilm_leech_rate": 0.45,
+        "super_pod_threshold": 45,
+        "analogue_mutation": 0.46,
+        "otolith_vector": 0.47,
+        "damping_radius": 46,
+    }
+    genome["experimental"] = {
+        "mamba_d_model": 51,
+        "mamba_d_state": 52,
+        "mamba_enabled": True,
+        "void_sanctuary_enabled": True,
+        "void_sanctuary_radius": 53,
+        "epsilon": 1e-6,
+        "selective_memory_decay_enabled": True,
+        "selective_memory_decay_threshold": 0.54,
+        "selective_compute_neighbor_threshold": 55,
+        "selective_low_decay_rate": 0.56,
+        "selective_high_decay_rate": 0.57,
+    }
+    genome["metadata"] = {
+        "name": "fully-populated-organism",
+        "version": "9.8.7",
+        "author": "test-author",
+        "description": "test-description",
+        "target_lambda": 2.5,
+    }
+    genome["topology"] = {
+        "states": ["VOID", "STRUCTURAL"],
+        "neighborhood": "von-neumann-3d",
+        "transition_mode": "totalistic",
+    }
+    return genome
+
+
+def test_fully_populated_genome_reconstructs_configuration(tmp_path):
+    genome = _fully_populated_genome()
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+
+    for field, expected in genome["stochastic"].items():
+        assert getattr(ca_config.stochastic, field) == expected
+    for field, expected in genome["contagion"].items():
+        assert getattr(ca_config.contagion, field) == expected
+    for field, expected in genome["decay"].items():
+        assert getattr(ca_config.decay, field) == expected
+    for field, expected in genome["cosmic_garden"].items():
+        assert getattr(ca_config.cosmic, field) == expected
+    for field, expected in genome["experimental"].items():
+        assert getattr(ca_config.experimental, field) == expected
+
+
+def test_valid_stochastic_values_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["stochastic"] = {"enabled": False, "baseline_transition_prob": 0.99}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.stochastic.enabled is False
+    assert ca_config.stochastic.baseline_transition_prob == 0.99
+    # Untouched fields keep their established defaults.
+    assert ca_config.stochastic.sensor_to_void_decay_prob == 0.004
+
+
+def test_valid_contagion_values_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["contagion"] = {"enabled": False, "energy_neighbor_threshold": 12}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.contagion.enabled is False
+    assert ca_config.contagion.energy_neighbor_threshold == 12
+    assert ca_config.contagion.compute_sensor_conversion_prob == 0.25
+
+
+def test_valid_decay_values_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["decay"] = {"enabled": False, "structural_inactive_steps_to_decay": 99}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.decay.enabled is False
+    assert ca_config.decay.structural_inactive_steps_to_decay == 99
+    assert ca_config.decay.inactivity_neighbor_threshold == 1
+
+
+def test_valid_cosmic_garden_values_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["cosmic_garden"] = {"shield_strength": 0.01, "damping_radius": 7}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.cosmic.shield_strength == 0.01
+    assert ca_config.cosmic.damping_radius == 7
+    assert ca_config.cosmic.bamboo_max_length == 500
+
+
+def test_valid_experimental_values_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["experimental"] = {"mamba_enabled": True, "epsilon": 1e-5}
+    p = _write(tmp_path, genome)
+    rule_spec, ca_config, _md = import_genome(p)
+    assert ca_config.experimental.mamba_enabled is True
+    assert ca_config.experimental.epsilon == 1e-5
+    assert ca_config.experimental.mamba_d_state == 16
+    # The rule_spec mirror of the selective-decay block is preserved too.
+    smd = rule_spec["params"]["experimental"]["selective_memory_decay"]
+    assert smd["enabled"] is False
+    assert smd["memory_strength_threshold"] == 0.75
+
+
+def test_valid_metadata_reaches_returned_metadata(tmp_path):
+    genome = _base_genome()
+    genome["metadata"] = {
+        "name": "demo-organism",
+        "version": "1.2.3",
+        "author": "someone",
+        "description": "a description",
+        "target_lambda": 1.9,
+    }
+    p = _write(tmp_path, genome)
+    rule_spec, _cfg, metadata = import_genome(p)
+    assert metadata["name"] == "demo-organism"
+    assert metadata["version"] == "1.2.3"
+    assert metadata["author"] == "someone"
+    assert rule_spec["rule"]["name"] == "demo-organism"
+    assert rule_spec["params"]["meta"]["description"] == "a description"
+    assert rule_spec["params"]["meta"]["target_lambda"] == 1.9
+
+
+def test_valid_topology_reaches_rule_spec_and_metadata(tmp_path):
+    genome = _base_genome()
+    genome["topology"] = {
+        "states": ["VOID", "COMPUTE"],
+        "neighborhood": "von-neumann-3d",
+        "transition_mode": "totalistic",
+    }
+    p = _write(tmp_path, genome)
+    rule_spec, _cfg, metadata = import_genome(p)
+    assert rule_spec["rule"]["states"] == ["VOID", "COMPUTE"]
+    assert rule_spec["rule"]["neighborhood"] == "von-neumann-3d"
+    assert rule_spec["rule"]["transition"] == "totalistic"
+    assert metadata["topology"] == genome["topology"]
+
+
+def test_valid_sections_reach_the_rule_spec_by_identity(tmp_path, monkeypatch):
+    # The validated section objects, not copies, are forwarded into rule_spec —
+    # confirming the helper returns the caller's object.
+    stoch = {"enabled": False}
+    genome = _base_genome()
+    genome["stochastic"] = stoch
+    _patch_loaded_genome(monkeypatch, genome)
+    p = _write(tmp_path, _base_genome())
+    rule_spec, _cfg, _md = import_genome(p)
+    assert rule_spec["params"]["stochastic"] is stoch
+
+
+# --------------------------------------------------------------------------
+# Validation order and precedence
+# --------------------------------------------------------------------------
+
+
+def test_malformed_root_precedes_section_validation(tmp_path):
+    p = _write(tmp_path, ["stochastic"])
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "genome must be a JSON object"
+
+
+def test_malformed_format_precedes_section_validation(tmp_path):
+    genome = _base_genome()
+    genome["format"] = []
+    genome["stochastic"] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "format must be a JSON object"
+
+
+def test_wrong_format_identifier_precedes_section_validation(tmp_path):
+    genome = _base_genome()
+    genome["format"] = {"format_id": "some-other-format"}
+    genome["stochastic"] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "unknown genome format"
+
+
+def test_malformed_transition_table_precedes_section_validation(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = []
+    genome["stochastic"] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition_table must be a JSON object"
+
+
+def test_malformed_source_mapping_precedes_section_validation(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"VOID": []}
+    genome["stochastic"] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition mappings must be a JSON object"
+
+
+@pytest.mark.parametrize("first_index", range(len(_SECTIONS)))
+def test_established_section_order_decides_the_refusal(first_index, tmp_path):
+    # Malform this section and every later one; the earliest must win.
+    genome = _base_genome()
+    for section in _SECTIONS[first_index:]:
+        genome[section] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == _refusal_message(_SECTIONS[first_index])
+
+
+def test_all_seven_malformed_refuses_on_the_first(tmp_path):
+    genome = _base_genome()
+    for section in _SECTIONS:
+        genome[section] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "stochastic must be a JSON object"
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_refusal_precedes_every_configuration_constructor(section, tmp_path, monkeypatch):
+    reached = _forbid_constructors(monkeypatch)
+    genome = _base_genome()
+    genome[section] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError):
+        import_genome(p)
+    assert reached == []
+
+
+def test_refusal_precedes_transition_semantic_conversion(tmp_path, monkeypatch):
+    # The source mapping is a well-shaped object, so the transition-container
+    # checks pass; "BOGUS" only fails later, during source/target conversion.
+    # Section validation sits between the two, so the section wins.
+    reached = _forbid_constructors(monkeypatch)
+    genome = _base_genome()
+    genome["transition_table"] = {"BOGUS": {"notanum": "ALSO-BOGUS"}}
+    genome["stochastic"] = []
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "stochastic must be a JSON object"
+    assert reached == []
+
+
+def test_transition_conversion_still_wins_when_sections_are_wellformed(tmp_path):
+    # Anti-vacuity for the test above: with valid sections the same genome does
+    # reach semantic conversion and refuses there.
+    genome = _base_genome()
+    genome["transition_table"] = {"BOGUS": {"notanum": "ALSO-BOGUS"}}
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition source state must be a known state name"
+
+
+# --------------------------------------------------------------------------
+# PUBLIC CLI reachability
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("section", _SECTIONS)
+def test_public_info_malformed_section_exits_2(section, tmp_path):
+    genome = _base_genome()
+    genome["metadata"] = {"name": "cli-organism"}
+    genome[section] = [_LEAK_MARKER]
+    p = _write(tmp_path, genome)
+    res = _info(p)
+
+    assert res.returncode == 2
+    assert _refusal_message(section) in res.stderr
+    assert "with transitions" not in res.stdout
+    assert _LEAK_MARKER not in res.stderr
+    assert _LEAK_MARKER not in res.stdout
+    assert "Traceback" not in res.stderr
+
+
+def test_public_info_valid_genome_success_output_unchanged(tmp_path):
+    genome = _base_genome()
+    genome["metadata"] = {"name": "demo-organism", "version": "4.5.6"}
+    p = _write(tmp_path, genome)
+    res = _info(p)
+    assert res.returncode == 0
+    assert "with transitions" in res.stdout
+    assert "name: demo-organism" in res.stdout
+    assert "version: 4.5.6" in res.stdout
+    assert "Traceback" not in res.stderr
+
+
+def test_public_info_valid_sections_success_output_unchanged(tmp_path):
+    genome = _fully_populated_genome()
+    p = _write(tmp_path, genome)
+    res = _info(p)
+    assert res.returncode == 0
+    assert "name: fully-populated-organism" in res.stdout
+    assert "version: 9.8.7" in res.stdout
+    assert "states: 1 with transitions" in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_json_syntax_error(tmp_path):
+    p = _write_raw(tmp_path, "{not valid json")
+    res = _info(p)
+    assert res.returncode != 2
+    assert "with transitions" not in res.stdout
+
+
+def test_public_info_does_not_broadly_catch_missing_file(tmp_path):
+    missing = tmp_path / "does_not_exist.json"
+    res = _info(missing)
+    assert res.returncode != 2
+    assert "with transitions" not in res.stdout
+
+
+def test_memory_error_is_not_converted_to_a_structural_refusal(tmp_path, monkeypatch):
+    # Exercised directly: an unrelated MemoryError must propagate unchanged, so
+    # it can never reach the CLI's PortableGenomeError catch.
+    assert not issubclass(MemoryError, PortableGenomeError)
+
+    class _ExhaustedSeam:
+        @staticmethod
+        def load(_fp):
+            raise MemoryError("out of memory")
+
+    monkeypatch.setattr(pg, "json", _ExhaustedSeam)
+    p = _write(tmp_path, _base_genome())
+    with pytest.raises(MemoryError):
+        import_genome(p)
+
+
+# --------------------------------------------------------------------------
+# Existing transition behavior locks (compact; the transition-focused module is
+# not modified by this package)
+# --------------------------------------------------------------------------
+
+
+def test_case_insensitive_source_and_target_names(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"void": {"1": "structural"}}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {
+        1: STATE_NAME_TO_ID["STRUCTURAL"]
+    }
+
+
+@pytest.mark.parametrize(
+    "spelling,expected",
+    [("+1", 1), ("  4  ", 4), ("007", 7), ("-2", -2)],
+    ids=["signed", "whitespace", "leading-zero", "negative"],
+)
+def test_accepted_count_spellings(spelling, expected, tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"VOID": {spelling: "COMPUTE"}}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {
+        expected: STATE_NAME_TO_ID["COMPUTE"]
+    }
+
+
+def test_duplicate_integer_keys_last_write_wins(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"VOID": {"5": "COMPUTE", "05": "ENERGY"}}
+    p = _write(tmp_path, genome)
+    _rs, ca_config, _md = import_genome(p)
+    assert ca_config.transition_table[STATE_NAME_TO_ID["VOID"]] == {
+        5: STATE_NAME_TO_ID["ENERGY"]
+    }
+
+
+def test_unknown_source_state_still_refused(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"NOSUCHSTATE": {"0": "VOID"}}
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition source state must be a known state name"
+
+
+def test_unknown_target_state_still_refused(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"VOID": {"0": "NOSUCHSTATE"}}
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition target state must be a known state name"
+
+
+def test_malformed_count_still_refused(tmp_path):
+    genome = _base_genome()
+    genome["transition_table"] = {"VOID": {"notanum": "VOID"}}
+    p = _write(tmp_path, genome)
+    with pytest.raises(PortableGenomeError) as exc:
+        import_genome(p)
+    assert str(exc.value) == "transition neighbor count must be an integer string"
+
+
+# --------------------------------------------------------------------------
+# Structural (AST) evidence — supplements the behavioral tests above
+# --------------------------------------------------------------------------
+
+
+def _module_tree() -> ast.Module:
+    return ast.parse(inspect.getsource(pg))
+
+
+def _function_node(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError("function not found: " + name)
+
+
+def _private_error_raising_function_names(tree: ast.Module) -> list:
+    """Module-level private functions that raise PortableGenomeError."""
+    found = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("_"):
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Raise)
+                and isinstance(sub.exc, ast.Call)
+                and isinstance(sub.exc.func, ast.Name)
+                and sub.exc.func.id == "PortableGenomeError"
+            ):
+                found.append(node.name)
+                break
+    return found
+
+
+def _ordered_helper_calls(func: ast.FunctionDef, helper_name: str) -> list:
+    calls = [
+        node
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == helper_name
+    ]
+    calls.sort(key=lambda n: (n.lineno, n.col_offset))
+    return calls
+
+
+def test_exactly_one_private_section_validation_helper():
+    assert len(_private_error_raising_function_names(_module_tree())) == 1
+
+
+def test_helper_uses_an_exact_builtin_dict_check():
+    tree = _module_tree()
+    helper = _function_node(tree, _private_error_raising_function_names(tree)[0])
+    exact_checks = [
+        node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Compare)
+        and len(node.ops) == 1
+        and isinstance(node.ops[0], (ast.Is, ast.IsNot))
+        and isinstance(node.left, ast.Call)
+        and isinstance(node.left.func, ast.Name)
+        and node.left.func.id == "type"
+        and isinstance(node.comparators[0], ast.Name)
+        and node.comparators[0].id == "dict"
+    ]
+    assert len(exact_checks) == 1
+    # No isinstance() anywhere in the helper — a dict subclass must not pass.
+    assert not [
+        node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "isinstance"
+    ]
+
+
+def test_helper_raises_portable_genome_error_with_a_fixed_message():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    helper = _function_node(tree, helper_name)
+    section_param = helper.args.args[-1].arg
+
+    raises = [node for node in ast.walk(helper) if isinstance(node, ast.Raise)]
+    assert len(raises) == 1
+    call = raises[0].exc
+    assert isinstance(call, ast.Call)
+    assert isinstance(call.func, ast.Name) and call.func.id == "PortableGenomeError"
+    assert len(call.args) == 1 and not call.keywords
+
+    message = call.args[0]
+    assert isinstance(message, ast.JoinedStr)
+    interpolated = {
+        sub.value.id
+        for sub in message.values
+        if isinstance(sub, ast.FormattedValue)
+    }
+    # The message is derived from the fixed section-name argument and nothing
+    # else: no supplied value, repr, or type name can enter it.
+    assert interpolated == {section_param}
+    literals = [
+        sub.value for sub in message.values if isinstance(sub, ast.Constant)
+    ]
+    assert literals == [" must be a JSON object"]
+
+
+def test_import_genome_calls_the_helper_exactly_seven_times():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    calls = _ordered_helper_calls(_function_node(tree, "import_genome"), helper_name)
+    assert len(calls) == 7
+
+
+def test_helper_call_sections_are_exactly_the_authorized_set_in_order():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    calls = _ordered_helper_calls(_function_node(tree, "import_genome"), helper_name)
+    names = []
+    for call in calls:
+        assert len(call.args) == 2
+        assert isinstance(call.args[0], ast.Name) and call.args[0].id == "genome"
+        assert isinstance(call.args[1], ast.Constant)
+        names.append(call.args[1].value)
+    assert tuple(names) == _SECTIONS
+    assert set(names) == set(_SECTIONS)
+
+
+def test_no_direct_get_remains_on_an_authorized_section():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    import_fn = _function_node(tree, "import_genome")
+
+    # (a) No authorized section is fetched straight off the genome any more.
+    for node in ast.walk(import_fn):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "genome"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            assert node.args[0].value not in _SECTIONS
+
+    # (b) Every binding that later has .get() called on it and is not a
+    # transition-table or format binding comes from a validated helper call.
+    validated = set()
+    for node in ast.walk(import_fn):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == helper_name
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            validated.add(node.targets[0].id)
+    assert len(validated) == 7
+
+    section_getters = {
+        node.func.value.id
+        for node in ast.walk(import_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and isinstance(node.func.value, ast.Name)
+    }
+    # `genome` (fitness/memory_layout, out of scope) and `fmt` (format_id) are
+    # the only unvalidated-by-this-package holders left.
+    assert section_getters - validated == {"genome", "fmt"}
+
+
+def test_no_broad_exception_handler_is_introduced():
+    for node in ast.walk(_module_tree()):
+        if isinstance(node, ast.ExceptHandler):
+            assert node.type is not None
+            assert getattr(node.type, "id", None) not in ("Exception", "BaseException")
+
+
+def test_public_cli_still_catches_only_portable_genome_error():
+    handlers = [
+        node
+        for node in ast.walk(_module_tree())
+        if isinstance(node, ast.ExceptHandler)
+        and isinstance(node.type, ast.Name)
+        and node.type.id == "PortableGenomeError"
+    ]
+    assert len(handlers) == 1
+    routed = [
+        node
+        for node in ast.walk(handlers[0])
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "error"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "parser"
+    ]
+    assert len(routed) == 1
+
+
+def test_extract_epigenetic_snapshot_untouched_by_this_package():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    fn = _function_node(tree, "extract_epigenetic_snapshot")
+    called = {
+        node.func.id
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    # The package did not extend into it …
+    assert helper_name not in called
+    assert not [node for node in ast.walk(fn) if isinstance(node, ast.Raise)]
+    # … and its own landmarks are still in place.
+    attrs = {
+        node.func.attr
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert {"b64decode", "frombuffer", "reshape", "load"} <= attrs
+
+
+def test_export_genome_untouched_by_this_package():
+    tree = _module_tree()
+    helper_name = _private_error_raising_function_names(tree)[0]
+    fn = _function_node(tree, "export_genome")
+    called = {
+        node.func.id
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert helper_name not in called
+    assert not [node for node in ast.walk(fn) if isinstance(node, ast.Raise)]
+    assert {"_load_transition_table", "_load_stochastic_config"} <= called
+
+
+def test_export_cli_snapshot_path_unchanged():
+    # Deliberately out of scope for this package: the export CLI still loads a
+    # snapshot exactly as before.
+    tree = _module_tree()
+    loads = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "load"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "np"
+    ]
+    assert len(loads) == 1
+    keywords = {kw.arg: kw.value for kw in loads[0].keywords}
+    assert set(keywords) == {"allow_pickle"}
+    assert isinstance(keywords["allow_pickle"], ast.Constant)
+    assert keywords["allow_pickle"].value is True


### PR DESCRIPTION
## Summary

`import_genome()` validated the genome root, `format`, `transition_table` and each transition source mapping, then fetched seven configuration sections with `genome.get(<name>, {})` and invoked `.get()` on the result directly. A JSON value is not necessarily an object: when any of those sections parsed as an array, string, number, Boolean or `null`, the importer raised an ambient `AttributeError` instead of its established `PortableGenomeError` structural-refusal boundary — and because the public `info` CLI catches `PortableGenomeError` specifically, those shapes bypassed the intentional argparse exit-2 lane and emitted a traceback.

This package closes the container-shape boundary for exactly those seven sections.

**Identity:** implemented by **Claude Opus 5** (`claude-opus-5`), **Ian seat only**.

---

## Lineage and boundary

| | |
|---|---|
| Live branch-cut base | `d11f96a65ad04c8c5a077e7befe11653ae83fb07` (`main`) |
| Final head | `b0b692e3138360e131e536b89f4b38ab97e1cfb2` |
| Lineage | `d11f96a → b0b692e` — **one commit**, direct parent is the base |
| Commit count | 1 (no amend, no rebase, no force-push, no merge from `main`) |

```
scripts/portable_genome.py                    +47 /  -16
tests/test_portable_genome_config_shapes.py +1195 /   -0
TOTAL                                       +1242 /  -16
```

Exactly two files. `tests/test_portable_genome.py` and every other existing test file are untouched.

---

## Independently reproduced pre-fix failures

Both reproductions drove the **genuine** `import_genome()` / `python -m scripts.portable_genome info` on a clean export of live `main` @ `d11f96a`, before any edit.

### Direct — 49/49 ambient `AttributeError`

Every section × every ordinary non-object JSON shape (`[]`, `"text"`, integer, float, `True`, `False`, `null`):

| Section | Pre-fix exception | Representative pre-fix message |
|---|---|---|
| `stochastic` | `AttributeError` | `'list' object has no attribute 'get'` |
| `contagion` | `AttributeError` | `'str' object has no attribute 'get'` |
| `decay` | `AttributeError` | `'int' object has no attribute 'get'` |
| `cosmic_garden` | `AttributeError` | `'float' object has no attribute 'get'` |
| `experimental` | `AttributeError` | `'bool' object has no attribute 'get'` |
| `metadata` | `AttributeError` | `'NoneType' object has no attribute 'get'` |
| `topology` | `AttributeError` | `'list' object has no attribute 'get'` |

Tally over the full 7 × 7 matrix: **`{'AttributeError': 49}`** — zero `PortableGenomeError`. `AttributeError` is not a `ValueError` subclass, so nothing in the chain could route it to the importer's refusal vocabulary.

### Public CLI — 14/14 traceback, exit 1

`python -m scripts.portable_genome info <tmp genome>` with the section malformed as a list and as a string, for all seven sections:

```
exit=1  traceback=True   (x14)
```

Full pre-fix stderr for a malformed `metadata`:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  ...
  File ".../scripts/portable_genome.py", line 286, in import_genome
    "name": meta.get("name", "imported-genome"),
            ^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

A valid genome exited 0 both before and after.

---

## Helper contract

```python
def _require_json_object_section(genome: dict, section_name: str) -> dict:
    section = genome.get(section_name, {})
    if type(section) is not dict:
        raise PortableGenomeError(f"{section_name} must be a JSON object")
    return section
```

* missing section → a **fresh** built-in empty `dict` (never a shared mutable default);
* exact built-in `dict` → returned **by identity**;
* every other type, including every `dict` subclass → `PortableGenomeError`;
* message is exact, value-free and section-anchored, built from the fixed `section_name` argument alone;
* no supplied value, representation or custom type name enters the message;
* no `get`, `__repr__`, `__str__`, `__eq__`, `__hash__`, `keys` or `items` of the section object is invoked while producing the refusal.

Exact-type gating (`type(x) is not dict`) matches the importer's existing root, format and transition-container boundaries.

## Authorized section set and validation order

```
stochastic → contagion → decay → cosmic_garden → experimental → metadata → topology
```

Each validation sits **at its existing retrieval site**, before any `.get()` on that value and before any configuration constructor consumes it. The broad execution order is unchanged: JSON load → root → format → transition container/mappings → **seven sections** → rule/config construction → transition source/count/target conversion → metadata return. When several authorized sections are malformed, the earliest in that order wins.

## Refusal messages

```
stochastic must be a JSON object
contagion must be a JSON object
decay must be a JSON object
cosmic_garden must be a JSON object
experimental must be a JSON object
metadata must be a JSON object
topology must be a JSON object
```

Identical wording on the direct and public paths — no punctuation or phrasing variant between them.

---

## Focused test module

`tests/test_portable_genome_config_shapes.py` — **59 test functions → 170 collected cases**.

**Direct malformed shapes (49 cases).** Every section × every non-object JSON shape asserts: exact type is `PortableGenomeError` (`type(exc.value) is PortableGenomeError`, not merely a `ValueError`); exact section-specific message; no supplied value reflected (payloads carry a `ZZ-SECRET-SECTION-VALUE-ZZ` marker, `987654321`, `1234.5678`); nothing returned; and **no downstream configuration constructor reached** — all eight of `StochasticConfig`, `ContagionConfig`, `DecayConfig`, `CosmicGardenConfig`, `ExperimentalConfig`, `DensityPhaseDetectorConfig`, `VoxelMemoryParams`, `CAConfig` are armed with sentinels. An explicit anti-vacuity test proves that sentinel seam is live: a genome that *does* get past section validation reaches `StochasticConfig` and trips it.

**Hook avoidance (29 cases).** Section values injected through a patched module-local JSON load seam: an object whose `.get()` raises, one whose `__repr__()` raises, one whose `__str__()` raises, and a `dict` subclass with hostile `get`/`keys`/`items`/`__repr__`/`__str__`/`__eq__`/`__hash__`. Each records into a plain list before raising, so the tests assert `calls == []` on ordinary Python objects and never feed a hostile object to assertion diagnostics. The `dict` subclass is refused precisely because `isinstance(x, dict)` is true while `type(x) is dict` is false, and no hook can reach the message.

**Missing and valid-section locks (40 cases).** Each section missing individually; all seven missing at once (with the established defaults pinned: `baseline_transition_prob=0.08`, `energy_neighbor_threshold=4`, `structural_inactive_steps_to_decay=6`, `shield_strength=0.85`, `mamba_d_model=64`, `imported-genome`, `moore-3d`, `outer-totalistic`); each present as an empty built-in dict; each present as a populated built-in dict; helper identity return; independent-default proof (two calls never share one object, mutating one leaves the others `{}`); a minimal valid genome; a fully populated genome whose **every** stochastic/contagion/decay/cosmic-garden/experimental field is compared against the reconstructed config; metadata into `rule_spec` and the returned metadata dict; topology into `rule_spec["rule"]` and `metadata["topology"]`; and a proof that a validated section reaches `rule_spec["params"]` **by identity**.

**Validation order (23 cases).** Malformed root, malformed `format`, wrong format identifier, malformed transition container and malformed source mapping each still win over a simultaneously malformed `stochastic`. Section order is proved by malforming section *i* and everything after it, for all seven *i*. Section refusal precedes every configuration constructor, and precedes transition source/count/target semantic conversion — with an anti-vacuity companion proving the same genome *does* refuse at semantic conversion once its sections are well-shaped.

**Public CLI (12 cases).** For all seven sections: exit code exactly `2`, exact refusal text on stderr, no `with transitions` on stdout, no leaked value on either stream, no `Traceback`. Plus: valid genome exits 0 with unchanged output; a fully populated valid genome exits 0; invalid JSON and a missing file both stay outside the catch (`returncode != 2`); and an unrelated `MemoryError`, exercised directly through the load seam, propagates unchanged.

**Transition behavior locks (11 cases).** Case-insensitive source/target names; signed, whitespace-padded, leading-zero and negative count spellings; duplicate integer keys last-write-wins; unknown source, unknown target and malformed count refusals.

**Structural / AST evidence (11 cases).** Exactly one module-level private function raises `PortableGenomeError`; it contains exactly one `type(...) is not dict` comparison and no `isinstance`; it raises exactly once, with a single positional `PortableGenomeError` argument whose f-string interpolates **only** the section-name parameter and whose literal part is exactly `" must be a JSON object"`; `import_genome()` calls it exactly seven times, always as `(genome, "<literal>")`, and the ordered literals equal the authorized tuple; no `genome.get("<authorized section>")` remains in `import_genome()`, and the only `.get()` holders left outside the seven validated bindings are `genome` (out-of-scope `fitness`/`memory_layout`) and `fmt` (`format_id`); no bare/`Exception`/`BaseException` handler exists anywhere in the module; exactly one `PortableGenomeError` handler exists and it is the one calling `parser.error(...)`; `extract_epigenetic_snapshot()` and `export_genome()` neither call the helper nor raise, and retain their own landmarks; the export CLI still calls `np.load` exactly once with `allow_pickle=True`.

---

## Local evidence — separated from CI

**pytest and NumPy are not installed on this machine, and nothing was installed.** There is therefore **no local maintained-suite run**. The local numbers below come from a scratch harness that executes the genuine production code with a minimal stand-in for the `numpy` *import* seam (`import_genome()` itself uses no NumPy at all; the seam exists only because the module and `continuous_evolution_ca` import it, the latter building one module-level lookup table). Every unsupported NumPy attribute in that stand-in raises loudly, so no probe can pass on fake behaviour. **This harness is supporting evidence only — not a pytest substitute and not equivalent to maintained CI.**

| | Pre-fix (`d11f96a`) | Post-fix (`b0b692e`) |
|---|---|---|
| Focused module | **57 passed, 113 failed** | **170 passed, 0 failed** |
| Direct 7 × 7 matrix | 49 × `AttributeError` | 49 × `PortableGenomeError` |
| Public CLI probes | exit 1 + traceback | exit 2, no traceback |

The 113 pre-fix failures are genuine behavioural failures, not source-text assertions — sampled tracebacks show `AttributeError: 'list' object has no attribute 'get'` at `enabled=stoch_section.get(...)`, `AssertionError: section .get() was called` from the hostile witness, and `assert res.returncode == 2` failing against the pre-fix exit 1.

Both files compile (`py_compile`, clean). Static AST count: 59 test functions → 170 cases, with no `parametrize` id/value cardinality mismatch.

Test isolation: files only beneath `tmp_path`; no network, engine, GPU, snapshot or epigenetic work; no repository artifact; no malicious payload constructed; no sleep or wall-clock dependence; patched constructors and JSON seams restored by `monkeypatch`; no execution-order dependence; environment, `sys.path`, `sys.modules` and package attributes left unchanged. The CLI subprocess tests run the genuine module only against temporary JSON files.

## CI and CodeQL

Observed read-only. No workflow was manually rerun.

**One CI event: green on the first head.** No failure, no follow-up commit, no correction. The rollup registered exactly **8 entries, all `SUCCESS`, none pending**:

| Check | Conclusion |
|---|---|
| `verify-python` (×2 — `push` and `pull_request` runs) | SUCCESS |
| `Analyze Python` | SUCCESS |
| `CodeQL` | SUCCESS |
| `agent-safety` | SUCCESS |
| `tripwire` | SUCCESS |
| `frontend-quality` (×2) | SUCCESS |

Nothing is claimed about checks that did not register.

**Corroboration arithmetic.** Baseline `main` @ `d11f96a` (run `30232102865`): **2288 passed, 13 skipped**. Head `b0b692e`: **2458 passed, 13 skipped, 0 failed** — reported identically by both `verify-python` jobs (runs `30267371020` and `30267463304`).

```
2458 − 2288 = +170 passed        skips unchanged at 13
```

That matches the 170 statically counted cases exactly, which is positive proof that no new case was skipped or silently uncollected.

---

## Documentation accuracy

Two production docstrings updated, no documentation file touched. `PortableGenomeError` no longer lists these seven sections as unresolved and now names them among the validated shapes; `import_genome()` documents the refusal contract and order. Both continue to state that **whole-importer totality is not achieved**, and disclose the residual malformed surfaces: internal field values inside otherwise valid section dictionaries, `fitness`, `memory_layout`, `epigenetic_snapshot`, `extract_epigenetic_snapshot()`, schema completeness, and semantic/range validation.

## Claims and explicit non-claims

**Claimed:** deterministic structural refusal for the seven authorized section containers; one unified `PortableGenomeError` vocabulary; public argparse exit-2 reachability for those malformed shapes; preservation of correctly shaped configurations.

**Not claimed:** whole-importer totality; full portable-genome schema validation; internal-value validation; semantic or numeric range correctness; epigenetic safety; base64 safety; memory-allocation safety; whole-file trustworthiness; engine compatibility; export correctness.

**Behavioural note.** Before this change, a malformed `metadata` or `topology` happened to fail first (inside `rule_spec` construction) while a malformed `stochastic` failed later. All of those were uncaught `AttributeError`s, so no contract existed; the now-established order is `stochastic` first.

## Isolation from parked packages

Cut fresh from live `main` @ `d11f96a`. No file overlaps any parked **Ian-seat** package — #419, #422, #424, #425, #426, #428, #429, #430, #431, #433, #434, #435 are untouched, and #419's computed mergeability was not queried. Kev-seat PR #420 was kept opaque (number, title, branch and open/draft identity only). Merged #423, #427 and #432 were treated purely as live-`main` history.

**Correction — the original "no overlap" statement was too broad.** As first written, this section claimed no overlap with any open package. That was inaccurate. An already-open package, **#436**, has since been established to also modify `scripts/portable_genome.py`, so this PR does overlap an open package on that file. The pre-mutation gate for this PR enumerated the open board and found no overlap with any package it could attribute to the Ian seat; it did not establish a no-overlap claim across the whole open board, and the wording should not have implied one.

**#436's seat provenance is not established by GitHub.** #437 identifies itself explicitly as Ian-seat work; #436 carries no reliable Ian-seat identity. It is therefore treated as **Kev-seat or unknown provenance** and left **completely untouched**: its implementation was not inspected, and it has not been commented on, edited, closed, labelled, reviewed, reconciled, branch-moved or disposed of in any way. Any reconciliation between #436 and #437 is a decision for the repo owner and the reviewing seat, not for this package.

Nothing in this correction changes #437's implementation, lineage, diffstat or CI evidence, all of which stand exactly as recorded above.

Opened as **draft**, to remain open and unmerged for individual Codex review.

