### PR TITLE
fix(shard-transport): retain partial receive state on failure

### DIFF
--- a/scripts/shard_transport_zmq.py
+++ b/scripts/shard_transport_zmq.py
@@ -115,6 +115,33 @@ class ZMQHaloExchange(HaloExchange):
         Combines self-loop packets already in the local inbox with ZMQ-delivered
         packets. Raises `TimeoutError` if the full count isn't received within
         `recv_timeout_ms`. This is the implicit per-step barrier.
+
+        Extracting the local inbox transfers packet ownership to this call, so
+        an exceptional exit past that point would otherwise drop every packet
+        held in hand — the local ones AND any already decoded off the wire.
+        PUSH/PULL delivers each frame exactly once, so a dropped wire packet is
+        never re-sent and the barrier can never be satisfied afterwards. The
+        gather loop therefore runs under a cleanup-only handler that hands the
+        in-hand packets back to `_local_inbox[target]` before re-raising.
+
+        Retention is bounded to packets this call had already accepted:
+
+          - Restored packets are PREPENDED, so they precede any self-loop
+            packet `send()` placed into the replacement inbox while the receive
+            was in progress, and their relative order is preserved.
+          - Packets are moved, never copied, so no later call can return a
+            duplicate.
+          - The exception is re-raised bare: class, message and traceback are
+            untouched, and nothing is swallowed. `zmq.Again` stays an internal
+            retry and never triggers restoration.
+          - A frame `HaloPacket.from_bytes()` refuses is NOT restored or
+            replayed — only previously valid packets are handed back. Malformed
+            frames remain discarded, exactly as before.
+
+        The claim is bounded to retention across an exceptional receive exit.
+        Cleanup is not claimed to be total under a SECOND failure (e.g. an
+        allocation failure during restoration itself), and this changes no
+        caller retry policy, generation validation, or over-delivery behaviour.
         """
         if self._closed:
             raise RuntimeError("ZMQHaloExchange is closed")
@@ -124,19 +151,24 @@ class ZMQHaloExchange(HaloExchange):
         self._local_inbox[target] = []
         pull = self._pulls[target]
         deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
-        while len(packets) < PACKETS_PER_SHARD_PER_STEP:
-            remaining_ms = int((deadline - time.monotonic()) * 1000)
-            if remaining_ms <= 0:
-                raise TimeoutError(
-                    f"ZMQHaloExchange.recv_all timed out for {target} "
-                    f"({len(packets)}/{PACKETS_PER_SHARD_PER_STEP} packets received)"
-                )
-            pull.setsockopt(zmq.RCVTIMEO, remaining_ms)
-            try:
-                buf = pull.recv()
-            except zmq.Again:
-                continue
-            packets.append(HaloPacket.from_bytes(buf))
+        try:
+            while len(packets) < PACKETS_PER_SHARD_PER_STEP:
+                remaining_ms = int((deadline - time.monotonic()) * 1000)
+                if remaining_ms <= 0:
+                    raise TimeoutError(
+                        f"ZMQHaloExchange.recv_all timed out for {target} "
+                        f"({len(packets)}/{PACKETS_PER_SHARD_PER_STEP} packets received)"
+                    )
+                pull.setsockopt(zmq.RCVTIMEO, remaining_ms)
+                try:
+                    buf = pull.recv()
+                except zmq.Again:
+                    continue
+                packets.append(HaloPacket.from_bytes(buf))
+        except BaseException:
+            # Cleanup only — give back what this call took, then propagate.
+            self._local_inbox[target] = packets + self._local_inbox[target]
+            raise
         return packets
 
     def barrier(self) -> None:

--- a/scripts/shard_transport_zmq.py
+++ b/scripts/shard_transport_zmq.py
@@ -13,6 +13,7 @@ Requires: pyzmq >= 27.0.0
 
 from __future__ import annotations
 
+import threading
 import time
 from collections import defaultdict
 from typing import Iterable, Mapping
@@ -72,6 +73,11 @@ class ZMQHaloExchange(HaloExchange):
         self._pulls: dict[ShardCoord, zmq.Socket] = {}
         self._pushes: dict[ShardCoord, zmq.Socket] = {}
         self._local_inbox: dict[ShardCoord, list[HaloPacket]] = defaultdict(list)
+        # Serializes every local-inbox transition against a concurrent
+        # self-loop `send()`. Held only for the O(1)/O(n) list handovers below —
+        # never across a ZMQ call, a frame decode or the receive deadline.
+        # Scope is the local inbox alone; see `recv_all` for what is NOT claimed.
+        self._inbox_lock = threading.Lock()
         self._closed = False
 
         # Bind one PULL socket per owned coord.
@@ -99,8 +105,11 @@ class ZMQHaloExchange(HaloExchange):
             raise RuntimeError("ZMQHaloExchange is closed")
         target = packet.target_coord
         if target in self.own_coords:
-            # Self-loop: skip ZMQ entirely.
-            self._local_inbox[target].append(packet)
+            # Self-loop: skip ZMQ entirely. Serialized against `recv_all`'s
+            # extraction and restoration so an append can never be discarded by
+            # a concurrent replacement of the inbox list.
+            with self._inbox_lock:
+                self._local_inbox[target].append(packet)
             return
         sock = self._pushes.get(target)
         if sock is None:
@@ -143,17 +152,30 @@ class ZMQHaloExchange(HaloExchange):
             replayed — only previously valid packets are handed back. Malformed
             frames remain discarded, exactly as before.
 
-        The claim is bounded to retention across an exceptional receive exit.
+        Both local-inbox handovers — the extraction/clear above and the
+        restoration below — run under `_inbox_lock`, the same lock a self-loop
+        `send()` takes around its append. Each handover replaces the stored list
+        wholesale, so without that mutual exclusion an append landing between
+        the read and the store would be silently dropped. The lock is released
+        before the gather loop and is NEVER held across a ZMQ call, a frame
+        decode or the receive deadline.
+
+        The claim is bounded to retention across an exceptional receive exit and
+        to serializing local-inbox transitions against self-loop `send()`.
         Cleanup is not claimed to be total under a SECOND failure (e.g. an
         allocation failure during restoration itself), and this changes no
         caller retry policy, generation validation, or over-delivery behaviour.
+        Broader thread-safety is explicitly NOT claimed: the PULL/PUSH sockets,
+        `close()` and the rest of the object lifecycle remain unsynchronized,
+        and concurrent `recv_all()` calls for the same target are unsupported.
         """
         if self._closed:
             raise RuntimeError("ZMQHaloExchange is closed")
         if target not in self.own_coords:
             raise ValueError(f"cannot recv for non-owned coord {target}")
