### PR TITLE
feat(tech-ledger): add quarantined validation core

### DIFF
--- a/.github/workflows/tech-ledger.yml
+++ b/.github/workflows/tech-ledger.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install lab dependencies
-        run: pip install pytest
-      - name: Run lab-local suite
-        run: python -m pytest experiments/tech_ledger/tests -q
+        run: pip install pytest pytest-asyncio
+      - name: Run lab-local suite (warnings are errors)
+        run: python -m pytest experiments/tech_ledger/tests -q -W error
       - name: Validate committed exemplar entries
         run: python -m experiments.tech_ledger.validate experiments/tech_ledger/entries

--- a/.github/workflows/tech-ledger.yml
+++ b/.github/workflows/tech-ledger.yml
@@ -1,0 +1,35 @@
+name: tech-ledger
+
+on:
+  pull_request:
+    paths:
+      - "experiments/tech_ledger/**"
+      - ".github/workflows/tech-ledger.yml"
+  push:
+    branches: [main]
+    paths:
+      - "experiments/tech_ledger/**"
+      - ".github/workflows/tech-ledger.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tech-ledger-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ledger-lab:
+    name: tech-ledger (non-required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - name: Install lab dependencies
+        run: pip install pytest
+      - name: Run lab-local suite
+        run: python -m pytest experiments/tech_ledger/tests -q
+      - name: Validate committed exemplar entries
+        run: python -m experiments.tech_ledger.validate experiments/tech_ledger/entries

--- a/experiments/tech_ledger/README.md
+++ b/experiments/tech_ledger/README.md
@@ -68,13 +68,19 @@ python -m experiments.tech_ledger.validate experiments/tech_ledger/entries
 ```
 
 Direct `.json` files only, deterministic filename order, duplicate-key-
-rejecting parsing. Every candidate is captured through a **verified
-descriptor boundary** (symlinks refused before and during capture;
-`O_NOFOLLOW` where the platform supplies it; `st_dev`/`st_ino` identity
-agreement across pre-open, opened-descriptor and post-open inspections —
-any mismatch, replacement or incomplete identity inspection fails closed
-on exit 4; no protection is claimed against an unobservable filesystem or
-kernel violation). Ceilings (256 entries, 128 KiB per entry, 4 MiB total)
+rejecting parsing. The **entries directory itself is verified and bound**:
+a symbolic-link, junction or equivalent reparse-path directory is refused;
+where directory-relative descriptors are supported, candidates are
+enumerated and opened relative to the verified directory descriptor, and
+elsewhere a fail-closed identity mechanism re-verifies the directory
+before every capture; a rename or replacement between enumeration and
+capture is detected and refused. Every candidate is then captured through
+a **verified descriptor boundary** (symlinks refused before and during
+capture; `O_NOFOLLOW` where the platform supplies it; `st_dev`/`st_ino`
+identity agreement across pre-open, opened-descriptor and post-open
+inspections — any mismatch, replacement or incomplete identity inspection
+fails closed on exit 4; no protection is claimed against an unobservable
+filesystem or kernel violation). Ceilings (256 entries, 128 KiB per entry, 4 MiB total)
 are enforced over the **exact captured bytes** — cheap stat checks run
 first, but the authoritative aggregate is the captured total, reading
 stops as soon as that total necessarily breaches, and nothing is parsed
@@ -95,7 +101,10 @@ Enforcement is two-part, matching how each direction can actually drift:
   library — nothing from `scripts/`, the engine, agents, CA, telemetry,
   Nextness or any other production path): lab-local static test
   (`tests/test_import_quarantine.py` here) under the path-scoped
-  tech-ledger workflow, which triggers whenever the lab changes.
+  tech-ledger workflow, which triggers whenever the lab changes. The scan
+  **discovers every non-test lab module automatically** (a future
+  `helpers.py` is examined the moment it exists — proven by synthetic
+  controls); the tests tree is scanned through its own separate allowlist.
 - **Reverse quarantine** (no maintained production module imports the
   lab): the **maintained main-suite guard**
   `tests/test_tech_ledger_reverse_quarantine.py`, which runs on ordinary

--- a/experiments/tech_ledger/README.md
+++ b/experiments/tech_ledger/README.md
@@ -68,22 +68,47 @@ python -m experiments.tech_ledger.validate experiments/tech_ledger/entries
 ```
 
 Direct `.json` files only, deterministic filename order, duplicate-key-
-rejecting parsing, symlink refusal, ceilings before parsing (256 entries,
-128 KiB per entry, 4 MiB total). Exit map: **0** all valid · **2** JSON /
-schema / cross-entry refusal · **4** path, symlink or inspection failure ·
-**5** ceiling breach. One concise `error:` line per expected failure; no
-writes; argparse usage errors keep argparse's own `SystemExit(2)`.
+rejecting parsing. Every candidate is captured through a **verified
+descriptor boundary** (symlinks refused before and during capture;
+`O_NOFOLLOW` where the platform supplies it; `st_dev`/`st_ino` identity
+agreement across pre-open, opened-descriptor and post-open inspections —
+any mismatch, replacement or incomplete identity inspection fails closed
+on exit 4; no protection is claimed against an unobservable filesystem or
+kernel violation). Ceilings (256 entries, 128 KiB per entry, 4 MiB total)
+are enforced over the **exact captured bytes** — cheap stat checks run
+first, but the authoritative aggregate is the captured total, reading
+stops as soon as that total necessarily breaches, and nothing is parsed
+until every candidate is captured and every actual-byte ceiling has
+passed; the summary's `total_entry_bytes` is the captured sum, never a
+stale stat size. Exit map: **0** all valid · **2** JSON / schema /
+cross-entry refusal · **4** path, symlink, replacement or inspection
+failure · **5** ceiling breach. Exactly **one physical `error:` stderr
+line** per expected failure (CR/LF in messages rendered as visible
+escapes); no writes; argparse usage errors keep argparse's own
+`SystemExit(2)`.
 
 ## Quarantine
 
-The lab imports **only the Python standard library** — nothing from
-`scripts/`, the engine, agents, CA, telemetry, Nextness or any other
-production path — and no maintained production module imports the lab
-(bidirectional, statically tested by
-`tests/test_import_quarantine.py`). Entry JSON files are data only and can
-never be imported as executable configuration. Lab tests live in
-`experiments/tech_ledger/tests/` under their own path-scoped workflow and
-are deliberately outside the main CI battery.
+Enforcement is two-part, matching how each direction can actually drift:
+
+- **Forward quarantine** (the lab imports only the Python standard
+  library — nothing from `scripts/`, the engine, agents, CA, telemetry,
+  Nextness or any other production path): lab-local static test
+  (`tests/test_import_quarantine.py` here) under the path-scoped
+  tech-ledger workflow, which triggers whenever the lab changes.
+- **Reverse quarantine** (no maintained production module imports the
+  lab): the **maintained main-suite guard**
+  `tests/test_tech_ledger_reverse_quarantine.py`, which runs on ordinary
+  repository CI and statically scans every maintained Python location —
+  so a production-only change can never bypass it merely because the lab
+  workflow did not trigger. (A fast lab-local snapshot of the same
+  direction also runs here.)
+
+Entry JSON files are data only and can never be imported as executable
+configuration. Lab tests live in `experiments/tech_ledger/tests/` under
+their own path-scoped workflow and are deliberately outside the main CI
+battery; the reverse guard is the one deliberate exception, living in the
+main battery by design.
 
 ## Growth discipline
 

--- a/experiments/tech_ledger/README.md
+++ b/experiments/tech_ledger/README.md
@@ -101,8 +101,12 @@ Enforcement is two-part, matching how each direction can actually drift:
   `tests/test_tech_ledger_reverse_quarantine.py`, which runs on ordinary
   repository CI and statically scans every maintained Python location —
   so a production-only change can never bypass it merely because the lab
-  workflow did not trigger. (A fast lab-local snapshot of the same
-  direction also runs here.)
+  workflow did not trigger. The guard resolves **both absolute and
+  relative imports** against each file's repository package context
+  (namespace-package aware), so `from .. import tech_ledger` inside the
+  `experiments` tree is caught exactly like
+  `import experiments.tech_ledger`. (A fast lab-local snapshot of the
+  same direction also runs here.)
 
 Entry JSON files are data only and can never be imported as executable
 configuration. Lab tests live in `experiments/tech_ledger/tests/` under

--- a/experiments/tech_ledger/README.md
+++ b/experiments/tech_ledger/README.md
@@ -72,9 +72,13 @@ rejecting parsing. The **entries directory itself is verified and bound**:
 a symbolic-link, junction or equivalent reparse-path directory is refused;
 where directory-relative descriptors are supported, candidates are
 enumerated and opened relative to the verified directory descriptor, and
-elsewhere a fail-closed identity mechanism re-verifies the directory
-before every capture; a rename or replacement between enumeration and
-capture is detected and refused. Every candidate is then captured through
+elsewhere a directory handle that denies delete/rename sharing is **held
+for the whole interval** from before enumeration until after the last
+capture — so the inspected directory cannot be renamed or replaced
+meanwhile, including during a transient swap-and-restore that no
+before/after identity check could observe. Where neither binding
+primitive exists the validator **fails closed before enumeration** rather
+than presenting identity rechecks as a binding. Every candidate is then captured through
 a **verified descriptor boundary** (symlinks refused before and during
 capture; `O_NOFOLLOW` where the platform supplies it; `st_dev`/`st_ino`
 identity agreement across pre-open, opened-descriptor and post-open

--- a/experiments/tech_ledger/README.md
+++ b/experiments/tech_ledger/README.md
@@ -1,0 +1,103 @@
+# Technology Ledger — Quarantined Validation Lab (`tech-ledger-v1`)
+
+**This lab formalises record structure only.** Its single central rule:
+
+> **Schema validity is not scientific validity, endorsement, implementation
+> authority or evidence that a claim is true.**
+
+## What this is — and is not
+
+- This lab validates ledger **records and their evidential labels**. It does
+  **not** validate scientific truth, score belief, or rank ideas.
+- It does **not** supersede `docs/MEDUSA_THEORY_INTAKE_LEDGER.md`. The prose
+  Theory Intake Ledger remains the authoritative intake instrument, and its
+  existing graduation and promotion gate remains the only promotion path.
+- Any update to that prose ledger remains a **separately authorised action**
+  (its own gate; nothing in this lab touches it).
+- **Inclusion is not endorsement.** **Validation is not factual
+  verification.** **Classification is not implementation permission.**
+- No entry may become a production truth constraint merely because it
+  validates. Speculative and unsupported ideas remain labelled as such —
+  that labelling is the point of the ledger, not a defect of it.
+- The lab performs **no network access, no model invocation, no engine
+  import, no telemetry import and no control path** of any kind. All
+  outputs are deterministic and timestamp-free.
+
+## Classification vocabulary (fixed)
+
+Every entry has **exactly one** `primary_classification`; other applicable
+labels are **qualifiers** (`classification_qualifiers`).
+
+| Label | Meaning |
+|---|---|
+| **A** | demonstrated software or systems-engineering technology |
+| **B** | established mathematical or scientific method |
+| **C** | active research-stage technology |
+| **D** | architecture analogy or inspiration only |
+| **E** | speculative physical hypothesis requiring empirical validation |
+| **F** | unsupported, misleading or technically mismatched claim |
+| **G** | external factual claim requiring primary-source verification before repository inclusion |
+
+## Record schema (`tech-ledger-v1`, closed)
+
+Entries are exact JSON objects with exactly these fields (see `schema.py`
+for the full typed rules): `schema`, `entry_id` (`TLV4-NNN`),
+`neutral_name`, `primary_classification`, `classification_qualifiers`
+(ordered, duplicate-free, never repeating the primary),
+`classification_rationale`, `legitimate_uses`, `unsuitable_uses`,
+`repository_placements` (from `executable-code` / `experiment` / `schema` /
+`research-ledger` / `future-watch`), `implementation_disposition`
+(`eligible` / `evidence-gated` / `deferred` / `prohibited`),
+`minimal_evidence_before_implementation`, `implementation_seam` (non-empty
+string or null), `provenance` (`source_kind`, `source_reference`,
+`attributed_author`, `recorded_date` — a real `YYYY-MM-DD` date —
+`verification_status`), `related_intake_ledger_entries`, `warnings`
+(non-empty), `status` (`active` / `future-watch` / `v5-deferred` / `parked`).
+
+Cross-field discipline (mechanically enforced): a primary **F** is always
+`prohibited` with a null seam; `prohibited` and `deferred` dispositions
+carry no seam; `eligible` and `evidence-gated` require one;
+`v5-deferred` status requires a `deferred` disposition and a null seam; a
+**G** classification never causes `verification_status` to be rewritten —
+validation never mutates, infers or upgrades anything.
+
+## Validator
+
+```bash
+python -m experiments.tech_ledger.validate experiments/tech_ledger/entries
+```
+
+Direct `.json` files only, deterministic filename order, duplicate-key-
+rejecting parsing, symlink refusal, ceilings before parsing (256 entries,
+128 KiB per entry, 4 MiB total). Exit map: **0** all valid · **2** JSON /
+schema / cross-entry refusal · **4** path, symlink or inspection failure ·
+**5** ceiling breach. One concise `error:` line per expected failure; no
+writes; argparse usage errors keep argparse's own `SystemExit(2)`.
+
+## Quarantine
+
+The lab imports **only the Python standard library** — nothing from
+`scripts/`, the engine, agents, CA, telemetry, Nextness or any other
+production path — and no maintained production module imports the lab
+(bidirectional, statically tested by
+`tests/test_import_quarantine.py`). Entry JSON files are data only and can
+never be imported as executable configuration. Lab tests live in
+`experiments/tech_ledger/tests/` under their own path-scoped workflow and
+are deliberately outside the main CI battery.
+
+## Growth discipline
+
+- This PR contains **five exemplar entries only**, proving the schema
+  end-to-end.
+- The complete thirty-entry seed pack is a **later, separately gated
+  content PR** (prepared and audited outside the repository first).
+- Subsequent PRs add **one coherent entry set per PR** — never a bulk
+  mixed drop.
+
+## Provenance note
+
+Contributor attribution (including AURA or other collaborating-AI
+attribution) appears only inside `provenance` data, where factually
+applicable. The exemplar entries cite Kev's supplied V4 technology audit
+handback as an **unverified, user-supplied audit source** — deliberately
+not a primary source.

--- a/experiments/tech_ledger/__init__.py
+++ b/experiments/tech_ledger/__init__.py
@@ -1,0 +1,8 @@
+"""Quarantined technology-ledger validation lab (schema ``tech-ledger-v1``).
+
+Record-structure validation only. Schema validity is not scientific
+validity, endorsement, implementation authority or evidence that a claim
+is true. See README.md for the full contract; the prose
+``docs/MEDUSA_THEORY_INTAKE_LEDGER.md`` remains the authoritative intake
+ledger and is not superseded by this lab.
+"""

--- a/experiments/tech_ledger/entries/TLV4-001.json
+++ b/experiments/tech_ledger/entries/TLV4-001.json
@@ -1,0 +1,44 @@
+{
+ "classification_qualifiers": [
+  "B",
+  "F"
+ ],
+ "classification_rationale": "The mathematics itself (Leech lattice, zeta function, higher-dimensional topology) is established (B face); any claim that these structures describe real physical mechanisms is a speculative physical hypothesis requiring empirical validation (primary E); presenting numerical coincidence as physical evidence is a technically mismatched claim (F face).",
+ "entry_id": "TLV4-001",
+ "implementation_disposition": "evidence-gated",
+ "implementation_seam": "Quarantined pure-mathematics lattice/packing utility or property test only -- deterministic, zero physics claims in code or naming",
+ "legitimate_uses": [
+  "Quarantined pure-mathematics lattice or packing utilities with property-based tests, carrying no physics claim",
+  "Hypothesis-labelled research-ledger entries recording the speculative model with its evidential status"
+ ],
+ "minimal_evidence_before_implementation": [
+  "A written, falsifiable model statement with declared scales and validity limits",
+  "A conventional-baseline comparison plan agreed before any computation is treated as evidence"
+ ],
+ "neutral_name": "Higher-dimensional topology, Riemann-zeta references and Leech-lattice models",
+ "primary_classification": "E",
+ "provenance": {
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
+  "recorded_date": "2026-08-01",
+  "source_kind": "user-supplied-audit",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "verification_status": "unverified"
+ },
+ "related_intake_ledger_entries": [
+  3
+ ],
+ "repository_placements": [
+  "research-ledger",
+  "experiment"
+ ],
+ "schema": "tech-ledger-v1",
+ "status": "active",
+ "unsuitable_uses": [
+  "Encoding a vacuum-lattice or engine-law truth claim as a simulation invariant or configuration default",
+  "Representing any numerical coincidence as physical evidence"
+ ],
+ "warnings": [
+  "No numerical coincidence may be represented as physical evidence.",
+  "No engine-law or vacuum-lattice truth claim; schema validity is not scientific validity."
+ ]
+}

--- a/experiments/tech_ledger/entries/TLV4-008.json
+++ b/experiments/tech_ledger/entries/TLV4-008.json
@@ -1,0 +1,36 @@
+{
+ "classification_qualifiers": [],
+ "classification_rationale": "Extraction of usable net energy from the vacuum has no credible demonstration and contradicts thermodynamics as established. Casimir-effect physics itself is real, established science; the claim classified here is specifically net-energy HARVESTING, which is unsupported -- the distinction is recorded so the F label cannot be misread as dismissing Casimir physics.",
+ "entry_id": "TLV4-008",
+ "implementation_disposition": "prohibited",
+ "implementation_seam": null,
+ "legitimate_uses": [
+  "A research-ledger record documenting why the harvesting claim is classified F, preserving the idea without endorsing it"
+ ],
+ "minimal_evidence_before_implementation": [
+  "Reclassification would require a peer-reviewed, independently replicated demonstration of net energy extraction (none known)"
+ ],
+ "neutral_name": "Zero-point-energy harvesting claims",
+ "primary_classification": "F",
+ "provenance": {
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
+  "recorded_date": "2026-08-01",
+  "source_kind": "user-supplied-audit",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "verification_status": "unverified"
+ },
+ "related_intake_ledger_entries": [],
+ "repository_placements": [
+  "research-ledger"
+ ],
+ "schema": "tech-ledger-v1",
+ "status": "active",
+ "unsuitable_uses": [
+  "Any energy-budget model, simulation parameter, configuration default or roadmap item that assumes zero-point-energy input",
+  "Any language implying the repository endorses feasibility of net vacuum-energy extraction"
+ ],
+ "warnings": [
+  "Established Casimir-effect physics is distinct from unsupported net-energy-harvesting claims; only the latter is classified F here.",
+  "A prohibited F entry has no implementation seam by definition; validation of this record is not evidence about the claim."
+ ]
+}

--- a/experiments/tech_ledger/entries/TLV4-008.json
+++ b/experiments/tech_ledger/entries/TLV4-008.json
@@ -1,6 +1,6 @@
 {
  "classification_qualifiers": [],
- "classification_rationale": "Extraction of usable net energy from the vacuum has no credible demonstration and contradicts thermodynamics as established. Casimir-effect physics itself is real, established science; the claim classified here is specifically net-energy HARVESTING, which is unsupported -- the distinction is recorded so the F label cannot be misread as dismissing Casimir physics.",
+ "classification_rationale": "The user-supplied audit supplies no independently replicated demonstration of a usable net-energy-harvesting technology. Casimir-effect physics is real but does not by itself demonstrate a cyclic net-work source, and idealised theoretical proposals and thermodynamic analyses require careful full-cycle energy accounting and do not establish an engineering technology. The F classification here is an evidence and engineering disposition for this repository, not a declaration that every idealised vacuum-work proposal is mathematically forbidden.",
  "entry_id": "TLV4-008",
  "implementation_disposition": "prohibited",
  "implementation_seam": null,
@@ -8,7 +8,7 @@
   "A research-ledger record documenting why the harvesting claim is classified F, preserving the idea without endorsing it"
  ],
  "minimal_evidence_before_implementation": [
-  "Reclassification would require a peer-reviewed, independently replicated demonstration of net energy extraction (none known)"
+  "Primary-source review and independent replicated evidence of a usable net-energy-harvesting technology, justifying a later separately audited reclassification"
  ],
  "neutral_name": "Zero-point-energy harvesting claims",
  "primary_classification": "F",
@@ -30,7 +30,8 @@
   "Any language implying the repository endorses feasibility of net vacuum-energy extraction"
  ],
  "warnings": [
-  "Established Casimir-effect physics is distinct from unsupported net-energy-harvesting claims; only the latter is classified F here.",
+  "Repository implementation remains prohibited unless primary-source review and independent replicated evidence justify a later separately audited reclassification.",
+  "Casimir-effect physics is real but does not by itself demonstrate a cyclic net-work source; the F label records this repository's evidence disposition, not a physical theorem.",
   "A prohibited F entry has no implementation seam by definition; validation of this record is not evidence about the claim."
  ]
 }

