### PR TITLE
policy(agent-safety): pin the #157 whole-payload recognition boundary

### DIFF
--- a/policy/agent_safety.rego
+++ b/policy/agent_safety.rego
@@ -56,11 +56,32 @@ is_encoded_payload(payload) {
 }
 
 # Base64 detection: 8+ total chars, alphanumeric + / + = optional padding.
-# Length floor of 8 rejects short alphanumeric strings like "test123" that
-# happen to match the base64 alphabet but aren't actually encoded content.
-# 8 is the smallest meaningful base64 output length (encodes 4-6 raw bytes
-# with padding), so this floor preserves detection of genuine short base64
-# while eliminating the false-positive class of plain words and identifiers.
+# Length floor of 8 rejects SHORT alphanumeric strings like "test123" (7
+# chars) that happen to match the base64 alphabet but aren't actually
+# encoded content. 8 is the smallest meaningful base64 output length
+# (encodes 4-6 raw bytes with padding), so this floor preserves detection of
+# genuine short base64.
+#
+# RECOGNITION BOUNDARY (issue #157, matrix-verified). The floor bounds the
+# false-positive surface by LENGTH ONLY. It does NOT eliminate plain words
+# and identifiers: any whole payload of 8+ characters drawn entirely from
+# [A-Za-z0-9+/] still matches. "password", "december", "baseline",
+# "deadbeefdeadbeef" (hex hash), "usr/local/bin" (path) and "abc123def456ghi"
+# are all classified as base64-like today. This over-inclusiveness is
+# retained deliberately, not overlooked:
+#
+#   - Detection means DENIAL, so the failure direction is fail-closed. A
+#     false positive costs availability; a false negative admits obfuscated
+#     content. Narrowing the matcher trades safety for availability.
+#   - The rule is gated behind data.agent_limits.enforce_encoded_payload,
+#     which is not set anywhere in this repository (config/agent_limits.yaml
+#     has no such key), so detection is off in every current configuration.
+#
+# Narrowing this surface (entropy, decode-and-verify, dictionary rejection)
+# is therefore a SEPARATE decision requiring its own threat model and
+# recorded rationale — it is not made here. The boundary above is pinned by
+# characterization tests in agent_safety_test.rego so any future narrowing
+# must update them deliberately.
 #
 # CONTRACT (issue #157): base64 detection is intentionally WHOLE-PAYLOAD —
 # the regex is anchored (^…$) on purpose. A base64-form token embedded

--- a/policy/agent_safety_test.rego
+++ b/policy/agent_safety_test.rego
@@ -116,6 +116,129 @@ test_encoded_payload_mixed_text_not_detected if {
 }
 
 # ---------------------------------------------------------------------------