-        packets = list(self._local_inbox[target])
-        self._local_inbox[target] = []
+        with self._inbox_lock:
+            packets = list(self._local_inbox[target])
+            self._local_inbox[target] = []
         try:
             pull = self._pulls[target]
             deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
@@ -172,7 +194,12 @@ class ZMQHaloExchange(HaloExchange):
                 packets.append(HaloPacket.from_bytes(buf))
         except BaseException:
             # Cleanup only — give back what this call took, then propagate.
-            self._local_inbox[target] = packets + self._local_inbox[target]
+            # The read/concatenate/store is one critical section, so a self-loop
+            # append racing this handover is never overwritten: it either lands
+            # before the read (and is preserved after the restored packets) or
+            # after the store (and is appended to the restored list).
+            with self._inbox_lock:
+                self._local_inbox[target] = packets + self._local_inbox[target]
             raise
         return packets
 

--- a/scripts/shard_transport_zmq.py
+++ b/scripts/shard_transport_zmq.py
@@ -120,9 +120,14 @@ class ZMQHaloExchange(HaloExchange):
         an exceptional exit past that point would otherwise drop every packet
         held in hand — the local ones AND any already decoded off the wire.
         PUSH/PULL delivers each frame exactly once, so a dropped wire packet is
-        never re-sent and the barrier can never be satisfied afterwards. The
-        gather loop therefore runs under a cleanup-only handler that hands the
-        in-hand packets back to `_local_inbox[target]` before re-raising.
+        never re-sent and the barrier can never be satisfied afterwards.
+
+        The protected ownership interval therefore begins IMMEDIATELY after the
+        stored inbox is cleared and covers everything up to the return: the
+        `_pulls[target]` lookup, the initial deadline construction, timeout
+        handling, socket operations and packet decoding. A cleanup-only handler
+        hands the in-hand packets back to `_local_inbox[target]` before
+        re-raising.
 
         Retention is bounded to packets this call had already accepted:
 
@@ -149,9 +154,9 @@ class ZMQHaloExchange(HaloExchange):
             raise ValueError(f"cannot recv for non-owned coord {target}")
         packets = list(self._local_inbox[target])
         self._local_inbox[target] = []
-        pull = self._pulls[target]
-        deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
         try:
+            pull = self._pulls[target]
+            deadline = time.monotonic() + self.recv_timeout_ms / 1000.0
             while len(packets) < PACKETS_PER_SHARD_PER_STEP:
                 remaining_ms = int((deadline - time.monotonic()) * 1000)
                 if remaining_ms <= 0:

--- a/tests/test_shard_transport_zmq.py
+++ b/tests/test_shard_transport_zmq.py
@@ -17,7 +17,9 @@ import pickle
 import subprocess
 import sys
 import textwrap
+import threading
 import time
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
@@ -527,26 +529,127 @@ def test_recv_all_socket_failure_restores_valid_packets(monkeypatch):
     exchange.close()
 
 