--- a/experiments/tech_ledger/entries/TLV4-016.json
+++ b/experiments/tech_ledger/entries/TLV4-016.json
@@ -1,0 +1,36 @@
+{
+ "classification_qualifiers": [],
+ "classification_rationale": "Demonstrated software-engineering discipline, already core practice in this repository (seeded runs, byte-identical canonical serialization, snapshot/resume equivalence). An engineering discipline, not a physics claim.",
+ "entry_id": "TLV4-016",
+ "implementation_disposition": "eligible",
+ "implementation_seam": "Same-input byte-identical replay or serialization test",
+ "legitimate_uses": [
+  "Standing requirement on new experiment and validation code, including this lab",
+  "Same-seed byte-identical output tests and canonical serialization conventions"
+ ],
+ "minimal_evidence_before_implementation": [
+  "Ordinary test evidence: repeated-run byte-identical outputs asserted in the relevant test suite"
+ ],
+ "neutral_name": "Deterministic execution, replay and reproducible experiment state",
+ "primary_classification": "A",
+ "provenance": {
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
+  "recorded_date": "2026-08-01",
+  "source_kind": "user-supplied-audit",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "verification_status": "unverified"
+ },
+ "related_intake_ledger_entries": [],
+ "repository_placements": [
+  "executable-code",
+  "experiment"
+ ],
+ "schema": "tech-ledger-v1",
+ "status": "active",
+ "unsuitable_uses": [
+  "Exempting informal or exploratory code from determinism on convenience grounds"
+ ],
+ "warnings": [
+  "An engineering discipline, not a physics claim; its presence in a design says nothing about any physical hypothesis attached to that design."
+ ]
+}

--- a/experiments/tech_ledger/entries/TLV4-025.json
+++ b/experiments/tech_ledger/entries/TLV4-025.json
@@ -1,0 +1,37 @@
+{
+ "classification_qualifiers": [],
+ "classification_rationale": "Established methodological standard of honest anomaly work: conventional explanations are itemised and tested before any observation may be escalated as anomalous. The method constrains PROCESS and record-keeping, never the outcome.",
+ "entry_id": "TLV4-025",
+ "implementation_disposition": "eligible",
+ "implementation_seam": "A state or record validator that refuses anomaly escalation until itemised conventional checks are recorded",
+ "legitimate_uses": [
+  "A record or state validator that refuses anomaly escalation until itemised conventional checks are recorded",
+  "Methodology sections of evidence schemas requiring non-empty conventional-explanation fields"
+ ],
+ "minimal_evidence_before_implementation": [
+  "None beyond ordinary test evidence: the gate enforces recording and sequence, not any scientific result"
+ ],
+ "neutral_name": "Conventional-explanation testing before anomaly escalation",
+ "primary_classification": "B",
+ "provenance": {
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
+  "recorded_date": "2026-08-01",
+  "source_kind": "user-supplied-audit",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "verification_status": "unverified"
+ },
+ "related_intake_ledger_entries": [],
+ "repository_placements": [
+  "schema",
+  "research-ledger"
+ ],
+ "schema": "tech-ledger-v1",
+ "status": "active",
+ "unsuitable_uses": [
+  "Rhetorical \"all conventional explanations were ruled out\" claims without itemised, recorded tests",
+  "Encoding any predetermined conclusion -- conventional OR exotic -- into the gate itself"
+ ],
+ "warnings": [
+  "Enforce sequence and evidence recording, never a predetermined outcome."
+ ]
+}

--- a/experiments/tech_ledger/entries/TLV4-029.json
+++ b/experiments/tech_ledger/entries/TLV4-029.json
@@ -1,0 +1,39 @@
+{
+ "classification_qualifiers": [
+  "G"
+ ],
+ "classification_rationale": "The ingestion mechanics (local, provenance-preserving intake of public material) are demonstrated engineering (primary A); every ingested CLAIM is an external factual claim requiring primary-source verification before repository inclusion (qualifier G). The entire concern is deferred to a later, separately authorised V5 arc.",
+ "entry_id": "TLV4-029",
+ "implementation_disposition": "deferred",
+ "implementation_seam": null,
+ "legitimate_uses": [
+  "A future-watch marker recording that this concern exists and is deliberately deferred"
+ ],
+ "minimal_evidence_before_implementation": [
+  "A separate V5 authorisation from the operator",
+  "Per-item provenance and primary-source verification for every ingested claim"
+ ],
+ "neutral_name": "Local ingestion of publicly released footage and reports",
+ "primary_classification": "A",
+ "provenance": {
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
+  "recorded_date": "2026-08-01",
+  "source_kind": "user-supplied-audit",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "verification_status": "unverified"
+ },
+ "related_intake_ledger_entries": [],
+ "repository_placements": [
+  "future-watch"
+ ],
+ "schema": "tech-ledger-v1",
+ "status": "v5-deferred",
+ "unsuitable_uses": [
+  "Downloading, ingesting or analysing any footage, media, report or external dataset under this entry or before a separate V5 authorisation",
+  "Preloading either a conventional or an exotic conclusion about any deferred material"
+ ],
+ "warnings": [
+  "No footage, media, report or external dataset may be downloaded, ingested or analysed under this entry.",
+  "The G qualifier never upgrades verification_status; ingested claims remain unverified until primary-source verification."
+ ]
+}

--- a/experiments/tech_ledger/schema.py
+++ b/experiments/tech_ledger/schema.py
@@ -1,0 +1,378 @@
+"""Closed in-Python schema for ``tech-ledger-v1`` entries.
+
+Pure, dependency-free (standard library only) validation of technology-
+ledger records. The central rule, stated once and enforced nowhere as a
+truth judgement:
+
+    Schema validity is not scientific validity, endorsement,
+    implementation authority or evidence that a claim is true.
+
+Validation is PURE and NON-MUTATING: it never rewrites a field, never
+infers a classification, placement, evidential status or scientific
+conclusion, and never upgrades a ``verification_status`` (in particular,
+a primary or qualifier ``G`` classification never causes
+``verification_status`` to become ``verified`` -- verification is a
+separate human act recorded in the data, not a validation side effect).
+
+Exact-type discipline: containers and scalars must be the exact built-in
+types (``bool`` is refused where ``int`` is required; subclasses are
+refused everywhere). Refusal messages never invoke hooks on rejected
+objects -- type names come from an identity table of builtins, foreign
+dictionary keys are never hashed, compared or stringified, and anything
+non-builtin is described generically.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any, Final
+
+SCHEMA_ID: Final[str] = "tech-ledger-v1"
+
+#: Evidential classification vocabulary (fixed; documented in README.md).
+CLASSIFICATIONS: Final[tuple[str, ...]] = ("A", "B", "C", "D", "E", "F", "G")
+
+PLACEMENTS: Final[tuple[str, ...]] = (
+    "executable-code",
+    "experiment",
+    "schema",
+    "research-ledger",
+    "future-watch",
+)
+
+DISPOSITIONS: Final[tuple[str, ...]] = (
+    "eligible",
+    "evidence-gated",
+    "deferred",
+    "prohibited",
+)
+
+STATUSES: Final[tuple[str, ...]] = (
+    "active",
+    "future-watch",
+    "v5-deferred",
+    "parked",
+)
+
+SOURCE_KINDS: Final[tuple[str, ...]] = (
+    "user-supplied-audit",
+    "repository",
+    "primary-source",
+    "secondary-source",
+)
+
+VERIFICATION_STATUSES: Final[tuple[str, ...]] = (
+    "verified",
+    "unverified",
+    "not-computable",
+)
+
+ENTRY_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"\ATLV4-\d{3}\Z")
+_DATE_PATTERN: Final[re.Pattern[str]] = re.compile(r"\A(\d{4})-(\d{2})-(\d{2})\Z")
+
+_ROOT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "schema",
+        "entry_id",
+        "neutral_name",
+        "primary_classification",
+        "classification_qualifiers",
+        "classification_rationale",
+        "legitimate_uses",
+        "unsuitable_uses",
+        "repository_placements",
+        "implementation_disposition",
+        "minimal_evidence_before_implementation",
+        "implementation_seam",
+        "provenance",
+        "related_intake_ledger_entries",
+        "warnings",
+        "status",
+    }
+)
+
+_PROVENANCE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "source_kind",
+        "source_reference",
+        "attributed_author",
+        "recorded_date",
+        "verification_status",
+    }
+)
+
+
+class LedgerEntryError(ValueError):
+    """A malformed, hostile or rule-violating ledger entry (fail closed)."""
+
+
+_BUILTIN_TYPE_NAMES: Final[tuple[tuple[type, str], ...]] = (
+    (bool, "bool"),  # before int: bool is an int subclass
+    (int, "int"),
+    (float, "float"),
+    (str, "str"),
+    (list, "list"),
+    (dict, "dict"),
+    (tuple, "tuple"),
+    (set, "set"),
+    (bytes, "bytes"),
+    (type(None), "NoneType"),
+)
+
+
+def _describe_type(value: Any) -> str:
+    """Hook-free type description: identity comparison against builtins
+    only; ``type(value).__name__`` is never read (a hostile metaclass can
+    make reading it execute code)."""
+    value_type = type(value)
+    for builtin, name in _BUILTIN_TYPE_NAMES:
+        if value_type is builtin:
+            return name
+    return "non-builtin value"
+
+
+def _exact_dict(value: Any, field: str, keys: frozenset[str]) -> dict[str, Any]:
+    """Exact built-in dict with exactly the given key set.
+
+    Foreign (non-``str``) keys are never hashed, compared, stringified or
+    represented: iteration alone collects exact-``str`` keys, anything
+    else is described generically and forces a refusal.
+    """
+    if type(value) is not dict:
+        raise LedgerEntryError(
+            f"{field}: expected builtin dict, got {_describe_type(value)}"
+        )
+    str_keys: set[str] = set()
+    foreign: list[str] = []
+    for key in value:
+        if type(key) is str:
+            str_keys.add(key)
+        else:
+            foreign.append(f"<{_describe_type(key)}>")
+    if foreign or str_keys != keys:
+        unknown = sorted(list(str_keys - keys) + foreign)
+        missing = sorted(keys - str_keys)
+        raise LedgerEntryError(
+            f"{field}: key set mismatch (unknown={unknown}, missing={missing})"
+        )
+    return value
+
+
+def _exact_str(value: Any, field: str) -> str:
+    if type(value) is not str:
+        raise LedgerEntryError(
+            f"{field}: expected builtin str, got {_describe_type(value)}"
+        )
+    return value
+
+
+def _non_empty_str(value: Any, field: str) -> str:
+    text = _exact_str(value, field)
+    if not text:
+        raise LedgerEntryError(f"{field}: must be a non-empty string")
+    return text
+
+
+def _enum(value: Any, field: str, allowed: tuple[str, ...]) -> str:
+    text = _exact_str(value, field)
+    if text not in allowed:
+        raise LedgerEntryError(
+            f"{field}: {text!r} not in the fixed vocabulary {list(allowed)}"
+        )
+    return text
+
+
+def _exact_list(value: Any, field: str) -> list[Any]:
+    if type(value) is not list:
+        raise LedgerEntryError(
+            f"{field}: expected builtin list, got {_describe_type(value)}"
+        )
+    return value
+
+
+def _non_empty_str_list(value: Any, field: str) -> list[str]:
+    items = _exact_list(value, field)
+    if not items:
+        raise LedgerEntryError(f"{field}: must be a non-empty list")
+    return [_non_empty_str(item, f"{field}[{i}]") for i, item in enumerate(items)]
+
+
+def _validate_date(value: Any, field: str) -> str:
+    """A real ISO ``YYYY-MM-DD`` calendar date (impossible dates refused)."""
+    text = _exact_str(value, field)
+    match = _DATE_PATTERN.match(text)
+    if match is None:
+        raise LedgerEntryError(f"{field}: {text!r} is not an ISO YYYY-MM-DD date")
+    year, month, day = (int(part) for part in match.groups())
+    try:
+        datetime.date(year, month, day)
+    except ValueError as e:
+        raise LedgerEntryError(
+            f"{field}: {text!r} is not a real calendar date"
+        ) from e
+    return text
+
+
+def validate_provenance(value: Any) -> None:
+    """Validate the closed provenance block. Pure; never mutates."""
+    block = _exact_dict(value, "provenance", _PROVENANCE_KEYS)
+    _enum(block["source_kind"], "provenance.source_kind", SOURCE_KINDS)
+    _non_empty_str(block["source_reference"], "provenance.source_reference")
+    _non_empty_str(block["attributed_author"], "provenance.attributed_author")
+    _validate_date(block["recorded_date"], "provenance.recorded_date")
+    _enum(
+        block["verification_status"],
+        "provenance.verification_status",
+        VERIFICATION_STATUSES,
+    )
+
+
+def validate_entry(obj: Any) -> None:
+    """Validate one ``tech-ledger-v1`` entry. Pure; raises
+    ``LedgerEntryError`` on the first refusal; returns ``None`` and never
+    mutates, infers or rewrites anything on success."""
+    entry = _exact_dict(obj, "entry", _ROOT_KEYS)
+
+    schema = _exact_str(entry["schema"], "schema")
+    if schema != SCHEMA_ID:
+        raise LedgerEntryError(
+            f"schema: unknown variant {schema!r} (expected {SCHEMA_ID!r})"
+        )
+
+    entry_id = _exact_str(entry["entry_id"], "entry_id")
+    if ENTRY_ID_PATTERN.match(entry_id) is None:
+        raise LedgerEntryError(
+            f"entry_id: {entry_id!r} does not match the fixed TLV4-NNN form"
+        )
+
+    _non_empty_str(entry["neutral_name"], "neutral_name")
+
+    primary = _enum(
+        entry["primary_classification"], "primary_classification", CLASSIFICATIONS
+    )
+
+    qualifiers = _exact_list(
+        entry["classification_qualifiers"], "classification_qualifiers"
+    )
+    seen_qualifiers: set[str] = set()
+    for i, item in enumerate(qualifiers):
+        qualifier = _enum(
+            item, f"classification_qualifiers[{i}]", CLASSIFICATIONS
+        )
+        if qualifier == primary:
+            raise LedgerEntryError(
+                f"classification_qualifiers[{i}]: must not repeat the "
+                f"primary classification {primary!r}"
+            )
+        if qualifier in seen_qualifiers:
+            raise LedgerEntryError(
+                f"classification_qualifiers[{i}]: duplicate {qualifier!r}"
+            )
+        seen_qualifiers.add(qualifier)
+
+    _non_empty_str(entry["classification_rationale"], "classification_rationale")
+    _non_empty_str_list(entry["legitimate_uses"], "legitimate_uses")
+    _non_empty_str_list(entry["unsuitable_uses"], "unsuitable_uses")
+
+    placements = _exact_list(entry["repository_placements"], "repository_placements")
+    if not placements:
+        raise LedgerEntryError("repository_placements: must be a non-empty list")
+    seen_placements: set[str] = set()
+    for i, item in enumerate(placements):
+        placement = _enum(item, f"repository_placements[{i}]", PLACEMENTS)
+        if placement in seen_placements:
+            raise LedgerEntryError(
+                f"repository_placements[{i}]: duplicate {placement!r}"
+            )
+        seen_placements.add(placement)
+
+    disposition = _enum(
+        entry["implementation_disposition"],
+        "implementation_disposition",
+        DISPOSITIONS,
+    )
+
+    _non_empty_str_list(
+        entry["minimal_evidence_before_implementation"],
+        "minimal_evidence_before_implementation",
+    )
+
+    seam = entry["implementation_seam"]
+    if seam is not None:
+        _non_empty_str(seam, "implementation_seam")
+
+    validate_provenance(entry["provenance"])
+
+    related = _exact_list(
+        entry["related_intake_ledger_entries"], "related_intake_ledger_entries"
+    )
+    seen_related: set[int] = set()
+    for i, item in enumerate(related):
+        # Exact builtin int only: bool is an int subclass and is refused.
+        if type(item) is not int:
+            raise LedgerEntryError(
+                f"related_intake_ledger_entries[{i}]: expected builtin int, "
+                f"got {_describe_type(item)}"
+            )
+        if item <= 0:
+            raise LedgerEntryError(
+                f"related_intake_ledger_entries[{i}]: must be a positive integer"
+            )
+        if item in seen_related:
+            raise LedgerEntryError(
+                f"related_intake_ledger_entries[{i}]: duplicate {item}"
+            )
+        seen_related.add(item)
+
+    _non_empty_str_list(entry["warnings"], "warnings")
+
+    status = _enum(entry["status"], "status", STATUSES)
+
+    # ---- Cross-field rules (record discipline, never truth judgement) ----
+
+    # Rule 1: a primary F (unsupported / misleading / technically
+    # mismatched claim) is never implementable and never carries a seam.
+    if primary == "F":
+        if disposition != "prohibited":
+            raise LedgerEntryError(
+                "primary classification F requires "
+                "implementation_disposition 'prohibited'"
+            )
+        if seam is not None:
+            raise LedgerEntryError(
+                "primary classification F requires a null implementation_seam"
+            )
+
+    # Rules 2-3: prohibited and deferred dispositions carry no seam.
+    if disposition in ("prohibited", "deferred") and seam is not None:
+        raise LedgerEntryError(
+            f"implementation_disposition {disposition!r} requires a null "
+            f"implementation_seam"
+        )
+
+    # Rule 4: eligible and evidence-gated dispositions require a seam.
+    if disposition in ("eligible", "evidence-gated") and seam is None:
+        raise LedgerEntryError(
+            f"implementation_disposition {disposition!r} requires a "
+            f"non-empty implementation_seam"
+        )
+
+    # Rule 5: v5-deferred status is deferred work with no seam.
+    if status == "v5-deferred":
+        if disposition != "deferred":
+            raise LedgerEntryError(
+                "status 'v5-deferred' requires implementation_disposition "
+                "'deferred'"
+            )
+        if seam is not None:
+            raise LedgerEntryError(
+                "status 'v5-deferred' requires a null implementation_seam"
+            )
+
+    # Rule 6 is enforced by construction: this validator never writes to
+    # the entry, so a primary or qualifier G can never cause
+    # verification_status to be rewritten. Rule 7 likewise: nothing above
+    # infers a classification, placement, evidential status or scientific
+    # conclusion -- every value is the operator's recorded statement,
+    # checked for shape only.

--- a/experiments/tech_ledger/schema.py
+++ b/experiments/tech_ledger/schema.py
@@ -68,8 +68,16 @@ VERIFICATION_STATUSES: Final[tuple[str, ...]] = (
     "not-computable",
 )
 
-ENTRY_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"\ATLV4-\d{3}\Z")
-_DATE_PATTERN: Final[re.Pattern[str]] = re.compile(r"\A(\d{4})-(\d{2})-(\d{2})\Z")
+#: Wire-format digits are ASCII ONLY. ``\d`` in Python str patterns
+#: matches every Unicode decimal digit (Arabic-Indic, Devanagari,
+#: Bengali, ...), and ``int()`` parses them too -- so explicit [0-9]
+#: classes are load-bearing here, not style: a ledger identifier or date
+#: written with non-ASCII digits is refused even though Python could
+#: parse it.
+ENTRY_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"\ATLV4-[0-9]{3}\Z")
+_DATE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\A([0-9]{4})-([0-9]{2})-([0-9]{2})\Z"
+)
 
 _ROOT_KEYS: Final[frozenset[str]] = frozenset(
     {

--- a/experiments/tech_ledger/tests/__init__.py
+++ b/experiments/tech_ledger/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Lab-local tests for the tech-ledger validation lab.
+
+Run by the path-scoped tech-ledger workflow only; deliberately outside the
+main repository battery (pytest.ini scopes collection to tests/).
+"""