+# Whole-payload contract — REJECTION boundary (issue #157)
+#
+# The cases below pin the anchoring itself. Each payload contains a
+# well-formed base64 token that an embedded/substring scanner WOULD flag;
+# under the whole-payload contract none of them is an encoded payload. They
+# are what makes the contract executable rather than merely commented: an
+# unanchored regex, a tokenizer, or an entropy scan added to is_base64_like
+# would turn every one of these red.
+# ---------------------------------------------------------------------------
+
+# Command-like content wrapped in ordinary words — the obfuscation shape the
+# issue raised. Deliberately NOT detected: the token is embedded, not whole.
+test_encoded_payload_embedded_command_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "run dGVzdGluZw== now"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Trailing punctuation breaks the whole-payload match ($ anchor).
+test_encoded_payload_trailing_punctuation_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "SGVsbG8gV29ybGQ=."} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Surrounding brackets break the whole-payload match (^ and $ anchors).
+test_encoded_payload_bracketed_token_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "(SGVsbG8gV29ybGQ=)"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Non-ASCII text around an ASCII base64 token still fails the anchors; the
+# regex is byte/rune-agnostic here because the anchors do the work.
+test_encoded_payload_unicode_surrounded_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "héllo SGVsbG8gV29ybGQ= wörld"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# ---------------------------------------------------------------------------
+# Whole-payload contract — MALFORMED candidates (issue #157)
+#
+# '=' is not a member of the character class, so padding is only ever legal
+# as the 0-2 trailing characters. These pin that padding placement is not
+# merely conventional but structurally enforced.
+# ---------------------------------------------------------------------------
+
+# Padding in an interior position: the leading run is too short to satisfy {4,}.
+test_encoded_payload_interior_padding_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "dGV=zdA="} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Leading padding: '^' requires the alphabet run to start the payload.
+test_encoded_payload_leading_padding_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "=dGVzdA="} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Three padding characters exceed the {0,2} bound.
+test_encoded_payload_triple_padding_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "dGVzdA==="} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Padding with no alphabet run at all.
+test_encoded_payload_padding_only_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "===="} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# Interior whitespace breaks the run.
+test_encoded_payload_internal_space_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "dGVzd A=="} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# ---------------------------------------------------------------------------
+# Length floor — the boundary is exactly 8 (issue #157)
+# ---------------------------------------------------------------------------
+
+# 4 chars: matches the regex but is below the count floor.
+test_encoded_payload_four_char_token_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "abcd"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# ---------------------------------------------------------------------------
+# CHARACTERIZATION — the retained over-inclusive surface (issue #157)
+#
+# These assert what the policy DOES today, not what is ideal. The length
+# floor bounds the false-positive surface by length only, so any whole
+# payload of 8+ characters drawn entirely from [A-Za-z0-9+/] is classified
+# base64-like — including ordinary words, hex hashes and slash-separated
+# paths. That is retained deliberately: detection means denial, so the bias
+# is fail-closed, and the rule is gated behind a flag that is not set
+# anywhere in this repository.
+#
+# They are NOT an endorsement. If a future decision narrows the matcher
+# (entropy, decode-and-verify, dictionary rejection), these tests must be
+# updated deliberately — which is the point of pinning them.
+# ---------------------------------------------------------------------------
+
+# An ordinary 8-letter English word is currently classified base64-like.
+test_encoded_payload_plain_word_is_currently_detected if {
+	safety.encoded_payload_detected with input as {"payload": "password"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# A hex digest is currently classified base64-like.
+test_encoded_payload_hex_hash_is_currently_detected if {
+	safety.encoded_payload_detected with input as {"payload": "deadbeefdeadbeef"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# '/' is a base64 alphabet member, so a bare path is currently classified
+# base64-like.
+test_encoded_payload_path_segment_is_currently_detected if {
+	safety.encoded_payload_detected with input as {"payload": "usr/local/bin"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# A hyphen is NOT in the alphabet, so slugs are not classified — this is the
+# other side of the same boundary.
+test_encoded_payload_hyphenated_slug_not_detected if {
+	not safety.encoded_payload_detected with input as {"payload": "my-blog-post-title"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# ---------------------------------------------------------------------------
+# URL-encoding boundary — lowercase hex digits (issue #157 matrix gap)
+# ---------------------------------------------------------------------------
+
+# The %XX class accepts lowercase hex; pins that the detector is not
+# uppercase-only and remains unanchored.
+test_encoded_payload_url_lowercase_hex if {
+	safety.encoded_payload_detected with input as {"payload": "a%2fb"} with data.agent_limits.enforce_encoded_payload as true
+}
+
+# ---------------------------------------------------------------------------
 # encoded_payload_detected isolated tests — flag disabled
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Issue #157's original ambiguity

[#157](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/issues/157) asked whether `agent.safety` should detect base64 **embedded** inside ordinary text. It surfaced from PR #156, when `test_encoded_payload_mixed_content` was found asserting behaviour the policy does not implement: `is_base64_like` uses an anchored whole-payload regex (`^[A-Za-z0-9+/]{4,}={0,2}$` plus a `count(payload) >= 8` floor) and so cannot match an embedded token. The issue framed the trade-off (obfuscation coverage vs. false positives) and asked for a decision.

**Important context, stated up front: the embedded-vs-whole-payload decision was already made.** PR #313 (merged `307868d`, 2026-07-11) locked the whole-payload contract, added the `CONTRACT (issue #157)` comment to `is_base64_like`, and added two mixed-text regressions — deliberately without closing #157. This PR does **not** reopen that decision. It completes the lock, and corrects a claim in the policy that the code does not deliver.

## Selected contract

**Option 2 — whole-payload detection only. Confirmed, and left unnarrowed.**

Evidence for confirming rather than revisiting:

- **Failure direction is fail-closed.** `encoded_payload_detected` feeds `not encoded_payload_detected` in `allow`, so detection means *denial*. A false positive costs availability; a false negative admits obfuscated content. Adding an embedded scanner would raise detection (safer, noisier); narrowing the existing matcher would lower it (quieter, less safe). Neither is free.
- **The rule is inert today.** Detection is gated behind `data.agent_limits.enforce_encoded_payload == true`. That key exists **nowhere in this repository** — `config/agent_limits.yaml` has no such field, and nothing loads it into OPA. A repo-wide search found **no runtime caller** that evaluates `agent.safety`; the policy is exercised only by the Agent Safety CI job (`opa fmt`, `opa check`, `opa test`). `AGENT_HANDOFF.md` corroborates this independently: the only policy-evaluating CLI ever proposed (PR #15) was a mock returning hardcoded `allow: True`, never landed, and was closed unmerged.
- **The issue's own criterion.** #157 says "If no: close this issue". #313 answered "no". What was missing was not another decision but an executable boundary.

## Alternatives considered and rejected

| Alternative | Why rejected |
|---|---|
| **Add embedded/substring base64 scanning** (option 1) | Already rejected by #313 on false-positive grounds; nothing since has changed that evidence. Re-deciding it here would be scope creep against a locked contract. |
| **Narrow the whole-payload matcher** (entropy, decode-and-verify, dictionary rejection) to remove the plain-word false positives | This *reduces* detection on a fail-closed rule — a safety-for-availability trade — and the rule is currently inert, so there is no live false-positive pain motivating it. It deserves its own threat model and recorded decision, exactly as the existing contract comment demands. Explicitly deferred, not silently skipped. |
| **Do nothing / close #157 on the strength of #313** | Would leave 27 of 41 matrix cases unpinned and leave a factually wrong claim in the policy comment. |

## Threat model

`encoded_payload_detected` exists to refuse payloads that look like encoded content when an operator turns enforcement on. Detection → denial, so:

- **False positive → over-denial.** Availability cost, no safety cost.
- **False negative → obfuscated payload admitted.** Safety cost.

The detector is therefore deliberately biased toward over-inclusion. Whole-payload anchoring is the *scope* limit (what counts as a candidate at all); the alphabet + length floor is the *shape* limit. Embedded scanning was rejected because scanning arbitrary prose multiplies the candidate surface without a caller that needs it.

## Exact recognition and rejection boundaries

`is_base64_like(payload)` is true iff **both**:

1. `^[A-Za-z0-9+/]{4,}={0,2}$` matches — the whole payload is an alphabet run of ≥4 chars followed by 0–2 trailing `=`; and
2. `count(payload) >= 8`.

`=` is **not** a member of the character class, so padding is structurally legal only in the final 0–2 positions. `is_url_encoded` (`%[0-9A-Fa-f]{2}`) is deliberately **unanchored** and case-insensitive in the hex digits; `is_data_uri` is prefix-based (`startswith "data:"`). None of that changed here.

## False-positive analysis — the correction in this PR

The comment on `is_base64_like` claimed the 8-char floor eliminated "the false-positive class of plain words and identifiers". **It does not.** The floor bounds the surface by **length only**. Any whole payload of ≥8 characters drawn entirely from `[A-Za-z0-9+/]` still matches:

| Payload | Detected today | Why |
|---|---|---|
| `password` | ✅ base64-like | 8 letters, all in alphabet |
| `december` | ✅ base64-like | 8 letters |
| `baseline` | ✅ base64-like | 8 letters |
| `deadbeefdeadbeef` | ✅ base64-like | hex digest, all in alphabet |
| `usr/local/bin` | ✅ base64-like | `/` **is** an alphabet member |
| `abc123def456ghi` | ✅ base64-like | alphanumeric run |
| `my-blog-post-title` | ❌ | `-` is **not** in the alphabet |

The policy comment now records this honestly, marks the over-inclusiveness as retained-by-design (fail-closed + inert), and states that narrowing requires its own recorded decision.

## Evaluation matrix summary

41 representative cases across the categories #157 called for. Evaluated against the detector semantics as written at base `ad735be2`.

| Category | Result |
|---|---|
| Padded whole-payload base64 (`SGVsbG8gV29ybGQ=`, `dGVzdA==`, `dGVzdHM=`) | detected ✅ |
| Unpadded whole-payload (`dGVzdGluZw`) | detected ✅ |
| Short tokens (`abc`, `abcd`, `test123`) | not detected — below floor |
| Embedded command-like (`run dGVzdGluZw== now`) | not detected — contract |
| Prose + base64 token (`Hello SGVsbG8gV29ybGQ= World`) | not detected — contract |
| Identifiers / plain words (`password`, `december`, `baseline`, `myVariableName`) | **detected** — over-inclusive |
| Hex digests | **detected** — over-inclusive |
| Path segments (`usr/local/bin`, `src/main/java`) | **detected** — `/` in alphabet |
| URL slugs (`my-blog-post-title`, `release/v1.2.3`) | not detected — `-`/`.` outside alphabet |
| Alphabet-only (`abcdefgh`, `ABCDEFGHIJ`) | **detected** — over-inclusive |
| Invalid padding (`dGV=zdA=`, `=dGVzdA=`, `====`, `dGVzdA===`) | not detected ✅ |
| Token boundaries (`SGVsbG8gV29ybGQ=.`, `(…)`, `SGVsbG8=,`) | not detected — anchors |
| Non-ASCII surroundings | not detected — anchors |
| URL-encoded (incl. embedded, lowercase hex) | detected ✅ |
| Data URIs | detected ✅ |
| Empty / whitespace / prose / JSON | not detected ✅ |

**11 cases contradict naive expectation** (all in the over-inclusive class above). **27 of 41 had no test at base.**

## Contract-gap evidence

The gap this PR closes is not a failing assertion — it is *absence*. At base `ad735be2`:

- **27 of 41** matrix cases had no test at all: every malformed-padding case, every token-boundary case, every non-ASCII case, the entire over-inclusive class, and the lowercase-hex URL case.
- The policy comment asserted a false-positive property (**plain words and identifiers eliminated**) that the code does not have.

**Discrimination proof.** Re-evaluating all 29 assertions against a hypothetical *embedded* scanner (unanchored `[A-Za-z0-9+/]{8,}={0,2}`, i.e. the rejected option 1) flips **7** of them. Four are newly added here — `embedded_command_not_detected`, `trailing_punctuation_not_detected`, `bracketed_token_not_detected`, `unicode_surrounded_not_detected` — so the new tests genuinely pin the whole-payload contract rather than restating the implementation. Before this PR only `mixed_text_not_detected` discriminated (plus two positives that flip for an unrelated reason, the hypothetical's `{8,}` run length).

## Validation

| Command | Result |
|---|---|
| `git diff --check` | **clean** |
| Exact changed-file verification | **2 files**, both authorized |
| `opa fmt policy/ --diff` | **NOT RUN** — `opa: command not found` |
| `opa check policy/` | **NOT RUN** — `opa: command not found` |
| `opa test -v --coverage policy/` | **NOT RUN** — `opa: command not found` |
| `scripts/matrix_runner.sh` | **not present in repo** (workflow skips it) |

OPA is not installed on this seat. The Agent Safety workflow installs a checksum-pinned OPA v0.59.0 in CI; that is not a documented local-dev install step, so nothing was installed here. **CI is the authoritative lane for every OPA assertion in this PR.**

*(A 39 MB `opa` binary is tracked at the repository root, but it is a **Linux ELF x86-64** executable and this seat is Windows, so it cannot run here. Its SHA-256 is `b52c1d58…`, which does **not** match the `5f615343…` trust anchor the workflow pins for `opa_linux_amd64_static` v0.59.0 — so it was not executed. Noted as an observation only; out of this PR's file boundary.)*

### Authoritative CI receipt — `agent-safety` job, synchronized head `219c6df`

[Run 30751914219 / job 91507327517](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/30751914219/job/91507327517) — **conclusion: success**. Every step succeeded under `set -euxo pipefail`:

| Step | Conclusion |
|---|---|
| Install OPA (checksum-verified v0.59.0) | success |
| `opa fmt policy/ --diff` + **`opa check policy/`** | success |
| **`opa test -v --coverage policy/`** | success |
| Run matrix (if present) | success — `scripts/matrix_runner.sh` absent, skipped |
| Upload artifacts | success |

**There is no `PASS: n/n` terminal line to quote**, and none is invented here: `opa test --coverage` replaces the pretty per-test listing with a JSON coverage report. The authoritative signal is the step's exit status — `opa test` returns non-zero if any test fails, and the step ran under `-e`, so success means every test passed. The report's terminal lines are:

```
  "covered_lines": 153,
  "not_covered_lines": 0,
  "coverage": 100
```

Test rules now executed by `opa test policy/`: **59** — 45 in `policy/agent_safety_test.rego` (30 before this PR + 15 added) plus 14 legacy inline rules in `policy/agent_safety.rego`.

### Other checks at synchronized head `219c6df`

| Workflow / job | Conclusion |
|---|---|
| `Agent Safety Suite / agent-safety` | **success** |
| `CI / verify-python` (pull_request + push) | success |
| `CI / frontend-quality` (pull_request + push) | success |

`Theory Tripwire / tripwire` passed at the pre-synchronization head `e21a593` and did **not** re-run here: it triggers only on `pull_request` types `opened`/`reopened`/`labeled`, not `synchronize`. It is by design never a blocking check and is not among the required contexts (`agent-safety`, `verify-python`, `frontend-quality`).

**Synchronization.** Merge commit `219c6df` merges `main` @ `c5d8adce16fbcfb57435b5a02e9ef943c8ddb662` (PR #445 — three `experiments/tech_ledger/` files) to satisfy branch protection's `required_status_checks.strict`. Parents are `e21a593` and `c5d8adc`. It was fully automatic and conflict-free and changed **neither** policy file — both blobs are byte-identical to `e21a593` (`545ba72b…`, `cd1bf65e…`), and the PR-relative diff is still exactly the same two files at +149/−5. `mergeStateStatus` is now **`CLEAN`**.

*Supporting evidence only, not a substitute for `opa test`:* a scratch harness (kept outside the repository and since deleted) modelled the three detector predicates exactly as written and produced the matrix above. Go RE2 vs Python `re` differ on `$`, so `\Z` was used to match Go's end-of-text semantics. It confirmed **15/15** new assertions and **14/14** pre-existing assertions against the current implementation, and produced the discrimination proof.

## Changed files

| File | + | − |
|---|---|---|
| `policy/agent_safety.rego` | 26 | 5 |
| `policy/agent_safety_test.rego` | 123 | 0 |
| **Total** | **149** | **5** |

`policy/agent_safety.rego` is **comment-only** — no rule logic changed. `policy/agent_safety_test.rego` is purely additive; no existing test was modified or removed.

## Explicit non-claims

- **No rule logic changed.** `is_base64_like`, `is_url_encoded`, `is_data_uri`, `encoded_payload_detected`, `allow`, `within_limits` and `ttl_guard` behave identically.
- **The over-inclusive surface is characterized, not endorsed and not fixed.** Four tests assert current behaviour so a future change is deliberate; they are not a claim that flagging `password` is correct.
- **No narrowing decision is made.** Entropy, decode-and-verify and dictionary rejection remain unimplemented and undecided.
- **No embedded/substring scanning** is added, and none is claimed to be unnecessary in general — only that it is unjustified *for this policy on current evidence*.
- **Not a claim that the policy is safe in production.** It has no runtime caller and the enforcement flag is unset; nothing here wires it up.
- Type coercion was not broadened; malformed padding is still rejected; URL-encoding and data-URI behaviour are untouched; no dependency added; no production hook added for testing.
- The matrix is representative, not exhaustive; it does not enumerate the full input space.
- `policy/agent_safety.rego` also contains legacy inline `test_*` rules in the `agent.safety` package (pre-dating #156's move to a separate test package). Noted, **not** touched — out of scope.

## Governance

`Refs #157` did not prevent automatic closure: an alternatives-table phrase elsewhere in this body was recognized by GitHub as an issue-closing keyword. Issue #157 remained open through Jack's independent pre-merge audit, then GitHub automatically closed it when this PR merged; the authorized resolution comment was subsequently added.