-def test_recv_all_restored_packets_precede_concurrent_self_loop_arrivals(monkeypatch):
-    """Restored original-local packets precede restored decoded-wire packets,
-    which precede self-loop packets that landed in the replacement inbox while
-    the failed call was in progress."""
+# -- genuine concurrency: self-loop send vs. inbox handover -------------------
+#
+# Both local-inbox handovers replace the stored list wholesale:
+#
+#     packets = list(self._local_inbox[target]); self._local_inbox[target] = []
+#     self._local_inbox[target] = packets + self._local_inbox[target]
+#
+# An unsynchronized `send()` append landing between the read and the store is
+# discarded by the store. The two tests below drive that window from a real
+# thread. They substitute only the inbox mapping — an existing dependency
+# boundary — so the production `recv_all` under test is the genuine one.
+
+# Bounded wait used at the assign point. An UNBOUNDED wait would deadlock by
+# construction once the handover is serialized, because the concurrent `send()`
+# is blocked on the very lock the handover holds. Expiry is therefore the
+# expected, correct outcome; prompt return means the append was NOT serialized.
+_ASSIGN_WINDOW_S = 0.25
+_JOIN_S = 10.0
+
+
+class _CoordinatedInbox(defaultdict):
+    """`_local_inbox` view that exposes the read-then-store window.
+
+    `on_assign` fires immediately before a replacement list is stored — exactly
+    the instant at which a racing `send()` append would be lost. Only `recv_all`
+    ever stores; `send()` appends in place, so the hook never fires on the
+    worker thread.
+    """
+
+    def __init__(self, source):
+        super().__init__(list, source)
+        self.on_assign = None
+
+    def __setitem__(self, key, value):
+        if self.on_assign is not None:
+            self.on_assign(key)
+        super().__setitem__(key, value)
+
+
+def _start_self_loop_sender(exchange, packet, release, done):
+    """Thread that performs one self-loop `send()` once `release` is set."""
+
+    def _worker():
+        release.wait(_JOIN_S)
+        exchange.send(packet)
+        done.set()
+
+    thread = threading.Thread(target=_worker, name="self-loop-sender", daemon=True)
+    thread.start()
+    return thread
+
+
+def test_concurrent_self_loop_send_survives_inbox_extraction(monkeypatch):
+    """Window 1 — a self-loop `send()` racing the extraction/clear at the start
+    of `recv_all()` must not be lost."""
+    wire = [_packet(100 + i).to_bytes() for i in range(PACKETS_PER_SHARD_PER_STEP - 3)]
+    exchange, pull, clock = _wired_exchange(monkeypatch, wire)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+    exchange._local_inbox = _CoordinatedInbox(exchange._local_inbox)
+
+    release, done = threading.Event(), threading.Event()
+    worker = _start_self_loop_sender(exchange, _packet(300), release, done)
+
+    def _on_assign(key):
+        # The extraction clear is the first (and here only) store.
+        if not release.is_set():
+            release.set()
+            done.wait(_ASSIGN_WINDOW_S)
+
+    exchange._local_inbox.on_assign = _on_assign
+
+    out = exchange.recv_all(_OWN)
+    worker.join(_JOIN_S)
+    assert not worker.is_alive()
+
+    # The barrier set is unaffected; the racing packet is retained for next step.
+    assert _gens(out) == [0, 1, 2] + [
+        100 + i for i in range(PACKETS_PER_SHARD_PER_STEP - 3)
+    ]
+    assert _gens(exchange._local_inbox[_OWN]) == [300]
+    exchange.close()
+
+
+def test_concurrent_self_loop_send_survives_exceptional_restoration(monkeypatch):
+    """Window 2 — a self-loop `send()` racing the exceptional restoration must
+    not be overwritten, and restored packets still precede it."""
     exchange, pull, clock = _wired_exchange(
         monkeypatch, [_packet(100).to_bytes()], timeout_ms=1_000
     )
-
-    def _arrive_then_expire():
-        # A self-loop send lands in the replacement inbox mid-call.
-        exchange.send(_packet(300))
-        clock.advance(2.0)
-
-    pull.on_exhausted = _arrive_then_expire
     for gen in (0, 1, 2):
         exchange.send(_packet(gen))
+    exchange._local_inbox = _CoordinatedInbox(exchange._local_inbox)
+
+    armed = threading.Event()
+
+    def _expire():
+        clock.advance(2.0)  # force the deadline past, triggering TimeoutError
+        armed.set()
+
+    pull.on_exhausted = _expire
+
+    release, done = threading.Event(), threading.Event()
+    worker = _start_self_loop_sender(exchange, _packet(300), release, done)
+
+    def _on_assign(key):
+        # Ignore the extraction store; coordinate only on the restoration store.
+        if armed.is_set() and not release.is_set():
+            release.set()
+            done.wait(_ASSIGN_WINDOW_S)
+
+    exchange._local_inbox.on_assign = _on_assign
 
     with pytest.raises(TimeoutError):
         exchange.recv_all(_OWN)
 
+    worker.join(_JOIN_S)
+    assert not worker.is_alive()
+
+    # Restored local packets, then the restored wire packet, then the racing
+    # self-loop arrival — none lost, none duplicated.
     assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2, 100, 300]
     exchange.close()
 

--- a/tests/test_shard_transport_zmq.py
+++ b/tests/test_shard_transport_zmq.py
@@ -357,6 +357,69 @@ def _wired_exchange(monkeypatch, script=(), timeout_ms=10_000):
     return exchange, pull, clock
 
 
