### PR TITLE
fix(observatory): validate genome snapshots and migrate legacy channels

### DIFF
--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -9,6 +9,7 @@ the organism on any compatible substrate.
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -64,8 +65,9 @@ class PortableGenomeError(ValueError):
     This does NOT make the module total. Still outside its structural boundary,
     and still surfacing as their original exceptions: individual field values
     *inside* an otherwise correctly shaped section, ``fitness``, schema
-    completeness, base64 payload lengths, dimension magnitudes, cross-field
-    consistency, and any semantic or numeric range validation.
+    completeness, cross-field consistency, and any semantic or numeric range
+    validation. (Base64 validity, payload lengths and dimension positivity ARE
+    now covered, by the epigenetic-snapshot wire-integrity checks.)
     """
 
 
@@ -274,6 +276,64 @@ def _require_json_object_section(genome: dict, section_name: str) -> dict:
     return section
 
 
+# Wire-integrity constants for the epigenetic snapshot payload.
+_LATTICE_RANK = 3
+_UINT8_BYTES = 1
+_FLOAT32_BYTES = 4
+
+
+def _require_json_boolean(section: dict, field_name: str, default: bool = False) -> bool:
+    """Return ``section[field_name]`` only when it is an actual JSON Boolean.
+
+    Absent yields ``default``. Truthiness is deliberately not accepted: a
+    string, number or array would otherwise silently enable or disable a code
+    path the exporter never wrote.
+    """
+    if field_name not in section:
+        return default
+    value = section[field_name]
+    if type(value) is not bool:
+        raise PortableGenomeError(f"{field_name} must be a JSON boolean")
+    return value
+
+
+def _decode_base64_strict(section: dict, field_name: str) -> bytes:
+    """Return the strictly decoded base64 payload of ``section[field_name]``.
+
+    ``base64.b64decode`` defaults to ``validate=False``, which silently DISCARDS
+    every character outside the alphabet and tolerates excess padding -- so
+    ``"!!!!!!!!"`` decodes to ``b""`` and ``"AAAA="`` to three bytes. Both then
+    fail much later, as a NumPy reshape mismatch, if at all. Strict decoding
+    refuses them deterministically at the field that owns them.
+
+    ``ValueError`` is the caught type, not merely ``binascii.Error``: for a
+    non-ASCII string ``b64decode`` fails in ``_bytes_from_decode_data`` and
+    raises a plain ``ValueError`` whose message quotes the argument, so
+    catching only ``binascii.Error`` would let a value-bearing message escape.
+    ``binascii.Error`` subclasses ``ValueError``, so one clause covers both,
+    and the scope is a single call on already-validated string input.
+    """
+    text = _require_json_string(section, field_name)
+    try:
+        return base64.b64decode(text, validate=True)
+    except ValueError as exc:
+        raise PortableGenomeError(f"{field_name} is not valid base64") from exc
+
+
+def _require_payload_length(payload: bytes, expected: int, field_name: str) -> None:
+    """Refuse a payload whose decoded length disagrees with the declared shape.
+
+    ``expected`` is computed with unbounded Python integers, so an enormous
+    declared dimension is compared exactly instead of reaching NumPy and
+    raising ``OverflowError`` -- and neither the expected nor the actual count
+    appears in the message.
+    """
+    if len(payload) != expected:
+        raise PortableGenomeError(
+            f"{field_name} payload length does not match the declared shape"
+        )
+
+
 def _require_json_string(section: dict, field_name: str) -> str:
     """Return ``section[field_name]`` only when it is a JSON string.
 
@@ -304,18 +364,28 @@ def _require_lattice_shape(section: dict) -> Tuple[int, ...]:
     ``__index__``, so NumPy would have accepted ``True`` as the dimension ``1``.
     No exporter emits Booleans here.
 
-    A missing key still raises ``KeyError``. Dimension *magnitudes* are NOT
-    checked: a negative dimension remains NumPy's ``ValueError``, and one
-    exceeding the platform index range remains its ``OverflowError``. An empty
-    array is likewise accepted and yields a 0-d lattice. Those are value-range
-    concerns, deliberately outside this structural boundary.
+    The lattice is a 3-D volume by construction, so the rank is fixed at three
+    and every dimension must be positive. Previously any rank was accepted --
+    a rank-2 or rank-4 array decoded silently into a non-3D lattice that broke
+    much later inside a consumer -- and a zero, negative or enormous dimension
+    was left for NumPy, surfacing as a ``ValueError`` echoing the supplied
+    values or, past the platform index range, an untranslatable
+    ``OverflowError``.
+
+    A missing key still raises ``KeyError``. Dimension magnitudes beyond
+    positivity are not checked here: the payload-length check that follows is
+    what bounds them, and it does so with exact Python integer arithmetic.
     """
     raw = section["lattice_shape"]
     if type(raw) is not list:
         raise PortableGenomeError("lattice_shape must be a JSON array")
+    if len(raw) != _LATTICE_RANK:
+        raise PortableGenomeError("lattice_shape must have exactly three dimensions")
     for dim in raw:
         if type(dim) is not int:
             raise PortableGenomeError("lattice_shape entries must be integers")
+        if dim <= 0:
+            raise PortableGenomeError("lattice_shape entries must be positive")
     return tuple(raw)
 
 
@@ -349,12 +419,21 @@ def _require_channel_count(layout: dict) -> int:
     deliberate narrowing, NOT the removal of a ``TypeError``: ``bool``
     implements ``__index__``, so NumPy would have accepted ``True`` as the
     dimension ``1``. No exporter emits a Boolean here.
+
+    A count of zero or less is refused: it cannot describe a memory grid, and
+    it previously reached NumPy as a degenerate or negative dimension. Which
+    POSITIVE counts the Observatory can actually consume is a separate,
+    downstream question -- see ``vis.observatory.loader``, which owns channel
+    compatibility. This function only guarantees the wire value is a usable
+    positive integer.
     """
     if "num_channels" not in layout:
         return MEMORY_CHANNELS
     value = layout["num_channels"]
     if type(value) is not int:
         raise PortableGenomeError("num_channels must be an integer")
+    if value <= 0:
+        raise PortableGenomeError("num_channels must be positive")
     return value
 
 
@@ -538,10 +617,9 @@ def extract_epigenetic_snapshot(filepath):
       - ``snapshot_generation`` / ``snapshot_ca_step`` must be integers when
         present, because consumers format them with ``:,``.
 
