### PR TITLE
fix(tech-ledger): restore deterministic refusals and nested test quarantine

### DIFF
--- a/experiments/tech_ledger/tests/test_import_quarantine.py
+++ b/experiments/tech_ledger/tests/test_import_quarantine.py
@@ -135,8 +135,29 @@ def test_forward_discovery_examines_new_modules(tmp_path):
     )
 
 
+def _test_tree_modules(tests_root: pathlib.Path) -> list[pathlib.Path]:
+    """Deterministic RECURSIVE discovery of every Python module under the
+    tests tree: a future nested module (e.g. ``tests/unit/test_helper.py``)
+    is examined automatically, exactly like the non-test discovery above.
+    Purely static -- nothing is imported or executed."""
+    return sorted(
+        path
+        for path in tests_root.rglob("*.py")
+        if "__pycache__" not in path.parts
+    )
+
+
 def test_lab_tests_import_stdlib_pytest_and_lab_only():
-    for path in sorted((_LAB_DIR / "tests").glob("*.py")):
+    modules = _test_tree_modules(_LAB_DIR / "tests")
+    names = {path.name for path in modules}
+    # Discovery must at minimum see today's modules; any future nested
+    # module is included automatically by construction.
+    assert {
+        "__init__.py",
+        "test_import_quarantine.py",
+        "test_validate_cli.py",
+    } <= names, names
+    for path in modules:
         imports = _imports_of(path)
         allowed = _ALLOWED_IMPORTS | {
             "pytest",
@@ -150,7 +171,46 @@ def test_lab_tests_import_stdlib_pytest_and_lab_only():
             if name not in allowed
             and not name.startswith("experiments.tech_ledger")
         }
-        assert not unexpected, f"{path.name}: unexpected imports {sorted(unexpected)}"
+        rel = path.relative_to(_LAB_DIR).as_posix()  # stable, lab-relative
+        assert not unexpected, f"{rel}: unexpected imports {sorted(unexpected)}"
+
+
+def test_tests_tree_discovery_examines_nested_modules(tmp_path):
+    # Synthetic positive control: a NESTED test module with a forbidden
+    # production import must be discovered and rejected -- proving the
+    # tests-tree scan cannot be evaded by directory depth. Purely
+    # static; nothing is imported or executed.
+    fake_tests = tmp_path / "tests"
+    (fake_tests / "unit").mkdir(parents=True)
+    (fake_tests / "test_direct.py").write_bytes(b"import json\n")
+    (fake_tests / "unit" / "test_helper.py").write_bytes(
+        b"import scripts.event_bus\n"
+    )
+    (fake_tests / "unit" / "__pycache__").mkdir()
+    (fake_tests / "unit" / "__pycache__" / "junk.py").write_bytes(
+        b"import socket\n"
+    )
+
+    discovered = _test_tree_modules(fake_tests)
+    rels = [p.relative_to(fake_tests).as_posix() for p in discovered]
+    # Deterministic order; nested module included; __pycache__ excluded.
+    assert rels == ["test_direct.py", "unit/test_helper.py"]
+    assert discovered == _test_tree_modules(fake_tests)  # repeatable
+
+    flagged = {
+        p.relative_to(fake_tests).as_posix(): sorted(
+            name for name in _imports_of(p) if name not in _ALLOWED_IMPORTS
+        )
+        for p in discovered
+    }
+    assert flagged["unit/test_helper.py"] == ["scripts.event_bus"]
+    assert flagged["test_direct.py"] == []  # direct children stay covered
+    # Negative control: a clean nested module passes.
+    (fake_tests / "unit" / "test_helper.py").write_bytes(b"import pathlib\n")
+    assert all(
+        not [n for n in _imports_of(p) if n not in _ALLOWED_IMPORTS]
+        for p in _test_tree_modules(fake_tests)
+    )
 
 
 def test_no_production_module_imports_the_lab():

--- a/experiments/tech_ledger/tests/test_validate_cli.py
+++ b/experiments/tech_ledger/tests/test_validate_cli.py
@@ -107,6 +107,31 @@ def test_deterministic_filename_order(tmp_path, capsys):
     ]
 
 