+class _SentinelError(Exception):
+    """Distinct type so the propagated object can be identity-checked."""
+
+
+class _ExplodingClock:
+    """Clock boundary that fails on the very first `monotonic()` call, i.e.
+    while the initial deadline is being constructed."""
+
+    def __init__(self, error):
+        self.error = error
+
+    def monotonic(self):
+        raise self.error
+
+
+class _RaisingPulls(dict):
+    """PULL-registry boundary whose lookup fails.
+
+    Subclasses `dict` so `close()` still finds working `values()`/`clear()`.
+    """
+
+    def __init__(self, error):
+        super().__init__()
+        self.error = error
+
+    def __getitem__(self, key):
+        raise self.error
+
+
+def test_recv_all_restores_packets_when_deadline_construction_fails(monkeypatch):
+    """The protected interval starts at the inbox clear, not at the loop: a
+    failure while building the initial deadline must still restore packets."""
+    exchange, pull, clock = _wired_exchange(monkeypatch)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+    sentinel = _SentinelError("clock unavailable")
+    monkeypatch.setattr(shard_transport_zmq, "time", _ExplodingClock(sentinel))
+
+    with pytest.raises(_SentinelError) as excinfo:
+        exchange.recv_all(_OWN)
+
+    assert excinfo.value is sentinel  # identical object, unwrapped
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2]
+    exchange.close()
+
+
+def test_recv_all_restores_packets_when_pull_lookup_fails(monkeypatch):
+    """A `_pulls[target]` lookup failure occurs after extraction but before the
+    loop; the packets must still come back in order."""
+    exchange, pull, clock = _wired_exchange(monkeypatch)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+    sentinel = _SentinelError("pull socket missing")
+    exchange._pulls = _RaisingPulls(sentinel)
+
+    with pytest.raises(_SentinelError) as excinfo:
+        exchange.recv_all(_OWN)
+
+    assert excinfo.value is sentinel  # identical object, unwrapped
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2]
+    exchange.close()
+
+
 def test_recv_all_restores_local_and_decoded_packets_on_timeout(monkeypatch):
     """Regression: a timeout must hand back the local packets AND every wire
     packet already decoded during the same call."""

--- a/tests/test_shard_transport_zmq.py
+++ b/tests/test_shard_transport_zmq.py
@@ -12,6 +12,7 @@ Two scopes:
 
 from __future__ import annotations
 
+import itertools
 import pickle
 import subprocess
 import sys
@@ -27,13 +28,15 @@ try:
 except ImportError:
     pytest.skip("pyzmq not installed", allow_module_level=True)
 
+import scripts.shard_transport_zmq as shard_transport_zmq
 from scripts.shard_protocol import (
+    HaloPacket,
     StepCoordinator,
     assemble_lattice,
     run_sharded_step,
     split_lattice,
 )
-from scripts.shard_transport_zmq import ZMQHaloExchange
+from scripts.shard_transport_zmq import PACKETS_PER_SHARD_PER_STEP, ZMQHaloExchange
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -259,3 +262,292 @@ def test_zmq_two_process_halo_exchange_equals_monolithic(tmp_path):
 
     np.testing.assert_array_equal(zmq_state, mono_state)
     np.testing.assert_array_equal(zmq_memory, mono_memory)