-    Each check runs immediately before the value it guards is dereferenced.
-    They are not all front-loaded: ``memory_layout`` and ``num_channels`` are
-    validated at the point the memory grid is decoded, which is after the
-    lattice has already been reshaped.
+    Every check now runs before ANY NumPy call: the wire-integrity package
+    moved both `frombuffer`/`reshape` pairs to the end of the function, so a
+    hostile shape can neither allocate nor overflow ahead of validation.
 
     Those ambient ``AttributeError`` and ``TypeError`` classes are programming
     -defect signals, so a caller that translates malformed input cannot catch
@@ -554,34 +632,78 @@ def extract_epigenetic_snapshot(filepath):
     yields the ``MEMORY_CHANNELS`` default; a missing required key still raises
     ``KeyError``; and a validly shaped genome decodes exactly as before.
 
-    This does NOT make the extractor total. Value ranges, base64 payload
-    lengths, dimension magnitudes and cross-field consistency are still
-    NumPy's or the caller's concern.
+    Wire integrity is settled in Python BEFORE NumPy is asked for anything:
+
+      - ``included`` must be an actual JSON Boolean when present;
+      - ``lattice_shape`` must be exactly three positive integers;
+      - both base64 payloads decode strictly, so an out-of-alphabet character
+        or bad padding is refused instead of being silently discarded;
+      - each decoded payload length must equal exactly what the declared shape
+        implies -- one byte per cell for the lattice, and
+        ``num_channels x cells x 4`` for the memory grid -- computed with
+        unbounded Python integers, so an enormous declared dimension is
+        rejected by comparison rather than reaching NumPy and raising
+        ``OverflowError``;
+      - ``num_channels`` must be a positive integer when a grid is present.
+
+    A deeply nested JSON document is translated at the single ``json.load``
+    call, because CPython's scanner raises ``RecursionError`` -- a
+    ``RuntimeError`` -- which no reasonable caller translates.
+
+    This does NOT make the extractor total, and it makes no claim about which
+    channel counts the Observatory can render: that is
+    ``vis.observatory.loader``'s boundary. Scientific value ranges, dimension
+    plausibility and cross-field semantics remain unvalidated.
     """
     filepath = Path(filepath)
     with open(filepath, "r", encoding="utf-8") as f:
-        genome = json.load(f)
+        try:
+            genome = json.load(f)
+        except RecursionError as exc:
+            # Scoped to this one decode call and to this input: CPython's JSON
+            # scanner recurses per nesting level, so a deeply nested document
+            # exhausts the stack. `RecursionError` is a `RuntimeError`, outside
+            # every sane translated set, so it would otherwise escape as a
+            # traceback for what is purely malformed input. Nothing else in
+            # this function is inside the handler.
+            raise PortableGenomeError("genome JSON is nested too deeply") from exc
 
     if type(genome) is not dict:
         raise PortableGenomeError("genome must be a JSON object")
 
     epi = _require_json_object_section(genome, "epigenetic_snapshot")
-    if not epi.get("included", False):
+    if not _require_json_boolean(epi, "included"):
         return None
+
+    # Wire integrity is settled entirely in Python before NumPy is asked for
+    # anything, so a hostile shape can neither allocate nor overflow first.
     shape = _require_lattice_shape(epi)
-    lattice_bytes = base64.b64decode(_require_json_string(epi, "lattice_b64"))
-    lattice = np.frombuffer(lattice_bytes, dtype=np.uint8).reshape(shape)
+    cells = shape[0] * shape[1] * shape[2]
+    lattice_bytes = _decode_base64_strict(epi, "lattice_b64")
+    _require_payload_length(lattice_bytes, cells * _UINT8_BYTES, "lattice_b64")
+
     memory_grid = None
+    mg_bytes = None
+    num_channels = None
     if "memory_grid_b64" in epi:
-        mg_bytes = base64.b64decode(_require_json_string(epi, "memory_grid_b64"))
+        mg_bytes = _decode_base64_strict(epi, "memory_grid_b64")
         num_channels = _require_channel_count(
             _require_json_object_section(genome, "memory_layout")
         )
-        memory_grid = np.frombuffer(mg_bytes, dtype=np.float32).reshape((num_channels,) + shape)
+        _require_payload_length(
+            mg_bytes, num_channels * cells * _FLOAT32_BYTES, "memory_grid_b64"
+        )
+
     snapshot_meta = {
         "generation": _require_counter(epi, "snapshot_generation"),
         "ca_step": _require_counter(epi, "snapshot_ca_step"),
     }
+
+    lattice = np.frombuffer(lattice_bytes, dtype=np.uint8).reshape(shape)
+    if mg_bytes is not None:
+        memory_grid = np.frombuffer(mg_bytes, dtype=np.float32).reshape(
+            (num_channels,) + shape
+        )
     return lattice.copy(), memory_grid.copy() if memory_grid is not None else None, snapshot_meta
 
 

--- a/tests/test_observatory_genome_loader.py
+++ b/tests/test_observatory_genome_loader.py
@@ -1,0 +1,359 @@
+"""Observatory channel compatibility for portable-genome JSON snapshots.
+
+Scope: the eight-channel contract every Observatory consumer relies on, and
+whether both snapshot formats deliver it.
+
+Before this package `load_npz` migrated legacy 3- and 5-channel memory grids
+inline, but `load_genome` did not: a portable-genome JSON snapshot carrying a
+legacy grid reached the Observatory unnormalised and failed later inside a
+consumer with an `IndexError` on channel 3..7. Both paths now share one seam,
+`loader._normalize_memory_grid`, which delegates to the engine's established
+migration rather than reimplementing it.
+
+Layer boundary: wire integrity (shape rank, payload lengths, base64, positive
+channel counts) belongs to `scripts.portable_genome` and is covered by
+`tests/test_portable_genome_epigenetic_snapshot.py`. This module owns which
+*positive* channel counts the Observatory can actually consume, and the
+end-to-end CLI reachability of both.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import types
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("matplotlib")
+
+import vis.observatory.loader as loader
+
+# Imported eagerly and deliberately. `load_genome`'s first statement imports
+# this module, and importing it pulls `scripts.continuous_evolution_ca`. Two
+# tests below patch that engine entry in `sys.modules`; if the extractor were
+# not already cached, that patch would break its import instead of the
+# migration under test — so a single-test or `-k` selection would fail.
+import scripts.portable_genome  # noqa: F401
+from vis.observatory.loader import load_genome, load_snapshot
+
+NUM_CHANNELS = loader.NUM_CHANNELS
+SHAPE = (2, 2, 2)
+CELLS = SHAPE[0] * SHAPE[1] * SHAPE[2]
+MIGRATION_MODULE = "scripts.continuous_evolution_ca"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _b64(array):
+    return base64.b64encode(np.ascontiguousarray(array).tobytes()).decode("ascii")
+
+
+def _genome(memory_grid=None, channels=None, shape=SHAPE, lattice=None):
+    """A well-formed portable genome, optionally carrying a memory grid."""
+    if lattice is None:
+        lattice = np.zeros(shape, dtype=np.uint8)
+        lattice[0, 0, 0] = 1
+    epi = {
+        "included": True,
+        "lattice_shape": list(shape),
+        "lattice_b64": _b64(lattice),
+        "snapshot_generation": 5,
+        "snapshot_ca_step": 6,
+    }
+    doc = {"epigenetic_snapshot": epi}
+    if memory_grid is not None:
+        epi["memory_grid_b64"] = _b64(memory_grid)
+        doc["memory_layout"] = {
+            "num_channels": channels if channels is not None else memory_grid.shape[0]
+        }
+    return doc
+
+
+def _write(tmp_path, doc, name="genome.json"):
+    path = tmp_path / name
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+def _grid(channels, fill=None):
+    """A memory grid whose every channel carries a distinct marker value.
+
+    Markers start at 10 and step by 10 so none of them collides with the
+    migration's own defaults (0.0 and 1.0). Without that, a channel asserted to
+    hold the default 1.0 could equally be an accidental copy of a source
+    channel, and the mapping test would not distinguish them.
+    """
+    grid = np.zeros((channels,) + SHAPE, dtype=np.float32)
+    for c in range(channels):
+        grid[c] = float((c + 1) * 10) if fill is None else fill
+    return grid
+
+
+# ---------------------------------------------------------------------------
+# Positive controls: valid data still works
+# ---------------------------------------------------------------------------
+
+
+def test_valid_eight_channel_genome_passes_through_unchanged(tmp_path):
+    grid = _grid(NUM_CHANNELS)
+    path = _write(tmp_path, _genome(grid))
+    snap = load_genome(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    assert snap.memory_grid.dtype == np.float32
+    assert snap.lattice.dtype == np.uint8
+    np.testing.assert_array_equal(snap.memory_grid, grid)
+
+
+def test_absent_memory_grid_still_yields_the_zero_grid(tmp_path):
+    """Established behaviour, unchanged."""
+    path = _write(tmp_path, _genome())
+    snap = load_genome(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    assert not snap.memory_grid.any()
+
+
+def test_metadata_and_lattice_survive_the_round_trip(tmp_path):
+    lattice = np.arange(CELLS, dtype=np.uint8).reshape(SHAPE)
+    path = _write(tmp_path, _genome(_grid(NUM_CHANNELS), lattice=lattice))
+    snap = load_genome(path)
+    np.testing.assert_array_equal(snap.lattice, lattice)
+    assert snap.generation == 5
+    assert snap.ca_step == 6
+
+
+def test_load_snapshot_routes_json_through_load_genome(tmp_path):
+    """Anti-vacuity: the public entry point reaches this path for `.json`."""
+    path = _write(tmp_path, _genome(_grid(NUM_CHANNELS)), name="organism.json")
+    snap = load_snapshot(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+
+
+# ---------------------------------------------------------------------------
+# Legacy migration -- exact historic placement, not merely the right shape
+# ---------------------------------------------------------------------------
+
+
+def test_five_channel_genome_migrates_to_eight(tmp_path):
+    """Phase 5 -> Phase 6: the five originals keep their index, and the three
+    new channels (signal, warmth, cooldown) are zero."""
+    grid = _grid(5)
+    path = _write(tmp_path, _genome(grid))
+    snap = load_genome(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    for c in range(5):
+        np.testing.assert_array_equal(snap.memory_grid[c], grid[c])
+    for c in range(5, NUM_CHANNELS):
+        assert not snap.memory_grid[c].any(), f"channel {c} should be zero"
+
+
+def test_three_channel_genome_migrates_to_eight_with_historic_mapping(tmp_path):
+    """Historic 3-channel mapping: 0->0, 1->2, 2->4, with channel 1 defaulting
+    to 0.0 and channel 3 to 1.0."""
+    grid = _grid(3)
+    path = _write(tmp_path, _genome(grid))
+    snap = load_genome(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    np.testing.assert_array_equal(snap.memory_grid[0], grid[0])
+    np.testing.assert_array_equal(snap.memory_grid[2], grid[1])
+    np.testing.assert_array_equal(snap.memory_grid[4], grid[2])
+    assert not snap.memory_grid[1].any()
+    np.testing.assert_array_equal(
+        snap.memory_grid[3], np.ones(SHAPE, dtype=np.float32)
+    )
+    for c in (5, 6, 7):
+        assert not snap.memory_grid[c].any(), f"channel {c} should be zero"
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_migrated_genome_grid_is_a_numpy_float32_array(tmp_path, channels):
+    path = _write(tmp_path, _genome(_grid(channels)))
+    snap = load_genome(path)
+    assert isinstance(snap.memory_grid, np.ndarray)
+    assert snap.memory_grid.dtype == np.float32
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4, 6, 7, 9, 16])
+def test_unsupported_channel_counts_fail_during_loading(tmp_path, channels):
+    """Not later, inside a renderer: `load_genome` itself refuses, with a
+    ValueError the CLI already translates."""
+    path = _write(tmp_path, _genome(_grid(channels)))
+    with pytest.raises(ValueError, match="Cannot migrate memory grid"):
+        load_genome(path)
+
+
+# ---------------------------------------------------------------------------
+# The shared seam is genuinely shared
+# ---------------------------------------------------------------------------
+
+
+def test_npz_and_genome_paths_use_the_same_normalization_seam():
+    """Structural: neither loader reimplements the migration."""
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(loader)))
+    for name in ("load_npz", "load_genome"):
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == name
+        )
+        called = {
+            n.func.id for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        assert "_normalize_memory_grid" in called, f"{name} bypasses the seam"
+        assert "_migrate_memory_grid" not in called, f"{name} reimplements migration"
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_npz_and_genome_produce_identical_grids_for_the_same_legacy_data(
+    tmp_path, channels
+):
+    """The strongest statement of the contract: same legacy input, same
+    Observatory snapshot, whichever format carried it."""
+    grid = _grid(channels)
+    lattice = np.zeros(SHAPE, dtype=np.uint8)
+    lattice[1, 1, 1] = 2
+
+    npz_path = tmp_path / "snap.npz"
+    np.savez(npz_path, lattice=lattice, memory_grid=grid,
+             generation=5, ca_step=6, best_fitness=0.0)
+    json_path = _write(tmp_path, _genome(grid, lattice=lattice))
+
+    from_npz = load_snapshot(npz_path)
+    from_json = load_snapshot(json_path)
+    np.testing.assert_array_equal(from_npz.memory_grid, from_json.memory_grid)
+    np.testing.assert_array_equal(from_npz.lattice, from_json.lattice)
+
+
+# ---------------------------------------------------------------------------
+# NPZ behaviour preserved: archive lifetime and the ImportError fallback
+# ---------------------------------------------------------------------------
+
+
+def test_npz_legacy_migration_still_works_through_the_shared_seam(tmp_path):
+    """The NPZ path keeps migrating legacy grids after the extraction.
+
+    Archive *lifetime* is deliberately not re-asserted here: POSIX `unlink`
+    of an open file succeeds, so a "delete after load" check is vacuous on the
+    Linux CI runner. `tests/test_observatory_loader.py` already holds the real,
+    platform-independent witness — it records `archive.closed` at the migration
+    seam itself — and that test is unmodified by this package.
+    """
+    path = tmp_path / "snap.npz"
+    grid = _grid(3)
+    np.savez(path, lattice=np.zeros(SHAPE, dtype=np.uint8),
+             memory_grid=grid, generation=0, ca_step=0, best_fitness=0.0)
+    snap = load_snapshot(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    np.testing.assert_array_equal(snap.memory_grid[0], grid[0])
+    np.testing.assert_array_equal(snap.memory_grid[2], grid[1])
+    np.testing.assert_array_equal(snap.memory_grid[4], grid[2])
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_import_error_fallback_zero_pads(monkeypatch, tmp_path, channels):
+    """Established fallback, explicitly characterised and preserved: when the
+    engine cannot be imported, the grid is zero-padded rather than migrated —
+    so the historic 3-channel remapping does NOT apply on this path."""
+    monkeypatch.setitem(sys.modules, MIGRATION_MODULE, None)  # import -> ImportError
+    grid = _grid(channels)
+    path = _write(tmp_path, _genome(grid))
+    snap = load_genome(path)
+    assert snap.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    for c in range(channels):
+        np.testing.assert_array_equal(snap.memory_grid[c], grid[c])
+    for c in range(channels, NUM_CHANNELS):
+        assert not snap.memory_grid[c].any()
+
+
+def test_device_array_result_is_converted_to_numpy(monkeypatch, tmp_path):
+    """A GPU device array from the engine still satisfies the NumPy contract."""
+
+    class _FakeDevice:
+        def __init__(self, array):
+            self._array = array
+
+        def get(self):
+            return self._array
+
+    migrated = np.ones((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    stub = types.ModuleType(MIGRATION_MODULE)
+    stub._migrate_memory_grid = lambda grid, shape: _FakeDevice(migrated)
+    monkeypatch.setitem(sys.modules, MIGRATION_MODULE, stub)
+
+    path = _write(tmp_path, _genome(_grid(3)))
+    snap = load_genome(path)
+    assert isinstance(snap.memory_grid, np.ndarray)
+    np.testing.assert_array_equal(snap.memory_grid, migrated)
+
+
+# ---------------------------------------------------------------------------
+# CLI reachability -- the real command, the real loader
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(argv):
+    """Drive the genuine CLI end to end.
+
+    Nothing is faked: these all use `info`, whose dispatch imports only
+    `vis.observatory.constants` and NumPy — no renderer, no GUI, no output
+    file. The loader and extractor are the real ones.
+    """
+    from vis.observatory import cli as cli_mod
+
+    return cli_mod.main(argv)
+
+
+@pytest.mark.parametrize(
+    "mutate, fragment",
+    [
+        pytest.param(lambda d: d["epigenetic_snapshot"].__setitem__(
+            "lattice_shape", [2, 2]), "three dimensions", id="rank"),
+        pytest.param(lambda d: d["epigenetic_snapshot"].__setitem__(
+            "lattice_shape", [2, 0, 2]), "positive", id="zero-dim"),
+        pytest.param(lambda d: d["epigenetic_snapshot"].__setitem__(
+            "lattice_b64", "!!!!"), "valid base64", id="base64"),
+        pytest.param(lambda d: d["epigenetic_snapshot"].__setitem__(
+            "lattice_b64", base64.b64encode(b"\x00").decode()), "payload length",
+            id="payload"),
+        pytest.param(lambda d: d["epigenetic_snapshot"].__setitem__(
+            "included", "yes"), "JSON boolean", id="included"),
+    ],
+)
+def test_malformed_genome_is_a_one_line_cli_error(tmp_path, capsys, mutate, fragment):
+    doc = _genome()
+    mutate(doc)
+    path = _write(tmp_path, doc)
+    assert _run_cli(["info", str(path)]) == 1
+    err = capsys.readouterr().err
+    assert "Traceback (most recent call last)" not in err
+    assert len(err.strip().splitlines()) == 1
+    assert fragment in err
+
+
+def test_unsupported_channel_count_is_a_one_line_cli_error(tmp_path, capsys):
+    path = _write(tmp_path, _genome(_grid(4)))
+    assert _run_cli(["info", str(path)]) == 1
+    err = capsys.readouterr().err
+    assert "Traceback (most recent call last)" not in err
+    assert len(err.strip().splitlines()) == 1
+    assert "Cannot migrate memory grid" in err
+
+
+@pytest.mark.parametrize("channels", [3, 5, 8])
+def test_valid_genome_reports_through_the_cli(tmp_path, capsys, channels):
+    """Positive control at the CLI: legacy grids now render metadata instead of
+    crashing in a consumer."""
+    path = _write(tmp_path, _genome(_grid(channels)))
+    assert _run_cli(["info", str(path)]) == 0
+    out = capsys.readouterr().out
+    assert "Generation: 5" in out
+    assert "Ch 7" in out          # channel 7 is reachable -> grid really is 8-deep

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1185,7 +1185,12 @@ def test_extract_epigenetic_snapshot_reuses_this_packages_section_helper():
         for node in ast.walk(fn)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
     }
-    assert {"b64decode", "frombuffer", "reshape", "load"} <= attrs
+    assert {"frombuffer", "reshape", "load"} <= attrs
+    # `b64decode` was a landmark here until the wire-integrity package moved
+    # decoding into `_decode_base64_strict` so it could be validated rather
+    # than run permissively. The extractor still owns the decode, now by
+    # delegation — assert that rather than the raw call it replaced.
+    assert "_decode_base64_strict" in called
 
 
 def test_export_genome_untouched_by_this_package():

--- a/tests/test_portable_genome_epigenetic_snapshot.py
+++ b/tests/test_portable_genome_epigenetic_snapshot.py
@@ -9,8 +9,11 @@ scope -- it asserted the function was *untouched* by its package. That lock has
 been updated there, deliberately, to record that this package extends into the
 extractor and reuses its section helper rather than duplicating it.
 
-Whole-schema validation, value ranges, payload lengths, dimension magnitudes
-and cross-field consistency remain out of scope and are not asserted here.
+Wire integrity — base64 validity, payload lengths, lattice rank and dimension
+positivity — is now in scope and asserted here. Whole-schema validation,
+scientific value ranges and cross-field semantic consistency remain out of
+scope. Which *positive* channel counts the Observatory can consume is a
+separate layer; see ``tests/test_observatory_genome_loader.py``.
 
 Before this package every one of those was dereferenced without a shape check,
 so a genome that parsed as valid JSON with the wrong type raised an ambient
@@ -238,6 +241,177 @@ def test_absent_snapshot_counter_defaults_to_zero(tmp_path, field):
 
 
 # ---------------------------------------------------------------------------
+# Wire integrity: rank, positivity, strict base64, payload lengths
+#
+# Everything below is settled in Python before NumPy is asked for anything, so
+# a hostile shape can neither allocate nor overflow first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param([], id="rank-0-empty"),
+        pytest.param([8], id="rank-1"),
+        pytest.param([2, 4], id="rank-2"),
+        pytest.param([2, 2, 2, 1], id="rank-4"),
+    ],
+)
+def test_lattice_shape_must_have_exactly_three_dimensions(tmp_path, shape):
+    """A non-3D lattice used to decode silently and break in a consumer."""
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = shape
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(
+        PortableGenomeError, match="lattice_shape must have exactly three dimensions"
+    ):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param([2, 0, 2], id="zero"),
+        pytest.param([0, 0, 0], id="all-zero"),
+        pytest.param([2, -2, 2], id="negative"),
+        pytest.param([-1, -1, -1], id="all-negative"),
+    ],
+)
+def test_lattice_shape_dimensions_must_be_positive(tmp_path, shape):
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = shape
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(
+        PortableGenomeError, match="lattice_shape entries must be positive"
+    ):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("field", ["lattice_b64", "memory_grid_b64"])
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("!!!!!!!!", id="out-of-alphabet"),
+        pytest.param("AAAA=", id="excess-padding"),
+        pytest.param("AA=A", id="discontinuous-padding"),
+        pytest.param("AAA", id="truncated-group"),
+        pytest.param("AA AA", id="embedded-space"),
+    ],
+)
+def test_base64_is_decoded_strictly(tmp_path, field, text):
+    """`b64decode` defaults to validate=False, which silently DISCARDS
+    out-of-alphabet characters -- '!!!!!!!!' decoded to b'' and 'AAAA=' to
+    three bytes, both surfacing much later as a reshape mismatch, if at all."""
+    epi = _valid_epi()
+    epi[field] = text
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match=f"{field} is not valid base64"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("nbytes", [0, 1, 7, 9, 64])
+def test_lattice_payload_length_must_match_the_declared_shape(tmp_path, nbytes):
+    """SHAPE is (2,2,2) -> exactly 8 uint8 bytes."""
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_b64"] = base64.b64encode(b"\x00" * nbytes).decode("ascii")
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(
+        PortableGenomeError,
+        match="lattice_b64 payload length does not match the declared shape",
+    ):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("nbytes", [0, 4, 252, 260])
+def test_memory_payload_length_must_match_shape_and_channels(tmp_path, nbytes):
+    """8 channels x 8 cells x 4 bytes == 256."""
+    epi = _valid_epi()
+    epi["memory_grid_b64"] = base64.b64encode(b"\x00" * nbytes).decode("ascii")
+    path = _write(tmp_path, {
+        "epigenetic_snapshot": epi,
+    })
+    with pytest.raises(
+        PortableGenomeError,
+        match="memory_grid_b64 payload length does not match the declared shape",
+    ):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param([10 ** 7, 10 ** 7, 10 ** 7], id="1e21-cells"),
+        pytest.param([2 ** 62, 2, 2], id="beyond-ssize-t"),
+        pytest.param([2 ** 200, 1, 1], id="astronomically-large"),
+    ],
+)
+def test_enormous_dimensions_are_refused_without_overflow_or_allocation(tmp_path, shape):
+    """The expected byte count is computed with unbounded Python integers, so
+    an enormous declared dimension is rejected by comparison instead of
+    reaching NumPy and raising an untranslatable OverflowError -- and nothing
+    of that size is ever allocated."""
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = shape
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError) as excinfo:
+        extract_epigenetic_snapshot(path)
+    assert "payload length does not match" in str(excinfo.value)
+
+
+def test_enormous_dimension_message_does_not_echo_the_value(tmp_path):
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_shape"] = [10 ** 7, 10 ** 7, 10 ** 7]
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError) as excinfo:
+        extract_epigenetic_snapshot(path)
+    message = str(excinfo.value)
+    assert "10000000" not in message
+    assert len(message.splitlines()) == 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param("yes", id="string"), pytest.param(1, id="number-one"),
+     pytest.param(0, id="number-zero"), pytest.param([], id="array"),
+     pytest.param({}, id="object"), pytest.param(None, id="null")],
+)
+def test_included_must_be_an_actual_json_boolean(tmp_path, value):
+    """Truthiness used to decide this: `"included": "no"` enabled extraction."""
+    epi = _valid_epi(with_memory=False)
+    epi["included"] = value
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError, match="included must be a JSON boolean"):
+        extract_epigenetic_snapshot(path)
+
+
+@pytest.mark.parametrize("value", [0, -1, -8])
+def test_num_channels_must_be_positive(tmp_path, value):
+    path = _write(tmp_path, {
+        "epigenetic_snapshot": _valid_epi(),
+        "memory_layout": {"num_channels": value},
+    })
+    with pytest.raises(PortableGenomeError, match="num_channels must be positive"):
+        extract_epigenetic_snapshot(path)
+
+
+def test_deeply_nested_json_is_a_domain_refusal(tmp_path):
+    """CPython's JSON scanner recurses per level, so a deeply nested document
+    raises RecursionError -- a RuntimeError no caller sanely translates."""
+    path = tmp_path / "deep.json"
+    path.write_text("[" * 60000 + "]" * 60000, encoding="utf-8")
+    with pytest.raises(PortableGenomeError, match="genome JSON is nested too deeply"):
+        extract_epigenetic_snapshot(path)
+
+
+def test_ordinary_json_syntax_error_is_unchanged(tmp_path):
+    """Anti-vacuity: the nesting guard did not swallow normal decode errors."""
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        extract_epigenetic_snapshot(path)
+
+
+# ---------------------------------------------------------------------------
 # Absence is still KeyError -- shape checks did not swallow it
 # ---------------------------------------------------------------------------
 