+def test_first_invalid_refusal_is_enumeration_order_independent(
+    tmp_path, capsys, monkeypatch
+):
+    # Two ordinary non-regular .json paths (directories -- no symlink
+    # privilege needed).  Whatever raw order enumeration returns, the
+    # FIRST reported refusal must be the lexically first invalid name:
+    # filename ordering is established before any per-entry inspection,
+    # so refusal order can never depend on filesystem enumeration order.
+    (tmp_path / "a.json").mkdir()
+    (tmp_path / "b.json").mkdir()
+
+    for raw_order in (("a.json", "b.json"), ("b.json", "a.json")):
+        def _forced_order(target, _order=raw_order):
+            return list(_order)
+
+        monkeypatch.setattr(os, "listdir", _forced_order)
+        rc = main([str(tmp_path)])
+        err = capsys.readouterr().err
+        monkeypatch.undo()
+        assert rc == 4
+        _assert_one_error_line(err)
+        assert err.startswith("error: a.json:"), err  # lexically first, pinned
+        assert "not a regular file" in err
+
+
 def test_duplicate_json_key_refused_exit2(tmp_path, capsys):
     _write_entry(tmp_path, "TLV4-001")
     raw = (tmp_path / "TLV4-001.json").read_text(encoding="utf-8")

--- a/experiments/tech_ledger/validate.py
+++ b/experiments/tech_ledger/validate.py
@@ -475,9 +475,11 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
             names = os.listdir(binding.fd)
         else:
             names = os.listdir(binding.path)
-        for name in names:
-            if not name.endswith(".json"):
-                continue  # only direct .json entry files are inspected
+        # Deterministic filename order is established BEFORE any per-entry
+        # inspection (only direct .json entry files are considered): the
+        # first symlink / non-regular-file refusal must never depend on
+        # raw filesystem enumeration order.
+        for name in sorted(n for n in names if n.endswith(".json")):
             probe = os.stat(
                 name if binding.fd is not None else os.path.join(binding.path, name),
                 dir_fd=binding.fd,
@@ -492,7 +494,8 @@ def validate_directory(entries_dir: pathlib.Path) -> dict[str, Any]:
                     f"{name}: entry path is not a regular file"
                 )
             candidates.append((name, probe.st_size))
-        candidates.sort()  # deterministic filename order
+        # candidates was built in sorted filename order above; no later
+        # sort is needed (and none could repair refusal-order determinism).
 
         # Ceilings BEFORE any parsing (cheap stat-based checks first).
         if len(candidates) > MAX_ENTRIES:


### PR DESCRIPTION
## What this is

A tightly bounded correction for the **two post-merge review findings** posted on merged PR #439 at 2026-08-02T06:34:10Z (thread IDs referenced factually):

1. **`PRRT_kwDOO6R-Vs6Vuobl`** (`experiments/tech_ledger/validate.py`) — invalid `.json` paths were inspected in raw `os.listdir()` order *before* `candidates.sort()`, so with multiple invalid entries the **first reported refusal depended on filesystem enumeration order**, contradicting the validator's deterministic filename-order contract.
2. **`PRRT_kwDOO6R-Vs6Vuobn`** (`experiments/tech_ledger/tests/test_import_quarantine.py`) — the tests-tree allowlist scan used direct-child `glob("*.py")`, so a **future nested test module** (e.g. `tests/unit/test_helper.py`) importing a production module would evade the forward quarantine.