+
+
+# -- recv_all failure atomicity ----------------------------------------------
+#
+# `recv_all` extracts the local inbox and clears it before the barrier count is
+# reached, so an exceptional exit past that point used to drop every packet held
+# in hand. PUSH/PULL delivers each frame exactly once, so those packets are never
+# re-sent. These tests drive the GENUINE `recv_all` implementation; only the
+# socket and the clock are faked — no real TCP port, subprocess, sleep, network,
+# engine, GPU work or repository data is involved.
+
+_OWN = (0, 0, 0)
+_INPROC_SEQ = itertools.count()
+
+
+class _FakePull:
+    """Stands in for the bound PULL socket.
+
+    `script` is replayed one entry per `recv()`: `bytes` are returned as a wire
+    frame, a `BaseException` instance is raised. Once exhausted, `recv()` raises
+    `zmq.Again` — the same signal a real socket gives when `RCVTIMEO` expires.
+    """
+
+    def __init__(self, script=(), on_exhausted=None, observe=None):
+        self.script = list(script)
+        self.on_exhausted = on_exhausted
+        self.observe = observe
+        self.opts = {}
+        self.recv_calls = 0
+
+    def setsockopt(self, opt, value):
+        self.opts[opt] = value
+
+    def recv(self):
+        self.recv_calls += 1
+        if self.observe is not None:
+            self.observe()
+        if not self.script:
+            if self.on_exhausted is not None:
+                self.on_exhausted()
+            raise zmq.Again()
+        item = self.script.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    def close(self, linger=None):
+        pass
+
+
+class _FakeClock:
+    """Deterministic stand-in for the module's `time`; never sleeps."""
+
+    def __init__(self, start=1_000.0):
+        self.t = start
+
+    def monotonic(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+def _packet(generation, target=_OWN):
+    """A real `HaloPacket`, tagged by `generation` so it stays identifiable."""
+    return HaloPacket(
+        source_coord=(9, 9, 9),
+        target_coord=target,
+        direction=(1, 0, 0),
+        generation=generation,
+        state_slab=np.full((1, 1, 1), generation % 256, dtype=np.uint8),
+        memory_slab=np.full((1, 1, 1, 1), float(generation), dtype=np.float32),
+    )
+
+
+def _gens(packets):
+    return [p.generation for p in packets]
+
+
+def _wired_exchange(monkeypatch, script=(), timeout_ms=10_000):
+    """A real `ZMQHaloExchange` whose PULL socket and clock are faked."""
+    endpoint = f"inproc://recv-atomicity-{next(_INPROC_SEQ)}"
+    exchange = ZMQHaloExchange(
+        own_coords={_OWN},
+        endpoints={_OWN: endpoint},
+        recv_timeout_ms=timeout_ms,
+    )
+    exchange._pulls[_OWN].close(linger=0)  # release the genuinely bound socket
+    pull = _FakePull(script)
+    exchange._pulls[_OWN] = pull
+    clock = _FakeClock()
+    monkeypatch.setattr(shard_transport_zmq, "time", clock)
+    return exchange, pull, clock
+
+
+def test_recv_all_restores_local_and_decoded_packets_on_timeout(monkeypatch):
+    """Regression: a timeout must hand back the local packets AND every wire
+    packet already decoded during the same call."""
+    wire = [_packet(100).to_bytes(), _packet(101).to_bytes()]
+    exchange, pull, clock = _wired_exchange(monkeypatch, wire, timeout_ms=1_000)
+    pull.on_exhausted = lambda: clock.advance(2.0)  # blow past the deadline
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(TimeoutError, match="5/26 packets received"):
+        exchange.recv_all(_OWN)
+
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2, 100, 101]
+    exchange.close()
+
+
+def test_recv_all_timeout_then_retry_completes_the_barrier(monkeypatch):
+    """Regression: after a timeout, a retry supplied with only the genuine
+    remaining packets can still satisfy the per-step barrier."""
+    exchange, pull, clock = _wired_exchange(
+        monkeypatch, [_packet(100).to_bytes(), _packet(101).to_bytes()], timeout_ms=1_000
+    )
+    pull.on_exhausted = lambda: clock.advance(2.0)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(TimeoutError):
+        exchange.recv_all(_OWN)
+
+    # The peer now delivers only what it still owed — nothing is re-sent.
+    remaining = PACKETS_PER_SHARD_PER_STEP - 5
+    pull.script = [_packet(200 + i).to_bytes() for i in range(remaining)]
+    pull.on_exhausted = None
+    clock.t = 1_000.0
+
+    out = exchange.recv_all(_OWN)
+
+    assert len(out) == PACKETS_PER_SHARD_PER_STEP
+    assert _gens(out) == [0, 1, 2, 100, 101] + [200 + i for i in range(remaining)]
+    assert exchange._local_inbox[_OWN] == []
+    exchange.close()
+
+
+def test_recv_all_retry_returns_each_packet_exactly_once(monkeypatch):
+    """No retained or newly received packet may be duplicated by the retry."""
+    exchange, pull, clock = _wired_exchange(
+        monkeypatch, [_packet(100).to_bytes()], timeout_ms=1_000
+    )
+    pull.on_exhausted = lambda: clock.advance(2.0)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(TimeoutError):
+        exchange.recv_all(_OWN)
+
+    remaining = PACKETS_PER_SHARD_PER_STEP - 4
+    pull.script = [_packet(200 + i).to_bytes() for i in range(remaining)]
+    pull.on_exhausted = None
+    clock.t = 1_000.0
+
+    out = exchange.recv_all(_OWN)
+
+    seen = _gens(out)
+    assert len(seen) == len(set(seen)) == PACKETS_PER_SHARD_PER_STEP
+    assert exchange._local_inbox[_OWN] == []
+    exchange.close()
+
+
+def test_recv_all_malformed_frame_restores_valid_packets_only(monkeypatch):
+    """A `HaloPacket.from_bytes()` refusal propagates unchanged, prior valid
+    packets come back, and the malformed raw frame is NOT restored."""
+    bad_frame = b"nope"  # shorter than the fixed header
+    exchange, pull, clock = _wired_exchange(
+        monkeypatch, [_packet(100).to_bytes(), bad_frame, _packet(101).to_bytes()]
+    )
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(ValueError, match="frame shorter than the fixed header"):
+        exchange.recv_all(_OWN)
+
+    retained = exchange._local_inbox[_OWN]
+    assert _gens(retained) == [0, 1, 2, 100]
+    assert all(isinstance(p, HaloPacket) for p in retained)
+    assert bad_frame not in retained  # the refused frame is discarded, not replayed
+    exchange.close()
+
+
+def test_recv_all_socket_failure_restores_valid_packets(monkeypatch):
+    """A non-`zmq.Again` ZMQ error propagates unchanged and prior valid packets
+    are restored."""
+    failure = zmq.ZMQError(zmq.ETERM)
+    assert not isinstance(failure, zmq.Again)
+    exchange, pull, clock = _wired_exchange(
+        monkeypatch, [_packet(100).to_bytes(), failure]
+    )
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(zmq.ZMQError) as excinfo:
+        exchange.recv_all(_OWN)
+
+    assert excinfo.value is failure  # class, message and traceback untouched
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2, 100]
+    exchange.close()
+
+
+def test_recv_all_restored_packets_precede_concurrent_self_loop_arrivals(monkeypatch):
+    """Restored original-local packets precede restored decoded-wire packets,
+    which precede self-loop packets that landed in the replacement inbox while
+    the failed call was in progress."""
+    exchange, pull, clock = _wired_exchange(
+        monkeypatch, [_packet(100).to_bytes()], timeout_ms=1_000
+    )
+
+    def _arrive_then_expire():
+        # A self-loop send lands in the replacement inbox mid-call.
+        exchange.send(_packet(300))
+        clock.advance(2.0)
+
+    pull.on_exhausted = _arrive_then_expire
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(TimeoutError):
+        exchange.recv_all(_OWN)
+
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2, 100, 300]
+    exchange.close()
+
+
+def test_recv_all_again_continues_without_premature_restoration(monkeypatch):
+    """`zmq.Again` stays an internal retry: the loop continues and nothing is
+    handed back to the inbox while it is still running."""
+    wire = [zmq.Again(), zmq.Again()] + [
+        _packet(100 + i).to_bytes() for i in range(PACKETS_PER_SHARD_PER_STEP - 3)
+    ]
+    exchange, pull, clock = _wired_exchange(monkeypatch, wire)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    sizes = []
+    pull.observe = lambda: sizes.append(len(exchange._local_inbox[_OWN]))
+
+    out = exchange.recv_all(_OWN)
+
+    assert len(out) == PACKETS_PER_SHARD_PER_STEP
+    assert sizes and all(size == 0 for size in sizes)  # never restored mid-loop
+    assert exchange._local_inbox[_OWN] == []
+    exchange.close()
+
+
+def test_recv_all_success_preserves_order_and_drains_inbox(monkeypatch):
+    """The established success path is unchanged: local packets first, then wire
+    packets in arrival order, and the inbox is left drained."""
+    wire = [_packet(100 + i).to_bytes() for i in range(PACKETS_PER_SHARD_PER_STEP - 3)]
+    exchange, pull, clock = _wired_exchange(monkeypatch, wire)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    out = exchange.recv_all(_OWN)
+
+    assert len(out) == PACKETS_PER_SHARD_PER_STEP
+    assert _gens(out) == [0, 1, 2] + [
+        100 + i for i in range(PACKETS_PER_SHARD_PER_STEP - 3)
+    ]
+    assert exchange._local_inbox[_OWN] == []
+    exchange.close()
+
+
+def test_recv_all_closed_exchange_leaves_inbox_untouched(monkeypatch):
+    """The closed-exchange guard fires before extraction, so nothing moves."""
+    exchange, pull, clock = _wired_exchange(monkeypatch)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+    exchange.close()
+
+    with pytest.raises(RuntimeError, match="is closed"):
+        exchange.recv_all(_OWN)
+
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2]
+
+
+def test_recv_all_non_owned_target_leaves_inbox_untouched(monkeypatch):
+    """The non-owned guard fires before extraction, so nothing moves."""
+    exchange, pull, clock = _wired_exchange(monkeypatch)
+    for gen in (0, 1, 2):
+        exchange.send(_packet(gen))
+
+    with pytest.raises(ValueError, match="non-owned"):
+        exchange.recv_all((1, 0, 0))
+
+    assert _gens(exchange._local_inbox[_OWN]) == [0, 1, 2]
+    exchange.close()


