### PR TITLE
feat(observatory-cli): user-error contract for the Observatory CLI (#67 tranche)

### DIFF
--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -46,21 +46,26 @@ MEMORY_CHANNEL_DEFS = [
 class PortableGenomeError(ValueError):
     """Structural refusal for malformed portable-genome shapes.
 
-    Raised by :func:`import_genome` for the narrow set of structural shapes
-    validated in this module: the genome root, ``format``, ``transition_table``,
-    each source-state mapping, each source/target state name and neighbor-count
-    key, and the container shape of the seven configuration sections
+    Raised by :func:`import_genome` for the narrow set of structural shapes it
+    validates: the genome root, ``format``, ``transition_table``, each
+    source-state mapping, each source/target state name and neighbor-count key,
+    and the container shape of the seven configuration sections
     ``stochastic``, ``contagion``, ``decay``, ``cosmic_garden``,
-    ``experimental``, ``metadata`` and ``topology``. Subclasses
-    :class:`ValueError` so existing callers that catch ``ValueError`` keep
-    working; the public ``info`` CLI catches this type specifically.
+    ``experimental``, ``metadata`` and ``topology``.
 
-    This does NOT make the whole importer total. Still outside this module's
-    structural boundary, and still surfacing as their original exceptions:
-    individual field values *inside* an otherwise correctly shaped section,
-    ``fitness``, ``memory_layout``, ``epigenetic_snapshot``,
-    :func:`extract_epigenetic_snapshot`, schema completeness, and any
-    semantic or numeric range validation.
+    Also raised by :func:`extract_epigenetic_snapshot` for the shapes IT
+    dereferences: the genome root, ``epigenetic_snapshot``, ``memory_layout``,
+    ``lattice_shape``, the two base64 payload fields, ``num_channels`` and the
+    two snapshot-metadata counters.
+
+    Subclasses :class:`ValueError` so existing callers that catch ``ValueError``
+    keep working; the public ``info`` CLI catches this type specifically.
+
+    This does NOT make the module total. Still outside its structural boundary,
+    and still surfacing as their original exceptions: individual field values
+    *inside* an otherwise correctly shaped section, ``fitness``, schema
+    completeness, base64 payload lengths, dimension magnitudes, cross-field
+    consistency, and any semantic or numeric range validation.
     """
 
 
@@ -269,6 +274,90 @@ def _require_json_object_section(genome: dict, section_name: str) -> dict:
     return section
 
 
+def _require_json_string(section: dict, field_name: str) -> str:
+    """Return ``section[field_name]`` only when it is a JSON string.
+
+    A missing key still raises ``KeyError`` exactly as before -- absence is not
+    this helper's concern, shape is. Every non-string JSON value is refused,
+    because ``base64.b64decode`` raises an ambient ``TypeError`` on a number,
+    array, Boolean or ``null`` instead of a structural refusal.
+
+    The message is built from ``field_name`` alone; the supplied value is never
+    rendered and none of its methods is invoked.
+    """
+    value = section[field_name]
+    if type(value) is not str:
+        raise PortableGenomeError(f"{field_name} must be a JSON string")
+    return value
+
+
+def _require_lattice_shape(section: dict) -> Tuple[int, ...]:
+    """Return ``section['lattice_shape']`` only when it is a JSON array of ints.
+
+    ``tuple()`` and the later ``reshape`` both dereference this value, so a
+    scalar, ``null`` or a non-integer entry raises an ambient ``TypeError``
+    from inside ``tuple``/NumPy rather than a structural refusal.
+
+    ``bool`` is excluded because the check is ``type(dim) is int``, matching the
+    exact-type convention used elsewhere in this module. That is a deliberate
+    narrowing, NOT the removal of a ``TypeError``: ``bool`` implements
+    ``__index__``, so NumPy would have accepted ``True`` as the dimension ``1``.
+    No exporter emits Booleans here.
+
+    A missing key still raises ``KeyError``. Dimension *magnitudes* are NOT
+    checked: a negative dimension remains NumPy's ``ValueError``, and one
+    exceeding the platform index range remains its ``OverflowError``. An empty
+    array is likewise accepted and yields a 0-d lattice. Those are value-range
+    concerns, deliberately outside this structural boundary.
+    """
+    raw = section["lattice_shape"]
+    if type(raw) is not list:
+        raise PortableGenomeError("lattice_shape must be a JSON array")
+    for dim in raw:
+        if type(dim) is not int:
+            raise PortableGenomeError("lattice_shape entries must be integers")
+    return tuple(raw)
+
+
+def _require_counter(section: dict, field_name: str) -> int:
+    """Return ``section[field_name]`` only when it is a JSON integer.
+
+    Absent yields ``0``, the established default. These counters are carried
+    into the returned snapshot metadata and are formatted with ``:,`` by
+    consumers, so a string yields ``ValueError: Cannot specify ',' with 's'``
+    and ``null``/array/object yield ``TypeError`` -- ambient defect signals
+    raised far from this file. Validating the shape here keeps the refusal
+    where the value is read.
+    """
+    if field_name not in section:
+        return 0
+    value = section[field_name]
+    if type(value) is not int:
+        raise PortableGenomeError(f"{field_name} must be an integer")
+    return value
+
+
+def _require_channel_count(layout: dict) -> int:
+    """Return ``layout['num_channels']`` only when it is a JSON integer.
+
+    Absent yields the established ``MEMORY_CHANNELS`` default. The value is
+    dereferenced by ``reshape``, so a string, array or ``null`` would otherwise
+    surface as an ambient ``TypeError``.
+
+    ``bool`` is excluded because the check is ``type(value) is int``, matching
+    the exact-type convention used elsewhere in this module. That is a
+    deliberate narrowing, NOT the removal of a ``TypeError``: ``bool``
+    implements ``__index__``, so NumPy would have accepted ``True`` as the
+    dimension ``1``. No exporter emits a Boolean here.
+    """
+    if "num_channels" not in layout:
+        return MEMORY_CHANNELS
+    value = layout["num_channels"]
+    if type(value) is not int:
+        raise PortableGenomeError("num_channels must be an integer")
+    return value
+
+
 def import_genome(filepath):
     """Import a portable genome and reconstruct the rule_spec and CAConfig.
 
@@ -429,22 +518,70 @@ def import_genome(filepath):
 
 
 def extract_epigenetic_snapshot(filepath):
-    """Extract lattice and memory_grid from a genome epigenetic snapshot."""
+    """Extract lattice and memory_grid from a genome epigenetic snapshot.
+
+    Structural refusals raise :class:`PortableGenomeError` -- a ``ValueError``
+    subclass -- with an exact, value-free message, each validated at the site
+    that dereferences it and before any of its contents is read:
+
+      - the genome root, ``epigenetic_snapshot`` and (when a memory grid is
+        present) ``memory_layout`` must be JSON objects. Previously each was
+        dereferenced with ``.get()``, so any other JSON root -- an array,
+        string, number, Boolean or ``null`` -- raised an ambient
+        ``AttributeError``;
+      - ``lattice_shape`` must be a JSON array of integers, because ``tuple()``
+        and ``reshape`` dereference it;
+      - ``lattice_b64`` / ``memory_grid_b64`` must be JSON strings, because
+        ``base64.b64decode`` raises ``TypeError`` on other types;
+      - ``num_channels`` must be an integer when present, because ``reshape``
+        dereferences it;
+      - ``snapshot_generation`` / ``snapshot_ca_step`` must be integers when
+        present, because consumers format them with ``:,``.
+
+    Each check runs immediately before the value it guards is dereferenced.
+    They are not all front-loaded: ``memory_layout`` and ``num_channels`` are
+    validated at the point the memory grid is decoded, which is after the
+    lattice has already been reshaped.
+
+    Those ambient ``AttributeError`` and ``TypeError`` classes are programming
+    -defect signals, so a caller that translates malformed input cannot catch
+    them without also masking real bugs. Raising the module's existing domain
+    error instead lets an ordinary ``ValueError`` handler translate a bad file
+    while genuine defects keep propagating.
+
+    Unchanged: an absent ``epigenetic_snapshot`` and one with
+    ``included`` false both return ``None``; an absent ``memory_layout`` still
+    yields the ``MEMORY_CHANNELS`` default; a missing required key still raises
+    ``KeyError``; and a validly shaped genome decodes exactly as before.
+
+    This does NOT make the extractor total. Value ranges, base64 payload
+    lengths, dimension magnitudes and cross-field consistency are still
+    NumPy's or the caller's concern.
+    """
     filepath = Path(filepath)
     with open(filepath, "r", encoding="utf-8") as f:
         genome = json.load(f)
-    epi = genome.get("epigenetic_snapshot", {})
+
+    if type(genome) is not dict:
+        raise PortableGenomeError("genome must be a JSON object")
+
+    epi = _require_json_object_section(genome, "epigenetic_snapshot")
     if not epi.get("included", False):
         return None
-    shape = tuple(epi["lattice_shape"])
-    lattice_bytes = base64.b64decode(epi["lattice_b64"])
+    shape = _require_lattice_shape(epi)
+    lattice_bytes = base64.b64decode(_require_json_string(epi, "lattice_b64"))
     lattice = np.frombuffer(lattice_bytes, dtype=np.uint8).reshape(shape)
     memory_grid = None
     if "memory_grid_b64" in epi:
-        mg_bytes = base64.b64decode(epi["memory_grid_b64"])
-        num_channels = genome.get("memory_layout", {}).get("num_channels", MEMORY_CHANNELS)
+        mg_bytes = base64.b64decode(_require_json_string(epi, "memory_grid_b64"))
+        num_channels = _require_channel_count(
+            _require_json_object_section(genome, "memory_layout")
+        )
         memory_grid = np.frombuffer(mg_bytes, dtype=np.float32).reshape((num_channels,) + shape)
-    snapshot_meta = {"generation": epi.get("snapshot_generation", 0), "ca_step": epi.get("snapshot_ca_step", 0)}
+    snapshot_meta = {
+        "generation": _require_counter(epi, "snapshot_generation"),
+        "ca_step": _require_counter(epi, "snapshot_ca_step"),
+    }
     return lattice.copy(), memory_grid.copy() if memory_grid is not None else None, snapshot_meta
 
 

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -89,6 +89,26 @@ def _snapshot(shape=(4, 5, 6)):
     )
 
 
+def _write_frames(directory, count=2):
+    """Write real .npz frames the genuine loader can read.
+
+    The animate path deliberately runs the real `load_snapshot_series`, so its
+    input must be real files -- patching the loader away would stop exercising
+    the boundary whose contract is under test.
+    """
+    snap = _snapshot()
+    for index in range(count):
+        np.savez(
+            directory / f"v070_{index:03d}.npz",
+            lattice=snap.lattice,
+            memory_grid=snap.memory_grid,
+            generation=snap.generation + index,
+            ca_step=snap.ca_step,
+            best_fitness=snap.best_fitness,
+        )
+    return directory
+
+
 @pytest.fixture
 def cli(monkeypatch, tmp_path):
     """Install boundary doubles and return a small driver.
@@ -127,8 +147,13 @@ def cli(monkeypatch, tmp_path):
     dashboard = types.ModuleType("vis.observatory.dashboard")
     dashboard.observatory_dashboard = _record("observatory_dashboard", fig)
 
+    # Only the render/save phase is faked. `load_snapshot_series` is NOT
+    # patched, so the animate path exercises the genuine input boundary.
+    # `animate_from_directory` is deliberately NOT provided: the CLI must not
+    # use it (it fuses the load and render phases). If a regression reached for
+    # it again, the import would fail loudly instead of passing silently.
     animation = types.ModuleType("vis.observatory.animation")
-    animation.animate_from_directory = _record("animate_from_directory", None)
+    animation.animate_slices = _record("animate_slices", "out.gif")
 
     # Inert on purpose: recording here would overwrite `calls.name` and mask
     # which renderer the CLI actually dispatched to.
@@ -154,11 +179,15 @@ def cli(monkeypatch, tmp_path):
     # NameError rather than reading the enclosing local.
     frames_dir = tmp_path / "frames"
     frames_dir.mkdir()
+    _write_frames(frames_dir)          # real, loadable frames
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()                  # exists, but holds no matching frames
 
     class _Driver:
         calls = None
         snapshot_path = str(snap_path)
         anim_dir = str(frames_dir)
+        empty_anim_dir = str(empty_dir)
         tmp = tmp_path
         fig = None
 
@@ -227,10 +256,39 @@ def test_channel_subcommand_dispatches(cli, mode, expected_renderer):
 
 
 def test_animate_dispatches_and_returns_zero(cli):
+    """Real frames are discovered and loaded by the genuine loader; only the
+    render/save phase is faked, so no GIF is produced."""
     assert cli.run(["animate", cli.anim_dir]) == 0
-    assert cli.calls.name == "animate_from_directory"
-    assert cli.calls.kwargs["fps"] == 4
-    assert cli.calls.kwargs["max_frames"] == 50
+    assert cli.calls.name == "animate_slices"
+    snapshots = cli.calls.args[0]
+    assert len(snapshots) == 2
+    assert all(isinstance(s, ObservatorySnapshot) for s in snapshots)
+    assert cli.calls.kwargs == {
+        "output_path": "observatory_timelapse.gif",
+        "fps": 4,
+        "overlay_channel": None,
+        "axis": "z",
+    }
+
+
+def test_animate_passes_options_through_unchanged(cli):
+    assert cli.run([
+        "animate", cli.anim_dir,
+        "--output", "custom.gif", "--fps", "7",
+        "--channel", "2", "--axis", "x",
+    ]) == 0
+    assert cli.calls.kwargs == {
+        "output_path": "custom.gif",
+        "fps": 7,
+        "overlay_channel": 2,
+        "axis": "x",
+    }
+
+
+def test_animate_max_frames_limits_the_series(cli):
+    """`--max-frames` is the series limit, applied during loading."""
+    assert cli.run(["animate", cli.anim_dir, "--max-frames", "1"]) == 0
+    assert len(cli.calls.args[0]) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -348,28 +406,58 @@ def test_file_where_animation_directory_expected_is_user_error(cli, capsys):
     assert "not a directory" in _assert_user_error(capsys)
 
 
+def test_animation_directory_without_matching_frames_is_user_error(cli, capsys):
+    """Discovery failure, raised by the REAL loader against a real directory."""
+    assert cli.run(["animate", cli.empty_anim_dir]) == 1
+    err = _assert_user_error(capsys)
+    assert "cannot animate" in err
+    assert "No files matching" in err
+
+
+def test_unreadable_series_member_is_user_error(cli, capsys):
+    """A frame that is not a readable archive, decoded by the REAL loader."""
+    broken = cli.tmp / "broken"
+    broken.mkdir()
+    (broken / "v070_000.npz").write_bytes(b"this is not an npz archive")
+    assert cli.run(["animate", str(broken)]) == 1
+    err = _assert_user_error(capsys)
+    assert "cannot animate" in err
+
+
+def test_empty_series_member_is_user_error(cli, capsys):
+    """A zero-byte frame -- NumPy raises EOFError, which is not an OSError."""
+    broken = cli.tmp / "empty_member"
+    broken.mkdir()
+    (broken / "v070_000.npz").write_bytes(b"")
+    assert cli.run(["animate", str(broken)]) == 1
+    assert "cannot animate" in _assert_user_error(capsys)
+
+
+# --- render phase: NOT part of the input-translation boundary ---------------
+#
+# Regression for the boundary defect: `animate_from_directory()` performs both
+# discovery/loading and rendering/saving in one call, so wrapping it translated
+# renderer defects into user errors and swallowed their tracebacks. The classes
+# below are all members of `_unreadable_input_errors()`, which is precisely why
+# a custom sentinel would not have caught this.
+
+
 @pytest.mark.parametrize(
-    "boom, fragment",
+    "boom",
     [
-        (FileNotFoundError("No files matching 'v070_*.npz' in frames"), "No files matching"),
-        (KeyError("memory_grid"), "memory_grid"),
-        (EOFError("No data left in file"), "No data left"),
+        ValueError("renderer defect: inconsistent frame shape"),
+        OSError("cannot write output gif"),
+        KeyError("palette"),
     ],
 )
-def test_unreadable_animation_input_is_user_error(cli, capsys, boom, fragment):
-    """No frames at all, or one unreadable frame, is the same input class."""
-
+def test_render_phase_exception_propagates(cli, boom):
     def _raise(*a, **k):
         raise boom
 
-    # Reach the double through sys.modules: `import pkg.sub as x` binds the
-    # package attribute, which may be the REAL module if another test imported
-    # it first, so plain attribute assignment could miss the double entirely.
-    cli.patch_render("vis.observatory.animation", "animate_from_directory", _raise)
-    assert cli.run(["animate", cli.anim_dir]) == 1
-    err = _assert_user_error(capsys)
-    assert "cannot animate" in err
-    assert fragment in err
+    cli.patch_render("vis.observatory.animation", "animate_slices", _raise)
+    with pytest.raises(type(boom)) as excinfo:
+        cli.run(["animate", cli.anim_dir])
+    assert excinfo.value is boom
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -149,13 +149,16 @@ def cli(monkeypatch, tmp_path):
 
     snap_path = tmp_path / "snap.npz"
     snap_path.write_bytes(b"not really an npz -- the loader is faked")
-    anim_dir = tmp_path / "frames"
-    anim_dir.mkdir()
+    # Distinct from the class attribute below: a class body resolves names in
+    # its own namespace first, so `anim_dir = str(anim_dir)` would raise
+    # NameError rather than reading the enclosing local.
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
 
     class _Driver:
         calls = None
         snapshot_path = str(snap_path)
-        anim_dir = str(anim_dir)
+        anim_dir = str(frames_dir)
         tmp = tmp_path
         fig = None
 

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -26,6 +26,8 @@ deliberately inert so it cannot be mistaken for a dispatch target.
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 import runpy
 import subprocess
@@ -46,6 +48,10 @@ from vis.observatory import loader as loader_mod
 from vis.observatory.loader import ObservatorySnapshot
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Captured before any fixture patches it, so a test can opt back in to the
+# genuine loader and exercise the real decode path end to end.
+_REAL_LOAD_SNAPSHOT = loader_mod.load_snapshot
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +204,11 @@ def cli(monkeypatch, tmp_path):
         @staticmethod
         def set_loader(fn):
             monkeypatch.setattr(loader_mod, "load_snapshot", fn)
+
+        @staticmethod
+        def use_real_loader():
+            """Restore the genuine loader so the real decode path runs."""
+            monkeypatch.setattr(loader_mod, "load_snapshot", _REAL_LOAD_SNAPSHOT)
 
         @staticmethod
         def patch_render(module_name, attr, fn):
@@ -605,6 +616,127 @@ def test_error_stays_one_line_for_path_with_cr_lf(cli, capsys):
     assert "Traceback (most recent call last)" not in err
 
 
+# ---------------------------------------------------------------------------
+# Malformed portable-genome JSON, through the REAL loader
+#
+# Reachability half of the contract in
+# tests/test_portable_genome_epigenetic_snapshot.py. The fixture replaces
+# `load_snapshot` with a double for speed; `use_real_loader()` puts the genuine
+# function back, so a `.json` snapshot really is decoded by the real
+# `load_genome()` -> `extract_epigenetic_snapshot()` path. These therefore prove
+# the end-to-end lane rather than a patched-away boundary.
+#
+# Before the fix a non-object JSON root reached `genome.get(...)` and raised an
+# ambient `AttributeError`, which is not in the CLI's translated set, so the
+# command emitted a traceback instead of the promised one-line status 1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "root",
+    [
+        pytest.param([], id="array-empty"),
+        pytest.param([1, 2, 3], id="array"),
+        pytest.param("genome", id="string"),
+        pytest.param(5, id="number"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="null"),
+    ],
+)
+def test_non_object_json_snapshot_is_a_one_line_user_error(cli, capsys, root):
+    cli.use_real_loader()
+    path = cli.tmp / "bad_root.json"
+    path.write_text(json.dumps(root), encoding="utf-8")
+    assert cli.run(["info", str(path)]) == 1
+    err = _assert_user_error(capsys)
+    # Assert the specific refusal, not just the CLI's prefix: a weaker check
+    # would pass for any translated exception and would not notice the
+    # structural refusal disappearing.
+    assert "genome must be a JSON object" in err
+
+
+def _epi(**overrides):
+    shape = (2, 2, 2)
+    epi = {
+        "included": True,
+        "lattice_shape": list(shape),
+        "lattice_b64": base64.b64encode(
+            np.zeros(shape, dtype=np.uint8).tobytes()
+        ).decode("ascii"),
+        "snapshot_generation": 9,
+        "snapshot_ca_step": 21,
+    }
+    epi.update(overrides)
+    return epi
+
+
+@pytest.mark.parametrize(
+    "document, expected",
+    [
+        pytest.param({"epigenetic_snapshot": []},
+                     "epigenetic_snapshot must be a JSON object", id="epi-array"),
+        pytest.param({"epigenetic_snapshot": "x"},
+                     "epigenetic_snapshot must be a JSON object", id="epi-string"),
+        pytest.param({"epigenetic_snapshot": _epi(lattice_shape=5)},
+                     "lattice_shape must be a JSON array", id="shape-scalar"),
+        pytest.param({"epigenetic_snapshot": _epi(lattice_shape=[2, "2", 2])},
+                     "lattice_shape entries must be integers", id="shape-entry"),
+        pytest.param({"epigenetic_snapshot": _epi(lattice_b64=5)},
+                     "lattice_b64 must be a JSON string", id="b64-number"),
+        pytest.param({"epigenetic_snapshot": _epi(snapshot_generation="x")},
+                     "snapshot_generation must be an integer", id="counter"),
+        pytest.param({"epigenetic_snapshot": _epi(memory_grid_b64="AAAA"),
+                      "memory_layout": []},
+                     "memory_layout must be a JSON object", id="layout-array"),
+        pytest.param({"epigenetic_snapshot": _epi(memory_grid_b64="AAAA"),
+                      "memory_layout": {"num_channels": "eight"}},
+                     "num_channels must be an integer", id="channels"),
+    ],
+)
+def test_malformed_extraction_shape_is_a_one_line_user_error(
+    cli, capsys, document, expected
+):
+    """Each refusal reaches the CLI's status-1 lane with its own message."""
+    cli.use_real_loader()
+    path = cli.tmp / "bad_section.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    assert cli.run(["info", str(path)]) == 1
+    assert expected in _assert_user_error(capsys)
+
+
+def test_valid_genome_without_epigenetic_data_keeps_established_outcome(cli, capsys):
+    """Unchanged behaviour: a well-formed genome that simply has no epigenetic
+    snapshot is still the established `ValueError` -> status 1 lane."""
+    cli.use_real_loader()
+    path = cli.tmp / "no_epi.json"
+    path.write_text(json.dumps({"format": {"format_id": "x"}}), encoding="utf-8")
+    assert cli.run(["info", str(path)]) == 1
+    assert "no epigenetic snapshot" in _assert_user_error(capsys)
+
+
+def test_valid_genome_with_epigenetic_data_still_loads(cli, capsys):
+    """The positive control: a well-formed genome decodes through the real
+    extractor and `info` reports it."""
+    cli.use_real_loader()
+    shape = (2, 2, 2)
+    document = {
+        "epigenetic_snapshot": {
+            "included": True,
+            "lattice_shape": list(shape),
+            "lattice_b64": base64.b64encode(
+                np.zeros(shape, dtype=np.uint8).tobytes()
+            ).decode("ascii"),
+            "snapshot_generation": 9,
+            "snapshot_ca_step": 21,
+        }
+    }
+    path = cli.tmp / "good.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    assert cli.run(["info", str(path)]) == 0
+    assert "Generation: 9" in capsys.readouterr().out
+
+
 class _Sentinel(Exception):
     """A stand-in for a programming defect, not a user error."""
 
@@ -625,6 +757,37 @@ def test_unexpected_exception_from_loader_propagates(cli):
     cli.set_loader(_boom)
     with pytest.raises(_Sentinel, match="defect inside the loader"):
         cli.run(["info", cli.snapshot_path])
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        AttributeError("'Widget' object has no attribute 'get'"),
+        TypeError("unsupported operand type(s)"),
+    ],
+)
+def test_ambient_defect_classes_still_propagate_from_the_loader(cli, boom):
+    """The fix must NOT have widened the translated set. `AttributeError` and
+    `TypeError` are the exact classes the malformed-genome shapes used to raise
+    ambiently; they remain defect signals and must keep their traceback."""
+
+    def _raise(_path):
+        raise boom
+
+    cli.set_loader(_raise)
+    with pytest.raises(type(boom)) as excinfo:
+        cli.run(["info", cli.snapshot_path])
+    assert excinfo.value is boom
+
+
+@pytest.mark.parametrize(
+    "defect", [AttributeError, TypeError, IndexError, RecursionError, NameError]
+)
+def test_translated_error_set_never_covers_a_defect_class(defect):
+    """Guards the boundary by SUBCLASS, not identity: adding `Exception`,
+    `LookupError` or `ArithmeticError` would slip past a `not in` check."""
+    translated = cli_mod._unreadable_input_errors()
+    assert not any(issubclass(defect, caught) for caught in translated)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -1,0 +1,580 @@
+"""Tests for the Cosmic Observatory CLI user-error contract (issue #67 tranche).
+
+Scope: the CLI's exit/error surface only. Snapshot semantics, rendering
+algorithms, file formats and successful output are unchanged and are not
+re-tested here.
+
+Exit taxonomy under test:
+    0  success -- a subcommand dispatched and completed
+    2  usage   -- argparse's conventional status: unknown/mistyped command,
+                  unknown flag, missing argument, out-of-range option value
+    1  runtime -- an expected, actionable user error found while running:
+                  unusable snapshot path or data, unusable animation directory,
+                  slice level outside the selected axis
+
+What is faked, and why: only the boundaries. The loader and the four rendering
+modules are substituted so nothing renders and no window opens. Argument
+parsing, validation, dispatch, error translation and exit statuses -- the logic
+under test -- are the genuine production code.
+
+``matplotlib.pyplot`` is also substituted, but note it is normally already
+imported (``vis/__init__.py`` pulls ``vis.timeseries_plot``, which selects the
+Agg backend), so the CLI usually binds the real, headless pyplot. The double is
+a belt-and-braces guard, not the reason no window appears -- and it is
+deliberately inert so it cannot be mistaken for a dispatch target.
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# The CLI's package imports pull NumPy (loader) and matplotlib (sibling vis
+# modules). Self-skip cleanly when either is absent rather than erroring at
+# collection, matching tests/test_observatory.py.
+np = pytest.importorskip("numpy")
+pytest.importorskip("matplotlib")
+
+from vis.observatory import cli as cli_mod
+from vis.observatory import loader as loader_mod
+from vis.observatory.loader import ObservatorySnapshot
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Boundary doubles
+# ---------------------------------------------------------------------------
+
+
+class _Fig:
+    """Stands in for a matplotlib/plotly figure."""
+
+    def __init__(self):
+        self.shown = False
+
+    def show(self):
+        self.shown = True
+
+
+class _Calls:
+    """Records which renderer the CLI dispatched to, and with what."""
+
+    def __init__(self):
+        self.name = None
+        self.kwargs = None
+        self.args = None
+
+
+def _snapshot(shape=(4, 5, 6)):
+    """A real ObservatorySnapshot -- the domain object, not a fake."""
+    lattice = np.zeros(shape, dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    lattice[1, 1, 1] = 2
+    memory = np.zeros((8,) + shape, dtype=np.float32)
+    memory[0, 0, 0, 0] = 0.5
+    return ObservatorySnapshot(
+        lattice=lattice,
+        memory_grid=memory,
+        generation=7,
+        ca_step=11,
+        best_fitness=0.25,
+        source_path="/fake/snap.npz",
+    )
+
+
+@pytest.fixture
+def cli(monkeypatch, tmp_path):
+    """Install boundary doubles and return a small driver.
+
+    Returns an object exposing:
+        run(argv)      -> int | SystemExit code via pytest.raises at call site
+        calls          -> which renderer ran
+        snapshot_path  -> an existing .npz path that passes path validation
+        set_loader(fn) -> replace the snapshot loader
+    """
+    calls = _Calls()
+
+    def _record(name, returns):
+        def _fn(*args, **kwargs):
+            calls.name = name
+            calls.args = args
+            calls.kwargs = kwargs
+            return returns
+        return _fn
+
+    fig = _Fig()
+
+    slicer = types.ModuleType("vis.observatory.slicer")
+    slicer.slice_composite = _record("slice_composite", (fig, None))
+    slicer.slice_lattice = _record("slice_lattice", (fig, None))
+    slicer.slice_channel = _record("slice_channel", (fig, None))
+    slicer.tri_slice = _record("tri_slice", fig)
+
+    scatter = types.ModuleType("vis.observatory.scatter3d")
+    scatter.organism_body = _record("organism_body", fig)
+    scatter.signal_field_3d = _record("signal_field_3d", fig)
+    scatter.warmth_glow_3d = _record("warmth_glow_3d", fig)
+    scatter.compute_elders_3d = _record("compute_elders_3d", fig)
+    scatter.channel_overlay = _record("channel_overlay", fig)
+
+    dashboard = types.ModuleType("vis.observatory.dashboard")
+    dashboard.observatory_dashboard = _record("observatory_dashboard", fig)
+
+    animation = types.ModuleType("vis.observatory.animation")
+    animation.animate_from_directory = _record("animate_from_directory", None)
+
+    # Inert on purpose: recording here would overwrite `calls.name` and mask
+    # which renderer the CLI actually dispatched to.
+    pyplot = types.ModuleType("matplotlib.pyplot")
+    pyplot.show = lambda *a, **k: None
+    pyplot.close = lambda *a, **k: None
+
+    for name, module in (
+        ("vis.observatory.slicer", slicer),
+        ("vis.observatory.scatter3d", scatter),
+        ("vis.observatory.dashboard", dashboard),
+        ("vis.observatory.animation", animation),
+        ("matplotlib.pyplot", pyplot),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setattr(loader_mod, "load_snapshot", lambda p: _snapshot())
+
+    snap_path = tmp_path / "snap.npz"
+    snap_path.write_bytes(b"not really an npz -- the loader is faked")
+    anim_dir = tmp_path / "frames"
+    anim_dir.mkdir()
+
+    class _Driver:
+        calls = None
+        snapshot_path = str(snap_path)
+        anim_dir = str(anim_dir)
+        tmp = tmp_path
+        fig = None
+
+        @staticmethod
+        def run(argv):
+            return cli_mod.main(argv)
+
+        @staticmethod
+        def set_loader(fn):
+            monkeypatch.setattr(loader_mod, "load_snapshot", fn)
+
+        @staticmethod
+        def patch_render(module_name, attr, fn):
+            """Patch the installed double, reached via sys.modules.
+
+            `import pkg.sub as x` resolves through the package attribute and
+            only falls back to sys.modules, so patching via `import` can hit
+            the real module instead of the double once anything else in the
+            session has imported it.
+            """
+            monkeypatch.setattr(sys.modules[module_name], attr, fn)
+
+    _Driver.calls = calls
+    _Driver.fig = fig
+    return _Driver
+
+
+# ---------------------------------------------------------------------------
+# Successful dispatch -- every subcommand returns 0
+# ---------------------------------------------------------------------------
+
+
+def test_info_dispatches_and_returns_zero(cli, capsys):
+    assert cli.run(["info", cli.snapshot_path]) == 0
+    out = capsys.readouterr().out
+    assert "Generation: 7" in out
+    assert "CA Step:    11" in out
+
+
+@pytest.mark.parametrize(
+    "argv_tail, expected_renderer",
+    [
+        (["body"], "organism_body"),
+        (["slice"], "slice_lattice"),
+        (["slice", "--channel", "3"], "slice_composite"),
+        (["tri"], "tri_slice"),
+        (["signal"], "signal_field_3d"),
+        (["warmth"], "warmth_glow_3d"),
+        (["elders"], "compute_elders_3d"),
+        (["dashboard"], "observatory_dashboard"),
+    ],
+)
+def test_each_subcommand_dispatches_and_returns_zero(cli, argv_tail, expected_renderer):
+    argv = [argv_tail[0], cli.snapshot_path] + argv_tail[1:]
+    assert cli.run(argv) == 0
+    assert cli.calls.name == expected_renderer
+
+
+@pytest.mark.parametrize(
+    "mode, expected_renderer",
+    [("3d", "channel_overlay"), ("slice", "slice_channel")],
+)
+def test_channel_subcommand_dispatches(cli, mode, expected_renderer):
+    assert cli.run(["channel", cli.snapshot_path, "3", "--mode", mode]) == 0
+    assert cli.calls.name == expected_renderer
+
+
+def test_animate_dispatches_and_returns_zero(cli):
+    assert cli.run(["animate", cli.anim_dir]) == 0
+    assert cli.calls.name == "animate_from_directory"
+    assert cli.calls.kwargs["fps"] == 4
+    assert cli.calls.kwargs["max_frames"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Help and ordinary usage errors -- conventional statuses preserved
+# ---------------------------------------------------------------------------
+
+
+def test_help_exits_zero(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["--help"])
+    assert exc.value.code == 0
+
+
+def test_no_arguments_is_usage_error(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run([])
+    assert exc.value.code == 2
+
+
+def test_unknown_flag_is_usage_error(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["info", cli.snapshot_path, "--nope"])
+    assert exc.value.code == 2
+
+
+def test_subcommand_help_exits_zero(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["slice", "--help"])
+    assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# "did you mean?" -- only when a close match exists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "typo, expected",
+    [("slize", "slice"), ("anmiate", "animate"), ("dashbord", "dashboard")],
+)
+def test_close_typo_suggests_command(cli, capsys, typo, expected):
+    with pytest.raises(SystemExit) as exc:
+        cli.run([typo, cli.snapshot_path])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "did you mean" in err.lower()
+    assert repr(expected) in err or expected in err
+
+
+def test_distant_typo_gets_no_suggestion(cli, capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["zzzzzzzzzz", cli.snapshot_path])
+    assert exc.value.code == 2
+    assert "did you mean" not in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot path contract -- runtime status 1, no traceback
+# ---------------------------------------------------------------------------
+
+
+def _assert_user_error(capsys):
+    err = capsys.readouterr().err
+    assert "Traceback (most recent call last)" not in err
+    assert len(err.strip().splitlines()) == 1
+    return err
+
+
+def test_missing_snapshot_is_user_error(cli, capsys):
+    assert cli.run(["info", str(cli.tmp / "absent.npz")]) == 1
+    assert "not found" in _assert_user_error(capsys)
+
+
+def test_directory_where_snapshot_expected_is_user_error(cli, capsys):
+    assert cli.run(["info", cli.anim_dir]) == 1
+    _assert_user_error(capsys)
+
+
+def test_unsupported_snapshot_suffix_is_user_error(cli, capsys):
+    bad = cli.tmp / "snap.txt"
+    bad.write_text("x")
+    assert cli.run(["info", str(bad)]) == 1
+    assert "unsupported snapshot format" in _assert_user_error(capsys)
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        KeyError("memory_grid"),
+        ValueError("Genome has no epigenetic snapshot"),
+        OSError("truncated archive"),
+        # NumPy signals a damaged archive in several non-OSError ways.
+        EOFError("No data left in file"),
+        __import__("zipfile").BadZipFile("File is not a zip file"),
+        __import__("zlib").error("invalid distance too far back"),
+        __import__("pickle").UnpicklingError("Failed to interpret file as a pickle"),
+    ],
+)
+def test_malformed_snapshot_data_is_user_error(cli, capsys, boom):
+    def _raise(_path):
+        raise boom
+
+    cli.set_loader(_raise)
+    assert cli.run(["info", cli.snapshot_path]) == 1
+    assert "cannot read snapshot" in _assert_user_error(capsys)
+
+
+def test_missing_animation_directory_is_user_error(cli, capsys):
+    assert cli.run(["animate", str(cli.tmp / "no_such_dir")]) == 1
+    assert "directory not found" in _assert_user_error(capsys)
+
+
+def test_file_where_animation_directory_expected_is_user_error(cli, capsys):
+    assert cli.run(["animate", cli.snapshot_path]) == 1
+    assert "not a directory" in _assert_user_error(capsys)
+
+
+@pytest.mark.parametrize(
+    "boom, fragment",
+    [
+        (FileNotFoundError("No files matching 'v070_*.npz' in frames"), "No files matching"),
+        (KeyError("memory_grid"), "memory_grid"),
+        (EOFError("No data left in file"), "No data left"),
+    ],
+)
+def test_unreadable_animation_input_is_user_error(cli, capsys, boom, fragment):
+    """No frames at all, or one unreadable frame, is the same input class."""
+
+    def _raise(*a, **k):
+        raise boom
+
+    # Reach the double through sys.modules: `import pkg.sub as x` binds the
+    # package attribute, which may be the REAL module if another test imported
+    # it first, so plain attribute assignment could miss the double entirely.
+    cli.patch_render("vis.observatory.animation", "animate_from_directory", _raise)
+    assert cli.run(["animate", cli.anim_dir]) == 1
+    err = _assert_user_error(capsys)
+    assert "cannot animate" in err
+    assert fragment in err
+
+
+# ---------------------------------------------------------------------------
+# Numeric option contract -- usage status 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["8", "9", "-1", "99"])
+@pytest.mark.parametrize("command", ["slice", "tri"])
+def test_channel_option_rejects_out_of_range(cli, command, value):
+    with pytest.raises(SystemExit) as exc:
+        cli.run([command, cli.snapshot_path, "--channel", value])
+    assert exc.value.code == 2
+
+
+def test_animate_channel_option_rejects_out_of_range(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["animate", cli.anim_dir, "--channel", "8"])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("value", ["8", "-1"])
+def test_channel_positional_rejects_out_of_range(cli, value):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["channel", cli.snapshot_path, value])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("channel", ["0", "7"])
+def test_channel_boundaries_are_accepted(cli, channel):
+    assert cli.run(["channel", cli.snapshot_path, channel]) == 0
+
+
+@pytest.mark.parametrize("channel", ["0", "7"])
+@pytest.mark.parametrize("command", ["slice", "tri"])
+def test_channel_option_boundaries_are_accepted(cli, command, channel):
+    assert cli.run([command, cli.snapshot_path, "--channel", channel]) == 0
+
+
+@pytest.mark.parametrize("channel", ["0", "7"])
+def test_animate_channel_option_boundaries_are_accepted(cli, channel):
+    assert cli.run(["animate", cli.anim_dir, "--channel", channel]) == 0
+
+
+def test_json_snapshot_suffix_is_accepted(cli):
+    """Both documented suffixes pass path validation, not just .npz."""
+    genome = cli.tmp / "organism.genome.json"
+    genome.write_text("{}")
+    assert cli.run(["info", str(genome)]) == 0
+
+
+def test_help_with_trailing_typo_still_exits_zero(cli):
+    """A help request wins over the did-you-mean path."""
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["--help", "slize"])
+    assert exc.value.code == 0
+
+
+@pytest.mark.parametrize("value", ["nan", "NaN"])
+def test_threshold_rejects_nan(cli, value):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["signal", cli.snapshot_path, "--threshold", value])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("flag", ["--max-frames", "--fps"])
+@pytest.mark.parametrize("value", ["0", "-1", "-99"])
+def test_animate_positive_ints_reject_zero_and_negative(cli, flag, value):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["animate", cli.anim_dir, flag, value])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("value", ["-0.1", "-1", "-99.5"])
+def test_threshold_rejects_negative(cli, value):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["signal", cli.snapshot_path, "--threshold", value])
+    assert exc.value.code == 2
+
+
+def test_threshold_zero_is_accepted(cli):
+    assert cli.run(["signal", cli.snapshot_path, "--threshold", "0"]) == 0
+    assert cli.calls.kwargs["threshold"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Axis-specific level bounds -- checked after the snapshot is loaded
+# ---------------------------------------------------------------------------
+
+# _snapshot() has shape (4, 5, 6): x extent 4, y extent 5, z extent 6.
+
+
+@pytest.mark.parametrize("axis, last", [("x", 3), ("y", 4), ("z", 5)])
+def test_level_lower_and_upper_bounds_accepted(cli, axis, last):
+    assert cli.run(["slice", cli.snapshot_path, "--axis", axis, "--level", "0"]) == 0
+    assert cli.run(
+        ["slice", cli.snapshot_path, "--axis", axis, "--level", str(last)]
+    ) == 0
+
+
+@pytest.mark.parametrize("axis, beyond", [("x", 4), ("y", 5), ("z", 6)])
+def test_level_beyond_axis_is_user_error(cli, capsys, axis, beyond):
+    assert cli.run(
+        ["slice", cli.snapshot_path, "--axis", axis, "--level", str(beyond)]
+    ) == 1
+    err = _assert_user_error(capsys)
+    assert f"axis {axis!r}" in err
+
+
+@pytest.mark.parametrize("axis, extent", [("x", 4), ("y", 5), ("z", 6)])
+def test_negative_level_keeps_python_indexing(cli, axis, extent):
+    """`--level -1` selected the last slice before this contract existed
+    (numpy.take with mode='raise' indexes from the end); it still does."""
+    assert cli.run(["slice", cli.snapshot_path, "--axis", axis, "--level", "-1"]) == 0
+    assert cli.run(
+        ["slice", cli.snapshot_path, "--axis", axis, "--level", str(-extent)]
+    ) == 0
+
+
+@pytest.mark.parametrize("axis, too_negative", [("x", -5), ("y", -6), ("z", -7)])
+def test_level_below_negative_extent_is_user_error(cli, capsys, axis, too_negative):
+    assert cli.run(
+        ["slice", cli.snapshot_path, "--axis", axis, "--level", str(too_negative)]
+    ) == 1
+    _assert_user_error(capsys)
+
+
+def test_channel_slice_mode_validates_level(cli, capsys):
+    assert cli.run(
+        ["channel", cli.snapshot_path, "2", "--mode", "slice", "--level", "99"]
+    ) == 1
+    _assert_user_error(capsys)
+
+
+# ---------------------------------------------------------------------------
+# Message hygiene and defect visibility
+# ---------------------------------------------------------------------------
+
+
+def test_error_stays_one_line_for_path_with_cr_lf(cli, capsys):
+    hostile = str(cli.tmp / "we\rird\nname.npz")
+    assert cli.run(["info", hostile]) == 1
+    err = capsys.readouterr().err
+    assert len(err.strip().splitlines()) == 1
+    assert "Traceback (most recent call last)" not in err
+
+
+class _Sentinel(Exception):
+    """A stand-in for a programming defect, not a user error."""
+
+
+def test_unexpected_exception_from_renderer_propagates(cli):
+    def _boom(*a, **k):
+        raise _Sentinel("defect inside the renderer")
+
+    cli.patch_render("vis.observatory.scatter3d", "organism_body", _boom)
+    with pytest.raises(_Sentinel, match="defect inside the renderer"):
+        cli.run(["body", cli.snapshot_path])
+
+
+def test_unexpected_exception_from_loader_propagates(cli):
+    def _boom(_path):
+        raise _Sentinel("defect inside the loader")
+
+    cli.set_loader(_boom)
+    with pytest.raises(_Sentinel, match="defect inside the loader"):
+        cli.run(["info", cli.snapshot_path])
+
+
+# ---------------------------------------------------------------------------
+# Module entry point propagates main()'s result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("result", [0, 1])
+def test_module_entry_point_propagates_status(monkeypatch, result):
+    """The wiring: whatever main() returns becomes the exit status."""
+    monkeypatch.setattr(cli_mod, "main", lambda: result)
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("vis.observatory", run_name="__main__")
+    assert exc.value.code == result
+
+
+def _run_module(*args):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    env["MPLBACKEND"] = "Agg"
+    return subprocess.run(
+        [sys.executable, "-m", "vis.observatory", *args],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_module_entry_point_end_to_end_help_exits_zero():
+    """End-to-end through the real main(), not a double."""
+    assert _run_module("--help").returncode == 0
+
+
+def test_module_entry_point_end_to_end_user_error_exits_one(tmp_path):
+    proc = _run_module("info", str(tmp_path / "absent.npz"))
+    assert proc.returncode == 1
+    assert "Traceback (most recent call last)" not in proc.stderr
+    assert len(proc.stderr.strip().splitlines()) == 1
+
+
+def test_module_entry_point_end_to_end_usage_error_exits_two():
+    assert _run_module("zzzzzzzzzz").returncode == 2

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -380,10 +380,28 @@ def test_hostile_section_does_not_alter_the_message(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------
 
 
+def _section_helper_names(tree: ast.Module) -> list:
+    """Private refusal helpers with this package's section signature.
+
+    A later package added sibling private refusal helpers for the
+    epigenetic-snapshot extraction contract (see
+    ``tests/test_portable_genome_epigenetic_snapshot.py``), so "private function
+    that raises PortableGenomeError" is no longer a singleton. This package's
+    helper is still uniquely identified by its ``(genome, section_name)``
+    signature -- structure, not name.
+    """
+    return [
+        name
+        for name in _private_error_raising_function_names(tree)
+        if [arg.arg for arg in _function_node(tree, name).args.args]
+        == ["genome", "section_name"]
+    ]
+
+
 def _helper():
     """Resolve the private section-validation helper by structure, not name."""
     tree = ast.parse(inspect.getsource(pg))
-    names = _private_error_raising_function_names(tree)
+    names = _section_helper_names(tree)
     assert len(names) == 1
     return getattr(pg, names[0])
 
@@ -987,7 +1005,7 @@ def _ordered_helper_calls(func: ast.FunctionDef, helper_name: str) -> list:
 
 
 def test_exactly_one_private_section_validation_helper():
-    assert len(_private_error_raising_function_names(_module_tree())) == 1
+    assert len(_section_helper_names(_module_tree())) == 1
 
 
 def test_helper_uses_an_exact_builtin_dict_check():
@@ -1140,19 +1158,28 @@ def test_public_cli_still_catches_only_portable_genome_error():
     assert len(routed) == 1
 
 
-def test_extract_epigenetic_snapshot_untouched_by_this_package():
+def test_extract_epigenetic_snapshot_reuses_this_packages_section_helper():
+    """Superseded lock, updated deliberately.
+
+    This test previously asserted the extractor was *untouched* by this
+    package. A later package -- the epigenetic-snapshot extraction contract in
+    ``tests/test_portable_genome_epigenetic_snapshot.py`` -- extended into it on
+    purpose, reusing this package's section helper rather than duplicating it,
+    and added its own structural refusals. What this module still owns is that
+    the shared helper is the one reused and that the extractor's own decode
+    landmarks are intact.
+    """
     tree = _module_tree()
-    helper_name = _private_error_raising_function_names(tree)[0]
+    helper_name = _section_helper_names(tree)[0]
     fn = _function_node(tree, "extract_epigenetic_snapshot")
     called = {
         node.func.id
         for node in ast.walk(fn)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
-    # The package did not extend into it …
-    assert helper_name not in called
-    assert not [node for node in ast.walk(fn) if isinstance(node, ast.Raise)]
-    # … and its own landmarks are still in place.
+    # The shared section helper is reused, not re-implemented …
+    assert helper_name in called
+    # … and the extractor's own landmarks are still in place.
     attrs = {
         node.func.attr
         for node in ast.walk(fn)

--- a/tests/test_portable_genome_epigenetic_snapshot.py
+++ b/tests/test_portable_genome_epigenetic_snapshot.py
@@ -1,0 +1,323 @@
+"""Structural refusal for ``scripts.portable_genome.extract_epigenetic_snapshot()``.
+
+Scope: the *container shapes* this extractor dereferences -- the genome root,
+``epigenetic_snapshot``, ``memory_layout``, ``lattice_shape``, the two base64
+payload fields and ``num_channels``. Sibling module
+``test_portable_genome_config_shapes.py`` covers ``import_genome()``'s seven
+configuration sections. That module did not merely leave this function out of
+scope -- it asserted the function was *untouched* by its package. That lock has
+been updated there, deliberately, to record that this package extends into the
+extractor and reuses its section helper rather than duplicating it.
+
+Whole-schema validation, value ranges, payload lengths, dimension magnitudes
+and cross-field consistency remain out of scope and are not asserted here.
+
+Before this package every one of those was dereferenced without a shape check,
+so a genome that parsed as valid JSON with the wrong type raised an ambient
+``AttributeError`` (``.get()`` on a non-object) or ``TypeError`` (``tuple()``,
+``base64.b64decode`` or ``reshape`` on a non-conforming value). Both are
+programming-defect signals, so the Observatory CLI could not translate them
+without also masking real bugs -- see
+``tests/test_observatory_cli.py`` for the reachability half of this contract.
+
+``PortableGenomeError`` subclasses ``ValueError``, so an ordinary
+``ValueError`` handler translates a malformed file while genuine defects keep
+propagating.
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import inspect
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+import scripts.portable_genome as pg
+from scripts.portable_genome import PortableGenomeError, extract_epigenetic_snapshot
+
+SHAPE = (2, 2, 2)
+CHANNELS = 8
+
+# Every non-object JSON root. `{}` is excluded: it is a valid object.
+NON_OBJECT_JSON = [
+    pytest.param([], id="array-empty"),
+    pytest.param([1, 2, 3], id="array"),
+    pytest.param("genome", id="string"),
+    pytest.param(5, id="number-int"),
+    pytest.param(1.5, id="number-float"),
+    pytest.param(True, id="bool-true"),
+    pytest.param(False, id="bool-false"),
+    pytest.param(None, id="null"),
+]
+
+
+def _b64(array):
+    return base64.b64encode(array.tobytes()).decode("ascii")
+
+
+def _valid_epi(with_memory=True):
+    epi = {
+        "included": True,
+        "lattice_shape": list(SHAPE),
+        "lattice_b64": _b64(np.zeros(SHAPE, dtype=np.uint8)),
+        "snapshot_generation": 12,
+        "snapshot_ca_step": 34,
+    }
+    if with_memory:
+        epi["memory_grid_b64"] = _b64(np.zeros((CHANNELS,) + SHAPE, dtype=np.float32))
+    return epi
+
+
+def _write(tmp_path, document, name="genome.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Valid genomes keep working
+# ---------------------------------------------------------------------------
+
+
+def test_valid_genome_with_epigenetic_data_loads(tmp_path):
+    path = _write(tmp_path, {
+        "epigenetic_snapshot": _valid_epi(),
+        "memory_layout": {"num_channels": CHANNELS},
+    })
+    lattice, memory_grid, meta = extract_epigenetic_snapshot(path)
+    assert lattice.shape == SHAPE
+    assert memory_grid.shape == (CHANNELS,) + SHAPE
+    assert meta == {"generation": 12, "ca_step": 34}
+
+
+def test_valid_genome_without_memory_grid_yields_none_grid(tmp_path):
+    path = _write(tmp_path, {"epigenetic_snapshot": _valid_epi(with_memory=False)})
+    lattice, memory_grid, _ = extract_epigenetic_snapshot(path)
+    assert lattice.shape == SHAPE
+    assert memory_grid is None
+
+
+def test_absent_memory_layout_uses_default_channel_count(tmp_path):
+    """The established default is preserved when the section is absent."""
+    path = _write(tmp_path, {"epigenetic_snapshot": _valid_epi()})
+    _, memory_grid, _ = extract_epigenetic_snapshot(path)
+    assert memory_grid.shape == (pg.MEMORY_CHANNELS,) + SHAPE
+
+
+def test_absent_epigenetic_snapshot_returns_none(tmp_path):
+    path = _write(tmp_path, {"format": {"format_id": "utilityfog-portable-genome"}})
+    assert extract_epigenetic_snapshot(path) is None
+
+
+def test_epigenetic_snapshot_not_included_returns_none(tmp_path):
+    path = _write(tmp_path, {"epigenetic_snapshot": {"included": False}})
+    assert extract_epigenetic_snapshot(path) is None
+
+
+# ---------------------------------------------------------------------------
+# Structural refusals -- each at the site that dereferences the value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("root", NON_OBJECT_JSON)
+def test_non_object_root_is_refused(tmp_path, root):
+    """The reported defect: valid JSON with a non-object root."""
+    path = _write(tmp_path, root)
+    with pytest.raises(PortableGenomeError, match="genome must be a JSON object"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("section", NON_OBJECT_JSON)
+def test_non_object_epigenetic_snapshot_is_refused(tmp_path, section):
+    path = _write(tmp_path, {"epigenetic_snapshot": section})
+    with pytest.raises(PortableGenomeError, match="epigenetic_snapshot must be a JSON object"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("section", NON_OBJECT_JSON)
+def test_non_object_memory_layout_is_refused(tmp_path, section):
+    path = _write(tmp_path, {
+        "epigenetic_snapshot": _valid_epi(),
+        "memory_layout": section,
+    })
+    with pytest.raises(PortableGenomeError, match="memory_layout must be a JSON object"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(5, id="number"), pytest.param("xyz", id="string"),
+     pytest.param(None, id="null"), pytest.param(True, id="bool"),
+     pytest.param({"x": 1}, id="object")],
+)
+def test_non_array_lattice_shape_is_refused(tmp_path, value):
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = value
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match="lattice_shape must be a JSON array"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [pytest.param("2", id="string"), pytest.param(2.0, id="float"),
+     pytest.param(None, id="null"), pytest.param(True, id="bool"),
+     pytest.param([2], id="nested-array")],
+)
+def test_non_integer_lattice_shape_entry_is_refused(tmp_path, entry):
+    """`bool` is excluded on purpose: ``type(True) is bool``, not ``int``."""
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = [2, entry, 2]
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match="lattice_shape entries must be integers"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("field", ["lattice_b64", "memory_grid_b64"])
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(5, id="number"), pytest.param(None, id="null"),
+     pytest.param(True, id="bool"), pytest.param([], id="array"),
+     pytest.param({}, id="object")],
+)
+def test_non_string_base64_field_is_refused(tmp_path, field, value):
+    epi = _valid_epi()
+    epi[field] = value
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match=f"{field} must be a JSON string"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param("eight", id="string"), pytest.param(None, id="null"),
+     pytest.param([8], id="array"), pytest.param(8.0, id="float"),
+     pytest.param(True, id="bool")],
+)
+def test_non_integer_num_channels_is_refused(tmp_path, value):
+    path = _write(tmp_path, {
+        "epigenetic_snapshot": _valid_epi(),
+        "memory_layout": {"num_channels": value},
+    })
+    with pytest.raises(PortableGenomeError, match="num_channels must be an integer"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("field", ["snapshot_generation", "snapshot_ca_step"])
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param("x", id="string"), pytest.param(None, id="null"),
+     pytest.param([1], id="array"), pytest.param({}, id="object"),
+     pytest.param(1.5, id="float"), pytest.param(True, id="bool")],
+)
+def test_non_integer_snapshot_counter_is_refused(tmp_path, field, value):
+    """These are carried into the snapshot and formatted with ``:,`` by
+    consumers, so a wrong type used to surface as a ValueError/TypeError raised
+    far from this module."""
+    epi = _valid_epi(with_memory=False)
+    epi[field] = value
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match=f"{field} must be an integer"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("field", ["snapshot_generation", "snapshot_ca_step"])
+def test_absent_snapshot_counter_defaults_to_zero(tmp_path, field):
+    epi = _valid_epi(with_memory=False)
+    del epi[field]
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    _, _, meta = extract_epigenetic_snapshot(path)
+    key = "generation" if field == "snapshot_generation" else "ca_step"
+    assert meta[key] == 0
+
+
+# ---------------------------------------------------------------------------
+# Absence is still KeyError -- shape checks did not swallow it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["lattice_shape", "lattice_b64"])
+def test_missing_required_field_still_raises_keyerror(tmp_path, field):
+    epi = _valid_epi(with_memory=False)
+    del epi[field]
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(KeyError):
+        extract_epigenetic_snapshot(path)
+
+
+# ---------------------------------------------------------------------------
+# Message hygiene and the translation contract
+# ---------------------------------------------------------------------------
+
+
+def test_portable_genome_error_is_a_valueerror():
+    """This is what lets an ordinary ValueError handler translate the refusal
+    without catching AttributeError or TypeError wholesale."""
+    assert issubclass(PortableGenomeError, ValueError)
+
+
+HOSTILE = "s3cr3t-\r\n-value-<script>"
+
+
+@pytest.mark.parametrize(
+    "document, expected",
+    [
+        ({"epigenetic_snapshot": HOSTILE}, "epigenetic_snapshot must be a JSON object"),
+        ({"epigenetic_snapshot": [HOSTILE]}, "epigenetic_snapshot must be a JSON object"),
+    ],
+)
+def test_refusal_message_is_single_line_and_value_free(tmp_path, document, expected):
+    path = _write(tmp_path, document)
+    with pytest.raises(PortableGenomeError) as excinfo:
+        extract_epigenetic_snapshot(path)
+    message = str(excinfo.value)
+    assert message == expected
+    assert len(message.splitlines()) == 1
+    assert HOSTILE not in message
+    assert "s3cr3t" not in message
+
+
+def test_hostile_lattice_shape_entry_is_not_echoed(tmp_path):
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = [2, HOSTILE, 2]
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError) as excinfo:
+        extract_epigenetic_snapshot(path)
+    assert str(excinfo.value) == "lattice_shape entries must be integers"
+
+
+# ---------------------------------------------------------------------------
+# No broad exception handler was introduced
+# ---------------------------------------------------------------------------
+
+
+def _handlers(func):
+    source = textwrap.dedent(inspect.getsource(func))
+    return [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ExceptHandler)
+    ]
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        extract_epigenetic_snapshot,
+        pg._require_json_object_section,
+        pg._require_json_string,
+        pg._require_lattice_shape,
+        pg._require_channel_count,
+        pg._require_counter,
+    ],
+)
+def test_no_exception_handler_in_the_refusal_path(func):
+    """The refusals are type checks, not caught-and-retranslated exceptions:
+    nothing here can swallow an unrelated defect."""
+    assert _handlers(func) == []