@@ -309,15 +483,53 @@ def _handlers(func):
 @pytest.mark.parametrize(
     "func",
     [
-        extract_epigenetic_snapshot,
         pg._require_json_object_section,
         pg._require_json_string,
         pg._require_lattice_shape,
         pg._require_channel_count,
         pg._require_counter,
+        pg._require_json_boolean,
+        pg._require_payload_length,
     ],
 )
 def test_no_exception_handler_in_the_refusal_path(func):
-    """The refusals are type checks, not caught-and-retranslated exceptions:
-    nothing here can swallow an unrelated defect."""
+    """Every shape refusal is a plain type check, not a caught-and-retranslated
+    exception: none of these can swallow an unrelated defect."""
     assert _handlers(func) == []
+
+
+@pytest.mark.parametrize(
+    "func, expected",
+    [
+        # `ValueError`, not just `binascii.Error`: a non-ASCII string fails in
+        # `_bytes_from_decode_data` with a plain, value-quoting `ValueError`,
+        # which would otherwise escape the value-free message contract.
+        # `binascii.Error` subclasses `ValueError`, so one clause covers both.
+        (pg._decode_base64_strict, ["ValueError"]),
+        (extract_epigenetic_snapshot, ["RecursionError"]),
+    ],
+)
+def test_the_only_handlers_are_narrow_and_input_specific(func, expected):
+    """Two handlers exist in the whole path, each wrapping a single call on
+    already-validated input. Neither catches `Exception`, `BaseException`,
+    `TypeError`, `AttributeError` or a bare `except`."""
+    caught = []
+    for handler in _handlers(func):
+        assert handler.type is not None, "bare except introduced"
+        caught.append(ast.unparse(handler.type))
+    assert caught == expected
+    for banned in ("Exception", "BaseException", "TypeError", "AttributeError"):
+        assert banned not in caught
+
+
+def test_non_ascii_base64_is_still_a_domain_refusal(tmp_path):
+    """Anti-regression for the widened catch: a non-ASCII payload must not
+    escape as a bare ValueError quoting the argument."""
+    epi = _valid_epi(with_memory=False)
+    epi["lattice_b64"] = "AAA€"
+    path = _write(tmp_path, {"epigenetic_snapshot": epi})
+    with pytest.raises(PortableGenomeError) as excinfo:
+        extract_epigenetic_snapshot(path)
+    message = str(excinfo.value)
+    assert message == "lattice_b64 is not valid base64"
+    assert "€" not in message

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -62,6 +62,48 @@ class ObservatorySnapshot:
 
 
 # ---------------------------------------------------------------------------