### PR DESCRIPTION
## The pre-fix packet-loss seam

`ZMQHaloExchange.recv_all()` transferred packet ownership on these two lines, before the barrier count was reached:

```python
packets = list(self._local_inbox[target])
self._local_inbox[target] = []
```

From that point the local packets — and every packet subsequently decoded off the wire — existed **only** in the local variable `packets`, which is destroyed when the call exits exceptionally. Nothing restored them, and the exchange was never poisoned (`_closed` stayed `False`), so it continued to present itself as reusable while having silently discarded state.

Because PUSH/PULL delivers each frame exactly once, a discarded wire packet is never re-sent — so after a failed call the per-step barrier is **permanently unsatisfiable**, even if the peer delivers everything it still owes.

## The protected ownership interval

The `try:` opens **immediately after the stored inbox is cleared**, so the protected interval spans everything from the ownership transfer to the return:

| Stage inside the protected interval | Failure that can arise |
|---|---|
| `_pulls[target]` lookup | registry / lookup failure |
| Initial deadline construction | `time.monotonic()` failure |
| Timeout handling | `TimeoutError` on deadline expiry |
| Socket operations | non-`zmq.Again` `zmq.ZMQError` |
| Packet decoding | `HaloPacket.from_bytes()` `ValueError` |

Every one of these restores all previously valid packets. A cleanup-only `except BaseException` prepends the in-hand packets back onto `_local_inbox[target]` and re-raises bare.