--- a/vis/observatory/__main__.py
+++ b/vis/observatory/__main__.py
@@ -1,5 +1,9 @@
 """Enable ``python -m vis.observatory`` CLI execution."""
 
+import sys
+
 from vis.observatory.cli import main
 
-main()
+# Propagate the CLI result as the process exit status: 0 success, 1 expected
+# user error, 2 usage (argparse raises SystemExit(2) itself).
+sys.exit(main())

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -17,8 +17,208 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import difflib
 import sys
 from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Error contract
+#
+# Exit taxonomy (the smallest set the evidence supports):
+#   0  success -- a subcommand dispatched and completed
+#   2  usage   -- argparse's own conventional status: unknown/mistyped command,
+#                 unknown flag, missing argument, out-of-range option value
+#   1  runtime -- an expected, actionable user error discovered while running:
+#                 unusable snapshot path or data, unusable animation directory,
+#                 slice level outside the selected axis
+#
+# `--help` keeps argparse's conventional exit status 0.
+#
+# Expected failures print ONE physical stderr line and no traceback. Unexpected
+# failures are deliberately NOT caught: only the narrow operations known to fail
+# on bad user input are wrapped, so a defect inside a renderer still propagates
+# with its traceback intact for developers.
+# ---------------------------------------------------------------------------
+
+SUPPORTED_SNAPSHOT_SUFFIXES = (".npz", ".json")
+NUM_MEMORY_CHANNELS = 8
+_AXIS_INDEX = {"x": 0, "y": 1, "z": 2}
+
+
+class _UserError(Exception):
+    """An expected, actionable user-facing failure (exit status 1)."""
+
+
+def _one_line(text: object) -> str:
+    """Collapse a message to a single physical line.
+
+    A path supplied on the command line may contain CR/LF (or other line
+    boundaries Python recognises), which would otherwise split one error across
+    several stderr lines and break line-oriented consumers.
+    """
+    return " ".join(str(text).splitlines()).strip()
+
+
+def _channel_index(raw: str) -> int:
+    """argparse type: a memory channel index in 0-7."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not an integer") from None
+    if not 0 <= value < NUM_MEMORY_CHANNELS:
+        raise argparse.ArgumentTypeError(
+            f"channel must be 0-{NUM_MEMORY_CHANNELS - 1}, got {value}"
+        )
+    return value
+
+
+def _positive_int(raw: str) -> int:
+    """argparse type: an integer strictly greater than zero."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not an integer") from None
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"must be greater than 0, got {value}")
+    return value
+
+
+def _non_negative_float(raw: str) -> float:
+    """argparse type: a float >= 0 (zero is preserved as meaningful).
+
+    Written as ``not (value >= 0)`` rather than ``value < 0`` so NaN -- which
+    compares False against everything -- is rejected instead of slipping
+    through to produce a silently empty render.
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not a number") from None
+    if not value >= 0:
+        raise argparse.ArgumentTypeError(f"must not be negative, got {value}")
+    return value
+
+
+def _first_command_token(argv):
+    """Return the first non-option token, i.e. the intended subcommand."""
+    for token in argv:
+        if token == "--":
+            return None
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
+
+def _suggest_command(parser, argv, commands):
+    """Emit a 'did you mean?' usage error when a typo has a close match.
+
+    Only fires when `difflib` finds a near neighbour; a distant token falls
+    through to argparse's ordinary invalid-choice error so behaviour there is
+    unchanged. A help request always wins, so `--help` keeps exiting 0 whatever
+    else appears on the line.
+    """
+    if "-h" in argv or "--help" in argv:
+        return
+    token = _first_command_token(argv)
+    if token is None or token in commands:
+        return
+    matches = difflib.get_close_matches(token, commands, n=1, cutoff=0.6)
+    if not matches:
+        return
+    parser.error(
+        f"unknown command {_one_line(token)!r}. Did you mean {matches[0]!r}?"
+    )
+
+
+def _validated_snapshot_path(raw: str) -> Path:
+    """Check a snapshot argument is a supported, readable file before loading."""
+    path = Path(raw)
+    # Directory first: a bare directory has no suffix, so checking the suffix
+    # ahead of this would report "unsupported format" for what is really a
+    # wrong kind of path.
+    if path.is_dir():
+        raise _UserError(f"snapshot path is a directory, not a file: {raw}")
+    if path.suffix not in SUPPORTED_SNAPSHOT_SUFFIXES:
+        raise _UserError(
+            f"unsupported snapshot format {path.suffix or '(none)'!r} for {raw}; "
+            f"expected one of {', '.join(SUPPORTED_SNAPSHOT_SUFFIXES)}"
+        )
+    if not path.exists():
+        raise _UserError(f"snapshot not found: {raw}")
+    return path
+
+
+def _validated_directory(raw: str) -> Path:
+    """Check an animation argument is an existing, usable directory."""
+    path = Path(raw)
+    if not path.exists():
+        raise _UserError(f"directory not found: {raw}")
+    if not path.is_dir():
+        raise _UserError(f"not a directory: {raw}")
+    return path
+
+
+def _unreadable_input_errors():
+    """The exception types that mean 'these bytes are not a usable snapshot'.
+
+    Deliberately assembled rather than replaced by a bare ``except Exception``:
+    the tuple is what separates a bad *file* from a bad *program*. NumPy signals
+    a damaged archive in several unrelated ways -- an empty file raises
+    ``EOFError``, non-archive bytes fall through to the pickle path and raise
+    ``UnpicklingError``, a corrupt member raises ``BadZipFile`` or ``zlib.error``
+    -- and none of those derive from ``OSError`` or ``ValueError``.
+    """
+    import pickle
+    import zlib
+    from zipfile import BadZipFile
+
+    # OSError covers FileNotFoundError / IsADirectoryError / NotADirectoryError
+    # / PermissionError. ValueError and KeyError cover an unsupported format, a
+    # genome without an epigenetic snapshot, and a key-missing NPZ.
+    return (
+        OSError,
+        ValueError,
+        KeyError,
+        EOFError,
+        BadZipFile,
+        zlib.error,
+        pickle.UnpicklingError,
+    )
+
+
+def _load_snapshot_checked(path):
+    """Load a snapshot, translating known input failures into user errors.
+
+    The translation is scoped to the load call alone. Anything raised later --
+    by a renderer, by matplotlib, by a genuine defect -- is untouched.
+    """
+    from vis.observatory.loader import load_snapshot
+
+    try:
+        return load_snapshot(path)
+    except _unreadable_input_errors() as exc:
+        raise _UserError(f"cannot read snapshot {path}: {exc}") from exc
+
+
+def _validated_level(snapshot, axis: str, level):
+    """Check an explicit slice level against the selected axis of the snapshot.
+
+    Negative levels keep their ordinary Python meaning -- `numpy.take` with the
+    default ``mode='raise'`` already indexes from the end, and `--level -1`
+    rendered the last slice before this contract existed. The accepted range is
+    therefore ``-extent <= level < extent``, which preserves that behaviour
+    while still refusing an index the axis cannot satisfy.
+    """
+    if level is None:
+        return None
+    extent = snapshot.shape[_AXIS_INDEX[axis]]
+    if not -extent <= level < extent:
+        raise _UserError(
+            f"level {level} is outside axis {axis!r} of size {extent} "
+            f"(valid range {-extent} to {extent - 1})"
+        )
+    return level
 
 
 def main(argv=None):
@@ -40,14 +240,14 @@ def main(argv=None):
     p_slice.add_argument("snapshot")
     p_slice.add_argument("--axis", choices=["x", "y", "z"], default="z")
     p_slice.add_argument("--level", type=int, default=None)
-    p_slice.add_argument("--channel", type=int, default=None,
+    p_slice.add_argument("--channel", type=_channel_index, default=None,
                          help="Overlay memory channel (0-7)")
     p_slice.add_argument("--save", help="Save as PNG file")
 
     # ---- tri: three orthogonal slices -------------------------------------
     p_tri = sub.add_parser("tri", help="Three orthogonal slices (matplotlib)")
     p_tri.add_argument("snapshot")
-    p_tri.add_argument("--channel", type=int, default=None,
+    p_tri.add_argument("--channel", type=_channel_index, default=None,
                        help="Show memory channel instead of states (0-7)")
     p_tri.add_argument("--save", help="Save as PNG file")
 
@@ -55,7 +255,7 @@ def main(argv=None):
     p_signal = sub.add_parser("signal", help="Signal field 3D view (Plotly)")
     p_signal.add_argument("snapshot")
     p_signal.add_argument("--save", help="Save as HTML")
-    p_signal.add_argument("--threshold", type=float, default=0.01)
+    p_signal.add_argument("--threshold", type=_non_negative_float, default=0.01)
 
     # ---- warmth: metta warmth 3D view ------------------------------------
     p_warmth = sub.add_parser("warmth", help="Metta warmth 3D view (Plotly)")
@@ -70,7 +270,7 @@ def main(argv=None):
     # ---- channel: arbitrary channel view ----------------------------------
     p_chan = sub.add_parser("channel", help="View any memory channel")
     p_chan.add_argument("snapshot")
-    p_chan.add_argument("channel_index", type=int, choices=range(8),
+    p_chan.add_argument("channel_index", type=_channel_index,
                         metavar="CHANNEL")
     p_chan.add_argument("--mode", choices=["slice", "3d"], default="3d")
     p_chan.add_argument("--axis", choices=["x", "y", "z"], default="z")
@@ -85,10 +285,10 @@ def main(argv=None):
     # ---- animate: time-lapse GIF ------------------------------------------
     p_anim = sub.add_parser("animate", help="Animated time-lapse GIF")
     p_anim.add_argument("data_dir", help="Directory containing .npz files")
-    p_anim.add_argument("--max-frames", type=int, default=50)
-    p_anim.add_argument("--fps", type=int, default=4)
+    p_anim.add_argument("--max-frames", type=_positive_int, default=50)
+    p_anim.add_argument("--fps", type=_positive_int, default=4)
     p_anim.add_argument("--output", default="observatory_timelapse.gif")
-    p_anim.add_argument("--channel", type=int, default=None,
+    p_anim.add_argument("--channel", type=_channel_index, default=None,
                         help="Overlay memory channel (0-7)")
     p_anim.add_argument("--axis", choices=["x", "y", "z"], default="z")
 
@@ -96,10 +296,33 @@ def main(argv=None):
     p_info = sub.add_parser("info", help="Show snapshot metadata and statistics")
     p_info.add_argument("snapshot")
 
+    if argv is None:
+        argv = sys.argv[1:]
+    _suggest_command(parser, argv, sorted(sub.choices))
+
     args = parser.parse_args(argv)
 
+    try:
+        return _dispatch(args)
+    except _UserError as exc:
+        print(f"{parser.prog}: error: {_one_line(exc)}", file=sys.stderr)
+        return 1
+
+
+def _dispatch(args):
+    """Run one parsed command, returning 0 on success.
+
+    Raises `_UserError` for expected, actionable user failures. Every other
+    exception propagates untouched so genuine defects stay visible.
+    """
+    # Validate user-supplied paths BEFORE paying for the heavy lazy imports:
+    # an unusable path should not first cost a NumPy/matplotlib import.
+    if getattr(args, "snapshot", None) is not None:
+        _validated_snapshot_path(args.snapshot)
+    if getattr(args, "data_dir", None) is not None:
+        _validated_directory(args.data_dir)
+
     # Lazy imports to keep CLI fast
-    from vis.observatory.loader import load_snapshot
     from vis.observatory.constants import (
         STATE_NAMES, CHANNEL_NAMES, SIGNAL_FIELD_CHANNEL, WARMTH_CHANNEL,
         COMPUTE_AGE_CHANNEL,
@@ -108,7 +331,7 @@ def main(argv=None):
     # ---- Dispatch ---------------------------------------------------------
 
     if args.command == "info":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         print(f"Source:     {snap.source_path}")
         print(f"Shape:      {snap.shape}")
         print(f"Generation: {snap.generation:,}")
@@ -129,10 +352,11 @@ def main(argv=None):
                 print(f"  Ch {ci} {cname:22s}: "
                       f"min={nonvoid.min():+.4f}  max={nonvoid.max():+.4f}  "
                       f"mean={nonvoid.mean():+.4f}")
-        return
+        return 0
 
     if args.command == "slice":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
+        _validated_level(snap, args.axis, args.level)
         if args.channel is not None:
             from vis.observatory.slicer import slice_composite
             fig, _ = slice_composite(
@@ -150,10 +374,10 @@ def main(argv=None):
         else:
             import matplotlib.pyplot as plt
             plt.close(fig)
-        return
+        return 0
 
     if args.command == "tri":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.slicer import tri_slice
         fig = tri_slice(snap, channel=args.channel, save_path=args.save)
         if not args.save:
@@ -162,43 +386,45 @@ def main(argv=None):
         else:
             import matplotlib.pyplot as plt
             plt.close(fig)
-        return
+        return 0
 
     if args.command == "body":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.scatter3d import organism_body
         fig = organism_body(snap, show_void=args.show_void, save_html=args.save)
         if not args.save:
             fig.show()
-        return
+        return 0
 
     if args.command == "signal":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.scatter3d import signal_field_3d
         fig = signal_field_3d(snap, threshold=args.threshold, save_html=args.save)
         if not args.save:
             fig.show()
-        return
+        return 0
 
     if args.command == "warmth":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.scatter3d import warmth_glow_3d
         fig = warmth_glow_3d(snap, save_html=args.save)
         if not args.save:
             fig.show()
-        return
+        return 0
 
     if args.command == "elders":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.scatter3d import compute_elders_3d
         fig = compute_elders_3d(snap, save_html=args.save)
         if not args.save:
             fig.show()
-        return
+        return 0
 
     if args.command == "channel":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         if args.mode == "slice":
+            # `--level` only applies to the slice mode; the 3D mode ignores it.
+            _validated_level(snap, args.axis, args.level)
             from vis.observatory.slicer import slice_channel
             fig, _ = slice_channel(
                 snap, args.channel_index, axis=args.axis, level=args.level,
@@ -217,10 +443,10 @@ def main(argv=None):
             )
             if not args.save:
                 fig.show()
-        return
+        return 0
 
     if args.command == "dashboard":
-        snap = load_snapshot(args.snapshot)
+        snap = _load_snapshot_checked(args.snapshot)
         from vis.observatory.dashboard import observatory_dashboard
         fig = observatory_dashboard(snap, save_path=args.save)
         if not args.save:
@@ -229,20 +455,30 @@ def main(argv=None):
         else:
             import matplotlib.pyplot as plt
             plt.close(fig)
-        return
+        return 0
 
     if args.command == "animate":
         from vis.observatory.animation import animate_from_directory
-        animate_from_directory(
-            args.data_dir,
-            max_frames=args.max_frames,
-            output_path=args.output,
-            fps=args.fps,
-            overlay_channel=args.channel,
-            axis=args.axis,
-        )
-        return
+        try:
+            animate_from_directory(
+                args.data_dir,
+                max_frames=args.max_frames,
+                output_path=args.output,
+                fps=args.fps,
+                overlay_channel=args.channel,
+                axis=args.axis,
+            )
+        except _unreadable_input_errors() as exc:
+            # No matching frames in the directory, or one of the frames is
+            # itself unreadable -- the same input class the single-snapshot
+            # path already reports as a user error.
+            raise _UserError(f"cannot animate {args.data_dir}: {exc}") from exc
+        return 0
+
+    # argparse enforces `required=True` on the subcommand, so this is
+    # unreachable for parsed input; it keeps the contract total.
+    raise AssertionError(f"unhandled command: {args.command!r}")
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -315,8 +315,12 @@ def _dispatch(args):
     Raises `_UserError` for expected, actionable user failures. Every other
     exception propagates untouched so genuine defects stay visible.
     """