+# Channel compatibility
+# ---------------------------------------------------------------------------
+
+def _normalize_memory_grid(memory_grid, shape) -> np.ndarray:
+    """Return an 8-channel NumPy memory grid for any supported legacy shape.
+
+    Every Observatory consumer indexes channels 0-7, so this is the single
+    contract both snapshot formats must satisfy. The migration itself belongs
+    to the engine and is NOT reimplemented here: this delegates to
+    ``scripts.continuous_evolution_ca._migrate_memory_grid``, which owns the
+    established Phase-5-to-Phase-6 and historic 3-channel mappings.
+
+    Extracted verbatim from ``load_npz``, where it previously lived inline, so
+    that ``load_genome`` gets the same guarantee. Before this, a portable-genome
+    JSON snapshot carrying a legacy 3- or 5-channel grid reached the Observatory
+    unnormalised and failed later inside a consumer with an ``IndexError``.
+
+    Behaviour preserved exactly, including the fallback's scope: the ``try``
+    still spans the import, the migration and the device-array conversion, so
+    an ``ImportError`` raised anywhere in that block still selects the
+    zero-padding fallback. An unsupported channel count raises the engine's
+    ``ValueError`` -- a translatable, actionable loading failure -- rather than
+    surfacing as a renderer ``IndexError``.
+    """
+    if memory_grid.shape[0] == NUM_CHANNELS:
+        return memory_grid
+    try:
+        from scripts.continuous_evolution_ca import _migrate_memory_grid
+        migrated = _migrate_memory_grid(memory_grid, tuple(shape))
+        if not isinstance(migrated, np.ndarray):
+            # engine helper may return a GPU device array; the snapshot contract is NumPy
+            migrated = migrated.get()
+        return migrated
+    except ImportError:
+        # Fallback: zero-pad to 8 channels
+        old_ch = memory_grid.shape[0]
+        new_grid = np.zeros((NUM_CHANNELS,) + tuple(shape), dtype=np.float32)
+        new_grid[:old_ch] = memory_grid[:old_ch]
+        return new_grid
+
+
+# ---------------------------------------------------------------------------
 # Loaders
 # ---------------------------------------------------------------------------
 