## The lock boundary (P2 fix, `ca7e96f`)

Both local-inbox handovers replace the stored list wholesale, so each is a read/compute/store sequence rather than an atomic operation:

```python
packets = list(self._local_inbox[target]); self._local_inbox[target] = []   # extraction
self._local_inbox[target] = packets + self._local_inbox[target]             # restoration
```

A self-loop `send()` appending from another thread **between the read and the store** was silently discarded by the store — at extraction the packet vanished outright, at restoration it was overwritten by the concatenated replacement. Both contradicted this branch's retention guarantee and could leave a retry permanently short of its barrier count.

`_inbox_lock` (a stdlib `threading.Lock`) is now taken around exactly the three sites where the local inbox transitions:

| Site | Critical section |
|---|---|
| `send()` self-loop | the `append` |
| `recv_all()` start | `list(...)` copy **and** the `= []` clear, together |
| `recv_all()` cleanup | the read, concatenate **and** store, together |

Those are the only places the local inbox changes. Each section is a bounded list handover. **The lock is released before the gather loop and is never held across a ZMQ call, a frame decode or the receive deadline**, so a blocked receive cannot stall a self-loop sender. The bare `raise` stays outside the critical section, leaving exception class, message, traceback and identity untouched.

Why neither window can now lose a packet: a racing append either completes **before** the handover's read — in which case it is included and, at restoration, ordered after the restored packets — or it blocks until the handover's store has completed and then appends to the new list. There is no interleaving in which it lands in a list that is about to be discarded.

`threading` is stdlib, so no dependency was added, and no production hook exists solely for testing.

Guarantees:

- **Ordering** — restored packets are prepended, so original-local packets precede restored decoded-wire packets, which precede any self-loop packet that arrived during the call.
- **No duplication** — packets are moved, never copied.
- **Exception preservation** — `raise` is bare; the tests assert the propagated exception is the *identical object*.
- **`zmq.Again`** — remains an internal retry; never triggers restoration.
- **Success path** — unchanged returned ordering and unchanged inbox drain.

**Malformed raw frames remain discarded.** A frame the decoder refused is not restored or replayed.

## File boundary

Exactly two files. Cumulative against current base `main` @ `4b84955`: **+542 / −20** — unchanged by the synchronization merge.

| File | + | − |
|---|---|---|
| `scripts/shard_transport_zmq.py` | 83 | 19 |
| `tests/test_shard_transport_zmq.py` | 459 | 1 |

The production change is confined to `recv_all()`, the self-loop branch of `send()`, and the lock's construction. No other method, file, dependency or workflow is touched.

## Commits

| SHA | Message |
|---|---|
| `5652542` | fix(shard-transport): retain partial receive state on failure |
| `657f212` | fix(shard-transport): protect the full receive ownership interval |
| `ca7e96f` | fix(shard-transport): serialize local-inbox handovers with self-loop sends |
| `2c54149` | Merge branch 'main' into fix/zmq-recv-all-failure-atomicity *(synchronization only)* |

No commit was amended, rebased or force-pushed; each is an ordinary fast-forward on the last.

`2c54149` is a synchronization-only merge of `main` @ `4b849554decc2968217dc47746787d0db1c4c73d`, made to satisfy branch protection's `required_status_checks.strict`. Its parents are `ca7e96f` and `4b84955`. It was fully automatic and conflict-free, and it changed **neither** authorized file — both blobs are byte-identical to `ca7e96f` (`d3dd3854…` and `3f0ead8e…`), and the PR diff against current `main` is still exactly the same two files at +542/−20.

## Tests actually run, and their exact results

**On the Ian seat:**

| Command | Result |
|---|---|
| `python -m py_compile scripts/shard_transport_zmq.py tests/test_shard_transport_zmq.py` | **exit 0** |
| `git diff --check` | **clean** |
| `python -m pytest tests/test_shard_transport_zmq.py -q` | **NOT RUN** — `ModuleNotFoundError: No module named 'pytest'` (also `numpy`, `zmq`); installing is unauthorized |
| `python -m pytest tests/test_shard_protocol.py tests/test_shard_transport_zmq.py -q` | **NOT RUN** — same reason |

No passing substitute was manufactured. CI is the only execution of the pytest file.

**CI at synchronized head `2c54149` — every check passes.** The authoritative `verify-python` job is the `pull_request`-event one, [run 30740569022 / job 91477121664](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/30740569022/job/91477121664). Its exact terminal pytest line:

```
3001 passed, 13 skipped in 41.87s
```

| Workflow / job | Conclusion |
|---|---|
| `CI / verify-python` (pull_request) | **success** |
| `CI / verify-python` (push) | **success** — `3001 passed, 13 skipped in 47.30s` |
| `CI / frontend-quality` (both events) | success |
| `Agent Safety Suite / agent-safety` | success |
| `CodeQL (Python baseline) / Analyze Python` | success |
| `CodeQL` | success |

Both events now report the same total, because after the synchronization merge the branch already contains current `main`, so the merge ref and the branch are equivalent. Against `main` @ `4b84955` = 2988, the delta is **+13**: 2988 + 13 = 3001.