-    # Validate user-supplied paths BEFORE paying for the heavy lazy imports:
-    # an unusable path should not first cost a NumPy/matplotlib import.
+    # Validate user-supplied paths before the per-command imports performed
+    # below by this module. This does NOT mean an invalid path avoids NumPy or
+    # matplotlib altogether: running `python -m vis.observatory` first executes
+    # the `vis` and `vis.observatory` package initializers, which import the
+    # loader (and, through sibling `vis` modules, matplotlib). Narrowing that
+    # is a separate change to package initialization and is not made here.
     if getattr(args, "snapshot", None) is not None:
         _validated_snapshot_path(args.snapshot)
     if getattr(args, "data_dir", None) is not None:
@@ -458,21 +462,34 @@ def _dispatch(args):
         return 0
 
     if args.command == "animate":
-        from vis.observatory.animation import animate_from_directory
+        # Two phases with different contracts, so they are invoked separately.
+        # `animate_from_directory()` performs both in a single call, which is
+        # why it is not used here: wrapping it would translate a renderer or
+        # output defect into a user error and swallow its traceback.
+        #
+        # Phase 1 -- discovery and loading. This is input handling, so the same
+        # unreadable-input set the single-snapshot path uses applies. Omitting
+        # `pattern` keeps the loader's own default, which is the value
+        # `animate_from_directory()` would have passed.
+        from vis.observatory.loader import load_snapshot_series
+
         try:
-            animate_from_directory(
-                args.data_dir,
-                max_frames=args.max_frames,
-                output_path=args.output,
-                fps=args.fps,
-                overlay_channel=args.channel,
-                axis=args.axis,
-            )
+            snapshots = load_snapshot_series(args.data_dir, max_count=args.max_frames)
         except _unreadable_input_errors() as exc:
-            # No matching frames in the directory, or one of the frames is
-            # itself unreadable -- the same input class the single-snapshot
-            # path already reports as a user error.
             raise _UserError(f"cannot animate {args.data_dir}: {exc}") from exc
+
+        # Phase 2 -- rendering and saving. Deliberately OUTSIDE the translation
+        # boundary: a failure here is a defect, not bad user input, and must
+        # keep its traceback.
+        from vis.observatory.animation import animate_slices
+
+        animate_slices(
+            snapshots,
+            output_path=args.output,
+            fps=args.fps,
+            overlay_channel=args.channel,
+            axis=args.axis,
+        )
         return 0
 
     # argparse enforces `required=True` on the subcommand, so this is


### PR DESCRIPTION
## Scope — one tranche of #67, not #67

This implements a **user-error contract for the Cosmic Observatory CLI**: the "Enhanced Error Messages" section of issue #67.

It is explicitly **not** completion of #67. Untouched and unclaimed: interactive mode / guided setup wizard, progress indicators and spinners, shell completion scripts (bash/zsh/fish), configuration management (`ufog config`), the `examples`/`doctor` commands, and documentation links in errors.