Both findings were **reproduced against the exact merged base** (the #439 squash `4b84955…`) before any edit.

## Heads and topology

- **Correction commit:** `e9dfcc26428c8bfafc6017c9f80ee8d67c6a4b70` — one ordinary commit on the #439 squash `4b849554…`; exactly 3 paths, **+94/−6**.
- **Synchronization merge (current head):** `a3fdc863789220c918859aad2683b5e031edb48b` — one ordinary two-parent merge: **first parent `e9dfcc2…`** (the audited correction head), **second parent `ad735be2…`** (live `main`, the #440 merge). Conflict-free by construction and in fact (disjoint path sets); **no manual resolution, no content edit**.
- **Why the sync:** after this branch was cut from the squash, PR #440 (zmq shard-transport) merged to `main` at 09:41:28Z, touching only `scripts/shard_transport_zmq.py` + `tests/test_shard_transport_zmq.py` — fully disjoint from this PR's three paths. That advance made this PR **MERGEABLE/BEHIND** under strict status checks. *(An earlier revision of this body said "MERGEABLE/CLEAN against current main" — that was stale at the time it was written; the live state was BEHIND. Corrected here.)*
- **Byte preservation across the sync (verified by blob SHA):** all three audited correction blobs are identical before and after (`validate.py` `d586d5fb…`, `test_validate_cli.py` `fb2d35d9…`, `test_import_quarantine.py` `e099a585…`); both main-side files are identical to `ad735be`'s versions (`d3dd3854…`, `3f0ead8e…`); the PR diff vs current `main` remains **exactly the 3 authorized paths, +94/−6**, with no other change.
- No amend, rebase, cherry-pick, force-push, or second synchronization. No new content correction rode along. **No B1 work.**

## Failing-before evidence (disposable reproductions; no repository file touched)

- **Finding 1:** with `a.json` and `b.json` as ordinary directories (non-regular paths, no symlink privilege) and enumeration forced to both orders, the merged validator reported `a.json` first in one run and `b.json` first in the other (typed `LedgerPathError`, exit 4, one sanitized line each).
- **Finding 2:** `tests/unit/test_helper.py` containing `import scripts.event_bus` was invisible to the direct-child scan (no violation) and found by a recursive scan; a clean nested control passes.

## Corrections (exactly 3 paths)

- **`validate.py`** — deterministic filename order established **before any per-entry inspection** (sorted, filtered to direct `.json`); redundant post-loop sort removed. Both binding lanes, refusal semantics, ceilings-before-parse, capture-before-parse, typed exit map, one-line sanitized `error:` contract, deterministic summary, and resource closing unchanged.
- **`test_validate_cli.py`** — regression: reversing raw enumeration order cannot change the first invalid filename reported (lexically-first `error: a.json:` pinned, both forced orders; fails on the unpatched base).
- **`test_import_quarantine.py`** — recursive deterministic tests-tree discovery (`_test_tree_modules`: `rglob`, `__pycache__` excluded, sorted; identical allowlist; lab-relative reporting) plus synthetic nested controls (forbidden nested import rejected; clean nested passes; direct children covered; repeatable; AST-only — nothing imported or executed).

## Receipts — integrated (local, Windows, at sync head `a3fdc86`)

- Focused regressions **2 passed** · full lab `-W error` **81 passed, 8 skipped** (byte-for-byte the same split as the pre-sync content — the sync is a lab no-op) · forward-quarantine file **7 passed** · maintained reverse guard **4 passed** · full maintained battery **2879 passed, 48 skipped** (= pre-#440 2866 + exactly the 13 new zmq tests)
- Validator over the five committed exemplars **as raw LF blobs, twice**: exit 0, byte-identical output, **`entry_count: 5`**, **`total_entry_bytes: 10,121`** (blob sizes re-summed: 2,199+2,425+1,703+1,856+1,938), sorted IDs **001, 008, 016, 025, 029**, receipt sha256 **`a715541f…`** — all recomputed at this head.

## Receipts — CI (sync head `a3fdc86` — all registered checks conclusively successful; authoritative logs inspected)

- **tech-ledger (non-required)** (pull_request, run 30744502552): **82 passed, 7 skipped** under `-W error` (both new regressions ran); real exemplar-validator step exit 0 (`"entry_count": 5`).
- **CI / verify-python** — pull_request merge-ref run 30744502553: **3001 passed, 13 skipped**; branch push run 30744501760: **3001 passed, 13 skipped**. Branch-head and merge-ref counts have **converged** (pre-sync they differed 2988 vs 3001 because only the merge ref contained #440's 13 new zmq tests; after the sync the branch itself contains `main`, so both events test identical trees) and both equal the verified live-main baseline.
- **frontend-quality** (×2) and **agent-safety**: success. (Theory Tripwire fires only on opened/reopened/labeled — its existing success from PR open stands; no new run expected or produced on synchronize.)

## Untouched (explicitly)

Schema files, all ledger entry JSONs, README files, workflows, the maintained reverse-quarantine test, seed-pack and durable handoff artifacts, B1 planning files, and the prose Theory Intake Ledger. #439's body and metadata are untouched; its two current threads have no replies or reactions from this work.

## Non-claim

**Schema validity is not scientific validity, endorsement, implementation authority, or evidence that a claim is true.** The prose `docs/MEDUSA_THEORY_INTAKE_LEDGER.md` remains authoritative and untouched.

## Status

**MERGED 2026-08-02T10:53:39Z** under Kev's typed authorization for this arc (Jack's audit preceding it): ready transition followed by an exact-head-matched squash at sync head `a3fdc863…`. **Squash on `main`: `c5d8adce16fbcfb57435b5a02e9ef943c8ddb662`** — single parent `ad735be2…` (the live-main second parent of the sync), squash tree identical to the sync-head tree, main-parent diff exactly the 3 audited paths **+94/−6**, all three landed blobs byte-identical to the audited `e9dfcc2…` correction. Post-merge CI on `main` green from authoritative logs: tech-ledger **82/7** (`-W error`) + validator success; verify-python **3001/13**. The head branch was auto-deleted by the repo-level `delete_branch_on_merge=true` (recorded; no manual action). The two #439 findings threads (`PRRT_kwDOO6R-Vs6Vuobl`, `PRRT_kwDOO6R-Vs6Vuobn`) were resolved without replies per the authorization. Not self-certified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