@@ -101,21 +143,7 @@ def load_npz(path: str | Path) -> ObservatorySnapshot:
 
     # Auto-migrate old memory grid formats. The archive is already closed here,
     # so neither the engine import nor the migration retains the file handle.
-    if memory_grid.shape[0] != NUM_CHANNELS:
-        try:
-            from scripts.continuous_evolution_ca import _migrate_memory_grid
-            memory_grid = _migrate_memory_grid(memory_grid, lattice.shape)
-            if not isinstance(memory_grid, np.ndarray):
-                # engine helper may return a GPU device array; the snapshot contract is NumPy
-                memory_grid = memory_grid.get()
-        except ImportError:
-            # Fallback: zero-pad to 8 channels
-            old_ch = memory_grid.shape[0]
-            new_grid = np.zeros(
-                (NUM_CHANNELS,) + lattice.shape, dtype=np.float32
-            )
-            new_grid[:old_ch] = memory_grid[:old_ch]
-            memory_grid = new_grid
+    memory_grid = _normalize_memory_grid(memory_grid, lattice.shape)
 
     return ObservatorySnapshot(
         lattice=lattice.astype(np.uint8),
@@ -132,6 +160,12 @@ def load_genome(path: str | Path) -> ObservatorySnapshot:
 
     Delegates to ``scripts.portable_genome.extract_epigenetic_snapshot()``.
     Raises ValueError if the genome has no epigenetic data.
+
+    Legacy 3- and 5-channel grids are normalised through the same seam the NPZ
+    path uses, so both formats hand the Observatory the identical 8-channel
+    contract. An absent memory grid still yields the established 8-channel
+    zero grid; an unsupported channel count fails here, during loading, rather
+    than later inside a renderer or metadata consumer.
     """
     from scripts.portable_genome import extract_epigenetic_snapshot
 
@@ -145,9 +179,12 @@ def load_genome(path: str | Path) -> ObservatorySnapshot:
     lattice, memory_grid, meta = result
     if memory_grid is None:
         memory_grid = np.zeros((NUM_CHANNELS,) + lattice.shape, dtype=np.float32)
+    else:
+        # Same 8-channel Observatory contract the NPZ path has always had.
+        memory_grid = _normalize_memory_grid(memory_grid, lattice.shape)
     return ObservatorySnapshot(
-        lattice=lattice,
-        memory_grid=memory_grid,
+        lattice=lattice.astype(np.uint8),
+        memory_grid=memory_grid.astype(np.float32),
         generation=meta.get("generation", 0),
         ca_step=meta.get("ca_step", 0),
         best_fitness=0.0,


### PR DESCRIPTION
## Scope

Portable-genome epigenetic-snapshot **wire integrity** and Observatory **legacy-channel compatibility** — a further tranche related to issue #67.

PR #447 corrected the structural *types* of the epigenetic snapshot and deliberately listed these gaps as out of scope. This closes them.

`Refs #67` — no closing keyword. Issue #67 stays open; this is not its completion.

**Base** `9efe9d7aca25b1545e56d5de88afb8630a5a5ba5` · **Head** `371adf5dcd079b4b9d51e94cf8d3bb6f099a48c8`

## Failing-first matrix

Reproduced against the exact base, driving the **genuine** extractor and loader with **real `.json` files on disk** — not patched-away boundaries.

| # | Case | Before | After |
|---|---|---|---|
| 1 | empty `lattice_shape` | `ValueError` (NumPy reshape) → status 1 | domain refusal: *must have exactly three dimensions* |
| 2 | rank 2 | **ACCEPTED** → 2-D lattice | refused |
| 2b | rank 4 | **ACCEPTED** → 4-D lattice | refused |
| 3 | zero dimension | `ValueError` (NumPy) | domain refusal: *must be positive* |
| 3b | negative dimension | `ValueError` (NumPy) | domain refusal |
| 4 | base64 out-of-alphabet `"!!!!!!!!"` | **silently decoded to `b""`**, failed later | *is not valid base64* |
| 4b | excess padding `"AAAA="` | **silently decoded to 3 bytes** | *is not valid base64* |
| 4c | discontinuous padding `"AA=A"` | `binascii.Error` | *is not valid base64* |
| 5 | lattice bytes ≠ declared shape | `ValueError` (NumPy, echoes shape) | *payload length does not match the declared shape* |
| 6 | memory bytes ≠ shape × channels | `ValueError` (NumPy) | domain refusal |
| 7 | `num_channels` 0 / negative | `ValueError` (NumPy) | *num_channels must be positive* |
| 7c | `num_channels` 4 (unsupported) | **ACCEPTED** → 4-channel grid, later `IndexError` | refused **during loading** (layer 2) |
| 8 | legacy **3-channel** JSON | **grid reached Observatory with 3 channels** | migrated to 8 |
| 9 | legacy **5-channel** JSON | **grid reached Observatory with 5 channels** | migrated to 8 |
| 10 | CLI behaviour for the above | traceback or wrong result | one-line status 1, or correct load |
| 11 | deeply nested JSON | **`RecursionError`** → traceback | *genome JSON is nested too deeply* |
| + | huge dims, tiny payload | **`OverflowError`** → traceback | payload-length refusal, no allocation |
| + | `"included": "yes"` | **ACCEPTED** (truthiness) | *included must be a JSON boolean* |

**22 escaping/silently-wrong cases → 0.** Valid inputs unchanged throughout: 8-channel grids, absent memory grid, `included: false`, absent `memory_layout`, absent counters.

Honest note: cases 1, 3, 5, 6 and 7 were **already** reaching the CLI's status-1 lane before this change — via NumPy's message, which echoes the supplied shape. They are corrected for determinism and value-freedom, not because they were tracebacks.

## Ownership by layer

| Layer | File | Owns |
|---|---|---|
| **Wire integrity** | `scripts/portable_genome.py` | `included` type, rank/positivity, strict base64, exact payload lengths, positive channel count, deep-JSON translation |
| **Channel compatibility** | `vis/observatory/loader.py` | which *positive* channel counts the Observatory can consume; 3/5→8 migration for both formats |
| **CLI reachability** | `vis/observatory/cli.py` — **unchanged** | `PortableGenomeError ⊂ ValueError` and the loader's migration `ValueError` already land in the status-1 lane |

That split is deliberate: the extractor guarantees the wire value is a usable positive integer; the loader decides what the renderer can actually use.

## Migration semantics — exact

Delegated to the engine's `_migrate_memory_grid`; **not** reimplemented, and `scripts/continuous_evolution_ca.py` is untouched.

| Source | Destination |
|---|---|
| **8** | passthrough, unchanged |
| **5** | `new[0:5] = old[0:5]`; channels 5, 6, 7 (signal, warmth, cooldown) zero |
| **3** | `new[0] = old[0]`, `new[2] = old[1]`, `new[4] = old[2]`; `new[1] = 0.0`, `new[3] = 1.0`; 5, 6, 7 zero |
| absent | established 8-channel zero grid |
| other | `ValueError: Cannot migrate memory grid with N channels`, raised **during loading** |

Tests assert the exact placement, not merely the resulting shape, with markers at 10/20/30 so no marker can be confused with the migration's own 0.0/1.0 defaults.

## Integrity checks and message contract

Every check runs **before any NumPy call** — both `frombuffer`/`reshape` pairs moved to the end of the function, so a hostile shape can neither allocate nor overflow first.

- expected counts use **unbounded Python integers**: `cells = d0*d1*d2`, lattice `cells × 1` bytes, memory `num_channels × cells × 4`. An enormous dimension is refused by comparison instead of reaching NumPy's `ssize_t` conversion.
- messages are **single-line, deterministic and value-free** — they name the field, never the supplied payload, shape or count. A `10**7` cubed shape yields *"lattice_b64 payload length does not match the declared shape"* with no digit of the input in it.

## Compatibility and explicit non-claims

- **`export_genome` output is unaffected**: it writes real JSON booleans, `list(lattice.shape)` (rank-3 plain ints), string payloads and an 8-entry `memory_layout`. Nothing it produces is newly refused.
- The genuine narrowings are all previously-nonsense inputs: `"included": 1`; `num_channels: -1` (NumPy read `-1` as *infer* and silently produced 8 channels); `num_channels: 0` with an empty payload; zero-size lattices; non-3D shapes.
- **Reachability caveat:** `export_genome` hardcodes `num_channels: MEMORY_CHANNELS` (8), so *this* repo's exporter cannot emit a 3/5-channel-declared genome. The migration path serves genomes written by an older exporter or built by hand.
- **The ImportError fallback is preserved, not narrowed** — its `try` still spans the import, the migration and the device-array conversion, exactly as before. A consequence now worth stating: `load_genome` **inherits** that scope, so if the engine ever raised `ImportError` internally, both paths would zero-pad rather than migrate, which for 3-channel data is a *different* layout. No failing test demonstrates it, so per the brief it is characterised rather than changed — `test_import_error_fallback_zero_pads` pins the zero-padding behaviour explicitly.
- Device-array `.get()` conversion and NPZ deterministic archive closure are unchanged; the existing platform-independent closure witness in `tests/test_observatory_loader.py` is untouched.
- **Not claimed:** whole-schema validation, scientific value ranges, dimension plausibility, cross-field semantic consistency, or any security property. Nesting-depth behaviour is interpreter-dependent.
- No new dependency, no test dependency, no production hook for tests.

## Changed files

Five, all inside the authorized boundary:

| File | + | − |
|---|---|---|
| `scripts/portable_genome.py` | 142 | 20 |
| `vis/observatory/loader.py` | 54 | 17 |
| `tests/test_portable_genome_epigenetic_snapshot.py` | 217 | 5 |
| `tests/test_portable_genome_config_shapes.py` | 6 | 1 |
| `tests/test_observatory_genome_loader.py` (new) | 359 | 0 |
| **Total** | **778** | **43** |

`scripts/continuous_evolution_ca.py`, `schemas/`, renderer modules, workflows, dependencies, configuration and tech-ledger files are **untouched**. `vis/observatory/cli.py` is not in the diff, so no caught exception class was broadened.

`tests/test_portable_genome_config_shapes.py` needed exactly one change: `b64decode` moved into `_decode_base64_strict`, so its landmark lock now asserts the delegation instead of the raw call it replaced.

## Validation

| Command | Result |
|---|---|
| `python -m py_compile` (all five files) | **exit 0** |
| `git diff --check` | **clean** |
| `python -m pytest -q …` (focused, adjacent, full suite) | **NOT RUN** — `No module named pytest`; NumPy and matplotlib also absent |

Nothing was installed. *Supporting evidence only, not a pytest substitute:* a labelled probe loaded the genuine `portable_genome.py` and `loader.py` by path with NumPy and the engine stubbed, and drove them against real `.json` files — 22 defects before, 0 after. A second probe replayed every AST structure lock. **CI is authoritative** for the pytest suite.

## Independent adversarial review

A bounded read-only agent audited the complete diff. It found **no confirmed functional bug** — notably confirming the 3- and 5-channel assertions match the engine character for character, that no NumPy call precedes any validation, and that the caught-exception set was not widened.

It raised five real issues, each reproduced by me and fixed before commit:

1. **Non-ASCII base64 escaped the contract** — `b64decode` fails in `_bytes_from_decode_data` with a plain, argument-quoting `ValueError`, not `binascii.Error`. The catch is now `ValueError` (which subsumes `binascii.Error`), scoped to that single call, with a regression test asserting the message is value-free.
2. **Two loader tests were order-dependent** through `sys.modules` — `load_genome` imports `scripts.portable_genome` first, so patching the engine could break *that* import under `-k` selection. The extractor is now imported eagerly at module top.
3. **An archive-lifetime test was vacuous on POSIX CI** (unlink of an open file succeeds). Replaced with a meaningful NPZ migration assertion, deferring lifetime to the existing platform-independent witness.
4. **Three docstrings contradicted the diff** (payload lengths "out of scope", validation ordering "after the lattice has been reshaped"). All corrected.
5. **Marker collision** — 3-channel markers of 1.0/2.0/3.0 could not be distinguished from the migration's own `new[3] = 1.0` default. Markers are now 10/20/30.

It also flagged that the base64 strictness is version-load-bearing (`validate=True` rejects excess padding only from Python 3.11+; CI pins 3.12) — recorded here rather than worked around.

## Open-PR overlap

| PR | Files | Overlap |
|---|---|---|
| #449 (draft) | `experiments/tech_ledger/**` | none |
| #443 | 5 `.github/workflows/*.yml` | none |
| #442, #441 | `crates/uft_ca/Cargo.toml` | none |

No open PR touches `scripts/portable_genome.py`, `vis/observatory/**` or any `tests/test_portable_genome*` / `tests/test_observatory*` file.

## Status

**Draft and unmerged**, for independent audit. Issue #67 remains open.


## CI receipts

**Head `371adf5` — every check passes on the first run.** Authoritative `verify-python` is the `pull_request`-event job, [run 30871379728 / job 91873916923](https://github.com/Goldislops/UtilityFog-Fractal-TreeOpen/actions/runs/30871379728/job/91873916923):

```
3276 passed, 13 skipped in 54.71s
```

Push-event job: `3276 passed, 13 skipped in 51.69s`. Baseline `verify-python` on base `9efe9d7a` is `3199 passed, 13 skipped`, so this package adds **+77 passing tests** and no skips.

| Workflow / job | Conclusion |
|---|---|
| `CI / verify-python` (pull_request + push) | **success** |
| `CI / frontend-quality` (pull_request + push) | success |
| `Agent Safety Suite / agent-safety` | success |
| `CodeQL (Python baseline) / Analyze Python` + `CodeQL` | success |
| `Theory Tripwire / tripwire` | success |

8 registered checks, 0 pending, queued, failing, cancelled or missing. No workflow was manually rerun.