`Refs #67` — no closing keyword. Issue #67 stays open.

**Base** `32fb32bdd2cb0d422069d8366908fb7c2c65da3d` · **Head** `901221ccb5b2c35d2ba5692fc443bd680de35e6d` · ready, unmerged, `MERGEABLE` / `CLEAN`

## Problem

The CLI has ten working subcommands but no error contract:

- `main()` returned `None` from every **successful** path and the module entry point discarded that result, so success carried no explicit status. Expected runtime failures were not caught at all: they raised, printed a traceback, and normally exited nonzero via the interpreter's default. There was no deliberate expected-runtime error contract — which is what this PR adds. *(An earlier revision of this section said the process "always exited 0 — including after a failure". That was wrong and is corrected here.)*
- `python -m vis.observatory` discarded `main()`'s result entirely.
- **Expected loader/input runtime failures** surfaced as a **raw traceback** — a missing snapshot, an unsupported suffix, a corrupt archive. (Argparse usage errors were already fine: they used the conventional status **2** with a usage message, and still do.)
- Validation ran **after** `cli.py`'s per-command lazy imports, so `--fps 0` first paid for those imports and then raised.
- `--channel` accepted any integer on `slice`, `tri` and `animate` (only the `channel` positional was constrained).
- `--max-frames 0`, `--fps -1` and `--threshold -5` were all accepted.
- A mistyped subcommand produced argparse's bare `invalid choice` with no suggestion.