(Before synchronization the two events differed — `2947` for the branch alone based on `eb853c5` = 2934 + 13, and `3001` for the merge ref — which confirmed the same +13 delta from both directions.)

**This package adds 13 tests** (17 total in the file, 4 pre-existing).

Genuine-concurrency coverage added in `ca7e96f`:

1. `test_concurrent_self_loop_send_survives_inbox_extraction` — a real thread races a self-loop `send()` against the extraction/clear.
2. `test_concurrent_self_loop_send_survives_exceptional_restoration` — a real thread races a self-loop `send()` against the exceptional restoration, and restored packets must still precede it.

Both use actual threads coordinated by `threading.Event`, not sleeps or probabilistic scheduling. They substitute only the inbox mapping — an existing dependency boundary — so the production `recv_all` under test is the genuine implementation, not a rewrite. These **replace** the former `test_recv_all_restored_packets_precede_concurrent_self_loop_arrivals`, which called `send()` synchronously from a fake-socket callback and therefore never exercised concurrency at all; its ordering assertion is preserved by test 2.

> One deliberate detail: at the store point each test waits on a **bounded** event. An unbounded wait would deadlock by construction once the handover is serialized, because the racing `send()` is blocked on the very lock the handover holds. Expiry is the expected, correct outcome; a prompt return means the append was *not* serialized.

Ownership-interval coverage added in `657f212`:

3. `test_recv_all_restores_packets_when_deadline_construction_fails`
4. `test_recv_all_restores_packets_when_pull_lookup_fails`

Added in `5652542`:

5. `test_recv_all_restores_local_and_decoded_packets_on_timeout`
6. `test_recv_all_timeout_then_retry_completes_the_barrier`
7. `test_recv_all_retry_returns_each_packet_exactly_once`
8. `test_recv_all_malformed_frame_restores_valid_packets_only`
9. `test_recv_all_socket_failure_restores_valid_packets`
10. `test_recv_all_again_continues_without_premature_restoration`
11. `test_recv_all_success_preserves_order_and_drains_inbox`
12. `test_recv_all_closed_exchange_leaves_inbox_untouched`
13. `test_recv_all_non_owned_target_leaves_inbox_untouched`

All timeout, decoder, socket-error, retry, ordering, guard and success-path coverage is retained. Tests use the real `HaloPacket` representation and the real `from_bytes` refusal. No real TCP port, subprocess, sleep, network access, engine execution, GPU work or repository data is used.

> **Erratum (retained).** The commit message on `5652542` says "11 focused in-process tests". The correct count for that commit is **10**. Correcting a commit message requires an amend and force-push, which is not authorized, so the message is left as-is and the error is recorded here.

**Supporting evidence only — not a pytest replacement.** A direct harness, kept outside the repository and since deleted, loaded the genuine `scripts/shard_transport_zmq.py` and drove the real `recv_all()` with stubs at the `zmq` and `scripts.shard_protocol` boundaries. Against the production file as it stood at prior head `657f212`, the racing packet was **lost** in window 1 (`remaining=[]`) and **overwritten** in window 2 (`inbox=[0, 1, 2, 100]` — the racing packet absent), while all earlier behaviours passed; against `ca7e96f` window 1 gave `remaining=[300]`, window 2 gave `inbox=[0, 1, 2, 100, 300]`, and every regression check passed.

## Explicit non-claims

- **Broader thread-safety is not claimed.** The PULL/PUSH sockets, `close()` and the rest of the object lifecycle remain unsynchronized, and concurrent `recv_all()` calls for the same target are unsupported. The lock's scope is the local inbox alone.
- Malformed raw frames are still discarded — no quarantine, no replay.
- A **second** failure during restoration itself (e.g. an allocation failure) is not claimed to be handled.
- **Generation validation and stale-generation detection are unchanged.** `HaloPacket` carries `generation`, but `apply_halos()` never reads it and `from_bytes()` explicitly declines to validate it. Any retry policy built on this retention needs its own generation guard — a separate package.
- **Caller retry policy is unchanged.** No production caller retries today; `run_sharded_step()` calls `apply_halos()` bare. This closes a latent contract violation and is **not** a production incident report.
- Over-delivery when the local inbox already exceeds the barrier count is unchanged.
- `RCVTIMEO` persistence on the shared socket, exchange poisoning, `barrier()`, socket construction, `HaloPacket`, `StepCoordinator`, `run_sharded_step` and every other transport or protocol backend are untouched and unclaimed.

## Status

Ian-seat work, **open, ready for review and unmerged**, at synchronized head `2c54149`, for one final independent audit. Not rebased, not amended, not force-pushed; no administrator bypass was used and auto-merge is not enabled.

Branch protection on `main` has `required_status_checks.strict: true`, so the branch had to be up to date before merging. That is now satisfied: `main` @ `4b849554decc2968217dc47746787d0db1c4c73d` was merged in as the ordinary, conflict-free merge commit `2c54149`, and GitHub reports **`mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`**. `main` had not touched either authorized file since the PR base, so the synchronization was purely mechanical and left the package diff untouched.