--- a/experiments/tech_ledger/tests/test_entries.py
+++ b/experiments/tech_ledger/tests/test_entries.py
@@ -1,0 +1,79 @@
+"""Committed exemplar entries: all validate; classifications exactly as
+authorised. Validation here proves record structure only -- never the
+truth of any claim.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from experiments.tech_ledger.validate import validate_directory
+
+_ENTRIES_DIR = pathlib.Path(__file__).resolve().parent.parent / "entries"
+
+
+def _load(entry_id):
+    return json.loads(
+        (_ENTRIES_DIR / f"{entry_id}.json").read_text(encoding="utf-8")
+    )
+
+
+def test_all_exemplars_validate_and_ids_match_filenames():
+    summary = validate_directory(_ENTRIES_DIR)
+    assert summary["entry_count"] == 5
+    for record in summary["entries"]:
+        assert record["filename"] == f"{record['entry_id']}.json"
+    assert [r["entry_id"] for r in summary["entries"]] == [
+        "TLV4-001",
+        "TLV4-008",
+        "TLV4-016",
+        "TLV4-025",
+        "TLV4-029",
+    ]
+
+
+def test_tlv4_001_topology_models():
+    entry = _load("TLV4-001")
+    assert entry["primary_classification"] == "E"
+    assert entry["classification_qualifiers"] == ["B", "F"]
+    assert entry["implementation_disposition"] == "evidence-gated"
+    assert "physical evidence" in " ".join(entry["warnings"])
+
+
+def test_tlv4_008_zero_point_claims():
+    entry = _load("TLV4-008")
+    assert entry["primary_classification"] == "F"
+    assert entry["implementation_disposition"] == "prohibited"
+    assert entry["implementation_seam"] is None
+    assert entry["repository_placements"] == ["research-ledger"]
+    assert "Casimir" in entry["classification_rationale"]
+
+
+def test_tlv4_016_deterministic_execution():
+    entry = _load("TLV4-016")
+    assert entry["primary_classification"] == "A"
+    assert entry["implementation_disposition"] == "eligible"
+    assert "byte-identical" in entry["implementation_seam"]
+
+
+def test_tlv4_025_conventional_explanations_first():
+    entry = _load("TLV4-025")
+    assert entry["primary_classification"] == "B"
+    assert entry["implementation_disposition"] == "eligible"
+    # The entry enforces sequence and recording -- it never encodes an
+    # anomaly outcome (neither conventional nor exotic).
+    text = json.dumps(entry)
+    assert "never a predetermined outcome" in text
+    assert "refuses anomaly escalation until" in entry["implementation_seam"]
+
+
+def test_tlv4_029_v5_deferred_ingestion():
+    entry = _load("TLV4-029")
+    assert entry["primary_classification"] == "A"
+    assert entry["classification_qualifiers"] == ["G"]
+    assert entry["status"] == "v5-deferred"
+    assert entry["implementation_disposition"] == "deferred"
+    assert entry["implementation_seam"] is None
+    assert entry["repository_placements"] == ["future-watch"]
+    assert entry["provenance"]["verification_status"] == "unverified"

--- a/experiments/tech_ledger/tests/test_entries.py
+++ b/experiments/tech_ledger/tests/test_entries.py
@@ -47,7 +47,22 @@ def test_tlv4_008_zero_point_claims():
     assert entry["implementation_disposition"] == "prohibited"
     assert entry["implementation_seam"] is None
     assert entry["repository_placements"] == ["research-ledger"]
-    assert "Casimir" in entry["classification_rationale"]
+    # Conservative-substance pins: the F label is an evidence and
+    # engineering disposition for THIS repository, never a physical
+    # theorem or a categorical scientific verdict.
+    rationale = entry["classification_rationale"]
+    assert "no independently replicated demonstration" in rationale
+    assert "does not by itself demonstrate a cyclic net-work source" in rationale
+    assert "full-cycle energy accounting" in rationale
+    assert "not a declaration" in rationale
+    warnings = " ".join(entry["warnings"])
+    assert "separately audited reclassification" in warnings
+    assert "not a physical theorem" in warnings
+    # Categorical wording stays out.
+    assert "contradicts thermodynamics" not in rationale
+    assert "none known" not in " ".join(
+        entry["minimal_evidence_before_implementation"]
+    )
 
 
 def test_tlv4_016_deterministic_execution():

--- a/experiments/tech_ledger/tests/test_import_quarantine.py
+++ b/experiments/tech_ledger/tests/test_import_quarantine.py
@@ -26,6 +26,7 @@ _ALLOWED_IMPORTS = {
     "os",
     "pathlib",
     "re",
+    "stat",
     "sys",
     "typing",
     "experiments.tech_ledger.schema",
@@ -96,9 +97,13 @@ def test_lab_tests_import_stdlib_pytest_and_lab_only():
 
 
 def test_no_production_module_imports_the_lab():
-    # Reverse quarantine: maintained production Python trees contain no
-    # reference to the lab package. Static text scan (cheap, total).
-    production_trees = ("scripts", "agent", "vis")
+    # Lab-local SNAPSHOT of the reverse direction over the highest-risk
+    # production trees. The CONTINUOUS, repository-wide reverse guard is
+    # tests/test_tech_ledger_reverse_quarantine.py in the maintained main
+    # battery (ordinary repository CI), which scans every maintained
+    # Python location automatically -- this lab-local check is a fast
+    # companion, not the enforcement boundary.
+    production_trees = ("scripts", "agent", "agents", "vis")
     offenders: list[str] = []
     for tree_name in production_trees:
         tree = _REPO_ROOT / tree_name

--- a/experiments/tech_ledger/tests/test_import_quarantine.py
+++ b/experiments/tech_ledger/tests/test_import_quarantine.py
@@ -69,14 +69,68 @@ def _imports_of(path: pathlib.Path) -> set[str]:
     return found
 
 
+def _non_test_lab_modules(lab_root: pathlib.Path) -> list[pathlib.Path]:
+    """Deterministic discovery of every non-test Python module under the
+    lab: any future module (e.g. helpers.py) is examined automatically.
+    The tests tree is excluded here and scanned through its own separate
+    allowlist below."""
+    tests_root = lab_root / "tests"
+    return sorted(
+        path
+        for path in lab_root.rglob("*.py")
+        if tests_root not in path.parents
+        and "__pycache__" not in path.parts
+    )
+
+
+def _forward_violations(path: pathlib.Path) -> list[str]:
+    """Every import of a lab module that falls outside the standard-library
+    + lab-local allowlist, or that matches a forbidden production/network
+    fragment. Purely static: nothing is imported."""
+    violations: list[str] = []
+    for name in _imports_of(path):
+        if name not in _ALLOWED_IMPORTS:
+            violations.append(name)
+            continue
+        for fragment in _FORBIDDEN_FRAGMENTS:
+            if fragment in name:
+                violations.append(name)
+    return violations
+
+
 def test_lab_modules_import_stdlib_only():
-    for module in ("__init__.py", "schema.py", "validate.py"):
-        imports = _imports_of(_LAB_DIR / module)
-        unexpected = imports - _ALLOWED_IMPORTS
-        assert not unexpected, f"{module}: unexpected imports {sorted(unexpected)}"
-        for name in imports:
-            for fragment in _FORBIDDEN_FRAGMENTS:
-                assert fragment not in name, f"{module}: forbidden import {name}"
+    modules = _non_test_lab_modules(_LAB_DIR)
+    names = {path.name for path in modules}
+    # Discovery must at minimum see today's modules; any future module is
+    # included automatically by construction.
+    assert {"__init__.py", "schema.py", "validate.py"} <= names, names
+    for path in modules:
+        violations = _forward_violations(path)
+        assert not violations, f"{path.name}: {violations}"
+
+
+def test_forward_discovery_examines_new_modules(tmp_path):
+    # Synthetic positive control: a NEWLY INTRODUCED non-test module with
+    # a production import must fail the forward guard -- proving the
+    # discovery actually examines modules that did not exist when the
+    # guard was written.
+    fake_lab = tmp_path / "fake_lab"
+    (fake_lab / "tests").mkdir(parents=True)
+    (fake_lab / "__init__.py").write_bytes(b"import json\n")
+    (fake_lab / "helpers.py").write_bytes(b"import scripts.event_bus\n")
+    (fake_lab / "tests" / "test_x.py").write_bytes(b"import subprocess\n")
+    discovered = {p.name for p in _non_test_lab_modules(fake_lab)}
+    assert discovered == {"__init__.py", "helpers.py"}  # tests tree excluded
+    flagged = {
+        p.name: _forward_violations(p) for p in _non_test_lab_modules(fake_lab)
+    }
+    assert flagged["helpers.py"] == ["scripts.event_bus"]
+    assert flagged["__init__.py"] == []
+    # Negative control: a clean new module passes.
+    (fake_lab / "helpers.py").write_bytes(b"import pathlib\n")
+    assert all(
+        not _forward_violations(p) for p in _non_test_lab_modules(fake_lab)
+    )
 
 
 def test_lab_tests_import_stdlib_pytest_and_lab_only():
@@ -84,6 +138,7 @@ def test_lab_tests_import_stdlib_pytest_and_lab_only():
         imports = _imports_of(path)
         allowed = _ALLOWED_IMPORTS | {
             "pytest",
+            "_winapi",  # Windows junction creation in one capability test
             "experiments.tech_ledger",
             "experiments.tech_ledger.tests",
         }

--- a/experiments/tech_ledger/tests/test_import_quarantine.py
+++ b/experiments/tech_ledger/tests/test_import_quarantine.py
@@ -1,0 +1,128 @@
+"""Bidirectional static import quarantine for the tech-ledger lab.
+
+The lab imports only the Python standard library (plus its own modules);
+no maintained production module imports the lab; the entry JSON files are
+data only. All checks are static -- nothing outside this directory tree is
+imported or executed.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_LAB_DIR = pathlib.Path(__file__).resolve().parent.parent
+_REPO_ROOT = _LAB_DIR.parent.parent
+
+#: The complete import allowlist for lab modules: standard library only,
+#: plus the lab's own package.
+_ALLOWED_IMPORTS = {
+    "__future__",
+    "argparse",
+    "ast",
+    "copy",
+    "datetime",
+    "json",
+    "os",
+    "pathlib",
+    "re",
+    "sys",
+    "typing",
+    "experiments.tech_ledger.schema",
+    "experiments.tech_ledger.validate",
+}
+
+_FORBIDDEN_FRAGMENTS = (
+    "scripts.",
+    "agent.",
+    "vis.",
+    "ca.",
+    "crates",
+    "telemetry",
+    "nextness",
+    "medusa",
+    "event_bus",
+    "orchestrat",
+    "tuning",
+    "swarm_hunter",
+    "theory_sandbox",
+    "subprocess",
+    "socket",
+    "http",
+    "urllib",
+    "requests",
+    "zmq",
+    "ollama",
+    "numpy",
+)
+
+
+def _imports_of(path: pathlib.Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found |= {alias.name for alias in node.names}
+        elif isinstance(node, ast.ImportFrom):
+            found.add(node.module or "")
+    return found
+
+
+def test_lab_modules_import_stdlib_only():
+    for module in ("__init__.py", "schema.py", "validate.py"):
+        imports = _imports_of(_LAB_DIR / module)
+        unexpected = imports - _ALLOWED_IMPORTS
+        assert not unexpected, f"{module}: unexpected imports {sorted(unexpected)}"
+        for name in imports:
+            for fragment in _FORBIDDEN_FRAGMENTS:
+                assert fragment not in name, f"{module}: forbidden import {name}"
+
+
+def test_lab_tests_import_stdlib_pytest_and_lab_only():
+    for path in sorted((_LAB_DIR / "tests").glob("*.py")):
+        imports = _imports_of(path)
+        allowed = _ALLOWED_IMPORTS | {
+            "pytest",
+            "experiments.tech_ledger",
+            "experiments.tech_ledger.tests",
+        }
+        unexpected = {
+            name
+            for name in imports
+            if name not in allowed
+            and not name.startswith("experiments.tech_ledger")
+        }
+        assert not unexpected, f"{path.name}: unexpected imports {sorted(unexpected)}"
+
+
+def test_no_production_module_imports_the_lab():
+    # Reverse quarantine: maintained production Python trees contain no
+    # reference to the lab package. Static text scan (cheap, total).
+    production_trees = ("scripts", "agent", "vis")
+    offenders: list[str] = []
+    for tree_name in production_trees:
+        tree = _REPO_ROOT / tree_name
+        if not tree.is_dir():
+            continue
+        for path in tree.rglob("*.py"):
+            if "tech_ledger" in path.read_text(encoding="utf-8", errors="replace"):
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert offenders == []
+
+
+def test_entries_are_data_only():
+    entries_dir = _LAB_DIR / "entries"
+    assert entries_dir.is_dir()
+    non_json = [p.name for p in entries_dir.iterdir() if not p.name.endswith(".json")]
+    assert non_json == []  # no __init__.py, no executable configuration
+    for path in entries_dir.glob("*.json"):
+        head = path.read_bytes()[:1]
+        assert head == b"{", f"{path.name}: entries must be JSON objects"
+
+
+def test_no_network_or_subprocess_anywhere_in_lab():
+    for path in sorted(_LAB_DIR.rglob("*.py")):
+        imports = _imports_of(path)
+        for name in imports:
+            for fragment in ("subprocess", "socket", "http", "urllib", "requests", "zmq"):
+                assert fragment not in name, f"{path.name}: {name}"

--- a/experiments/tech_ledger/tests/test_import_quarantine.py
+++ b/experiments/tech_ledger/tests/test_import_quarantine.py
@@ -23,12 +23,14 @@ _ALLOWED_IMPORTS = {
     "copy",
     "datetime",
     "json",
+    "msvcrt",  # stdlib: Windows directory-binding handle ownership
     "os",
     "pathlib",
     "re",
     "stat",
     "sys",
     "typing",
+    "_winapi",  # stdlib: Windows directory-binding primitive
     "experiments.tech_ledger.schema",
     "experiments.tech_ledger.validate",
 }

--- a/experiments/tech_ledger/tests/test_schema.py
+++ b/experiments/tech_ledger/tests/test_schema.py
@@ -1,0 +1,321 @@
+"""Schema tests: closed record structure, exact types, cross-field rules.
+
+Structure only -- nothing here judges, scores or infers scientific truth.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from experiments.tech_ledger.schema import (
+    CLASSIFICATIONS,
+    LedgerEntryError,
+    validate_entry,
+)
+
+
+def _valid_entry(**overrides):
+    entry = {
+        "schema": "tech-ledger-v1",
+        "entry_id": "TLV4-042",
+        "neutral_name": "Example demonstrated technology",
+        "primary_classification": "A",
+        "classification_qualifiers": [],
+        "classification_rationale": "Recorded rationale.",
+        "legitimate_uses": ["one legitimate use"],
+        "unsuitable_uses": ["one unsuitable use"],
+        "repository_placements": ["research-ledger"],
+        "implementation_disposition": "eligible",
+        "minimal_evidence_before_implementation": ["ordinary test evidence"],
+        "implementation_seam": "a deterministic test seam",
+        "provenance": {
+            "source_kind": "user-supplied-audit",
+            "source_reference": "example reference",
+            "attributed_author": "example author",
+            "recorded_date": "2026-08-01",
+            "verification_status": "unverified",
+        },
+        "related_intake_ledger_entries": [],
+        "warnings": ["schema validity is not scientific validity"],
+        "status": "active",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _refused(entry, match=None):
+    with pytest.raises(LedgerEntryError, match=match):
+        validate_entry(entry)
+
+
+def test_valid_entry_accepted():
+    assert validate_entry(_valid_entry()) is None
+
+
+def test_every_primary_classification_accepted():
+    for label in CLASSIFICATIONS:
+        if label == "F":
+            entry = _valid_entry(
+                primary_classification="F",
+                implementation_disposition="prohibited",
+                implementation_seam=None,
+            )
+        else:
+            entry = _valid_entry(primary_classification=label)
+        assert validate_entry(entry) is None, label
+
+
+def test_qualifier_cannot_repeat_primary():
+    _refused(
+        _valid_entry(classification_qualifiers=["A"]),
+        match="must not repeat the primary",
+    )
+
+
+def test_qualifier_duplicates_refused():
+    _refused(
+        _valid_entry(classification_qualifiers=["B", "B"]), match="duplicate"
+    )
+
+
+def test_qualifier_unknown_label_refused():
+    _refused(_valid_entry(classification_qualifiers=["X"]))
+
+
+def test_every_missing_root_field_refused():
+    for field in _valid_entry():
+        entry = _valid_entry()
+        del entry[field]
+        _refused(entry, match="key set mismatch")
+
+
+def test_every_missing_provenance_field_refused():
+    for field in _valid_entry()["provenance"]:
+        entry = _valid_entry()
+        del entry["provenance"][field]
+        _refused(entry, match="key set mismatch")
+
+
+def test_unknown_root_key_refused():
+    _refused(_valid_entry(surprise=1), match="key set mismatch")
+
+
+def test_unknown_provenance_key_refused():
+    entry = _valid_entry()
+    entry["provenance"]["surprise"] = 1
+    _refused(entry, match="key set mismatch")
+
+
+def test_root_must_be_exact_builtin_dict():
+    class HostileDict(dict):
+        pass
+
+    _refused(HostileDict(_valid_entry()), match="expected builtin dict")
+    _refused([], match="expected builtin dict")
+    _refused(None, match="expected builtin dict")
+
+
+def test_hostile_str_subclass_refused():
+    class HostileStr(str):
+        pass
+
+    _refused(
+        _valid_entry(neutral_name=HostileStr("sneaky")),
+        match="expected builtin str",
+    )
+
+
+def test_hostile_key_never_hashed_into_acceptance():
+    # A non-str key is described generically and forces a refusal; its
+    # __eq__/__hash__ must never let it satisfy a required field name.
+    class HostileKey:
+        def __hash__(self):
+            return hash("schema")
+
+        def __eq__(self, other):
+            return True
+
+    entry = _valid_entry()
+    del entry["schema"]
+    entry[HostileKey()] = "tech-ledger-v1"
+    _refused(entry, match="key set mismatch")
+
+
+def test_list_fields_must_be_exact_lists():
+    _refused(
+        _valid_entry(classification_qualifiers=("B",)),
+        match="expected builtin list",
+    )
+    _refused(_valid_entry(warnings="not-a-list"), match="expected builtin list")
+
+
+def test_wrong_enum_values_refused():
+    _refused(_valid_entry(schema="tech-ledger-v2"), match="unknown variant")
+    _refused(_valid_entry(primary_classification="H"))
+    _refused(_valid_entry(implementation_disposition="maybe"))
+    _refused(_valid_entry(status="unknown"))
+    for field, value in (
+        ("source_kind", "hearsay"),
+        ("verification_status", "assumed-true"),
+    ):
+        entry = _valid_entry()
+        entry["provenance"][field] = value
+        _refused(entry)
+
+
+def test_entry_id_form_enforced():
+    for bad in ("TLV4-1", "TLV4-0001", "TLV5-001", "tlv4-001", "TLV4-001 "):
+        _refused(_valid_entry(entry_id=bad), match="TLV4-NNN")
+
+
+def test_malformed_and_impossible_dates_refused():
+    for bad in ("2026-8-01", "01-08-2026", "2026/08/01", "not-a-date"):
+        entry = _valid_entry()
+        entry["provenance"]["recorded_date"] = bad
+        _refused(entry, match="ISO YYYY-MM-DD")
+    for impossible in ("2026-02-30", "2026-13-01", "2025-02-29", "0000-01-01"):
+        entry = _valid_entry()
+        entry["provenance"]["recorded_date"] = impossible
+        _refused(entry, match="real calendar date")
+
+
+def test_empty_strings_and_empty_lists_refused():
+    _refused(_valid_entry(neutral_name=""), match="non-empty")
+    _refused(_valid_entry(classification_rationale=""), match="non-empty")
+    _refused(_valid_entry(legitimate_uses=[]), match="non-empty list")
+    _refused(_valid_entry(unsuitable_uses=[""]), match="non-empty")
+    _refused(_valid_entry(repository_placements=[]), match="non-empty list")
+    _refused(
+        _valid_entry(minimal_evidence_before_implementation=[]),
+        match="non-empty list",
+    )
+    _refused(_valid_entry(warnings=[]), match="non-empty list")
+    _refused(_valid_entry(implementation_seam=""), match="non-empty")
+    entry = _valid_entry()
+    entry["provenance"]["source_reference"] = ""
+    _refused(entry, match="non-empty")
+
+
+def test_placement_duplicates_and_unknown_refused():
+    _refused(
+        _valid_entry(repository_placements=["experiment", "experiment"]),
+        match="duplicate",
+    )
+    _refused(_valid_entry(repository_placements=["everywhere"]))
+
+
+def test_related_entries_exact_positive_ints():
+    _refused(
+        _valid_entry(related_intake_ledger_entries=[3, 3]), match="duplicate"
+    )
+    _refused(
+        _valid_entry(related_intake_ledger_entries=[0]), match="positive"
+    )
+    _refused(
+        _valid_entry(related_intake_ledger_entries=[-2]), match="positive"
+    )
+    _refused(
+        _valid_entry(related_intake_ledger_entries=[True]),
+        match="expected builtin int",
+    )
+    _refused(
+        _valid_entry(related_intake_ledger_entries=[3.0]),
+        match="expected builtin int",
+    )
+    assert validate_entry(_valid_entry(related_intake_ledger_entries=[3, 14])) is None
+
+
+def test_disposition_seam_rules():
+    _refused(
+        _valid_entry(
+            implementation_disposition="prohibited",
+            implementation_seam="still here",
+        ),
+        match="null implementation_seam",
+    )
+    _refused(
+        _valid_entry(
+            implementation_disposition="deferred",
+            implementation_seam="still here",
+        ),
+        match="null implementation_seam",
+    )
+    _refused(
+        _valid_entry(
+            implementation_disposition="eligible", implementation_seam=None
+        ),
+        match="non-empty implementation_seam",
+    )
+    _refused(
+        _valid_entry(
+            implementation_disposition="evidence-gated",
+            implementation_seam=None,
+        ),
+        match="non-empty implementation_seam",
+    )
+    assert (
+        validate_entry(
+            _valid_entry(
+                implementation_disposition="prohibited",
+                implementation_seam=None,
+            )
+        )
+        is None
+    )
+
+
+def test_primary_f_rules():
+    _refused(
+        _valid_entry(primary_classification="F"),
+        match="requires implementation_disposition 'prohibited'",
+    )
+    _refused(
+        _valid_entry(
+            primary_classification="F",
+            implementation_disposition="prohibited",
+            implementation_seam="sneaky seam",
+        ),
+        match="null implementation_seam",
+    )
+    assert (
+        validate_entry(
+            _valid_entry(
+                primary_classification="F",
+                implementation_disposition="prohibited",
+                implementation_seam=None,
+            )
+        )
+        is None
+    )
+
+
+def test_v5_deferred_rules():
+    _refused(
+        _valid_entry(status="v5-deferred"),
+        match="requires implementation_disposition 'deferred'",
+    )
+    assert (
+        validate_entry(
+            _valid_entry(
+                status="v5-deferred",
+                implementation_disposition="deferred",
+                implementation_seam=None,
+            )
+        )
+        is None
+    )
+
+
+def test_validation_never_mutates_or_infers():
+    # Rule 6/7: pure validation -- the entry (including an unverified G
+    # claim) is byte-for-byte untouched, nothing is inferred or upgraded.
+    entry = _valid_entry(
+        primary_classification="G",
+        classification_qualifiers=["A"],
+    )
+    snapshot = copy.deepcopy(entry)
+    assert validate_entry(entry) is None
+    assert entry == snapshot
+    assert entry["provenance"]["verification_status"] == "unverified"

--- a/experiments/tech_ledger/tests/test_schema.py
+++ b/experiments/tech_ledger/tests/test_schema.py
@@ -170,6 +170,29 @@ def test_entry_id_form_enforced():
         _refused(_valid_entry(entry_id=bad), match="TLV4-NNN")
 
 
+def test_wire_formats_ascii_digits_only():
+    # Python's \d and int() both accept Unicode decimal digits; the wire
+    # formats must not. Valid ASCII forms stay valid.
+    assert validate_entry(_valid_entry(entry_id="TLV4-042")) is None
+    arabic_indic = "TLV4-٠١٦"  # TLV4-016 in Arabic-Indic digits
+    _refused(_valid_entry(entry_id=arabic_indic), match="TLV4-NNN")
+    devanagari = "TLV4-०१६"
+    _refused(_valid_entry(entry_id=devanagari), match="TLV4-NNN")
+    entry = _valid_entry()
+    entry["provenance"]["recorded_date"] = (
+        "২০২৬-০৮-০১"  # Bengali 2026-08-01
+    )
+    _refused(entry, match="ISO YYYY-MM-DD")
+    entry = _valid_entry()
+    entry["provenance"]["recorded_date"] = (
+        "2026-٠٨-01"  # mixed ASCII/Arabic-Indic
+    )
+    _refused(entry, match="ISO YYYY-MM-DD")
+    entry = _valid_entry()
+    entry["provenance"]["recorded_date"] = "2026-08-01"
+    assert validate_entry(entry) is None
+
+
 def test_malformed_and_impossible_dates_refused():
     for bad in ("2026-8-01", "01-08-2026", "2026/08/01", "not-a-date"):
         entry = _valid_entry()

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -268,3 +268,220 @@ def test_validate_directory_pure_and_reusable(tmp_path):
     assert first == second
     assert copy.deepcopy(first)["entry_count"] == 1
     assert _snapshot(tmp_path) == before
+
+
+# ---------------------------------------------------------------------------
+# Captured-byte aggregate enforcement and the capture-boundary races
+# (audit corrections 1 and 2) -- synchronized at the validator's real
+# pre-open inspection seam; no sleeps, no timing guesses.
+# ---------------------------------------------------------------------------
+
+
+def _mutate_once_at_capture(monkeypatch, mutate_once):
+    """Run ``mutate_once`` exactly once: after the initial stat pass, at
+    the first capture's pre-open inspection (the real race window)."""
+    real = validate_module._pre_open_inspect
+    state = {"done": False}
+
+    def _wrapped(path):
+        result = real(path)
+        if not state["done"]:
+            state["done"] = True
+            mutate_once()
+        return result
+
+    monkeypatch.setattr(validate_module, "_pre_open_inspect", _wrapped)
+
+
+def _padded_entry_bytes(entry_id, target_size=None, pad=0):
+    entry = _valid_entry(entry_id)
+    entry["classification_rationale"] = "Recorded rationale." + "a" * pad
+    raw = (json.dumps(entry, sort_keys=True, indent=1) + "\n").encode("utf-8")
+    if target_size is None:
+        return raw
+    base = len(raw) - pad
+    entry["classification_rationale"] = "Recorded rationale." + "a" * (
+        target_size - base
+    )
+    raw = (json.dumps(entry, sort_keys=True, indent=1) + "\n").encode("utf-8")
+    assert len(raw) == target_size
+    return raw
+
+
+def test_aggregate_growth_after_stat_refuses_exit5(tmp_path, capsys, monkeypatch):
+    # Stat total below 4 MiB; every file then grows (each staying under
+    # the 128 KiB per-entry ceiling) so the ACTUAL captured total breaches
+    # the aggregate ceiling. Content is junk: the refusal must arrive
+    # before any parse (proven by the exploding parser).
+    names = [f"junk-{i:03d}.json" for i in range(34)]
+    for name in names:
+        (tmp_path / name).write_bytes(b"x" * 100_000)  # stat total 3.4 MB
+
+    def _grow_all():
+        for name in names:
+            with (tmp_path / name).open("ab") as f:
+                f.write(b"y" * 27_000)  # each 127 000 < 131 072; total > 4 MiB
+
+    _mutate_once_at_capture(monkeypatch, _grow_all)
+
+    def _exploding(raw, filename):  # pragma: no cover - must never run
+        raise AssertionError("parse attempted despite aggregate breach")
+
+    monkeypatch.setattr(validate_module, "_parse_entry_bytes", _exploding)
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert "total" in err
+
+
+def test_actual_total_exactly_at_ceiling_accepted(tmp_path, capsys):
+    for i in range(32):
+        (tmp_path / f"TLV4-{i:03d}.json").write_bytes(
+            _padded_entry_bytes(f"TLV4-{i:03d}", target_size=127_000)
+        )
+    last = MAX_TOTAL_ENTRY_BYTES - 32 * 127_000
+    assert last <= MAX_ENTRY_BYTES
+    (tmp_path / "TLV4-032.json").write_bytes(
+        _padded_entry_bytes("TLV4-032", target_size=last)
+    )
+    assert main([str(tmp_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["total_entry_bytes"] == MAX_TOTAL_ENTRY_BYTES
+
+
+def test_actual_total_one_byte_over_refuses_exit5(tmp_path, capsys):
+    for i in range(32):
+        (tmp_path / f"TLV4-{i:03d}.json").write_bytes(
+            _padded_entry_bytes(f"TLV4-{i:03d}", target_size=127_000)
+        )
+    last = MAX_TOTAL_ENTRY_BYTES - 32 * 127_000 + 1
+    (tmp_path / "TLV4-032.json").write_bytes(
+        _padded_entry_bytes("TLV4-032", target_size=last)
+    )
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert "total" in err
+
+
+def test_summary_reports_captured_bytes_not_stat_size(
+    tmp_path, capsys, monkeypatch
+):
+    _write_entry(tmp_path, "TLV4-001")
+    stat_size = (tmp_path / "TLV4-001.json").stat().st_size
+    replacement = _padded_entry_bytes("TLV4-001", target_size=stat_size + 5_000)
+
+    def _rewrite():
+        (tmp_path / "TLV4-001.json").write_bytes(replacement)
+
+    _mutate_once_at_capture(monkeypatch, _rewrite)
+    assert main([str(tmp_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["total_entry_bytes"] == len(replacement)
+    assert summary["total_entry_bytes"] != stat_size
+
+
+def test_per_entry_growth_refusal_intact(tmp_path, capsys, monkeypatch):
+    _write_entry(tmp_path, "TLV4-001")
+
+    def _grow_past_entry_ceiling():
+        with (tmp_path / "TLV4-001.json").open("ab") as f:
+            f.write(b"z" * (MAX_ENTRY_BYTES + 10))
+
+    _mutate_once_at_capture(monkeypatch, _grow_past_entry_ceiling)
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert "per-entry ceiling" in err
+
+
+def test_symlink_replacement_during_capture_refused_exit4(
+    tmp_path, capsys, monkeypatch
+):
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    outside = tmp_path / "outside-target.json"
+    outside.write_bytes(
+        (json.dumps(_valid_entry("TLV4-099"), sort_keys=True, indent=1) + "\n").encode()
+    )
+    probe = tmp_path / "symlink-probe"
+    try:
+        os.symlink(str(outside), str(probe))
+    except (OSError, NotImplementedError):  # pragma: no cover - privilege
+        pytest.skip("platform lacks symlink privilege")
+    os.remove(probe)
+
+    def _replace_with_symlink():
+        os.remove(entries / "TLV4-001.json")
+        os.symlink(str(outside), str(entries / "TLV4-001.json"))
+
+    _mutate_once_at_capture(monkeypatch, _replace_with_symlink)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    assert rc == 4
+    _assert_one_error_line(captured.err)
+    # The outside target was neither accepted nor parsed into a summary.
+    assert captured.out == ""
+    assert "TLV4-099" not in captured.out
+
+
+def test_regular_file_replacement_during_capture_refused_exit4(
+    tmp_path, capsys, monkeypatch
+):
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    decoy = tmp_path / "decoy.json"
+    decoy.write_bytes(
+        (json.dumps(_valid_entry("TLV4-098"), sort_keys=True, indent=1) + "\n").encode()
+    )
+
+    def _replace_with_other_file():
+        os.replace(str(decoy), str(entries / "TLV4-001.json"))
+
+    _mutate_once_at_capture(monkeypatch, _replace_with_other_file)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    assert rc == 4
+    _assert_one_error_line(captured.err)
+    assert "identity" in captured.err
+    assert captured.out == ""
+
+
+def test_stable_files_still_succeed_with_capture_boundary(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    _write_entry(tmp_path, "TLV4-002")
+    assert main([str(tmp_path)]) == 0
+    assert json.loads(capsys.readouterr().out)["entry_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# One physical stderr line (audit correction 3)
+# ---------------------------------------------------------------------------
+
+
+def test_error_output_sanitizes_cr_and_lf(capsys):
+    from experiments.tech_ledger.validate import LedgerInputError, _fail
+
+    rc = _fail(LedgerInputError("bad\r\nsplit\nname"), 2)
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert err == "error: bad\\r\\nsplit\\nname\n"
+    assert err.count("\n") == 1
+
+
+def test_newline_bearing_filename_yields_one_error_line(tmp_path, capsys):
+    evil_name = "TLV4-666\n.json"
+    try:
+        (tmp_path / evil_name).write_bytes(b"{not json")
+    except OSError:  # pragma: no cover - platform rejects the name
+        pytest.skip("filesystem rejects newline-bearing filenames")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+    assert "\\n" in err

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -701,10 +701,13 @@ def test_fail_closed_without_any_binding_primitive(tmp_path, capsys, monkeypatch
     assert "binding" in err
 
 
-@pytest.mark.skipif(
+_dir_fd_only = pytest.mark.skipif(
     not validate_module._DIR_FD_SUPPORTED,
     reason="directory-relative descriptors unavailable on this platform",
 )
+
+
+@_dir_fd_only
 def test_capture_bound_to_inspected_directory_fd_mode(
     tmp_path, capsys, monkeypatch
 ):
@@ -735,14 +738,172 @@ def test_capture_bound_to_inspected_directory_fd_mode(
     assert summary["total_entry_bytes"] != len(replacement)
 
 
-def test_ordinary_directory_validates_under_identity_mode(
+@_dir_fd_only
+def test_fd_mode_inspections_go_through_directory_descriptor(
     tmp_path, capsys, monkeypatch
 ):
+    # Every candidate inspection must pass a real dir_fd and a bare
+    # filename -- never a reconstructed pathname -- when the descriptor
+    # lane is on.
+    _write_entry(tmp_path, "TLV4-001")
+    _write_entry(tmp_path, "TLV4-002")
+    seen = []
+    real = validate_module._pre_open_inspect
+
+    def _recording(path, dir_fd=None):
+        seen.append((path, dir_fd))
+        return real(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(validate_module, "_pre_open_inspect", _recording)
+    assert main([str(tmp_path)]) == 0
+    capsys.readouterr()
+    assert seen, "captures must run through the inspection seam"
+    assert all(dir_fd is not None for _path, dir_fd in seen)
+    assert all(os.sep not in path for path, _dir_fd in seen)
+
+
+@_dir_fd_only
+def test_transient_pathname_swap_during_enumeration_fd_mode(
+    tmp_path, capsys, monkeypatch
+):
+    # fd mode: enumeration reads the HELD descriptor, so a pathname
+    # swap-and-restore around os.listdir cannot subset or replace the
+    # candidate set.  (POSIX permits the renames -- unlike the Windows
+    # hold lane, which forbids them -- but the binding makes them
+    # irrelevant: every later probe and open goes through the held fd.)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    _write_entry(entries, "TLV4-016")
+    aside = tmp_path / "aside"
+    transient = tmp_path / "transient"
+    transient.mkdir()
+    _write_entry(transient, "TLV4-001")  # deliberately omits TLV4-016
+
+    real_listdir = os.listdir
+    state = {"done": False}
+
+    def _swapping_listdir(target):
+        if state["done"]:
+            return real_listdir(target)
+        state["done"] = True
+        os.rename(str(entries), str(aside))
+        os.rename(str(transient), str(entries))
+        try:
+            return real_listdir(target)  # target is the held descriptor
+        finally:  # restore before any later pathname cross-check
+            os.rename(str(entries), str(transient))
+            os.rename(str(aside), str(entries))
+
+    monkeypatch.setattr(os, "listdir", _swapping_listdir)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    monkeypatch.undo()
+    assert state["done"] is True, "the swap window must actually run"
+    assert rc == 0, captured.err
+    summary = json.loads(captured.out)
+    assert summary["entry_count"] == 2  # nothing silently omitted
+    assert {e["entry_id"] for e in summary["entries"]} == {
+        "TLV4-001",
+        "TLV4-016",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Capability-predicate correspondence (Ubuntu regression): the compiled
+# flag must track the primitives the fd lane genuinely calls, on real and
+# simulated capability shapes alike.  CPython never registers os.lstat in
+# os.supports_dir_fd on any build, so a predicate consulting it is False
+# everywhere -- which made every Linux run refuse ordinary validation.
+# ---------------------------------------------------------------------------
+
+
+def _linux_shaped_capabilities():
+    # The shape CPython v3.12.13 builds on Linux: os.stat (HAVE_FSTATAT)
+    # and os.open (HAVE_OPENAT) registered dir_fd-capable, os.listdir
+    # (HAVE_FDOPENDIR) fd-capable, O_DIRECTORY present -- while os.lstat
+    # is absent from supports_dir_fd even though os.lstat(path, dir_fd=fd)
+    # works there (fstatat with AT_SYMLINK_NOFOLLOW, the same capability
+    # that registers os.stat).
+    return {
+        "supports_dir_fd": {os.open, os.stat},
+        "supports_fd": {os.listdir, os.stat},
+        "has_o_directory": True,
+    }
+
+
+def test_predicate_true_on_linux_shaped_capability_sets():
+    caps = _linux_shaped_capabilities()
+    assert os.lstat not in caps["supports_dir_fd"]  # the exact Ubuntu trap
+    assert validate_module._dir_fd_binding_supported(**caps) is True
+
+
+@pytest.mark.parametrize(
+    "absent",
+    ["open", "stat", "listdir", "o_directory", "everything"],
+)
+def test_predicate_false_when_any_primitive_is_absent(absent):
+    caps = _linux_shaped_capabilities()
+    if absent == "open":
+        caps["supports_dir_fd"] = {os.stat}
+    elif absent == "stat":
+        caps["supports_dir_fd"] = {os.open}
+    elif absent == "listdir":
+        caps["supports_fd"] = set()
+    elif absent == "o_directory":
+        caps["has_o_directory"] = False
+    else:
+        caps = {
+            "supports_dir_fd": set(),
+            "supports_fd": set(),
+            "has_o_directory": False,
+        }
+    assert validate_module._dir_fd_binding_supported(**caps) is False
+
+
+def test_compiled_flag_matches_real_platform_capabilities():
+    # On every platform the module-level flag must equal the predicate
+    # over the REAL capability sets -- neither under- nor over-claiming.
+    assert validate_module._DIR_FD_SUPPORTED == (
+        validate_module._dir_fd_binding_supported(
+            os.supports_dir_fd, os.supports_fd, hasattr(os, "O_DIRECTORY")
+        )
+    )
+
+
+def test_posix_with_dir_fd_primitives_must_select_fd_mode():
+    # Anti-skip sentinel: wherever the platform really provides the
+    # descriptor primitives (every Linux CI runner), the fd lane MUST be
+    # on -- otherwise the @_dir_fd_only tests above silently skip and
+    # ordinary validation refuses, exactly the Ubuntu regression.
+    if not (
+        os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.listdir in os.supports_fd
+        and hasattr(os, "O_DIRECTORY")
+    ):
+        pytest.skip("platform genuinely lacks descriptor primitives")
+    assert validate_module._DIR_FD_SUPPORTED is True
+
+
+def test_ordinary_directory_without_dir_fd_binds_or_refuses(
+    tmp_path, capsys, monkeypatch
+):
+    # Without directory-relative descriptors the validator must either
+    # hold the fallback binding (Windows) or refuse before enumeration
+    # (platforms with neither primitive) -- never enumerate unbound.
     monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
     _write_entry(tmp_path, "TLV4-001")
     _write_entry(tmp_path, "TLV4-002")
-    assert main([str(tmp_path)]) == 0
-    assert json.loads(capsys.readouterr().out)["entry_count"] == 2
+    rc = main([str(tmp_path)])
+    captured = capsys.readouterr()
+    if validate_module._FALLBACK_BINDING_SUPPORTED:
+        assert rc == 0, captured.err
+        assert json.loads(captured.out)["entry_count"] == 2
+    else:
+        assert rc == 4
+        _assert_one_error_line(captured.err)
+        assert "binding" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -821,13 +821,16 @@ def test_transient_pathname_swap_during_enumeration_fd_mode(
 def _linux_shaped_capabilities():
     # The shape CPython v3.12.13 builds on Linux: os.stat (HAVE_FSTATAT)
     # and os.open (HAVE_OPENAT) registered dir_fd-capable, os.listdir
-    # (HAVE_FDOPENDIR) fd-capable, O_DIRECTORY present -- while os.lstat
-    # is absent from supports_dir_fd even though os.lstat(path, dir_fd=fd)
+    # (HAVE_FDOPENDIR) fd-capable, os.stat registered follow_symlinks-
+    # capable (HAVE_LSTAT/HAVE_FSTATAT -- the registry governing
+    # follow_symlinks=False), O_DIRECTORY present -- while os.lstat is
+    # absent from supports_dir_fd even though os.lstat(path, dir_fd=fd)
     # works there (fstatat with AT_SYMLINK_NOFOLLOW, the same capability
     # that registers os.stat).
     return {
         "supports_dir_fd": {os.open, os.stat},
         "supports_fd": {os.listdir, os.stat},
+        "supports_follow_symlinks": {os.stat},
         "has_o_directory": True,
     }
 
@@ -840,7 +843,7 @@ def test_predicate_true_on_linux_shaped_capability_sets():
 
 @pytest.mark.parametrize(
     "absent",
-    ["open", "stat", "listdir", "o_directory", "everything"],
+    ["open", "stat", "listdir", "follow_symlinks", "o_directory", "everything"],
 )
 def test_predicate_false_when_any_primitive_is_absent(absent):
     caps = _linux_shaped_capabilities()
@@ -850,12 +853,19 @@ def test_predicate_false_when_any_primitive_is_absent(absent):
         caps["supports_dir_fd"] = {os.open}
     elif absent == "listdir":
         caps["supports_fd"] = set()
+    elif absent == "follow_symlinks":
+        # dir_fd support alone is NOT enough: the lane's inspection call
+        # passes follow_symlinks=False, and an unregistered
+        # follow_symlinks raises NotImplementedError (not an OSError) at
+        # runtime -- the predicate must refuse the lane instead.
+        caps["supports_follow_symlinks"] = set()
     elif absent == "o_directory":
         caps["has_o_directory"] = False
     else:
         caps = {
             "supports_dir_fd": set(),
             "supports_fd": set(),
+            "supports_follow_symlinks": set(),
             "has_o_directory": False,
         }
     assert validate_module._dir_fd_binding_supported(**caps) is False
@@ -866,7 +876,10 @@ def test_compiled_flag_matches_real_platform_capabilities():
     # over the REAL capability sets -- neither under- nor over-claiming.
     assert validate_module._DIR_FD_SUPPORTED == (
         validate_module._dir_fd_binding_supported(
-            os.supports_dir_fd, os.supports_fd, hasattr(os, "O_DIRECTORY")
+            os.supports_dir_fd,
+            os.supports_fd,
+            os.supports_follow_symlinks,
+            hasattr(os, "O_DIRECTORY"),
         )
     )
 
@@ -879,6 +892,7 @@ def test_posix_with_dir_fd_primitives_must_select_fd_mode():
     if not (
         os.open in os.supports_dir_fd
         and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
         and os.listdir in os.supports_fd
         and hasattr(os, "O_DIRECTORY")
     ):

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -1,0 +1,270 @@
+"""Validator CLI tests: determinism, refusal lanes, ceilings, zero writes."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import pathlib
+
+import pytest
+
+import experiments.tech_ledger.validate as validate_module
+from experiments.tech_ledger.validate import (
+    MAX_ENTRIES,
+    MAX_ENTRY_BYTES,
+    MAX_TOTAL_ENTRY_BYTES,
+    main,
+    validate_directory,
+)
+
+_EXEMPLARS = (
+    pathlib.Path(__file__).resolve().parent.parent / "entries"
+)
+
+
+def _valid_entry(entry_id="TLV4-042"):
+    return {
+        "schema": "tech-ledger-v1",
+        "entry_id": entry_id,
+        "neutral_name": "Example demonstrated technology",
+        "primary_classification": "A",
+        "classification_qualifiers": [],
+        "classification_rationale": "Recorded rationale.",
+        "legitimate_uses": ["one legitimate use"],
+        "unsuitable_uses": ["one unsuitable use"],
+        "repository_placements": ["research-ledger"],
+        "implementation_disposition": "eligible",
+        "minimal_evidence_before_implementation": ["ordinary test evidence"],
+        "implementation_seam": "a deterministic test seam",
+        "provenance": {
+            "source_kind": "user-supplied-audit",
+            "source_reference": "example reference",
+            "attributed_author": "example author",
+            "recorded_date": "2026-08-01",
+            "verification_status": "unverified",
+        },
+        "related_intake_ledger_entries": [],
+        "warnings": ["schema validity is not scientific validity"],
+        "status": "active",
+    }
+
+
+def _write_entry(directory, entry_id="TLV4-042", filename=None, entry=None):
+    entry = entry if entry is not None else _valid_entry(entry_id)
+    name = filename or f"{entry_id}.json"
+    (directory / name).write_bytes(
+        (json.dumps(entry, sort_keys=True, indent=1) + "\n").encode("utf-8")
+    )
+    return name
+
+
+def _snapshot(directory):
+    return {
+        p.name: p.read_bytes() for p in sorted(directory.iterdir()) if p.is_file()
+    }
+
+
+def _assert_one_error_line(err):
+    assert err.startswith("error:")
+    assert err.count("\n") == 1 and err.endswith("\n")
+    assert "Traceback" not in err
+
+
+def test_success_canonical_deterministic_output(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    _write_entry(tmp_path, "TLV4-002")
+    before = _snapshot(tmp_path)
+    assert main([str(tmp_path)]) == 0
+    first = capsys.readouterr()
+    assert first.err == ""
+    assert main([str(tmp_path)]) == 0
+    second = capsys.readouterr()
+    # Repeated runs: byte-identical canonical output; zero writes.
+    assert first.out == second.out
+    assert first.out.endswith("\n")
+    assert "\r" not in first.out
+    assert _snapshot(tmp_path) == before
+    summary = json.loads(first.out)
+    assert summary["schema"] == "tech-ledger-v1"
+    assert summary["entry_count"] == 2
+    # Relative filenames and entry ids only -- no absolute path anywhere.
+    assert str(tmp_path) not in first.out
+    assert str(tmp_path).replace(os.sep, "/") not in first.out
+
+
+def test_deterministic_filename_order(tmp_path, capsys):
+    # Written in scrambled order; reported in sorted filename order.
+    _write_entry(tmp_path, "TLV4-030")
+    _write_entry(tmp_path, "TLV4-002")
+    _write_entry(tmp_path, "TLV4-100")
+    assert main([str(tmp_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert [e["filename"] for e in summary["entries"]] == [
+        "TLV4-002.json",
+        "TLV4-030.json",
+        "TLV4-100.json",
+    ]
+
+
+def test_duplicate_json_key_refused_exit2(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    raw = (tmp_path / "TLV4-001.json").read_text(encoding="utf-8")
+    patched = raw.replace(
+        '"status": "active"', '"status": "active", "status": "parked"', 1
+    )
+    (tmp_path / "TLV4-001.json").write_bytes(patched.encode("utf-8"))
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+    assert "duplicate JSON key" in err
+
+
+def test_malformed_json_refused_exit2(tmp_path, capsys):
+    (tmp_path / "TLV4-001.json").write_bytes(b"{not json")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+
+
+def test_root_non_object_refused_exit2(tmp_path, capsys):
+    (tmp_path / "TLV4-001.json").write_bytes(b"[]\n")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+    assert "JSON object" in err
+
+
+def test_schema_refusal_exit2(tmp_path, capsys):
+    entry = _valid_entry("TLV4-001")
+    entry["status"] = "no-such-status"
+    _write_entry(tmp_path, "TLV4-001", entry=entry)
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+
+
+def test_duplicate_entry_id_across_files_refused_exit2(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    _write_entry(tmp_path, "TLV4-001", filename="TLV4-001-copy.json")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 2
+    _assert_one_error_line(err)
+    assert "duplicate entry_id" in err
+
+
+def test_symlink_entry_refused_exit4(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    link = tmp_path / "TLV4-002.json"
+    try:
+        os.symlink(str(tmp_path / "TLV4-001.json"), str(link))
+    except (OSError, NotImplementedError):  # pragma: no cover - privilege
+        pytest.skip("platform lacks symlink privilege")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+    assert "symbolic-link" in err
+
+
+def test_missing_directory_exit4(tmp_path, capsys):
+    rc = main([str(tmp_path / "nope")])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+
+
+def test_non_directory_input_exit4(tmp_path, capsys):
+    target = tmp_path / "file.txt"
+    target.write_bytes(b"not a dir")
+    rc = main([str(target)])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+
+
+def test_entry_count_ceiling_exit5(tmp_path, capsys):
+    # Ceilings precede parsing: the files are junk bytes, never parsed.
+    for i in range(MAX_ENTRIES + 1):
+        (tmp_path / f"junk-{i:04d}.json").write_bytes(b"x")
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert f"{MAX_ENTRIES}-entry ceiling" in err
+
+
+def test_per_entry_byte_ceiling_exit5(tmp_path, capsys):
+    (tmp_path / "TLV4-001.json").write_bytes(b"x" * (MAX_ENTRY_BYTES + 1))
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert "per-entry ceiling" in err
+
+
+def test_total_byte_ceiling_exit5(tmp_path, capsys):
+    # Each file under the per-entry ceiling; the SUM breaches the total.
+    per_file = MAX_ENTRY_BYTES - 1024
+    count = (MAX_TOTAL_ENTRY_BYTES // per_file) + 1
+    for i in range(count):
+        (tmp_path / f"junk-{i:04d}.json").write_bytes(b"x" * per_file)
+    rc = main([str(tmp_path)])
+    err = capsys.readouterr().err
+    assert rc == 5
+    _assert_one_error_line(err)
+    assert "total entry bytes" in err
+
+
+def test_bounds_precede_parsing(tmp_path, monkeypatch, capsys):
+    # If parsing ran before the ceilings, the junk above would exit 2;
+    # prove no parse is even attempted on a ceiling breach.
+    def _exploding(raw, filename):  # pragma: no cover - must never run
+        raise AssertionError("parse attempted before ceilings")
+
+    monkeypatch.setattr(validate_module, "_parse_entry_bytes", _exploding)
+    (tmp_path / "TLV4-001.json").write_bytes(b"x" * (MAX_ENTRY_BYTES + 1))
+    rc = main([str(tmp_path)])
+    capsys.readouterr()
+    assert rc == 5
+
+
+def test_sentinel_programming_error_propagates(tmp_path, monkeypatch):
+    _write_entry(tmp_path, "TLV4-001")
+
+    def _sentinel(obj):
+        raise RuntimeError("sentinel-unrelated-programming-error")
+
+    monkeypatch.setattr(validate_module, "validate_entry", _sentinel)
+    with pytest.raises(RuntimeError, match="sentinel-unrelated"):
+        main([str(tmp_path)])
+
+
+def test_argparse_usage_error_systemexit2(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        main([])
+    assert excinfo.value.code == 2
+    assert "usage:" in capsys.readouterr().err
+
+
+def test_non_json_files_ignored(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    (tmp_path / "README.md").write_bytes(b"# not an entry\n")
+    assert main([str(tmp_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["entry_count"] == 1
+
+
+def test_validate_directory_pure_and_reusable(tmp_path):
+    _write_entry(tmp_path, "TLV4-001")
+    before = _snapshot(tmp_path)
+    first = validate_directory(tmp_path)
+    second = validate_directory(tmp_path)
+    assert first == second
+    assert copy.deepcopy(first)["entry_count"] == 1
+    assert _snapshot(tmp_path) == before

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -277,15 +277,16 @@ def test_validate_directory_pure_and_reusable(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _mutate_once_at_capture(monkeypatch, mutate_once):
-    """Run ``mutate_once`` exactly once: after the initial stat pass, at
-    the first capture's pre-open inspection (the real race window)."""
+def _mutate_once_at_capture(monkeypatch, mutate_once, *, on_call=1):
+    """Run ``mutate_once`` exactly once, at the ``on_call``-th pre-open
+    inspection (the real race window; call 1 = first capture's pre-lstat)."""
     real = validate_module._pre_open_inspect
-    state = {"done": False}
+    state = {"calls": 0, "done": False}
 
-    def _wrapped(path):
-        result = real(path)
-        if not state["done"]:
+    def _wrapped(path, dir_fd=None):
+        result = real(path, dir_fd=dir_fd)
+        state["calls"] += 1
+        if not state["done"] and state["calls"] == on_call:
             state["done"] = True
             mutate_once()
         return result
@@ -453,6 +454,125 @@ def test_regular_file_replacement_during_capture_refused_exit4(
 
 
 def test_stable_files_still_succeed_with_capture_boundary(tmp_path, capsys):
+    _write_entry(tmp_path, "TLV4-001")
+    _write_entry(tmp_path, "TLV4-002")
+    assert main([str(tmp_path)]) == 0
+    assert json.loads(capsys.readouterr().out)["entry_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Entries-directory binding (review finding 1): symlink/junction refusal,
+# rename/replacement detection, capture bound to the inspected directory
+# ---------------------------------------------------------------------------
+
+
+def test_symlink_entries_dir_refused_exit4(tmp_path, capsys):
+    real = tmp_path / "real_entries"
+    real.mkdir()
+    _write_entry(real, "TLV4-001")
+    link = tmp_path / "linked_entries"
+    try:
+        os.symlink(str(real), str(link), target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - privilege
+        pytest.skip("platform lacks symlink privilege")
+    rc = main([str(link)])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+    assert "symbolic link" in err
+
+
+def test_junction_entries_dir_refused_exit4(tmp_path, capsys):
+    try:
+        import _winapi
+        create_junction = _winapi.CreateJunction
+    except (ImportError, AttributeError):  # pragma: no cover - non-Windows
+        pytest.skip("platform has no directory junctions")
+    real = tmp_path / "real_entries"
+    real.mkdir()
+    _write_entry(real, "TLV4-001")
+    junction = tmp_path / "junction_entries"
+    create_junction(str(real), str(junction))
+    rc = main([str(junction)])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+    assert "reparse point" in err
+
+
+def test_directory_replacement_between_enumeration_and_capture_refused(
+    tmp_path, capsys, monkeypatch
+):
+    # Cross-platform via the fail-closed identity mechanism (forced), so
+    # the detection lane is exercised even where dir_fd exists.
+    monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    _write_entry(entries, "TLV4-002")
+    aside = tmp_path / "aside"
+
+    # Synchronize at the phase-boundary binding check itself: the swap
+    # happens exactly between enumeration/ceilings and the capture phase,
+    # then the REAL verification runs against the swapped directory.
+    real_verify = validate_module._verify_binding
+    state = {"done": False}
+
+    def _swapping_verify(binding):
+        if not state["done"]:
+            state["done"] = True
+            os.rename(str(entries), str(aside))
+            entries.mkdir()
+            _write_entry(entries, "TLV4-001")
+            _write_entry(entries, "TLV4-002")
+        return real_verify(binding)
+
+    monkeypatch.setattr(validate_module, "_verify_binding", _swapping_verify)
+    rc = main([str(entries)])
+    err = capsys.readouterr().err
+    assert rc == 4
+    _assert_one_error_line(err)
+    assert "renamed or replaced" in err
+
+
+@pytest.mark.skipif(
+    not validate_module._DIR_FD_SUPPORTED,
+    reason="directory-relative descriptors unavailable on this platform",
+)
+def test_capture_bound_to_inspected_directory_fd_mode(
+    tmp_path, capsys, monkeypatch
+):
+    # fd mode: after enumeration and the phase identity check, the
+    # pathname is swapped to a different directory whose same-named entry
+    # has DIFFERENT content. Captures go through the held descriptor, so
+    # the summary must describe the ORIGINAL directory's bytes.
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    original_size = (entries / "TLV4-001.json").stat().st_size
+    aside = tmp_path / "aside"
+    replacement = _padded_entry_bytes("TLV4-001", target_size=original_size + 4_000)
+
+    def _swap_directory():
+        os.rename(str(entries), str(aside))
+        entries.mkdir()
+        (entries / "TLV4-001.json").write_bytes(replacement)
+
+    # First pre-open inspection happens inside capture 1, AFTER the
+    # phase-level binding check -- exactly the bound-capture window.
+    _mutate_once_at_capture(monkeypatch, _swap_directory, on_call=1)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    summary = json.loads(captured.out)
+    assert summary["total_entry_bytes"] == original_size  # original dir bytes
+    assert summary["total_entry_bytes"] != len(replacement)
+
+
+def test_ordinary_directory_validates_under_identity_mode(
+    tmp_path, capsys, monkeypatch
+):
+    monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
     _write_entry(tmp_path, "TLV4-001")
     _write_entry(tmp_path, "TLV4-002")
     assert main([str(tmp_path)]) == 0

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -500,39 +500,205 @@ def test_junction_entries_dir_refused_exit4(tmp_path, capsys):
     assert "reparse point" in err
 
 
+_fallback_only = pytest.mark.skipif(
+    not validate_module._FALLBACK_BINDING_SUPPORTED,
+    reason="platform has no non-dir_fd directory-binding primitive",
+)
+
+
+def _force_fallback(monkeypatch):
+    """Exercise the non-dir_fd binding lane explicitly."""
+    monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
+
+
 def test_directory_replacement_between_enumeration_and_capture_refused(
     tmp_path, capsys, monkeypatch
 ):
-    # Cross-platform via the fail-closed identity mechanism (forced), so
-    # the detection lane is exercised even where dir_fd exists.
-    monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
+    # The binding must PREVENT the swap outright (or the validator must
+    # refuse before reading); an identity recheck alone is insufficient.
+    _force_fallback(monkeypatch)
     entries = tmp_path / "entries"
     entries.mkdir()
     _write_entry(entries, "TLV4-001")
     _write_entry(entries, "TLV4-002")
     aside = tmp_path / "aside"
 
-    # Synchronize at the phase-boundary binding check itself: the swap
-    # happens exactly between enumeration/ceilings and the capture phase,
-    # then the REAL verification runs against the swapped directory.
     real_verify = validate_module._verify_binding
-    state = {"done": False}
+    state = {"done": False, "blocked": None}
 
     def _swapping_verify(binding):
         if not state["done"]:
             state["done"] = True
-            os.rename(str(entries), str(aside))
-            entries.mkdir()
-            _write_entry(entries, "TLV4-001")
-            _write_entry(entries, "TLV4-002")
+            try:
+                os.rename(str(entries), str(aside))
+                state["blocked"] = False
+                entries.mkdir()
+                _write_entry(entries, "TLV4-001")
+                _write_entry(entries, "TLV4-002")
+            except OSError:
+                state["blocked"] = True
         return real_verify(binding)
 
     monkeypatch.setattr(validate_module, "_verify_binding", _swapping_verify)
     rc = main([str(entries)])
+    captured = capsys.readouterr()
+    if state["blocked"]:
+        assert rc == 0, captured.err  # binding held; nothing to detect
+        assert json.loads(captured.out)["entry_count"] == 2
+    else:
+        assert rc == 4
+        _assert_one_error_line(captured.err)
+
+
+@_fallback_only
+def test_persistent_late_replacement_prevented(tmp_path, capsys, monkeypatch):
+    # Residual finding 1: swap the inspected directory AFTER the last
+    # binding check but BEFORE the first candidate inspection. A held
+    # binding must make the rename impossible; the captured bytes must be
+    # the ORIGINAL directory's.
+    _force_fallback(monkeypatch)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    original_size = (entries / "TLV4-001.json").stat().st_size
+    aside = tmp_path / "aside"
+    replacement_dir = tmp_path / "replacement"
+    replacement_dir.mkdir()
+    replacement_bytes = _padded_entry_bytes(
+        "TLV4-001", target_size=original_size + 2_700
+    )
+    (replacement_dir / "TLV4-001.json").write_bytes(replacement_bytes)
+    assert len(replacement_bytes) != original_size
+
+    real_probe = validate_module._pre_open_inspect
+    state = {"done": False, "blocked": None}
+
+    def _swap_then_probe(path, dir_fd=None):
+        if not state["done"]:
+            state["done"] = True
+            try:
+                os.rename(str(entries), str(aside))
+                os.rename(str(replacement_dir), str(entries))
+                state["blocked"] = False
+            except OSError:
+                state["blocked"] = True
+        return real_probe(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(validate_module, "_pre_open_inspect", _swap_then_probe)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    assert state["blocked"] is True, "the held binding must prevent the rename"
+    assert rc == 0, captured.err
+    summary = json.loads(captured.out)
+    assert summary["total_entry_bytes"] == original_size
+    assert summary["total_entry_bytes"] != len(replacement_bytes)
+
+
+@_fallback_only
+def test_transient_enumeration_swap_and_restore_prevented(
+    tmp_path, capsys, monkeypatch
+):
+    # Residual finding 2: replace the directory ONLY while os.listdir
+    # runs (subset of filenames), then restore before any identity
+    # recheck. Before/after checks cannot see this; a held binding must
+    # prevent it, so the full candidate set is enumerated.
+    _force_fallback(monkeypatch)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    _write_entry(entries, "TLV4-016")
+    aside = tmp_path / "aside"
+    transient = tmp_path / "transient"
+    transient.mkdir()
+    _write_entry(transient, "TLV4-001")  # deliberately omits TLV4-016
+
+    real_listdir = os.listdir
+    state = {"done": False, "blocked": None}
+
+    def _swapping_listdir(target):
+        if state["done"]:
+            return real_listdir(target)
+        state["done"] = True
+        try:
+            os.rename(str(entries), str(aside))
+            os.rename(str(transient), str(entries))
+            state["blocked"] = False
+        except OSError:
+            state["blocked"] = True
+            return real_listdir(target)
+        try:
+            return real_listdir(target)
+        finally:  # restore before any later identity recheck
+            os.rename(str(entries), str(transient))
+            os.rename(str(aside), str(entries))
+
+    monkeypatch.setattr(os, "listdir", _swapping_listdir)
+    rc = main([str(entries)])
+    captured = capsys.readouterr()
+    monkeypatch.undo()
+    assert state["blocked"] is True, "the held binding must prevent the swap"
+    assert rc == 0, captured.err
+    summary = json.loads(captured.out)
+    assert summary["entry_count"] == 2  # nothing silently omitted
+    assert {e["entry_id"] for e in summary["entries"]} == {"TLV4-001", "TLV4-016"}
+
+
+@_fallback_only
+def test_binding_released_after_success(tmp_path, capsys, monkeypatch):
+    _force_fallback(monkeypatch)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    _write_entry(entries, "TLV4-001")
+    assert main([str(entries)]) == 0
+    capsys.readouterr()
+    os.rename(str(entries), str(tmp_path / "moved"))  # released, no error
+
+
+@_fallback_only
+@pytest.mark.parametrize(
+    "sabotage",
+    ["enumeration", "capture", "parse"],
+)
+def test_binding_released_after_failures(tmp_path, capsys, monkeypatch, sabotage):
+    _force_fallback(monkeypatch)
+    entries = tmp_path / "entries"
+    entries.mkdir()
+    if sabotage == "enumeration":
+        (entries / "TLV4-001.json").write_bytes(b"x" * (MAX_ENTRY_BYTES + 1))
+        expected = 5
+    elif sabotage == "capture":
+        _write_entry(entries, "TLV4-001")
+
+        def _boom(path, dir_fd=None):
+            raise OSError("synthetic capture failure")
+
+        monkeypatch.setattr(validate_module, "_pre_open_inspect", _boom)
+        expected = 4
+    else:
+        (entries / "TLV4-001.json").write_bytes(b"{not json")
+        expected = 2
+    assert main([str(entries)]) == expected
+    capsys.readouterr()
+    os.rename(str(entries), str(tmp_path / "moved"))  # released on failure paths
+
+
+def test_fail_closed_without_any_binding_primitive(tmp_path, capsys, monkeypatch):
+    # No dir_fd and no fallback primitive: refuse BEFORE enumeration
+    # rather than retaining identity-only checks as a "binding".
+    monkeypatch.setattr(validate_module, "_DIR_FD_SUPPORTED", False)
+    monkeypatch.setattr(validate_module, "_FALLBACK_BINDING_SUPPORTED", False)
+    _write_entry(tmp_path, "TLV4-001")
+
+    def _must_not_run(target):  # pragma: no cover - must never execute
+        raise AssertionError("enumeration ran without a binding")
+
+    monkeypatch.setattr(os, "listdir", _must_not_run)
+    rc = main([str(tmp_path)])
     err = capsys.readouterr().err
+    monkeypatch.undo()
     assert rc == 4
     _assert_one_error_line(err)
-    assert "renamed or replaced" in err
+    assert "binding" in err
 
 
 @pytest.mark.skipif(

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -33,6 +33,7 @@ import argparse
 import json
 import os
 import pathlib
+import stat as stat_module
 import sys
 from typing import Any, Final
 
@@ -58,6 +59,101 @@ class LedgerPathError(ValueError):
 
 class LedgerCeilingError(RuntimeError):
     """Entry-count, per-entry or total byte-ceiling breach (exit 5)."""
+
+
+def _pre_open_inspect(path: str) -> os.stat_result:
+    """The pre-open ``lstat`` of one candidate.
+
+    A deliberately narrow, production-neutral seam: behaviour is exactly
+    ``os.lstat(path)``; the capture-boundary race tests synchronize here.
+    """
+    return os.lstat(path)
+
+
+_READ_CHUNK_BYTES: Final[int] = 64 * 1024
+
+
+def _capture_entry(entries_dir: pathlib.Path, name: str) -> bytes:
+    """Capture one candidate through a verified descriptor (fail closed).
+
+    Sequence: pre-open ``lstat`` (symlinks and non-regular files refused);
+    ``os.open`` without following symlinks where the platform supplies
+    ``O_NOFOLLOW``; ``fstat`` of the opened descriptor must be a regular
+    file; post-open ``lstat`` must still be a regular non-link path; and
+    the three inspections must agree on stable filesystem identity
+    (``st_dev``/``st_ino``). Any mismatch, replacement, symlink or
+    incomplete identity inspection is a ``LedgerPathError`` (exit 4).
+    Bytes are read ONLY through the verified descriptor, bounded by the
+    per-entry ceiling plus one probe byte; the pathname is never reopened.
+    No protection is claimed against an unobservable filesystem or kernel
+    violation.
+    """
+    path = str(entries_dir / name)
+    pre = _pre_open_inspect(path)
+    if stat_module.S_ISLNK(pre.st_mode):
+        raise LedgerPathError(f"{name}: symbolic-link entry files are refused")
+    if not stat_module.S_ISREG(pre.st_mode):
+        raise LedgerPathError(f"{name}: entry path is not a regular file")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(path, flags)
+    except OSError as e:
+        # Under O_NOFOLLOW a symlink swapped in after the pre-open lstat
+        # surfaces here (ELOOP); any other open failure is equally a
+        # failed capture -- refuse, never fall through.
+        raise LedgerPathError(
+            f"{name}: entry could not be opened for verified capture "
+            f"(fail closed): {e}"
+        ) from e
+    try:
+        opened = os.fstat(fd)
+        if not stat_module.S_ISREG(opened.st_mode):
+            raise LedgerPathError(
+                f"{name}: opened descriptor is not a regular file"
+            )
+        post = _pre_open_inspect(path)
+        if stat_module.S_ISLNK(post.st_mode) or not stat_module.S_ISREG(post.st_mode):
+            raise LedgerPathError(
+                f"{name}: entry was replaced by a non-regular path during capture"
+            )
+        identities = {
+            (probe.st_dev, probe.st_ino) for probe in (pre, opened, post)
+        }
+        if len(identities) != 1:
+            raise LedgerPathError(
+                f"{name}: filesystem identity changed between inspection and "
+                f"capture (fail closed)"
+            )
+        if opened.st_ino == 0 and opened.st_dev == 0:
+            # Identity fields unavailable on this filesystem: identity
+            # verification would be vacuous, so the capture fails closed
+            # rather than silently weakening the symlink refusal.
+            raise LedgerPathError(
+                f"{name}: filesystem identity could not be established "
+                f"(fail closed)"
+            )
+        chunks: list[bytes] = []
+        remaining = MAX_ENTRY_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(fd, min(_READ_CHUNK_BYTES, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+    finally:
+        os.close(fd)
+    raw = b"".join(chunks)
+    if len(raw) > MAX_ENTRY_BYTES:
+        raise LedgerCeilingError(
+            f"{name}: grew past the {MAX_ENTRY_BYTES}-byte per-entry "
+            f"ceiling between inspection and read"
+        )
+    return raw
 
 
 def _parse_entry_bytes(raw: bytes, filename: str) -> Any:
@@ -142,21 +238,32 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
                 f"{MAX_TOTAL_ENTRY_BYTES}-byte ceiling"
             )
 
+        # Capture phase: every candidate is captured through the verified
+        # descriptor boundary with its EXACT byte count recorded, and the
+        # captured aggregate is enforced as it accumulates -- reading
+        # stops at the first file whose capture necessarily breaches the
+        # total ceiling. Memory stays bounded by the total ceiling plus at
+        # most one bounded probe read. NO JSON is parsed until every
+        # candidate has been captured and every actual-byte ceiling has
+        # passed.
+        captured: dict[str, bytes] = {}
+        captured_total = 0
+        for name in candidates:
+            raw = _capture_entry(entries_dir, name)
+            captured_total += len(raw)
+            if captured_total > MAX_TOTAL_ENTRY_BYTES:
+                raise LedgerCeilingError(
+                    f"{captured_total} captured total entry bytes exceed the "
+                    f"{MAX_TOTAL_ENTRY_BYTES}-byte ceiling"
+                )
+            captured[name] = raw
+
+        # Parse phase: captured bytes only; the summary's byte totals are
+        # the exact captured counts, never the earlier stat sizes.
         entries: list[dict[str, str]] = []
         seen_ids: dict[str, str] = {}
         for name in candidates:
-            # Bounded read: the stat-based ceiling above is re-enforced at
-            # the read itself, so a file grown between the stat and this
-            # read is refused without ever materializing more than the
-            # ceiling plus one probe byte (fail closed).
-            with (entries_dir / name).open("rb") as f:
-                raw = f.read(MAX_ENTRY_BYTES + 1)
-            if len(raw) > MAX_ENTRY_BYTES:
-                raise LedgerCeilingError(
-                    f"{name}: grew past the {MAX_ENTRY_BYTES}-byte per-entry "
-                    f"ceiling between inspection and read"
-                )
-            parsed = _parse_entry_bytes(raw, name)
+            parsed = _parse_entry_bytes(captured[name], name)
             if type(parsed) is not dict:
                 raise LedgerInputError(
                     f"{name}: entry root must be a JSON object"
@@ -186,7 +293,7 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
     return {
         "schema": SCHEMA_ID,
         "entry_count": len(entries),
-        "total_entry_bytes": total_bytes,
+        "total_entry_bytes": captured_total,
         "entries": entries,
     }
 
@@ -217,7 +324,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _fail(error: BaseException, code: int) -> int:
-    print(f"error: {error}", file=sys.stderr)
+    """Exactly ONE physical stderr line per expected failure: carriage
+    returns and newlines inside the message (for example from a hostile
+    filename) are rendered as visible escapes, then a single terminal
+    newline is printed."""
+    text = str(error).replace("\r", "\\r").replace("\n", "\\n")
+    print(f"error: {text}", file=sys.stderr)
     return code
 
 

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -62,24 +62,50 @@ class LedgerCeilingError(RuntimeError):
 
 
 def _pre_open_inspect(path: str, dir_fd: int | None = None) -> os.stat_result:
-    """The pre-open ``lstat`` of one candidate.
+    """The pre-open no-follow inspection of one candidate.
 
     A deliberately narrow, production-neutral seam: behaviour is exactly
-    ``os.lstat(path, dir_fd=dir_fd)``; the capture-boundary race tests
+    ``os.stat(path, dir_fd=dir_fd, follow_symlinks=False)`` -- the
+    documented equivalent of ``os.lstat`` -- expressed through ``os.stat``
+    because that is the function whose ``dir_fd`` capability CPython
+    registers in ``os.supports_dir_fd``; the capture-boundary race tests
     synchronize here.
     """
-    return os.lstat(path, dir_fd=dir_fd)
+    return os.stat(path, dir_fd=dir_fd, follow_symlinks=False)
+
+
+def _dir_fd_binding_supported(
+    supports_dir_fd: frozenset | set,
+    supports_fd: frozenset | set,
+    has_o_directory: bool,
+) -> bool:
+    """Whether every primitive the descriptor-bound lane actually calls
+    is available: ``os.open(..., dir_fd=...)``, ``os.stat(..., dir_fd=...,
+    follow_symlinks=False)`` and ``os.listdir(fd)``, plus ``O_DIRECTORY``.
+
+    Membership is tested for exactly the functions this module calls with
+    those parameters.  ``os.lstat`` must NOT be consulted here: CPython
+    never registers it in ``os.supports_dir_fd`` on any build (its
+    ``dir_fd`` support is clinic-gated on the same ``fstatat`` capability
+    that registers ``os.stat``), so requiring its membership is False
+    everywhere -- including Linux, where all of these primitives work.
+    Pure and injectable so other platforms' capability shapes are
+    testable anywhere.
+    """
+    return (
+        os.open in supports_dir_fd
+        and os.stat in supports_dir_fd
+        and os.listdir in supports_fd
+        and has_o_directory
+    )
 
 
 #: Directory-relative descriptor support (POSIX): candidates are
 #: enumerated and opened relative to a verified directory descriptor, so
 #: the inspected directory object -- not a re-resolved pathname -- is what
 #: every operation acts on.
-_DIR_FD_SUPPORTED: Final[bool] = (
-    os.open in os.supports_dir_fd
-    and os.lstat in os.supports_dir_fd
-    and os.listdir in os.supports_fd
-    and hasattr(os, "O_DIRECTORY")
+_DIR_FD_SUPPORTED: Final[bool] = _dir_fd_binding_supported(
+    os.supports_dir_fd, os.supports_fd, hasattr(os, "O_DIRECTORY")
 )
 
 try:  # Windows-only standard-library primitives (absent elsewhere)
@@ -297,8 +323,8 @@ def _capture_entry(binding: _DirBinding, name: str) -> bytes:
     held directory descriptor (``dir_fd``), never by reconstructing
     ``entries_dir / name``; in ``identity`` mode the directory's identity
     is re-verified immediately before the capture. Then, per entry:
-    pre-open ``lstat`` (symlinks and non-regular files refused);
-    ``os.open`` without following symlinks where the platform supplies
+    pre-open no-follow inspection (symlinks and non-regular files
+    refused); ``os.open`` without following symlinks where the platform supplies
     ``O_NOFOLLOW``; ``fstat`` of the opened descriptor must be a regular
     file; post-open ``lstat`` must still be a regular non-link path; and
     the three inspections must agree on stable filesystem identity
@@ -441,9 +467,10 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
         for name in names:
             if not name.endswith(".json"):
                 continue  # only direct .json entry files are inspected
-            probe = os.lstat(
+            probe = os.stat(
                 name if binding.fd is not None else os.path.join(binding.path, name),
                 dir_fd=binding.fd,
+                follow_symlinks=False,
             )
             if stat_module.S_ISLNK(probe.st_mode):
                 raise LedgerPathError(

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -61,22 +61,148 @@ class LedgerCeilingError(RuntimeError):
     """Entry-count, per-entry or total byte-ceiling breach (exit 5)."""
 
 
-def _pre_open_inspect(path: str) -> os.stat_result:
+def _pre_open_inspect(path: str, dir_fd: int | None = None) -> os.stat_result:
     """The pre-open ``lstat`` of one candidate.
 
     A deliberately narrow, production-neutral seam: behaviour is exactly
-    ``os.lstat(path)``; the capture-boundary race tests synchronize here.
+    ``os.lstat(path, dir_fd=dir_fd)``; the capture-boundary race tests
+    synchronize here.
     """
-    return os.lstat(path)
+    return os.lstat(path, dir_fd=dir_fd)
+
+
+#: Directory-relative descriptor support (POSIX): candidates can be
+#: enumerated and opened relative to a verified directory descriptor.
+#: Where unsupported (Windows), a fail-closed identity mechanism
+#: re-verifies the directory before every capture instead -- the claim is
+#: never silently weakened.
+_DIR_FD_SUPPORTED: Final[bool] = (
+    os.open in os.supports_dir_fd
+    and os.lstat in os.supports_dir_fd
+    and os.listdir in os.supports_fd
+    and hasattr(os, "O_DIRECTORY")
+)
+
+
+def _identity_of(probe: os.stat_result, what: str) -> tuple[int, int]:
+    identity = (probe.st_dev, probe.st_ino)
+    if identity == (0, 0):
+        raise LedgerPathError(
+            f"{what}: filesystem identity could not be established (fail closed)"
+        )
+    return identity
+
+
+def _refuse_reparse_dir(probe: os.stat_result, what: str) -> None:
+    """Refuse a symbolic-link or reparse-point (junction) directory."""
+    if stat_module.S_ISLNK(probe.st_mode):
+        raise LedgerPathError(f"{what} is a symbolic link (refused)")
+    attributes = getattr(probe, "st_file_attributes", 0)
+    reparse_flag = getattr(stat_module, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    if attributes & reparse_flag:
+        raise LedgerPathError(
+            f"{what} is a reparse point (junction or equivalent; refused)"
+        )
+
+
+class _DirBinding:
+    """The verified, bound entries directory.
+
+    ``fd`` mode (POSIX): enumeration and every candidate open go through
+    the held directory descriptor, so capture is inherently bound to the
+    originally inspected directory; a path-identity cross-check before
+    the capture phase detects rename/replacement. ``identity`` mode
+    (platforms without dir_fd): the directory's ``st_dev``/``st_ino``
+    identity and non-reparse status are re-verified before every capture,
+    failing closed on any change. Neither mode claims protection against
+    an unobservable filesystem or kernel violation.
+    """
+
+    def __init__(self, path: str, fd: int | None, identity: tuple[int, int]):
+        self.path = path
+        self.fd = fd
+        self.identity = identity
+
+    def close(self) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+
+def _open_entries_dir(entries_dir: pathlib.Path) -> _DirBinding:
+    path = str(entries_dir)
+    if not entries_dir.exists():
+        raise LedgerPathError(f"entries directory does not exist: {entries_dir}")
+    pre = os.lstat(path)
+    _refuse_reparse_dir(pre, "entries directory")
+    if not stat_module.S_ISDIR(pre.st_mode):
+        raise LedgerPathError(f"entries path is not a directory: {entries_dir}")
+    pre_identity = _identity_of(pre, "entries directory")
+    if _DIR_FD_SUPPORTED:
+        flags = (
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        fd = os.open(path, flags)
+        try:
+            opened = os.fstat(fd)
+            if not stat_module.S_ISDIR(opened.st_mode):
+                raise LedgerPathError(
+                    "entries directory descriptor is not a directory (fail closed)"
+                )
+            identity = _identity_of(opened, "entries directory")
+            if identity != pre_identity:
+                raise LedgerPathError(
+                    "entries directory changed between inspection and open "
+                    "(fail closed)"
+                )
+        except BaseException:
+            os.close(fd)
+            raise
+        return _DirBinding(path, fd, identity)
+    post = os.stat(path)
+    identity = _identity_of(post, "entries directory")
+    if identity != pre_identity:
+        raise LedgerPathError(
+            "entries directory changed between inspections (fail closed)"
+        )
+    return _DirBinding(path, None, identity)
+
+
+def _verify_binding(binding: _DirBinding) -> None:
+    """Re-verify the bound directory (rename/replacement detection).
+
+    In ``fd`` mode the original directory object is held open, so this
+    check detects a pathname now pointing elsewhere; in ``identity`` mode
+    it is the per-capture fail-closed identity mechanism itself.
+    """
+    probe = os.lstat(binding.path)
+    _refuse_reparse_dir(probe, "entries directory")
+    if not stat_module.S_ISDIR(probe.st_mode):
+        raise LedgerPathError(
+            "entries directory was replaced by a non-directory (fail closed)"
+        )
+    if _identity_of(probe, "entries directory") != binding.identity:
+        raise LedgerPathError(
+            "entries directory was renamed or replaced between enumeration "
+            "and capture (fail closed)"
+        )
 
 
 _READ_CHUNK_BYTES: Final[int] = 64 * 1024
 
 
-def _capture_entry(entries_dir: pathlib.Path, name: str) -> bytes:
-    """Capture one candidate through a verified descriptor (fail closed).
+def _capture_entry(binding: _DirBinding, name: str) -> bytes:
+    """Capture one candidate through a verified descriptor (fail closed),
+    bound to the inspected entries directory.
 
-    Sequence: pre-open ``lstat`` (symlinks and non-regular files refused);
+    In ``fd`` mode the candidate is inspected and opened RELATIVE to the
+    held directory descriptor (``dir_fd``), never by reconstructing
+    ``entries_dir / name``; in ``identity`` mode the directory's identity
+    is re-verified immediately before the capture. Then, per entry:
+    pre-open ``lstat`` (symlinks and non-regular files refused);
     ``os.open`` without following symlinks where the platform supplies
     ``O_NOFOLLOW``; ``fstat`` of the opened descriptor must be a regular
     file; post-open ``lstat`` must still be a regular non-link path; and
@@ -88,8 +214,14 @@ def _capture_entry(entries_dir: pathlib.Path, name: str) -> bytes:
     No protection is claimed against an unobservable filesystem or kernel
     violation.
     """
-    path = str(entries_dir / name)
-    pre = _pre_open_inspect(path)
+    if binding.fd is not None:
+        dir_fd: int | None = binding.fd
+        probe_path = name
+    else:
+        _verify_binding(binding)  # per-capture fail-closed identity check
+        dir_fd = None
+        probe_path = os.path.join(binding.path, name)
+    pre = _pre_open_inspect(probe_path, dir_fd=dir_fd)
     if stat_module.S_ISLNK(pre.st_mode):
         raise LedgerPathError(f"{name}: symbolic-link entry files are refused")
     if not stat_module.S_ISREG(pre.st_mode):
@@ -101,7 +233,10 @@ def _capture_entry(entries_dir: pathlib.Path, name: str) -> bytes:
         | getattr(os, "O_CLOEXEC", 0)
     )
     try:
-        fd = os.open(path, flags)
+        if dir_fd is not None:
+            fd = os.open(name, flags, dir_fd=dir_fd)
+        else:
+            fd = os.open(probe_path, flags)
     except OSError as e:
         # Under O_NOFOLLOW a symlink swapped in after the pre-open lstat
         # surfaces here (ELOOP); any other open failure is equally a
@@ -116,7 +251,7 @@ def _capture_entry(entries_dir: pathlib.Path, name: str) -> bytes:
             raise LedgerPathError(
                 f"{name}: opened descriptor is not a regular file"
             )
-        post = _pre_open_inspect(path)
+        post = _pre_open_inspect(probe_path, dir_fd=dir_fd)
         if stat_module.S_ISLNK(post.st_mode) or not stat_module.S_ISREG(post.st_mode):
             raise LedgerPathError(
                 f"{name}: entry was replaced by a non-regular path during capture"
@@ -192,28 +327,36 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
     refusal classes documented in the module docstring. Performs no
     writes and no network access; reads nothing outside ``entries_dir``.
     """
+    binding: _DirBinding | None = None
     try:
-        if not entries_dir.exists():
-            raise LedgerPathError(
-                f"entries directory does not exist: {entries_dir}"
-            )
-        if not entries_dir.is_dir():
-            raise LedgerPathError(
-                f"entries path is not a directory: {entries_dir}"
-            )
-        candidates: list[str] = []
-        for child in entries_dir.iterdir():
-            if not child.name.endswith(".json"):
+        # Verify and BIND the entries directory itself: a symbolic-link,
+        # junction or equivalent reparse-path directory is refused, and
+        # the inspected directory stays bound throughout enumeration and
+        # capture (descriptor-relative on platforms that support it,
+        # fail-closed identity re-verification elsewhere).
+        binding = _open_entries_dir(entries_dir)
+
+        candidates = []
+        if binding.fd is not None:
+            names = os.listdir(binding.fd)
+        else:
+            names = os.listdir(binding.path)
+        for name in names:
+            if not name.endswith(".json"):
                 continue  # only direct .json entry files are inspected
-            if os.path.islink(str(child)):
+            probe = os.lstat(
+                name if binding.fd is not None else os.path.join(binding.path, name),
+                dir_fd=binding.fd,
+            )
+            if stat_module.S_ISLNK(probe.st_mode):
                 raise LedgerPathError(
-                    f"{child.name}: symbolic-link entry files are refused"
+                    f"{name}: symbolic-link entry files are refused"
                 )
-            if not child.is_file():
+            if not stat_module.S_ISREG(probe.st_mode):
                 raise LedgerPathError(
-                    f"{child.name}: entry path is not a regular file"
+                    f"{name}: entry path is not a regular file"
                 )
-            candidates.append(child.name)
+            candidates.append((name, probe.st_size))
         candidates.sort()  # deterministic filename order
 
         # Ceilings BEFORE any parsing (cheap stat-based checks first).
@@ -222,21 +365,22 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
                 f"{len(candidates)} entry files exceed the {MAX_ENTRIES}-entry "
                 f"ceiling"
             )
-        sizes: dict[str, int] = {}
-        for name in candidates:
-            size = os.lstat(str(entries_dir / name)).st_size
+        for name, size in candidates:
             if size > MAX_ENTRY_BYTES:
                 raise LedgerCeilingError(
                     f"{name}: {size} bytes exceed the {MAX_ENTRY_BYTES}-byte "
                     f"per-entry ceiling"
                 )
-            sizes[name] = size
-        total_bytes = sum(sizes.values())
+        total_bytes = sum(size for _, size in candidates)
         if total_bytes > MAX_TOTAL_ENTRY_BYTES:
             raise LedgerCeilingError(
                 f"{total_bytes} total entry bytes exceed the "
                 f"{MAX_TOTAL_ENTRY_BYTES}-byte ceiling"
             )
+
+        # Rename/replacement detection between enumeration and capture:
+        # the bound directory must still be exactly the inspected one.
+        _verify_binding(binding)
 
         # Capture phase: every candidate is captured through the verified
         # descriptor boundary with its EXACT byte count recorded, and the
@@ -248,8 +392,8 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
         # passed.
         captured: dict[str, bytes] = {}
         captured_total = 0
-        for name in candidates:
-            raw = _capture_entry(entries_dir, name)
+        for name, _size in candidates:
+            raw = _capture_entry(binding, name)
             captured_total += len(raw)
             if captured_total > MAX_TOTAL_ENTRY_BYTES:
                 raise LedgerCeilingError(
@@ -262,7 +406,7 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
         # the exact captured counts, never the earlier stat sizes.
         entries: list[dict[str, str]] = []
         seen_ids: dict[str, str] = {}
-        for name in candidates:
+        for name, _size in candidates:
             parsed = _parse_entry_bytes(captured[name], name)
             if type(parsed) is not dict:
                 raise LedgerInputError(
@@ -289,6 +433,9 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
         raise LedgerPathError(
             f"filesystem inspection could not complete (fail closed): {e}"
         ) from e
+    finally:
+        if binding is not None:
+            binding.close()
 
     return {
         "schema": SCHEMA_ID,

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -1,0 +1,239 @@
+"""Directory validator CLI for ``tech-ledger-v1`` entries.
+
+Usage::
+
+    python -m experiments.tech_ledger.validate <entries-directory>
+
+Inspects the DIRECT ``.json`` files of one directory (no recursion), in
+deterministic filename order, with duplicate-key-rejecting JSON parsing,
+symlink refusal, and hard ceilings applied BEFORE any parsing. On success
+it prints one canonical sorted-key, LF-terminated, timestamp-free JSON
+summary carrying relative filenames and entry ids only. It writes
+nothing, and it performs no network access.
+
+Exit map (this lab's own; argparse usage errors keep argparse's ordinary
+``SystemExit(2)``):
+
+* 0 -- all entries valid
+* 2 -- malformed JSON, duplicate JSON key, schema or cross-entry
+  validation refusal (typed ``LedgerInputError`` / ``LedgerEntryError``)
+* 4 -- missing path, wrong path type, symlink, traversal or
+  filesystem-inspection failure (typed ``LedgerPathError``)
+* 5 -- entry-count, per-entry-byte or total-byte ceiling breach (typed
+  ``LedgerCeilingError``)
+
+Plain unrelated programming exceptions are deliberately NOT caught and
+propagate loudly. Schema validity is not scientific validity, endorsement,
+implementation authority or evidence that a claim is true.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from typing import Any, Final
+
+from experiments.tech_ledger.schema import (
+    SCHEMA_ID,
+    LedgerEntryError,
+    validate_entry,
+)
+
+#: Hard bounds, enforced before any JSON parsing (fail closed).
+MAX_ENTRIES: Final[int] = 256
+MAX_ENTRY_BYTES: Final[int] = 128 * 1024
+MAX_TOTAL_ENTRY_BYTES: Final[int] = 4 * 1024 * 1024
+
+
+class LedgerInputError(ValueError):
+    """Malformed JSON, duplicate JSON key or cross-entry refusal (exit 2)."""
+
+
+class LedgerPathError(ValueError):
+    """Missing path, wrong path type, symlink or inspection failure (exit 4)."""
+
+
+class LedgerCeilingError(RuntimeError):
+    """Entry-count, per-entry or total byte-ceiling breach (exit 5)."""
+
+
+def _parse_entry_bytes(raw: bytes, filename: str) -> Any:
+    """Duplicate-key-rejecting, bounded JSON parse of one entry file."""
+
+    def _no_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in out:
+                raise LedgerInputError(
+                    f"{filename}: duplicate JSON key {key!r}"
+                )
+            out[key] = value
+        return out
+
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as e:
+        raise LedgerInputError(f"{filename}: not valid UTF-8") from e
+    try:
+        return json.loads(text, object_pairs_hook=_no_duplicate_keys)
+    except LedgerInputError:
+        raise  # keep the precise duplicate-key message
+    except (json.JSONDecodeError, ValueError) as e:
+        raise LedgerInputError(f"{filename}: not valid JSON: {e}") from e
+    except RecursionError as e:
+        raise LedgerInputError(
+            f"{filename}: nesting exceeds the parser's depth limit"
+        ) from e
+
+
+def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
+    """Validate every direct ``.json`` entry of ``entries_dir``.
+
+    Returns the deterministic summary dict on success; raises the typed
+    refusal classes documented in the module docstring. Performs no
+    writes and no network access; reads nothing outside ``entries_dir``.
+    """
+    try:
+        if not entries_dir.exists():
+            raise LedgerPathError(
+                f"entries directory does not exist: {entries_dir}"
+            )
+        if not entries_dir.is_dir():
+            raise LedgerPathError(
+                f"entries path is not a directory: {entries_dir}"
+            )
+        candidates: list[str] = []
+        for child in entries_dir.iterdir():
+            if not child.name.endswith(".json"):
+                continue  # only direct .json entry files are inspected
+            if os.path.islink(str(child)):
+                raise LedgerPathError(
+                    f"{child.name}: symbolic-link entry files are refused"
+                )
+            if not child.is_file():
+                raise LedgerPathError(
+                    f"{child.name}: entry path is not a regular file"
+                )
+            candidates.append(child.name)
+        candidates.sort()  # deterministic filename order
+
+        # Ceilings BEFORE any parsing (cheap stat-based checks first).
+        if len(candidates) > MAX_ENTRIES:
+            raise LedgerCeilingError(
+                f"{len(candidates)} entry files exceed the {MAX_ENTRIES}-entry "
+                f"ceiling"
+            )
+        sizes: dict[str, int] = {}
+        for name in candidates:
+            size = os.lstat(str(entries_dir / name)).st_size
+            if size > MAX_ENTRY_BYTES:
+                raise LedgerCeilingError(
+                    f"{name}: {size} bytes exceed the {MAX_ENTRY_BYTES}-byte "
+                    f"per-entry ceiling"
+                )
+            sizes[name] = size
+        total_bytes = sum(sizes.values())
+        if total_bytes > MAX_TOTAL_ENTRY_BYTES:
+            raise LedgerCeilingError(
+                f"{total_bytes} total entry bytes exceed the "
+                f"{MAX_TOTAL_ENTRY_BYTES}-byte ceiling"
+            )
+
+        entries: list[dict[str, str]] = []
+        seen_ids: dict[str, str] = {}
+        for name in candidates:
+            # Bounded read: the stat-based ceiling above is re-enforced at
+            # the read itself, so a file grown between the stat and this
+            # read is refused without ever materializing more than the
+            # ceiling plus one probe byte (fail closed).
+            with (entries_dir / name).open("rb") as f:
+                raw = f.read(MAX_ENTRY_BYTES + 1)
+            if len(raw) > MAX_ENTRY_BYTES:
+                raise LedgerCeilingError(
+                    f"{name}: grew past the {MAX_ENTRY_BYTES}-byte per-entry "
+                    f"ceiling between inspection and read"
+                )
+            parsed = _parse_entry_bytes(raw, name)
+            if type(parsed) is not dict:
+                raise LedgerInputError(
+                    f"{name}: entry root must be a JSON object"
+                )
+            validate_entry(parsed)
+            entry_id = parsed["entry_id"]
+            if entry_id in seen_ids:
+                raise LedgerInputError(
+                    f"{name}: duplicate entry_id {entry_id!r} (already used "
+                    f"by {seen_ids[entry_id]})"
+                )
+            seen_ids[entry_id] = name
+            entries.append(
+                {
+                    "entry_id": entry_id,
+                    "filename": name,
+                    "primary_classification": parsed["primary_classification"],
+                }
+            )
+    except (LedgerInputError, LedgerPathError, LedgerCeilingError, LedgerEntryError):
+        raise
+    except OSError as e:
+        raise LedgerPathError(
+            f"filesystem inspection could not complete (fail closed): {e}"
+        ) from e
+
+    return {
+        "schema": SCHEMA_ID,
+        "entry_count": len(entries),
+        "total_entry_bytes": total_bytes,
+        "entries": entries,
+    }
+
+
+def serialize_summary(summary: dict[str, Any]) -> str:
+    """Canonical serialization: sorted keys, fixed separators, LF newline,
+    no timestamp, no absolute path."""
+    return (
+        json.dumps(summary, sort_keys=True, separators=(",", ": "), indent=1)
+        + "\n"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tech_ledger.validate",
+        description=(
+            "Validate tech-ledger-v1 entry files (record structure only; "
+            "schema validity is not scientific validity or endorsement). "
+            "Argparse usage errors also exit 2."
+        ),
+    )
+    parser.add_argument(
+        "entries_dir",
+        help="directory whose direct .json files are the entries to validate",
+    )
+    return parser
+
+
+def _fail(error: BaseException, code: int) -> int:
+    print(f"error: {error}", file=sys.stderr)
+    return code
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        summary = validate_directory(pathlib.Path(args.entries_dir))
+    except (LedgerInputError, LedgerEntryError) as e:
+        return _fail(e, 2)
+    except LedgerPathError as e:
+        return _fail(e, 4)
+    except LedgerCeilingError as e:
+        return _fail(e, 5)
+    sys.stdout.write(serialize_summary(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -71,17 +71,42 @@ def _pre_open_inspect(path: str, dir_fd: int | None = None) -> os.stat_result:
     return os.lstat(path, dir_fd=dir_fd)
 
 
-#: Directory-relative descriptor support (POSIX): candidates can be
-#: enumerated and opened relative to a verified directory descriptor.
-#: Where unsupported (Windows), a fail-closed identity mechanism
-#: re-verifies the directory before every capture instead -- the claim is
-#: never silently weakened.
+#: Directory-relative descriptor support (POSIX): candidates are
+#: enumerated and opened relative to a verified directory descriptor, so
+#: the inspected directory object -- not a re-resolved pathname -- is what
+#: every operation acts on.
 _DIR_FD_SUPPORTED: Final[bool] = (
     os.open in os.supports_dir_fd
     and os.lstat in os.supports_dir_fd
     and os.listdir in os.supports_fd
     and hasattr(os, "O_DIRECTORY")
 )
+
+try:  # Windows-only standard-library primitives (absent elsewhere)
+    import _winapi
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    _winapi = None  # type: ignore[assignment]
+    msvcrt = None  # type: ignore[assignment]
+
+#: Fallback directory BINDING for platforms without directory-relative
+#: descriptors. A Windows directory handle opened without
+#: ``FILE_SHARE_DELETE`` denies rename/delete of that directory for as
+#: long as it is held, which is a genuine binding over the whole
+#: enumeration-to-capture interval -- not an identity recheck. Identity
+#: rechecks alone cannot see a swap-and-restore window, so where no
+#: binding primitive exists the validator fails closed instead.
+_FALLBACK_BINDING_SUPPORTED: Final[bool] = (
+    _winapi is not None
+    and msvcrt is not None
+    and hasattr(_winapi, "CreateFile")
+    and hasattr(msvcrt, "open_osfhandle")
+)
+
+#: Win32 constants not re-exported by ``_winapi`` (documented values).
+_FILE_SHARE_READ: Final[int] = 0x00000001
+_FILE_SHARE_WRITE: Final[int] = 0x00000002  # FILE_SHARE_DELETE deliberately absent
+_FILE_FLAG_BACKUP_SEMANTICS: Final[int] = 0x02000000  # required to open a directory
 
 
 def _identity_of(probe: os.stat_result, what: str) -> tuple[int, int]:
@@ -106,27 +131,93 @@ def _refuse_reparse_dir(probe: os.stat_result, what: str) -> None:
 
 
 class _DirBinding:
-    """The verified, bound entries directory.
+    """The verified, BOUND entries directory.
 
     ``fd`` mode (POSIX): enumeration and every candidate open go through
-    the held directory descriptor, so capture is inherently bound to the
-    originally inspected directory; a path-identity cross-check before
-    the capture phase detects rename/replacement. ``identity`` mode
-    (platforms without dir_fd): the directory's ``st_dev``/``st_ino``
-    identity and non-reparse status are re-verified before every capture,
-    failing closed on any change. Neither mode claims protection against
-    an unobservable filesystem or kernel violation.
+    the held directory descriptor, so every operation acts on the
+    inspected directory object itself. ``hold`` mode (Windows): a
+    directory handle that denies delete/rename sharing is held for the
+    whole interval from before enumeration until after the last capture,
+    so the directory cannot be renamed or replaced meanwhile -- including
+    during a transient swap-and-restore that no before/after identity
+    check could observe. Exactly one of ``fd`` / ``hold_fd`` is set, and
+    each is closed exactly once. Neither mode claims protection against a
+    genuinely unobservable filesystem or kernel violation.
     """
 
-    def __init__(self, path: str, fd: int | None, identity: tuple[int, int]):
+    def __init__(
+        self,
+        path: str,
+        fd: int | None,
+        identity: tuple[int, int],
+        hold_fd: int | None = None,
+    ):
         self.path = path
         self.fd = fd
         self.identity = identity
+        self.hold_fd = hold_fd
 
     def close(self) -> None:
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
+        for attribute in ("fd", "hold_fd"):
+            descriptor = getattr(self, attribute)
+            if descriptor is not None:
+                setattr(self, attribute, None)  # never close twice
+                os.close(descriptor)
+
+
+def _acquire_fallback_binding(path: str, pre_identity: tuple[int, int]) -> int:
+    """Hold the inspected directory open with delete/rename sharing denied.
+
+    Returns a file descriptor owning the directory handle (closing the
+    descriptor closes the handle exactly once). The bound object's own
+    identity is read via ``os.fstat`` on that descriptor -- not by
+    re-resolving the pathname -- and must equal the inspected identity;
+    the pathname is then re-inspected once so a reparse point swapped in
+    between inspection and acquisition is refused.
+    """
+    try:
+        handle = _winapi.CreateFile(
+            path,
+            _winapi.GENERIC_READ,
+            _FILE_SHARE_READ | _FILE_SHARE_WRITE,
+            0,
+            _winapi.OPEN_EXISTING,
+            _FILE_FLAG_BACKUP_SEMANTICS,
+            0,
+        )
+    except OSError as e:
+        raise LedgerPathError(
+            f"entries directory could not be bound (fail closed): {e}"
+        ) from e
+    try:
+        fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+    except OSError as e:  # pragma: no cover - handle ownership not transferred
+        _winapi.CloseHandle(handle)
+        raise LedgerPathError(
+            f"entries directory binding could not be retained (fail closed): {e}"
+        ) from e
+    try:
+        bound = os.fstat(fd)
+        if not stat_module.S_ISDIR(bound.st_mode):
+            raise LedgerPathError(
+                "bound entries handle is not a directory (fail closed)"
+            )
+        if _identity_of(bound, "entries directory") != pre_identity:
+            raise LedgerPathError(
+                "entries directory changed between inspection and binding "
+                "(fail closed)"
+            )
+        post = os.lstat(path)
+        _refuse_reparse_dir(post, "entries directory")
+        if _identity_of(post, "entries directory") != pre_identity:
+            raise LedgerPathError(
+                "entries directory changed between inspection and binding "
+                "(fail closed)"
+            )
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
 
 
 def _open_entries_dir(entries_dir: pathlib.Path) -> _DirBinding:
@@ -162,21 +253,25 @@ def _open_entries_dir(entries_dir: pathlib.Path) -> _DirBinding:
             os.close(fd)
             raise
         return _DirBinding(path, fd, identity)
-    post = os.stat(path)
-    identity = _identity_of(post, "entries directory")
-    if identity != pre_identity:
+    if not _FALLBACK_BINDING_SUPPORTED:
+        # No directory-relative descriptors and no fallback binding
+        # primitive: refuse BEFORE enumeration rather than presenting
+        # identity-only rechecks as a binding they cannot provide.
         raise LedgerPathError(
-            "entries directory changed between inspections (fail closed)"
+            "no directory-binding primitive is available on this platform; "
+            "refusing to enumerate (fail closed)"
         )
-    return _DirBinding(path, None, identity)
+    hold_fd = _acquire_fallback_binding(path, pre_identity)
+    return _DirBinding(path, None, pre_identity, hold_fd=hold_fd)
 
 
 def _verify_binding(binding: _DirBinding) -> None:
-    """Re-verify the bound directory (rename/replacement detection).
+    """Cross-check that the bound directory is still the inspected one.
 
-    In ``fd`` mode the original directory object is held open, so this
-    check detects a pathname now pointing elsewhere; in ``identity`` mode
-    it is the per-capture fail-closed identity mechanism itself.
+    Defence in depth in BOTH modes: the binding itself (held descriptor
+    or held delete-denying handle) is what prevents rename/replacement;
+    this check merely surfaces a pathname that no longer resolves to the
+    bound object. It is not, and must not be presented as, the binding.
     """
     probe = os.lstat(binding.path)
     _refuse_reparse_dir(probe, "entries directory")
@@ -218,7 +313,9 @@ def _capture_entry(binding: _DirBinding, name: str) -> bytes:
         dir_fd: int | None = binding.fd
         probe_path = name
     else:
-        _verify_binding(binding)  # per-capture fail-closed identity check
+        # The held delete-denying handle is the binding; this cross-check
+        # is defence in depth, not the guarantee.
+        _verify_binding(binding)
         dir_fd = None
         probe_path = os.path.join(binding.path, name)
     pre = _pre_open_inspect(probe_path, dir_fd=dir_fd)

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -77,24 +77,32 @@ def _pre_open_inspect(path: str, dir_fd: int | None = None) -> os.stat_result:
 def _dir_fd_binding_supported(
     supports_dir_fd: frozenset | set,
     supports_fd: frozenset | set,
+    supports_follow_symlinks: frozenset | set,
     has_o_directory: bool,
 ) -> bool:
-    """Whether every primitive the descriptor-bound lane actually calls
+    """Whether every capability the descriptor-bound lane actually needs
     is available: ``os.open(..., dir_fd=...)``, ``os.stat(..., dir_fd=...,
     follow_symlinks=False)`` and ``os.listdir(fd)``, plus ``O_DIRECTORY``.
 
     Membership is tested for exactly the functions this module calls with
-    those parameters.  ``os.lstat`` must NOT be consulted here: CPython
-    never registers it in ``os.supports_dir_fd`` on any build (its
-    ``dir_fd`` support is clinic-gated on the same ``fstatat`` capability
-    that registers ``os.stat``), so requiring its membership is False
-    everywhere -- including Linux, where all of these primitives work.
-    Pure and injectable so other platforms' capability shapes are
-    testable anywhere.
+    those parameters, in the registries the documentation assigns to each
+    parameter: ``supports_dir_fd`` governs ``dir_fd`` and
+    ``supports_follow_symlinks`` governs ``follow_symlinks=False`` -- an
+    unsupported ``follow_symlinks=False`` raises ``NotImplementedError``,
+    which is not an ``OSError`` and would propagate loudly instead of
+    failing closed, so BOTH halves of the inspection call must be
+    registered before the lane may be selected.  ``os.lstat`` must NOT be
+    consulted here: CPython never registers it in ``os.supports_dir_fd``
+    on any build (its ``dir_fd`` support is clinic-gated on the same
+    ``fstatat`` capability that registers ``os.stat``), so requiring its
+    membership is False everywhere -- including Linux, where all of these
+    primitives work.  Pure and injectable so other platforms' capability
+    shapes are testable anywhere.
     """
     return (
         os.open in supports_dir_fd
         and os.stat in supports_dir_fd
+        and os.stat in supports_follow_symlinks
         and os.listdir in supports_fd
         and has_o_directory
     )
@@ -105,7 +113,10 @@ def _dir_fd_binding_supported(
 #: the inspected directory object -- not a re-resolved pathname -- is what
 #: every operation acts on.
 _DIR_FD_SUPPORTED: Final[bool] = _dir_fd_binding_supported(
-    os.supports_dir_fd, os.supports_fd, hasattr(os, "O_DIRECTORY")
+    os.supports_dir_fd,
+    os.supports_fd,
+    os.supports_follow_symlinks,
+    hasattr(os, "O_DIRECTORY"),
 )
 
 try:  # Windows-only standard-library primitives (absent elsewhere)

--- a/tests/test_tech_ledger_reverse_quarantine.py
+++ b/tests/test_tech_ledger_reverse_quarantine.py
@@ -7,7 +7,12 @@ forward direction -- the lab importing only the standard library -- is
 enforced lab-locally by experiments/tech_ledger/tests/ under the
 tech-ledger workflow.)
 
-This guard imports NO tech-ledger module: it is a pure static scan.
+The detector resolves BOTH absolute and relative imports against each
+scanned file's repository package context (namespace-package aware -- no
+``__init__.py`` is required on any ancestor), so ``from .. import
+tech_ledger`` inside the ``experiments`` tree is caught exactly like
+``import experiments.tech_ledger``. This guard imports NO tech-ledger
+module: it is a pure static scan.
 """
 
 from __future__ import annotations
@@ -16,6 +21,8 @@ import ast
 import pathlib
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_LAB_PACKAGE = ("experiments", "tech_ledger")
 
 #: Clearly non-source / generated / vendor locations, excluded by NAME at
 #: any depth. Everything else with a .py suffix is scanned automatically
@@ -51,39 +58,87 @@ def _iter_maintained_python_files():
                 yield child
 
 
-def _lab_imports_in(source: str) -> list[str]:
-    """Every import statement that reaches experiments.tech_ledger.
+def _package_context(module_relpath: tuple[str, ...] | None) -> tuple[str, ...] | None:
+    """The importing module's package, derived purely from its
+    repository-relative path parts (namespace-package layout: no
+    ``__init__.py`` is required anywhere).
 
-    Detects all three forms:
-    ``import experiments.tech_ledger...``,
-    ``from experiments.tech_ledger... import ...`` and
-    ``from experiments import tech_ledger``.
+    For an ordinary module ``experiments/sub/example.py`` the package is
+    ``("experiments", "sub")``; for a package ``__init__.py`` the module
+    IS the package, and relative level 1 refers to that same package --
+    so ``experiments/sub/__init__.py`` also yields
+    ``("experiments", "sub")``.
     """
-    tree = ast.parse(source)
+    if module_relpath is None or not module_relpath:
+        return None
+    *dirs, filename = module_relpath
+    if not filename.endswith(".py"):
+        return None
+    if filename == "__init__.py":
+        return tuple(dirs)
+    return tuple(dirs)
+
+
+def _resolved_lab_imports(
+    tree: ast.AST, module_relpath: tuple[str, ...] | None = None
+) -> list[str]:
+    """Every import statement that resolves to experiments.tech_ledger.
+
+    Absolute forms need no path context. Relative forms
+    (``ast.ImportFrom.level`` >= 1) are resolved against the importing
+    module's package context per Python's rules: base package = the
+    module's package with ``level - 1`` trailing components removed; a
+    given ``from``-module appends to the base; with no ``from``-module,
+    each alias appends to the base. A malformed or impossible level
+    (reaching past the top of the tree) never crashes the scan -- it
+    simply cannot resolve to the lab and is skipped.
+    """
+    package = _package_context(module_relpath)
     found: list[str] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name == "experiments.tech_ledger" or alias.name.startswith(
-                    "experiments.tech_ledger."
-                ):
+                parts = tuple(alias.name.split("."))
+                if parts[: len(_LAB_PACKAGE)] == _LAB_PACKAGE:
                     found.append(f"import {alias.name}")
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
-            if module == "experiments.tech_ledger" or module.startswith(
-                "experiments.tech_ledger."
-            ):
-                found.append(f"from {module} import ...")
-            elif module == "experiments":
+            level = node.level or 0
+            if level == 0:
+                base: tuple[str, ...] | None = ()
+                module_parts = tuple(module.split(".")) if module else ()
+            else:
+                if package is None or level - 1 > len(package):
+                    # No path context, or the level climbs past the top of
+                    # the repository tree: cannot resolve to the lab.
+                    continue
+                base = package[: len(package) - (level - 1)]
+                module_parts = tuple(module.split(".")) if module else ()
+            resolved_module = base + module_parts
+            if resolved_module[: len(_LAB_PACKAGE)] == _LAB_PACKAGE:
+                dots = "." * level
+                found.append(f"from {dots}{module} import ...")
+                continue
+            # ``from <pkg> import tech_ledger`` (absolute or relative):
+            # an alias names the lab package itself when the resolved
+            # parent is exactly ("experiments",).
+            if resolved_module == _LAB_PACKAGE[:-1]:
                 for alias in node.names:
-                    if alias.name == "tech_ledger":
-                        found.append("from experiments import tech_ledger")
+                    if alias.name == _LAB_PACKAGE[-1]:
+                        dots = "." * level
+                        found.append(
+                            f"from {dots}{module} import {alias.name}"
+                        )
     return found
 
 
-def test_detector_positive_controls():
-    # The detector must catch every import form; a silent detector would
-    # make the tree scan below meaningless.
+def _lab_imports_in(
+    source: str, module_relpath: tuple[str, ...] | None = None
+) -> list[str]:
+    return _resolved_lab_imports(ast.parse(source), module_relpath)
+
+
+def test_detector_absolute_positive_controls():
     assert _lab_imports_in("import experiments.tech_ledger")
     assert _lab_imports_in("import experiments.tech_ledger.schema")
     assert _lab_imports_in("from experiments.tech_ledger import schema")
@@ -91,18 +146,87 @@ def test_detector_positive_controls():
         "from experiments.tech_ledger.validate import validate_directory"
     )
     assert _lab_imports_in("from experiments import tech_ledger")
-    # Negative controls: neighbouring names must not trip it.
+
+
+def test_detector_relative_positive_controls():
+    # Explicit fake repository paths: the same syntax resolves to the lab
+    # exactly when the importing file's package context makes it so.
+    assert _lab_imports_in(
+        "from . import tech_ledger", ("experiments", "example.py")
+    )
+    assert _lab_imports_in(
+        "from .tech_ledger import schema", ("experiments", "example.py")
+    )
+    assert _lab_imports_in(
+        "from .. import tech_ledger", ("experiments", "sub", "example.py")
+    )
+    assert _lab_imports_in(
+        "from ..tech_ledger import validate", ("experiments", "sub", "example.py")
+    )
+    # Deeper nesting and submodule forms.
+    assert _lab_imports_in(
+        "from ...tech_ledger.schema import validate_entry",
+        ("experiments", "sub", "deeper", "example.py"),
+    )
+    assert _lab_imports_in(
+        "from ...tech_ledger import schema",
+        ("experiments", "sub", "deeper", "example.py"),
+    )
+    # A package __init__.py: level 1 refers to the package itself.
+    assert _lab_imports_in(
+        "from .tech_ledger import schema", ("experiments", "__init__.py")
+    )
+    assert _lab_imports_in(
+        "from ..tech_ledger import schema", ("experiments", "sub", "__init__.py")
+    )
+
+
+def test_detector_negative_controls():
+    # Same relative syntax under an unrelated top-level package.
+    assert not _lab_imports_in(
+        "from . import tech_ledger", ("otherpkg", "example.py")
+    )
+    assert not _lab_imports_in(
+        "from .tech_ledger import schema", ("otherpkg", "example.py")
+    )
+    assert not _lab_imports_in(
+        "from .. import tech_ledger", ("otherpkg", "sub", "example.py")
+    )
+    # Neighbouring names never trip it.
+    assert not _lab_imports_in(
+        "from . import tech_ledgerish", ("experiments", "example.py")
+    )
+    assert not _lab_imports_in(
+        "from ..other import tech_ledger", ("experiments", "sub", "example.py")
+    )
     assert not _lab_imports_in("import experiments.theory_other")
     assert not _lab_imports_in("from experiments import swarm_hunter_lab")
     assert not _lab_imports_in("import tech_ledgerish")
+    assert not _lab_imports_in(
+        "from . import swarm_hunter_lab", ("experiments", "example.py")
+    )
+    # Strings and comments containing import-like text are not imports.
+    assert not _lab_imports_in(
+        's = "from experiments.tech_ledger import schema"\n'
+        "# import experiments.tech_ledger\n",
+        ("experiments", "example.py"),
+    )
+    # Impossible relative levels never crash and never match.
+    assert not _lab_imports_in(
+        "from " + "." * 12 + " import tech_ledger",
+        ("experiments", "sub", "example.py"),
+    )
+    assert not _lab_imports_in("from . import tech_ledger", None)
+    assert not _lab_imports_in("from . import tech_ledger", ())
 
 
 def test_no_maintained_python_file_imports_the_lab():
     offenders: list[str] = []
     for path in _iter_maintained_python_files():
+        relpath = path.relative_to(_REPO_ROOT).parts
         try:
             source = path.read_text(encoding="utf-8", errors="replace")
-            hits = _lab_imports_in(source)
+            hits = _lab_imports_in(source, relpath)
         except SyntaxError:
             # Unparseable legacy material cannot import anything at
             # runtime; it is outside this guard's claim.

--- a/tests/test_tech_ledger_reverse_quarantine.py
+++ b/tests/test_tech_ledger_reverse_quarantine.py
@@ -1,0 +1,112 @@
+"""Continuous reverse import-quarantine guard for experiments/tech_ledger.
+
+Lives in the MAINTAINED tests/ battery so it runs on ordinary repository
+CI: a production-only change can never bypass the reverse quarantine
+merely because the lab's path-scoped workflow did not trigger. (The
+forward direction -- the lab importing only the standard library -- is
+enforced lab-locally by experiments/tech_ledger/tests/ under the
+tech-ledger workflow.)
+
+This guard imports NO tech-ledger module: it is a pure static scan.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: Clearly non-source / generated / vendor locations, excluded by NAME at
+#: any depth. Everything else with a .py suffix is scanned automatically
+#: -- including the plural agents tree, root-level Python files and any
+#: future maintained location.
+_EXCLUDED_DIR_NAMES = {
+    ".git",
+    ".claude",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    ".eggs",
+    "build",
+    "dist",
+    "site-packages",
+}
+
+
+def _iter_maintained_python_files():
+    lab_root = _REPO_ROOT / "experiments" / "tech_ledger"
+    stack = [_REPO_ROOT]
+    while stack:
+        directory = stack.pop()
+        for child in directory.iterdir():
+            if child.is_dir():
+                if child.name in _EXCLUDED_DIR_NAMES:
+                    continue
+                if child == lab_root:
+                    continue  # the lab itself is outside this guard's scope
+                stack.append(child)
+            elif child.suffix == ".py":
+                yield child
+
+
+def _lab_imports_in(source: str) -> list[str]:
+    """Every import statement that reaches experiments.tech_ledger.
+
+    Detects all three forms:
+    ``import experiments.tech_ledger...``,
+    ``from experiments.tech_ledger... import ...`` and
+    ``from experiments import tech_ledger``.
+    """
+    tree = ast.parse(source)
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "experiments.tech_ledger" or alias.name.startswith(
+                    "experiments.tech_ledger."
+                ):
+                    found.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "experiments.tech_ledger" or module.startswith(
+                "experiments.tech_ledger."
+            ):
+                found.append(f"from {module} import ...")
+            elif module == "experiments":
+                for alias in node.names:
+                    if alias.name == "tech_ledger":
+                        found.append("from experiments import tech_ledger")
+    return found
+
+
+def test_detector_positive_controls():
+    # The detector must catch every import form; a silent detector would
+    # make the tree scan below meaningless.
+    assert _lab_imports_in("import experiments.tech_ledger")
+    assert _lab_imports_in("import experiments.tech_ledger.schema")
+    assert _lab_imports_in("from experiments.tech_ledger import schema")
+    assert _lab_imports_in(
+        "from experiments.tech_ledger.validate import validate_directory"
+    )
+    assert _lab_imports_in("from experiments import tech_ledger")
+    # Negative controls: neighbouring names must not trip it.
+    assert not _lab_imports_in("import experiments.theory_other")
+    assert not _lab_imports_in("from experiments import swarm_hunter_lab")
+    assert not _lab_imports_in("import tech_ledgerish")
+
+
+def test_no_maintained_python_file_imports_the_lab():
+    offenders: list[str] = []
+    for path in _iter_maintained_python_files():
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+            hits = _lab_imports_in(source)
+        except SyntaxError:
+            # Unparseable legacy material cannot import anything at
+            # runtime; it is outside this guard's claim.
+            continue
+        if hits:
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}: {hits}")
+    assert offenders == []


### PR DESCRIPTION
## What this is

A neutral, machine-validated, explicitly quarantined technology-ledger lab at `experiments/tech_ledger/` (schema id `tech-ledger-v1`), through two prior audit-correction rounds, the review-triggered correction-and-synchronization pass, a follow-on binding-hold correction, an Ubuntu capability-detection correction, and a capability-registry completion below. **DRAFT — open, unmerged, not self-certified.** The ready transition triggered Jack's review (three findings); the PR was returned to draft for that pass and remains draft. Merging requires Kev's separately typed authorization.

Central rule: **validation is not endorsement or factual verification** — schema validity is not scientific validity, implementation authority, or evidence that a claim is true. The prose `docs/MEDUSA_THEORY_INTAKE_LEDGER.md` remains authoritative and untouched.

## Heads and topology

- Audited pre-review head: `0404cc9…`
- **Synchronization merge:** `8ab6a05e0a90e282de676c4b871f5fffb0b06aa3` — ordinary two-parent merge of exactly `origin/main` `ff29115…` (the #438 squash) into exactly `0404cc9…`; conflict-free by construction, no manual resolution, all sixteen audited #439 blobs and all three #438 blobs verified byte-preserved.
- **Review-findings correction:** `4b4fb61859a012ea281dd49274d0473dc67a5a4a` — exactly six existing PR paths (+420/−58).
- **Binding-hold correction:** `12d308caa8e331ad0d0a6daa6850e09d1db50b0b` — exactly four existing PR paths (+311/−42): on platforms without directory-relative descriptors the validator holds a **real** directory binding (a Windows directory handle opened without `FILE_SHARE_DELETE`, denying rename/delete for the whole enumeration-to-capture interval), and **fails closed before enumeration** where no binding primitive exists at all.
- **Ubuntu capability-detection correction:** `4d22e938d6f59c5248cf3725e4399ff383fd59f7` — exactly two existing PR paths (+203/−15): the descriptor-lane predicate had required `os.lstat in os.supports_dir_fd`, a membership CPython never registers on any build, so the fd lane was off everywhere and ordinary Ubuntu validation refused (24 failures at `12d308c`, run 30731254181). Detection error, not primitive absence; corrected to consult the registries of the primitives genuinely called.
- **Capability-registry completion (current head):** `4bec9922a83d774604fcf6abcb89fd60120265fd` — exactly two existing PR paths (+38/−13), detailed below.
- Ordinary commits and one plain push per pass throughout; no amend, rebase, force-push or history rewrite. **Cumulative PR boundary unchanged: the original sixteen paths, +3217/−0 vs `main`.**

## The three review findings → corrections (`4b4fb61`)

1. **Stable entries-directory boundary** (`validate.py`): the entries directory itself is verified and **bound** — symbolic-link / junction / reparse-path directories refused; on platforms with directory-relative descriptors, enumeration (`os.listdir(fd)`) and every candidate open (`dir_fd=`) go through the verified `O_DIRECTORY|O_NOFOLLOW` descriptor instead of reconstructing `entries_dir / name`; rename/replacement between enumeration and capture is detected at the phase boundary. Refusals remain typed `LedgerPathError`, exit 4, one sanitized `error:` line. *Failing-before:* a junction entries directory **validated** at the synchronized pre-correction state (reproduced).
2. **Forward-quarantine discovery** (`tests/test_import_quarantine.py`): hard-coded module tuple replaced by deterministic discovery of every non-test lab module, with synthetic positive/negative controls. *Failing-before:* the old guard **passed** over a lab copy containing `helpers.py` with `import scripts.event_bus` (reproduced).
3. **ASCII wire formats** (`schema.py`): `TLV4-NNN` and `YYYY-MM-DD` accept ASCII digits only; Arabic-Indic identifiers and Bengali dates previously **validated** (reproduced); now refused. No seed or exemplar JSON touched.

## The capability-registry completion (`4bec992`)

Reviewer finding (Jack): at `4d22e93` the predicate consulted `os.supports_dir_fd`, `os.supports_fd` and `O_DIRECTORY` — but the lane's inspection call is `os.stat(..., dir_fd=..., follow_symlinks=False)`, and the Python documentation assigns the `follow_symlinks=False` half to its **own** registry, `os.supports_follow_symlinks` ("To check whether a particular function accepts False for its follow_symlinks parameter, use the `in` operator on `supports_follow_symlinks`"; unsupported use raises `NotImplementedError`). The predicate was therefore incomplete: on a platform shape with `fstatat`-style `dir_fd` support but unregistered `follow_symlinks`, it would select a lane whose first inspection raises `NotImplementedError` — a `RuntimeError` subclass, **not** an `OSError` — escaping the validator's typed refusal lanes as a crash instead of failing closed. The earlier rejection of this conjunct ("true on Windows too, discriminates nothing") argued from platform discrimination and is **retracted**: the conjunct's job is faithful correspondence to the documented capability contract of the call being gated, and the predicate is a conjunction, so Windows already fails its `dir_fd` conjuncts. On current CPython builds the conjunct is value-inert (`HAVE_FSTATAT` registers `stat` in both sets) — but the two registries are documented and curated independently (CPython deliberately excludes `HAVE_FCHMODAT` from the follow registry while keeping it in the dir_fd registry), and the coincidence is not a contract.

**Correction (two paths: `validate.py`, `tests/test_validate_cli.py`):** `_dir_fd_binding_supported()` gains a `supports_follow_symlinks` input and requires `os.stat` membership there; the compiled flag supplies the real `os.supports_follow_symlinks`. Tests: the Linux-shaped fixture registers `os.stat` follow_symlinks-capable; a new absent-`follow_symlinks` case proves `dir_fd` support alone must not select the lane; the real-platform correspondence test and the anti-skip sentinel consult the same registry. Windows fallback, the fail-closed refusal branch, the race seam, and every other protection are untouched.

*Failing-before receipts (against unchanged `4d22e93`):* the predicate had **no parameter through which missing follow-symlink support could even be expressed** and returned **True** for the stipulated shape (`TypeError` on the explicit kwarg — captured); a mechanical demonstration showed `NotImplementedError` propagating out of `main()` past both the `except OSError` conversion and the typed handlers (crash, exit 1 — never the typed exit-4 refusal); the updated test set fails 8 (of 9) against pinned `4d22e93` code and passes after the correction.

## Receipts — Local (head `4bec992`, Windows)

- Lab suite `-W error`: **79 passed, 8 skipped** (fd-lane and sentinel tests skip on Windows; fallback-binding and junction tests run)
- Focused predicate/correspondence/sentinel selection: **8 passed, 1 skipped** · Reverse-quarantine guard: **4 passed** · Full maintained battery: **2866 passed, 48 skipped, 0 failed**
- Exemplar validator: exit 0, byte-identical twice, output sha256 `a715541f…` — **unchanged across every correction in this PR**
- Both committed blobs LF-only; exact two-path correction audit passed; tree vs `origin/main` = exactly the sixteen PR paths

## Receipts — CI (head `4bec992`)

All registered checks conclusively **successful**: `tech-ledger (non-required)` **passed on Ubuntu (Python 3.12.13) in 9s** — lab suite `-W error` **80 passed, 7 skipped** (exactly +1 vs `4d22e93`: the new absent-`follow_symlinks` case; the skip set is unchanged, so every fd-lane test still ran and the anti-skip sentinel passed, proving the descriptor lane is genuinely selected under the completed predicate) and the real exemplar-validator step exited 0 through the descriptor lane; `verify-python` ×2 (carries the reverse guard), `frontend-quality` ×2 and `agent-safety` all passed (runs 30734995495 / 30734996476 / 30734996486 / 30734996490).

## Review threads

The three `4b4fb61` findings correspond to the three unresolved review threads; per authorization, **no thread was replied to or resolved** — thread disposition belongs to the reviewer.

## Retained limitations and non-claims

- No protection is claimed against an unobservable filesystem or kernel violation, in either binding mode.
- Green tests demonstrate exactly the exercised paths: the fd lane is proven on Ubuntu CI and the fallback lane on Windows; a platform with neither primitive refuses before enumeration, and that refusal is itself tested.
- The one-line stderr contract covers **expected, handled failures** only: every typed refusal is routed through `_fail`, which renders CR/LF as visible escapes, and `test_newline_bearing_filename_yields_one_error_line` demonstrates the newline-bearing-filename case end-to-end on Ubuntu CI (formerly recorded as residual A2 — now demonstrated handled, and that residual is retired). Deliberately propagated unrelated programming errors (tracebacks) are outside the contract by design.
- Schema validity remains a statement about record structure only.

## Seed pack

Still outside git; unchanged by this pass. A later, separately gated content PR remains its only path into the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