## Exit / error taxonomy

The smallest set the evidence supports:

| Status | Meaning | Raised by |
|---|---|---|
| **0** | success — a subcommand dispatched and completed | `main()` returns `0` |
| **2** | usage — unknown/mistyped command, unknown flag, missing argument, out-of-range option value | argparse `SystemExit(2)` |
| **1** | runtime — expected, actionable user error: unusable snapshot path or data, unusable animation directory, slice level outside the axis | `main()` returns `1` |

`--help` keeps argparse's conventional **0**, and a help request now wins over every other pre-parse path.

An **unexpected** exception is not assigned a status at all — it propagates with its traceback, which is what distinguishes a defect from a user error.

## Design decisions

**Validation precedes `cli.py`'s per-command imports.** Path and numeric checks are stdlib-only and run before this module imports the loader, the renderers or matplotlib.

This is a narrow claim, and worth stating precisely: it does **not** mean bad input avoids NumPy or matplotlib altogether. The documented `python -m vis.observatory` path first executes the `vis` and `vis.observatory` package initializers, which import the loader and — through sibling `vis` modules — matplotlib, all before `main()` runs. So the saving is on `cli.py`'s own per-command imports, not on the scientific stack as a whole. **This PR does not change package initialization**; narrowing that is a separate change and out of this file boundary.

**The caught set is assembled explicitly, never `except Exception`.** That tuple is what separates a bad *file* from a bad *program*. NumPy signals a damaged archive in several unrelated ways — an empty file raises `EOFError`, non-archive bytes fall through to the pickle path and raise `UnpicklingError`, a corrupt member raises `BadZipFile` or `zlib.error` — and **none of those derive from `OSError` or `ValueError`**. Translation is scoped to the load/animate calls alone, so a renderer defect still raises.

**Negative slice levels keep their Python meaning.** `numpy.take` with the default `mode='raise'` already indexes from the end, so `--level -1` rendered the last slice before this change. The accepted range is `-extent .. extent-1`, not `0 .. extent-1` — bounding the axis without breaking a working invocation.

**Single-line errors.** Messages pass through `str.splitlines()` and rejoin, so a path containing CR or LF cannot split one error across several stderr lines.

## Command and option matrix

| Command | Snapshot/dir checked | Channel 0–7 | Level vs axis | Other |
|---|---|---|---|---|
| `info` | ✅ | — | — | — |
| `body` | ✅ | — | — | — |
| `slice` | ✅ | ✅ `--channel` | ✅ always | — |
| `tri` | ✅ | ✅ `--channel` | — | — |
| `signal` | ✅ | — | — | `--threshold` ≥ 0, NaN rejected |
| `warmth` | ✅ | — | — | — |
| `elders` | ✅ | — | — | — |
| `channel` | ✅ | ✅ positional | ✅ `--mode slice` only | 3D mode ignores `--level` |
| `dashboard` | ✅ | — | — | — |
| `animate` | ✅ directory | ✅ `--channel` | — | `--max-frames`/`--fps` > 0 |

Snapshot paths are checked for **directory → suffix → existence**, in that order (a bare directory has no suffix, so checking suffix first would misreport it as "unsupported format").

## Failing-first receipts

A labelled probe (outside the repo, since pytest cannot run here — see Validation) exercised the argparse/validation layer against the **unmodified** `cli.py` at base `5d2e091`, then against this branch:

| | Unmodified base | This branch |
|---|---|---|
| Probe cases passing | **4 / 21** | **21 / 21** |

The 17 pre-existing failures: no did-you-mean for `slize`/`anmiate`; `--max-frames 0/-3`, `--fps 0/-1`, `--threshold -0.5` all accepted; `--channel 9/-1/8/12` accepted on `slice`/`tri`/`animate`; missing snapshot, directory-as-snapshot, unsupported suffix, missing animation directory and file-as-directory all raising instead of returning 1; CR/LF path splitting the message.

Diagnostic detail worth recording: on the unmodified CLI most of those cases failed with `ModuleNotFoundError: numpy` — proof that validation sat *behind* the heavy import.

## Independent adversarial review

A bounded read-only review agent audited the diff and test module before commit. It found **4 confirmed bugs**, all reproduced by me and fixed in this commit:

1. `--help slize` exited **2** instead of 0 — the suggestion hook pre-empted argparse's help action. *(Fixed: help wins.)*
2. Corrupt-`.npz` classes `EOFError` / `UnpicklingError` / `zlib.error` escaped as tracebacks. *(Fixed: caught set widened, deliberately and explicitly.)*
3. Two tests patched the **real** renderer module rather than the installed double — `import pkg.sub as x` binds via the package attribute and only falls back to `sys.modules`, so with plotly installed the test would silently miss. *(Fixed: patched through `sys.modules`.)*
4. `--level -1` regressed from "renders last slice" to exit 1. *(Fixed: negative indexing preserved.)*

Also fixed from its lower-priority findings: directory check ordered before suffix; `--threshold nan` rejected (`not (v >= 0)`); `animate` now translates the same unreadable-input set as single-snapshot loads; the inert `pyplot` double no longer overwrites the dispatch recorder; coverage added for `.json` suffix, `BadZipFile`/`zlib`/`pickle` arms, `--channel 0/7` acceptance, and a genuine end-to-end entry-point test.

Its confirmed-clean checks included: `sorted(sub.choices)` correctness, `argv is None` handling, `_AXIS_INDEX` agreeing with `slicer._take_slice`, no misfire on any *valid* invocation, and `--help` output byte-identical to HEAD for all five inspected parsers.

## Validation

| Command | Result |
|---|---|
| `python -m py_compile vis/observatory/cli.py vis/observatory/__main__.py tests/test_observatory_cli.py` | **exit 0** |
| `git diff --check` | **clean** |
| `python -m pytest -q tests/test_observatory_cli.py` | **NOT RUN** — `No module named pytest` |
| `python -m pytest -q tests/test_observatory_cli.py tests/test_observatory.py tests/test_observatory_loader.py tests/test_observatory_loader_order.py` | **NOT RUN** — same |
| `python -m pytest -q` | **NOT RUN** — same |

`pytest`, `numpy`, `matplotlib`, `plotly` and `imageio` are all absent on this seat and installing was not authorized. **CI is the authoritative lane for the pytest suite.**

*Supporting evidence only, clearly not a pytest substitute:* the probes load `cli.py` **directly by file path** and drive the real `main()`. That bypasses the `vis` / `vis.observatory` package initializers entirely, which is the only reason they run at all here — it is a property of the probe harness, **not** evidence that a normal `python -m vis.observatory` invocation avoids importing NumPy or matplotlib. It does not. Anything requiring NumPy — successful dispatch, post-load level bounds, malformed-data translation, sentinel propagation, the real animation loading boundary and the entry point — is covered by the pytest module in CI, not by the probes.

## Changed files

Six files. The package began as three; a review finding required a justified, recorded expansion — see *Boundary expansion* below.

| File | + | − |
|---|---|---|
| `vis/observatory/cli.py` | 285 | 32 |
| `vis/observatory/__main__.py` | 5 | 1 |
| `tests/test_observatory_cli.py` (new) | 834 | 0 |
| `scripts/portable_genome.py` | 158 | 21 |
| `tests/test_portable_genome_epigenetic_snapshot.py` (new) | 323 | 0 |
| `tests/test_portable_genome_config_shapes.py` | 35 | 8 |
| **Total** | **1640** | **62** |

(Cumulative across all six commits, against base `32fb32bd`. Exactly **one** production file is new to the package: `scripts/portable_genome.py`.)

### Boundary expansion — recorded and justified

The package began as three files. Closing the P2 required three more, each necessary rather than convenient:

- **`scripts/portable_genome.py`** — the defect is *in* the extractor. Widening the CLI's caught set instead would have masked real `AttributeError`/`TypeError` defects, which the contract forbids. The fix has to live where the structure is dereferenced.
- **`tests/test_portable_genome_epigenetic_snapshot.py`** (new) — the direct domain contract, a sibling to the existing `test_portable_genome_config_shapes.py`.
- **`tests/test_portable_genome_config_shapes.py`** — **not** convenience. It carried AST locks asserting the extractor was *untouched* and that exactly one private refusal helper existed. This change deliberately extends into the extractor, so those locks were stale and **would have failed CI**. They now resolve the section helper by its `(genome, section_name)` signature — still a singleton lock — and record that the extractor reuses that helper. Its decode landmarks stay asserted.

`vis/observatory/cli.py` and `vis/observatory/__main__.py` were **not** touched by the corrective commit: no caught exception class was broadened.

### Commits

| SHA | Message |
|---|---|
| `2d49323` | feat(observatory-cli): user-error contract for the Observatory CLI |
| `f69f604` | test(observatory-cli): fix class-body name shadowing in the cli fixture |
| `88d3ae5` | fix(observatory-cli): split the animate load and render phases |
| `3906501` | fix(portable-genome): structural refusal for the epigenetic-snapshot extractor |
| `be87e00` | Merge branch 'main' into fix/observatory-cli-error-contract *(synchronization only)* |
| `901221c` | Merge branch 'main' into fix/observatory-cli-error-contract *(synchronization only)* |

No amend, no rebase, no force-push — each is an ordinary commit on the last.

### `3906501` — the malformed-genome structural boundary (P2, `discussion_r3701839053`)

A `.json` snapshot holding valid JSON with a non-object root reached `extract_epigenetic_snapshot()`, which called `genome.get(...)` and raised an ambient `AttributeError`. That class is deliberately absent from the CLI's translated set, so the command emitted a traceback instead of its promised one-line status-1 error.

**Reproduced first, and the finding was broader than reported.** A matrix of valid-JSON documents driven through the genuine extractor found **22** escaping shapes: the genome root, `epigenetic_snapshot` and `memory_layout` each raised `AttributeError` for *every* non-object JSON type, while `lattice_shape`, both base64 payload fields and `num_channels` raised `TypeError` from `tuple`, `b64decode` and `reshape`. An adversarial review then found the same mistake one layer out — `snapshot_generation`/`snapshot_ca_step` are formatted with `:,` by consumers, so a string yields `ValueError: Cannot specify ',' with 's'` and null/array yield `TypeError`, raised *outside* the CLI's translation scope. After the fix: **0 escaping shapes.**

**Fixed where the value is dereferenced, not where it explodes.** Each shape is validated immediately before use and raises the module's existing `PortableGenomeError`, reusing the established `_require_json_object_section` helper rather than duplicating it. Because that error subclasses `ValueError`, the CLI's existing lane translates it — so `AttributeError`, `TypeError` and `Exception` stay **out** of `_unreadable_input_errors()` and genuine defects keep their traceback. No `try`/`except` was added anywhere; every refusal is a plain type check, and a test asserts the refusal path contains no exception handler at all.

**Preserved:** absent `epigenetic_snapshot` and `included: false` both still return `None`; absent `memory_layout` still yields the `MEMORY_CHANNELS` default; absent counters still default to `0`; missing required keys still raise `KeyError`; and a genuinely exported genome round-trips unchanged — the exporter writes plain `int`s and `str`s, all of which satisfy the exact-type gates.

### `be87e00` and `901221c` — synchronization only

Two synchronization merges, both to satisfy branch protection's `required_status_checks.strict`, and both made necessary by unrelated tech-ledger PRs landing on `main` while this one was in audit:

| Merge | Incorporated `main` | Advance |
|---|---|---|
| `be87e00` | `b73248c6d7bed96ceea4460cf30da1f35bdddf1a` | PR #446 — five tech-ledger entry JSON files + `experiments/tech_ledger/tests/test_entries.py` |
| `901221c` | `32fb32bdd2cb0d422069d8366908fb7c2c65da3d` | PR #448 — five tech-ledger entry JSON files + `experiments/tech_ledger/tests/test_entries.py` |

Both were fully automatic and conflict-free, and **neither changed any of this package's six files** — every blob is byte-identical across both merges, verified individually, and the PR-relative diff stayed exactly `+1640 / −62`. No rebase, squash, force-push or manual conflict resolution at any point.

### `88d3ae5` — the animate exception-boundary correction

Jack's audit found the animate dispatch wrapped the **whole** call to `animate_from_directory()` in `_unreadable_input_errors()`. That helper performs two phases with different contracts — discovery/loading, then rendering/saving — so a renderer or output defect raising `ValueError`, `KeyError`, `OSError`, `BadZipFile` or `zlib.error` was reported as malformed input and lost its traceback, contradicting this package's own rule. The defect was introduced by me in `2d49323`, which widened the caught set around the entire call instead of around the loading step.

Reproduced before fixing (labelled probe, driving the real `main()`): with the render phase raising `ValueError`, `OSError` or `KeyError`, `main()` returned **1** instead of propagating. After the fix all three propagate unchanged, and the load phase still returns 1 with a one-line message.

The CLI now calls the two phases separately using existing public functions — `load_snapshot_series(data_dir, max_count=max_frames)` inside the boundary (with `pattern` omitted so the loader's own default applies, the same value `animate_from_directory()` would have passed) and `animate_slices(...)` outside it. `vis/observatory/animation.py` is untouched.

A custom sentinel exception could **not** have exposed this: every misreported class is already a member of `_unreadable_input_errors()`. The regressions therefore use those real classes.

The animate tests now exercise the **genuine** input boundary — the fixture writes real `v070_*.npz` frames and `load_snapshot_series` is not patched, so discovery and decoding really run. Only the render/save phase is faked, so no GIF is written and no window opens. The `animate_from_directory` double was removed so a regression back to it fails loudly instead of passing silently.

`tests/test_observatory.py` was **not** modified — its `TestCLI` ignores `main()`'s return value, so `None` → `0` needs no compatibility change.

## Compatibility and non-claims

- Snapshot semantics, rendering algorithms, file formats and successful output are unchanged. `--help` text is byte-identical to HEAD for the top-level parser and for `channel`, `animate`, `signal` and `slice`.
- Only the *error text* changed for the `channel` positional (`invalid choice` → `channel must be 0-7`); same exit 2, same accepted range.
- **No security claim** about filesystem races or hostile replacement between validation and load. The path checks are usability guards, not a TOCTOU defence.
- No restriction was invented on valid `--save` paths or output formats; the rendering layers keep whatever they already supported.
- No new dependency (`difflib`, `zipfile`, `zlib`, `pickle` are stdlib). No dependency file, workflow, configuration or documentation touched.
- No production hook exists solely for tests.
- An unexpected defect propagating out of `main()` also terminates with status 1 (Python's default for an uncaught exception) — the same number as an expected user error. The traceback is what distinguishes them; the status alone does not.
- The `--` separator disables the did-you-mean suggestion, and a misplaced option value can be reported as the unknown command. Both cases are already-invalid input with unchanged exit status; noted rather than fixed.
- The issue text says "nine useful subcommands"; there are in fact **ten** (`body`, `slice`, `tri`, `signal`, `warmth`, `elders`, `channel`, `dashboard`, `animate`, `info`). All ten are covered.

Non-claims specific to the malformed-genome boundary, all still true after `3906501` and each verified rather than assumed:

- **Deeply nested JSON** still raises `RecursionError` from `json.load`, before any shape check runs. Not translated; out of this boundary.
- **An oversized dimension** still raises NumPy's `OverflowError`, and an **empty `lattice_shape`** is accepted and yields a 0-d lattice. Dimension *magnitudes* are value-range concerns, deliberately not validated here.
- **A genome declaring fewer than 8 channels** decodes cleanly and then fails later in the Observatory: unlike the NPZ path, `load_genome()` performs no 3/5→8 channel migration. That is a loader gap, not an extractor one, and is untouched.
- `bool` is excluded from the integer gates by the module's exact-type convention (`type(x) is int`). That is a deliberate narrowing, **not** the removal of a `TypeError` — `bool` implements `__index__`, so NumPy would have accepted `True` as dimension `1`. No exporter emits Booleans here.
- Field *values* inside correctly shaped structures, base64 payload lengths, schema completeness and cross-field consistency remain unvalidated.

## Open-PR overlap

| PR | Files | Overlap |
|---|---|---|
| #441 | `crates/uft_ca/Cargo.toml` | none |
| #442 | `crates/uft_ca/Cargo.toml` | none |
| #443 | 5 `.github/workflows/*.yml` | none — but **operationally relevant**: it bumps the actions used by the CI that gates this PR. Not touched. |
| #448 | `experiments/tech_ledger/**` | none |

(#446 merged and became this PR's new base.) No open PR touches `vis/observatory/**`, `scripts/portable_genome.py`, `tests/test_observatory*` or `tests/test_portable_genome*`.

## CI receipts

**Head `901221c` — every check passes.** Authoritative `verify-python` is the `pull_request`-event job, [run 30868438824 / job 91865191883](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/30868438824/job/91865191883):

```
3199 passed, 13 skipped in 48.33s
```

Push-event job: `3199 passed, 13 skipped in 51.42s`. Baseline `verify-python` on `main` is `3001 passed, 13 skipped`, so this package adds **+198 passing tests** and no skips. The same `3199 passed, 13 skipped` was reported at the corrective head `3906501` and at both synchronized heads `be87e00` and `901221c` — the two synchronization merges changed no test outcome.

`CodeQL (Python baseline)` now also runs, because the package touches `scripts/**`; `Analyze Python` and `CodeQL` both pass.

| Workflow / job | Conclusion |
|---|---|
| `CI / verify-python` (pull_request + push) | **success** |
| `CI / frontend-quality` (pull_request + push) | success |
| `Agent Safety Suite / agent-safety` | success |

`Theory Tripwire / tripwire` passed at the first head `2d49323` and has not re-run since: it subscribes only to `pull_request` types `opened`/`reopened`/`labeled`, not `synchronize`. It is non-blocking by design and not a required context.

### CI caught a real defect — corrective commit `f69f604`

The first head `2d49323` **failed** `verify-python`: `84 errors, 0 failed`, every error the same `NameError: name 'anim_dir' is not defined` at fixture setup. Inside the `_Driver` class body, `anim_dir = str(anim_dir)` resolves the name in the class namespace — where it is the attribute being defined — rather than the enclosing local. The sibling line worked only because its names differ (`snapshot_path = str(snap_path)`).

Notably the 5 tests that do **not** use that fixture passed on the failing head (`3006 passed` = baseline 3001 + 5), which localised the fault precisely. `f69f604` renames the enclosing local to `frames_dir`; an AST check confirms no other class-body assignment in the module reads a name it also defines. No production file and no assertion changed.

This is exactly the class of defect the local probe could not reach — it never constructs the pytest fixture.

## Status

**Open, ready for review, and unmerged**, at synchronized head `901221c` on base `32fb32bd`. `MERGEABLE` / `CLEAN` — the strict up-to-date requirement is satisfied. Issue #67 remains **open**; `Refs #67` carries no closing keyword.

For Jack's independent re-audit. Not merged, no auto-merge.






