### PR TITLE
Observatory: `doctor` preflight and deterministic JSON reporting

### DIFF
--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -1261,12 +1261,18 @@ def test_a_source_path_cannot_forge_doctor_report_lines(cli, capsys):
     cli.set_loader(lambda _p: bad)
 
     assert cli.run(["doctor", cli.snapshot_path]) == 1
-    out = capsys.readouterr().out
-    assert out.count("[PASS]") == 12
-    assert out.count("[FAIL]") == 1
-    assert "OK: all 13 checks passed." not in out
-    assert len([ln for ln in out.splitlines()
-                if ln.startswith(("OK:", "FAILED:"))]) == 1
+    lines = capsys.readouterr().out.splitlines()
+
+    # The forged text is not erased -- it is still visible, inert, on the
+    # Snapshot line. What it may not do is become its own row: structure is
+    # what a reader and a grep go by, so structure is what is asserted.
+    body = [ln for ln in lines if ln.startswith("  [")]
+    assert len(body) == 13
+    assert sum(1 for ln in body if ln.startswith("  [PASS]")) == 12
+    assert sum(1 for ln in body if ln.startswith("  [FAIL]")) == 1
+    assert [ln for ln in lines if ln.startswith(("OK:", "FAILED:"))] == [
+        "FAILED: 1 of 13 checks did not pass."
+    ]
 
 
 def test_a_source_path_cannot_forge_info_rows(cli, capsys):
@@ -1274,8 +1280,9 @@ def test_a_source_path_cannot_forge_info_rows(cli, capsys):
     object.__setattr__(bad, "source_path", "/tmp/a\n  Void        :       99 (99.9%)")
     cli.set_loader(lambda _p: bad)
     assert cli.run(["info", cli.snapshot_path]) == 0
-    out = capsys.readouterr().out
-    assert out.count("Void") == 1
+    lines = capsys.readouterr().out.splitlines()
+    assert len([ln for ln in lines if ln.startswith("  Void")]) == 1
+    assert len([ln for ln in lines if ln.startswith("Source:")]) == 1
 
 
 def test_json_mode_round_trips_a_hostile_path_verbatim(cli, capsys):

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -1240,6 +1240,74 @@ def test_zero_size_lattice_does_not_crash_either_command(tmp_path, command, shap
                                  else "snapshot"] is not None
 
 
+# --- oversized counters through the genuine NPZ route ----------------------
+#
+# Reachability note. An ordinary portable-genome JSON file is NOT the route:
+# CPython applies the same integer-string ceiling when PARSING, so `json.load`
+# rejects an over-limit decimal literal before the loader ever sees it. The
+# NPZ route does reach it -- `load_npz` uses `allow_pickle=True` and then
+# `int(...)`, so a pickled Python int of any magnitude survives as a real int.
+# A snapshot built directly in a library call is the other valid witness.
+
+
+def _write_oversized_snapshot(path, field="generation"):
+    """A real .npz whose counter is a huge pickled Python int."""
+    lattice = np.zeros((2, 3, 4), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    payload = {
+        "lattice": lattice,
+        "memory_grid": np.zeros((8, 2, 3, 4), dtype=np.float32),
+        "generation": 7,
+        "ca_step": 11,
+        "best_fitness": 0.25,
+    }
+    payload[field] = np.array(10 ** 100000, dtype=object)
+    np.savez(path, **payload)
+    return str(path)
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_oversized_counter_does_not_traceback_in_info(tmp_path, field, argv_tail):
+    """Human `info` formats the counters directly with `:,`, which raises on a
+    value past the digit ceiling; `info --json` serialized it verbatim and
+    raised inside the encoder. Neither may traceback."""
+    path = _write_oversized_snapshot(tmp_path / f"big_{field}.npz", field)
+    proc = _run_module("info", path, *argv_tail)
+    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+    assert proc.returncode == 0
+    if argv_tail:
+        assert json.loads(proc.stdout)[field] is None
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_oversized_counter_is_reported_by_doctor(tmp_path, field, argv_tail):
+    """`doctor` must report it as a failed check, not die describing it."""
+    path = _write_oversized_snapshot(tmp_path / f"big_{field}.npz", field)
+    proc = _run_module("doctor", path, *argv_tail)
+    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+    assert proc.returncode == 1
+    if argv_tail:
+        document = json.loads(proc.stdout)
+        assert document["ok"] is False
+        failed = [c["name"] for c in document["checks"] if not c["ok"]]
+        assert f"{field}_non_negative_int" in failed
+        assert document["snapshot"][field] is None
+    else:
+        assert f"{field}_non_negative_int" in proc.stdout
+        assert "[FAIL]" in proc.stdout
+
+
+def test_ordinary_counters_still_render_normally(tmp_path):
+    """The guard must not disturb the established `info` layout."""
+    path = _write_snapshot(tmp_path / "normal.npz", generation=1234567, ca_step=11)
+    proc = _run_module("info", path)
+    assert proc.returncode == 0, proc.stderr
+    assert "Generation: 1,234,567" in proc.stdout
+    assert "CA Step:    11" in proc.stdout
+
+
 # --- untrusted pathnames may not forge output rows -------------------------
 
 

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -1211,6 +1211,84 @@ def test_memory_spatial_mismatch_still_produces_a_json_document(tmp_path):
     assert "Traceback (most recent call last)" not in human.stderr
 
 
+@pytest.mark.parametrize("command", ["info", "doctor"])
+@pytest.mark.parametrize(
+    "shape", [(0, 3, 4), (3, 0, 4), (3, 4, 0), (0, 0, 0)]
+)
+def test_zero_size_lattice_does_not_crash_either_command(tmp_path, command, shape):
+    """Settles a limitation the PR body claimed was outstanding.
+
+    On the base, human `info` raised ZeroDivisionError computing a percentage
+    over zero cells. The shared-statistics refactor made the percentage `None`
+    and `format_percent` renders that as `n/a`, so `info` now exits 0. `doctor`
+    reports the zero dimension as a failed check and exits 1. Neither
+    tracebacks -- which is what the body should have said.
+    """
+    lattice = np.zeros(shape, dtype=np.uint8)
+    memory = np.zeros((8,) + shape, dtype=np.float32)
+    path = _write_snapshot(tmp_path / "empty.npz", lattice=lattice, memory=memory)
+
+    proc = _run_module(command, path)
+    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+    assert proc.returncode == (0 if command == "info" else 1)
+    if command == "info":
+        assert "n/a" in proc.stdout
+
+    js = _run_module(command, path, "--json")
+    assert "Traceback (most recent call last)" not in js.stderr, js.stderr
+    assert json.loads(js.stdout)["total_cells" if command == "info"
+                                 else "snapshot"] is not None
+
+
+# --- untrusted pathnames may not forge output rows -------------------------
+
+
+FORGED_SOURCE = (
+    "/tmp/snap\n\n  [PASS] lattice_states_known  all state ids within [0, 1, 2, "
+    "3, 4]\n\nOK: all 13 checks passed.\n\nquarantined.npz"
+)
+
+
+def test_a_source_path_cannot_forge_doctor_report_lines(cli, capsys):
+    """A pathname is untrusted data. Rendered verbatim it could inject a
+    convincing extra PASS row and a second summary line ahead of the real
+    report, so a reader -- or a grep -- would see a verdict the run never
+    reached. The exit status was never at risk; the report's integrity was.
+    """
+    bad = _snapshot()
+    bad.lattice[0, 0, 0] = 99                      # genuinely fails a check
+    object.__setattr__(bad, "source_path", FORGED_SOURCE)
+    cli.set_loader(lambda _p: bad)
+
+    assert cli.run(["doctor", cli.snapshot_path]) == 1
+    out = capsys.readouterr().out
+    assert out.count("[PASS]") == 12
+    assert out.count("[FAIL]") == 1
+    assert "OK: all 13 checks passed." not in out
+    assert len([ln for ln in out.splitlines()
+                if ln.startswith(("OK:", "FAILED:"))]) == 1
+
+
+def test_a_source_path_cannot_forge_info_rows(cli, capsys):
+    bad = _snapshot()
+    object.__setattr__(bad, "source_path", "/tmp/a\n  Void        :       99 (99.9%)")
+    cli.set_loader(lambda _p: bad)
+    assert cli.run(["info", cli.snapshot_path]) == 0
+    out = capsys.readouterr().out
+    assert out.count("Void") == 1
+
+
+def test_json_mode_round_trips_a_hostile_path_verbatim(cli, capsys):
+    """JSON needs no collapsing -- escaping already makes it inert -- and the
+    value must survive unchanged so a consumer sees the real path."""
+    bad = _snapshot()
+    object.__setattr__(bad, "source_path", FORGED_SOURCE)
+    cli.set_loader(lambda _p: bad)
+    assert cli.run(["doctor", cli.snapshot_path, "--json"]) == 0
+    document, _ = _only_json(capsys)
+    assert document["source"] == FORGED_SOURCE
+
+
 def test_doctor_end_to_end_malformed_snapshot_is_status_one(tmp_path):
     path = tmp_path / "junk.npz"
     path.write_bytes(b"not an npz at all")

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -832,3 +832,502 @@ def test_module_entry_point_end_to_end_user_error_exits_one(tmp_path):
 
 def test_module_entry_point_end_to_end_usage_error_exits_two():
     assert _run_module("zzzzzzzzzz").returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# `doctor` preflight and `--json` reporting
+#
+# Reachability and process contract only. The check semantics themselves live
+# in tests/test_observatory_diagnostics.py; what matters here is that the CLI
+# reaches them, maps them onto the right exit status, and keeps stdout clean.
+#
+# `doctor` is the one command that can return 1 after a *successful* load:
+#   0 = loaded and every check passed
+#   1 = expected load failure, OR diagnostics completed with >=1 failure
+#   2 = argparse usage error
+# ---------------------------------------------------------------------------
+
+
+def _write_snapshot(path, lattice=None, memory=None, generation=7, ca_step=11,
+                    best_fitness=0.25, channels=8):
+    """A real .npz the genuine loader reads -- no doubles on this path."""
+    if lattice is None:
+        lattice = np.zeros((3, 4, 5), dtype=np.uint8)
+        lattice[0, 0, 0] = 1
+        lattice[1, 1, 1] = 2
+    if memory is None:
+        memory = np.zeros((channels,) + lattice.shape, dtype=np.float32)
+    np.savez(
+        path,
+        lattice=lattice,
+        memory_grid=memory,
+        generation=generation,
+        ca_step=ca_step,
+        best_fitness=best_fitness,
+    )
+    return str(path)
+
+
+def _canonical(document):
+    """Serialize a parsed document under the CLI's own strict settings."""
+    return json.dumps(document, sort_keys=True, allow_nan=False,
+                      separators=(",", ":"))
+
+
+def _only_json(capsys):
+    """Assert stdout is exactly one JSON document and return it."""
+    captured = capsys.readouterr()
+    text = captured.out
+    assert text.endswith("\n")
+    assert text.strip().count("\n") == 0, "JSON mode must emit a single line"
+    document = json.loads(text)          # raises if prose leaked in
+    assert isinstance(document, dict)
+    return document, captured
+
+
+# --- dispatch and exit status ----------------------------------------------
+
+
+def test_doctor_returns_zero_for_a_healthy_snapshot(cli, capsys):
+    assert cli.run(["doctor", cli.snapshot_path]) == 0
+    out = capsys.readouterr().out
+    assert "[PASS]" in out
+    assert "[FAIL]" not in out
+    assert out.strip().splitlines()[-1].startswith("OK:")
+
+
+def test_doctor_returns_one_when_a_check_fails(cli, capsys):
+    """A snapshot that loads cleanly but violates the contract: status 1
+    without an error message, because nothing failed to *load*."""
+    bad = _snapshot()
+    bad.lattice[0, 0, 0] = 99            # outside the state vocabulary
+    cli.set_loader(lambda _p: bad)
+    assert cli.run(["doctor", cli.snapshot_path]) == 1
+    captured = capsys.readouterr()
+    assert "[FAIL]" in captured.out
+    assert "lattice_states_known" in captured.out
+    assert captured.out.strip().splitlines()[-1].startswith("FAILED:")
+    assert "Traceback (most recent call last)" not in captured.err
+
+
+def test_doctor_reports_every_failure_not_just_the_first(cli, capsys):
+    bad = _snapshot()
+    bad.lattice[0, 0, 0] = 99
+    object.__setattr__(bad, "generation", -1)
+    object.__setattr__(bad, "best_fitness", float("nan"))
+    cli.set_loader(lambda _p: bad)
+    assert cli.run(["doctor", cli.snapshot_path]) == 1
+    out = capsys.readouterr().out
+    assert out.count("[FAIL]") == 3
+    assert "FAILED: 3 of" in out
+
+
+def test_doctor_missing_path_is_the_ordinary_user_error_lane(cli, capsys):
+    """Path validation, which runs before any load: one stderr line, no
+    traceback, no diagnostic report."""
+    assert cli.run(["doctor", str(cli.tmp / "absent.npz")]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert len(captured.err.strip().splitlines()) == 1
+    assert "Traceback (most recent call last)" not in captured.err
+
+
+def _unreadable_npz(cli):
+    """A path that passes validation but fails inside the genuine loader, so
+    the failure really is a *load* failure and not a path check."""
+    cli.use_real_loader()
+    path = cli.tmp / "corrupt.npz"
+    path.write_bytes(b"this is not a zip archive")
+    return str(path)
+
+
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_doctor_load_failure_emits_no_report(cli, capsys, argv_tail):
+    """A genuine load failure must not produce a half-built document, in
+    either output mode. `_emit_json` is never reached, so stdout stays empty
+    and the single-line stderr contract holds."""
+    assert cli.run(["doctor", _unreadable_npz(cli), *argv_tail]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert len(captured.err.strip().splitlines()) == 1
+    assert "Traceback (most recent call last)" not in captured.err
+
+
+# --- argparse surface -------------------------------------------------------
+
+
+def test_doctor_help_exits_zero(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["doctor", "--help"])
+    assert exc.value.code == 0
+
+
+def test_doctor_is_listed_in_top_level_help(cli, capsys):
+    with pytest.raises(SystemExit):
+        cli.run(["--help"])
+    assert "doctor" in capsys.readouterr().out
+
+
+def test_doctor_without_a_snapshot_is_a_usage_error(cli):
+    with pytest.raises(SystemExit) as exc:
+        cli.run(["doctor"])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_unknown_flag_on_json_commands_is_a_usage_error(cli, command):
+    with pytest.raises(SystemExit) as exc:
+        cli.run([command, cli.snapshot_path, "--jsonn"])
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_flag_takes_no_value(cli, command):
+    with pytest.raises(SystemExit) as exc:
+        cli.run([command, cli.snapshot_path, "--json", "pretty"])
+    assert exc.value.code == 2
+
+
+# --- JSON output ------------------------------------------------------------
+
+
+def test_doctor_json_is_a_single_valid_document(cli, capsys):
+    assert cli.run(["doctor", cli.snapshot_path, "--json"]) == 0
+    document, captured = _only_json(capsys)
+    assert captured.err == ""
+    assert document["kind"] == "doctor"
+    assert document["ok"] is True
+    assert document["summary"]["failed"] == 0
+    assert [c["name"] for c in document["checks"]] == [
+        c.name for c in _diagnostics().diagnose(_snapshot())
+    ]
+
+
+def test_doctor_json_failure_still_returns_one_with_a_full_report(cli, capsys):
+    bad = _snapshot()
+    bad.lattice[0, 0, 0] = 99
+    cli.set_loader(lambda _p: bad)
+    assert cli.run(["doctor", cli.snapshot_path, "--json"]) == 1
+    document, captured = _only_json(capsys)
+    assert captured.err == ""
+    assert document["ok"] is False
+    assert document["summary"]["failed"] == 1
+    failed = [c["name"] for c in document["checks"] if not c["ok"]]
+    assert failed == ["lattice_states_known"]
+
+
+def test_info_json_is_a_single_valid_document(cli, capsys):
+    assert cli.run(["info", cli.snapshot_path, "--json"]) == 0
+    document, captured = _only_json(capsys)
+    assert captured.err == ""
+    assert document["kind"] == "info"
+    assert document["generation"] == 7
+    assert document["ca_step"] == 11
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_mode_emits_no_human_prose(cli, capsys, command):
+    """The healthy snapshot returns 0 for both commands; the point of the test
+    is that stdout carries the document and nothing else."""
+    assert cli.run([command, cli.snapshot_path, "--json"]) == 0
+    out = capsys.readouterr().out
+    for prose in ("Source:", "Generation:", "CA Step:", "Non-void:",
+                  "[PASS]", "[FAIL]", "OK:", "FAILED:"):
+        assert prose not in out
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_output_is_byte_identical_for_equivalent_snapshots(tmp_path, command):
+    """Determinism, proven end to end over two genuinely distinct files with
+    identical content: the documents must differ only in the source path.
+
+    Driven through real files rather than the fixture's loader double, which
+    reports one fixed source no matter which path it is handed and so could not
+    tell a deterministic serializer from a constant one.
+    """
+    first_path = _write_snapshot(tmp_path / "one.npz")
+    second_path = _write_snapshot(tmp_path / "two.npz")
+
+    first = json.loads(_run_module(command, first_path, "--json").stdout)
+    second = json.loads(_run_module(command, second_path, "--json").stdout)
+
+    assert first["source"] != second["source"]
+    first.pop("source")
+    second.pop("source")
+    assert _canonical(first) == _canonical(second)
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_output_is_stable_across_repeated_runs(tmp_path, command):
+    path = _write_snapshot(tmp_path / "stable.npz")
+    first = _run_module(command, path, "--json").stdout
+    second = _run_module(command, path, "--json").stdout
+    assert first == second
+    assert first.strip().count("\n") == 0
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_never_emits_non_standard_tokens(cli, capsys, command):
+    """`allow_nan=False`: non-finite values become null, never bare NaN /
+    Infinity, which no strict JSON parser accepts."""
+    bad = _snapshot()
+    bad.memory_grid[0] = np.nan
+    bad.memory_grid[1] = np.inf
+    object.__setattr__(bad, "best_fitness", float("-inf"))
+    cli.set_loader(lambda _p: bad)
+    cli.run([command, cli.snapshot_path, "--json"])
+    out = capsys.readouterr().out
+    assert "NaN" not in out and "Infinity" not in out
+    json.loads(out)
+
+
+def _diagnostics():
+    from vis.observatory import diagnostics
+
+    return diagnostics
+
+
+def test_info_json_agrees_with_the_human_rendering(cli, capsys):
+    """The shared-statistics refactor, asserted: one source of truth, so the
+    two renderings cannot drift."""
+    assert cli.run(["info", cli.snapshot_path]) == 0
+    human = capsys.readouterr().out
+    assert cli.run(["info", cli.snapshot_path, "--json"]) == 0
+    document = json.loads(capsys.readouterr().out)
+
+    assert f"Generation: {document['generation']}" in human
+    assert f"CA Step:    {document['ca_step']}" in human
+    for entry in document["state_counts"]:
+        if entry["count"]:
+            assert entry["name"] in human
+            assert str(entry["count"]) in human
+
+
+# --- end to end through the genuine loader ----------------------------------
+
+
+def test_doctor_passes_a_real_npz_snapshot(tmp_path):
+    proc = _run_module("doctor", _write_snapshot(tmp_path / "real.npz"))
+    assert proc.returncode == 0, proc.stderr
+    assert "[FAIL]" not in proc.stdout
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_doctor_passes_a_legacy_channel_snapshot(tmp_path, channels):
+    """The landed loader normalization seam, reached from `doctor`: a legacy
+    3- or 5-channel grid is migrated to 8 before the contract is checked, so
+    the channel-count check must pass rather than flag a historical file."""
+    path = _write_snapshot(tmp_path / f"legacy{channels}.npz", channels=channels)
+    proc = _run_module("doctor", path)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_doctor_fails_a_real_snapshot_that_breaks_the_contract(tmp_path):
+    lattice = np.zeros((3, 4, 5), dtype=np.uint8)
+    lattice[0, 0, 0] = 200               # loads fine; not in the vocabulary
+    path = _write_snapshot(tmp_path / "bad.npz", lattice=lattice)
+    proc = _run_module("doctor", path)
+    assert proc.returncode == 1
+    assert "[FAIL]" in proc.stdout
+    assert "Traceback (most recent call last)" not in proc.stderr
+
+
+def test_doctor_json_end_to_end_parses(tmp_path):
+    proc = _run_module("doctor", _write_snapshot(tmp_path / "real.npz"), "--json")
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout)["ok"] is True
+
+
+def test_doctor_passes_a_portable_genome_without_a_memory_grid(cli, capsys):
+    """The other public route, through the genuine loader. A genome carrying no
+    memory grid is filled with the established 8-channel zero grid, so it
+    satisfies the contract rather than being reported as broken."""
+    cli.use_real_loader()
+    path = cli.tmp / "genome.json"
+    path.write_text(json.dumps({"epigenetic_snapshot": _epi()}), encoding="utf-8")
+    assert cli.run(["doctor", str(path), "--json"]) == 0
+    document, _ = _only_json(capsys)
+    assert document["ok"] is True
+    route = next(c for c in document["checks"] if c["name"] == "source_loadable")
+    assert "portable-genome JSON" in route["detail"]
+
+
+def test_doctor_names_the_npz_route(cli, capsys):
+    assert cli.run(["doctor", cli.snapshot_path, "--json"]) == 0
+    document, _ = _only_json(capsys)
+    route = next(c for c in document["checks"] if c["name"] == "source_loadable")
+    assert route["ok"] is True
+    assert "npz" in route["detail"]
+
+
+# --- regressions: the report must survive what the checks are meant to flag --
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_non_finite_memory_does_not_crash_either_output_mode(tmp_path, command):
+    """Regression. `snapshot_statistics` maps non-finite values to None so the
+    JSON stays strict; the human table then received None for a channel's
+    min/max/mean and died on `:+.4f`. A snapshot carrying NaN is exactly what
+    `doctor` exists to report, so neither mode may traceback on it."""
+    memory = np.zeros((8, 3, 4, 5), dtype=np.float32)
+    memory[0] = np.nan
+    memory[1] = np.inf
+    memory[2] = -np.inf
+    path = _write_snapshot(tmp_path / "nonfinite.npz", memory=memory)
+
+    for argv_tail in ([], ["--json"]):
+        proc = _run_module(command, path, *argv_tail)
+        assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+        # info always 0; doctor reports the finiteness failure as 1.
+        assert proc.returncode == (0 if command == "info" else 1)
+        if argv_tail:
+            assert json.loads(proc.stdout)          # strict parse, no NaN token
+            assert "NaN" not in proc.stdout and "Infinity" not in proc.stdout
+        else:
+            assert "non-finite" in proc.stdout
+
+
+def test_memory_spatial_mismatch_still_produces_a_json_document(tmp_path):
+    """Regression. Masking a (4,4,4) channel with an (8,8,8) lattice mask
+    raises IndexError, so `doctor --json` died with a traceback and emitted no
+    document at all -- on precisely the snapshot the shape check reports.
+    Human `doctor` handled it correctly, so the two modes disagreed."""
+    lattice = np.zeros((8, 8, 8), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    memory = np.zeros((8, 4, 4, 4), dtype=np.float32)
+    path = _write_snapshot(tmp_path / "mismatch.npz", lattice=lattice, memory=memory)
+
+    proc = _run_module("doctor", path, "--json")
+    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+    assert proc.returncode == 1
+    document = json.loads(proc.stdout)
+    assert document["ok"] is False
+    failed = [c["name"] for c in document["checks"] if not c["ok"]]
+    assert "memory_shape_matches_lattice" in failed
+    assert all(c["populated"] is False for c in document["snapshot"]["channels"])
+
+    human = _run_module("doctor", path)
+    assert human.returncode == 1
+    assert "Traceback (most recent call last)" not in human.stderr
+
+
+def test_doctor_end_to_end_malformed_snapshot_is_status_one(tmp_path):
+    path = tmp_path / "junk.npz"
+    path.write_bytes(b"not an npz at all")
+    proc = _run_module("doctor", str(path))
+    assert proc.returncode == 1
+    assert "Traceback (most recent call last)" not in proc.stderr
+    assert len(proc.stderr.strip().splitlines()) == 1
+
+
+def test_doctor_does_not_write_report_files(tmp_path):
+    """Read-only: `doctor` reports, it does not persist.
+
+    Both directories are watched. `_run_module` runs with `cwd=REPO_ROOT`, so a
+    relative-path write would land there, not in `tmp_path` -- watching only
+    the temporary directory would be looking in the one place it could not go.
+    """
+    path = _write_snapshot(tmp_path / "real.npz")
+    tmp_before = sorted(p.name for p in tmp_path.iterdir())
+    repo_before = sorted(p.name for p in REPO_ROOT.iterdir())
+
+    assert _run_module("doctor", path, "--json").returncode == 0
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == tmp_before
+    assert sorted(p.name for p in REPO_ROOT.iterdir()) == repo_before
+
+
+# --- no renderer on the doctor path -----------------------------------------
+
+
+RENDERER_MODULES = (
+    "vis.observatory.slicer",
+    "vis.observatory.scatter3d",
+    "vis.observatory.dashboard",
+    "vis.observatory.animation",
+)
+
+
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_doctor_imports_no_renderer_module(cli, monkeypatch, argv_tail):
+    """`doctor` preflights without opening a renderer.
+
+    The fixture's doubles are evicted and a meta-path finder records any
+    attempt to import them, so a renderer import is caught whether it would
+    have resolved to a double or to the real module.
+    """
+    attempted = []
+
+    class _Recorder:
+        def find_module(self, fullname, path=None):     # legacy protocol
+            return self.find_spec(fullname, path)
+
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in RENDERER_MODULES:
+                attempted.append(fullname)
+            return None                                  # never actually import
+
+    for name in RENDERER_MODULES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_Recorder(), *sys.meta_path])
+
+    # `attempted` is the live assertion. A `cli.calls.name` check would be dead
+    # here: the doubles that record into it were just evicted, so a real
+    # renderer import would resolve to the genuine module and never touch it.
+    assert cli.run(["doctor", cli.snapshot_path, *argv_tail]) == 0
+    assert attempted == []
+
+
+def test_info_json_imports_no_renderer_module(cli, monkeypatch):
+    attempted = []
+
+    class _Recorder:
+        def find_module(self, fullname, path=None):
+            return self.find_spec(fullname, path)
+
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in RENDERER_MODULES:
+                attempted.append(fullname)
+            return None
+
+    for name in RENDERER_MODULES:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_Recorder(), *sys.meta_path])
+
+    assert cli.run(["info", cli.snapshot_path, "--json"]) == 0
+    assert attempted == []
+
+
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_doctor_invokes_no_renderer(cli, argv_tail):
+    """The invocation half of "no renderer", with the recording doubles left
+    installed so `calls` is genuinely live: every renderer entry point the CLI
+    can reach is a double that records into `cli.calls`, and none of them ran.
+    """
+    assert cli.run(["doctor", cli.snapshot_path, *argv_tail]) == 0
+    assert cli.calls.name is None, f"doctor invoked renderer {cli.calls.name}"
+    assert cli.fig.shown is False
+
+
+# --- defects still propagate ------------------------------------------------
+
+
+@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
+def test_unexpected_exception_from_diagnostics_propagates(cli, monkeypatch, argv_tail):
+    """A defect inside the reporting seam is not a user error."""
+
+    def _boom(_snapshot):
+        raise _Sentinel("defect inside diagnostics")
+
+    monkeypatch.setattr(_diagnostics(), "diagnose", _boom)
+    with pytest.raises(_Sentinel, match="defect inside diagnostics"):
+        cli.run(["doctor", cli.snapshot_path, *argv_tail])
+
+
+def test_unexpected_exception_from_the_loader_propagates_through_doctor(cli):
+    def _boom(_path):
+        raise _Sentinel("defect inside the loader")
+
+    cli.set_loader(_boom)
+    with pytest.raises(_Sentinel, match="defect inside the loader"):
+        cli.run(["doctor", cli.snapshot_path])

--- a/tests/test_observatory_diagnostics.py
+++ b/tests/test_observatory_diagnostics.py
@@ -1,0 +1,695 @@
+"""Observatory snapshot diagnostics and machine-readable reporting.
+
+Scope: `vis.observatory.diagnostics` — the ordered runtime-data-contract checks
+behind `doctor`, the shared statistics both `info` renderings are built from,
+and the JSON documents. CLI dispatch, exit statuses and end-to-end reachability
+live in `tests/test_observatory_cli.py`.
+
+These checks describe the Observatory's *runtime data contract*, not scientific
+validity. An all-void lattice, an all-zero channel and a zero fitness are legal
+snapshots and must pass — asserted explicitly below, because a diagnostic that
+fails healthy data is worse than none.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("matplotlib")
+
+from vis.observatory import diagnostics
+from vis.observatory.constants import CHANNEL_NAMES, NUM_CHANNELS, STATE_NAMES
+from vis.observatory.loader import ObservatorySnapshot
+
+SHAPE = (2, 3, 4)
+
+
+def _snapshot(lattice=None, memory=None, generation=7, ca_step=11,
+              best_fitness=0.5, source="/fake/snap.npz"):
+    if lattice is None:
+        lattice = np.zeros(SHAPE, dtype=np.uint8)
+        lattice[0, 0, 0] = 1
+        lattice[1, 1, 1] = 2
+    if memory is None:
+        memory = np.zeros((NUM_CHANNELS,) + lattice.shape, dtype=np.float32)
+        memory[0] = 1.5
+    return ObservatorySnapshot(
+        lattice=lattice,
+        memory_grid=memory,
+        generation=generation,
+        ca_step=ca_step,
+        best_fitness=best_fitness,
+        source_path=source,
+    )
+
+
+def _named(checks):
+    return {c.name: c for c in checks}
+
+
+# ---------------------------------------------------------------------------
+# Positive controls -- healthy data must pass
+# ---------------------------------------------------------------------------
+
+
+def test_valid_snapshot_passes_every_check():
+    checks = diagnostics.diagnose(_snapshot())
+    assert diagnostics.all_ok(checks)
+    assert diagnostics.summarize(checks)["failed"] == 0
+
+
+@pytest.mark.parametrize(
+    "mutate, why",
+    [
+        pytest.param(lambda s: dict(lattice=np.zeros(SHAPE, dtype=np.uint8)),
+                     "all-void lattice", id="all-void"),
+        pytest.param(lambda s: dict(
+            memory=np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)),
+            "all-zero memory", id="all-zero-memory"),
+        pytest.param(lambda s: dict(best_fitness=0.0), "zero fitness", id="zero-fitness"),
+        pytest.param(lambda s: dict(best_fitness=-12.5),
+                     "negative but finite fitness", id="negative-fitness"),
+        pytest.param(lambda s: dict(generation=0, ca_step=0),
+                     "zero counters", id="zero-counters"),
+        pytest.param(lambda s: dict(
+            memory=np.full((NUM_CHANNELS,) + SHAPE, 1e30, dtype=np.float32)),
+            "large but finite values", id="large-finite"),
+    ],
+)
+def test_unusual_but_legal_snapshots_still_pass(mutate, why):
+    """Not scientific validity: these are legal snapshots."""
+    checks = diagnostics.diagnose(_snapshot(**mutate(None)))
+    failed = [c.name for c in checks if not c.ok]
+    assert failed == [], f"{why} should not fail: {failed}"
+
+
+@pytest.mark.parametrize("state_id", sorted(STATE_NAMES))
+def test_every_vocabulary_state_is_accepted(state_id):
+    lattice = np.full(SHAPE, state_id, dtype=np.uint8)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice)))
+    assert checks["lattice_states_known"].ok
+
+
+# ---------------------------------------------------------------------------
+# Source route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source, route",
+    [("/x/snap.npz", "npz"), ("/x/genome.json", "portable-genome JSON")],
+    ids=["npz", "portable-genome"],
+)
+def test_source_route_check_names_the_public_route(source, route):
+    check = _named(diagnostics.diagnose(_snapshot(source=source)))["source_loadable"]
+    assert check.ok
+    assert route in check.detail
+
+
+@pytest.mark.parametrize("source", ["/x/SNAP.NPZ", "/x/genome.JSON"])
+def test_source_route_check_is_case_sensitive_like_the_loader(source):
+    """The check must not be more permissive than the route it describes.
+
+    `loader.load_snapshot` compares `path.suffix == ".npz"` exactly, and the
+    CLI rejects any other suffix before loading, so an upper-cased extension is
+    NOT loadable. Reporting it as loadable would be a check that fails open.
+    """
+    check = _named(diagnostics.diagnose(_snapshot(source=source)))["source_loadable"]
+    assert not check.ok
+
+
+def test_source_route_check_is_reported_first():
+    """Self-describing reports: a reader sees the provenance before the
+    contract findings that depend on it."""
+    assert diagnostics.diagnose(_snapshot())[0].name == "source_loadable"
+
+
+@pytest.mark.parametrize(
+    "source", ["/x/snap.txt", "/x/snap", "/x/snap.npy", "/x/snap.json.gz"]
+)
+def test_unsupported_source_suffix_fails(source):
+    check = _named(diagnostics.diagnose(_snapshot(source=source)))["source_loadable"]
+    assert not check.ok
+    assert "not a public load route" in check.detail
+
+
+def test_snapshot_without_a_source_fails_the_route_check():
+    """An in-memory snapshot did not come through a public route."""
+    check = _named(diagnostics.diagnose(_snapshot(source=None)))["source_loadable"]
+    assert not check.ok
+    assert "no source path" in check.detail
+
+
+def test_source_route_check_does_not_reopen_the_file(tmp_path):
+    """Side-effect-free: the row reports the route the snapshot names, it does
+    not re-read the source. A path that no longer exists still passes."""
+    missing = tmp_path / "deleted.npz"
+    assert not missing.exists()
+    checks = _named(diagnostics.diagnose(_snapshot(source=str(missing))))
+    assert checks["source_loadable"].ok
+    assert not missing.exists()
+
+
+# ---------------------------------------------------------------------------
+# Individual contract failures
+# ---------------------------------------------------------------------------
+
+
+def test_non_array_lattice_fails_without_raising():
+    # `memory` is supplied explicitly: the helper's default derives the memory
+    # shape from `lattice.shape`, which a plain list does not have.
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=[[[1]]], memory=memory)))
+    assert not checks["lattice_is_array"].ok
+    # Dependent checks report their own failure rather than exploding.
+    assert not checks["lattice_rank_is_three"].ok
+    assert not checks["lattice_states_known"].ok
+
+
+@pytest.mark.parametrize(
+    "shape", [(8,), (2, 4), (2, 2, 2, 2)], ids=["rank-1", "rank-2", "rank-4"]
+)
+def test_non_three_dimensional_lattice_fails(shape):
+    lattice = np.zeros(shape, dtype=np.uint8)
+    memory = np.zeros((NUM_CHANNELS,) + shape, dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice, memory=memory)))
+    assert not checks["lattice_rank_is_three"].ok
+    assert str(len(shape)) in checks["lattice_rank_is_three"].detail
+
+
+@pytest.mark.parametrize("shape", [(0, 2, 2), (2, 0, 2), (2, 2, 0)])
+def test_zero_size_dimension_fails(shape):
+    lattice = np.zeros(shape, dtype=np.uint8)
+    memory = np.zeros((NUM_CHANNELS,) + shape, dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice, memory=memory)))
+    assert not checks["lattice_dimensions_positive"].ok
+
+
+def test_memory_spatial_mismatch_fails():
+    memory = np.zeros((NUM_CHANNELS, 9, 9, 9), dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert not checks["memory_shape_matches_lattice"].ok
+    assert "expected" in checks["memory_shape_matches_lattice"].detail
+
+
+@pytest.mark.parametrize("channels", [3, 5, 7, 9])
+def test_wrong_channel_count_fails(channels):
+    """Reaches the seam when a snapshot is built directly; the loader
+    normalizes legacy counts before this point on the file routes."""
+    memory = np.zeros((channels,) + SHAPE, dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert not checks["memory_shape_matches_lattice"].ok
+
+
+def test_non_array_memory_fails_without_raising():
+    checks = _named(diagnostics.diagnose(_snapshot(memory=[0.0])))
+    assert not checks["memory_is_array"].ok
+    assert not checks["memory_shape_matches_lattice"].ok
+    assert not checks["memory_values_finite"].ok
+
+
+@pytest.mark.parametrize(
+    "value, label",
+    [(np.nan, "nan"), (np.inf, "+inf"), (-np.inf, "-inf")],
+)
+def test_non_finite_memory_values_fail(value, label):
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    memory[3, 0, 0, 0] = value
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert not checks["memory_values_finite"].ok
+    assert "1 non-finite" in checks["memory_values_finite"].detail
+
+
+def test_multiple_non_finite_values_are_counted():
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    memory[0, 0, 0, 0] = np.nan
+    memory[1, 0, 0, 1] = np.inf
+    memory[2, 0, 0, 2] = -np.inf
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert "3 non-finite" in checks["memory_values_finite"].detail
+
+
+@pytest.mark.parametrize(
+    "state_id", [5, 6, 200, 255], ids=["just-above", "6", "200", "wraparound-255"]
+)
+def test_state_id_outside_the_vocabulary_fails(state_id):
+    """255 matters: uint8 arithmetic wraps, so an out-of-range id can appear as
+    a large value rather than a negative one."""
+    lattice = np.zeros(SHAPE, dtype=np.uint8)
+    lattice[0, 0, 0] = state_id
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice)))
+    assert not checks["lattice_states_known"].ok
+    assert str(state_id) in checks["lattice_states_known"].detail
+
+
+def test_wrong_lattice_dtype_fails():
+    lattice = np.zeros(SHAPE, dtype=np.int16)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice)))
+    assert not checks["lattice_dtype"].ok
+
+
+def test_wrong_memory_dtype_fails():
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float64)
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert not checks["memory_dtype"].ok
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize(
+    "value", [-1, -100], ids=["minus-one", "minus-hundred"]
+)
+def test_negative_counters_fail(field, value):
+    checks = _named(diagnostics.diagnose(_snapshot(**{field: value})))
+    assert not checks[f"{field}_non_negative_int"].ok
+    assert "negative" in checks[f"{field}_non_negative_int"].detail
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize(
+    "value", [1.0, "3", None, True], ids=["float", "str", "none", "bool"]
+)
+def test_non_integer_counters_fail(field, value):
+    checks = _named(diagnostics.diagnose(_snapshot(**{field: value})))
+    assert not checks[f"{field}_non_negative_int"].ok
+
+
+@pytest.mark.parametrize(
+    "value", [float("nan"), float("inf"), float("-inf")],
+    ids=["nan", "inf", "-inf"],
+)
+def test_non_finite_fitness_fails(value):
+    checks = _named(diagnostics.diagnose(_snapshot(best_fitness=value)))
+    assert not checks["best_fitness_finite"].ok
+
+
+@pytest.mark.parametrize("value", ["0.5", None], ids=["str", "none"])
+def test_non_numeric_fitness_fails(value):
+    checks = _named(diagnostics.diagnose(_snapshot(best_fitness=value)))
+    assert not checks["best_fitness_finite"].ok
+
+
+def test_several_failures_are_all_reported_together():
+    """No short-circuit: a broken snapshot yields every failure at once."""
+    lattice = np.zeros((2, 2), dtype=np.int16)
+    lattice[0, 0] = 99
+    memory = np.zeros((3, 2, 2), dtype=np.float64)
+    memory[0, 0, 0] = np.nan
+    checks = diagnostics.diagnose(
+        _snapshot(lattice=lattice, memory=memory, generation=-1, best_fitness=np.inf)
+    )
+    failed = {c.name for c in checks if not c.ok}
+    assert {
+        "lattice_rank_is_three", "lattice_dtype", "lattice_states_known",
+        "memory_shape_matches_lattice", "memory_dtype", "memory_values_finite",
+        "generation_non_negative_int", "best_fitness_finite",
+    } <= failed
+    assert diagnostics.summarize(checks)["failed"] == len(failed)
+
+
+# ---------------------------------------------------------------------------
+# Determinism and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_check_order_is_stable_regardless_of_outcome():
+    healthy = [c.name for c in diagnostics.diagnose(_snapshot())]
+    broken = [c.name for c in diagnostics.diagnose(
+        _snapshot(lattice=np.zeros((2, 2), dtype=np.int16), generation=-5)
+    )]
+    assert healthy == broken
+    assert len(healthy) == len(set(healthy)), "check names must be unique"
+
+
+def test_summary_counts_match_the_checks():
+    checks = diagnostics.diagnose(_snapshot(generation=-1))
+    counts = diagnostics.summarize(checks)
+    assert counts["total"] == len(checks)
+    assert counts["passed"] + counts["failed"] == counts["total"]
+    assert counts["failed"] == sum(1 for c in checks if not c.ok)
+    assert diagnostics.all_ok(checks) is False
+
+
+# ---------------------------------------------------------------------------
+# JSON safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value", [float("nan"), float("inf"), float("-inf"), np.float32("nan")],
+)
+def test_json_number_maps_non_finite_to_none(value):
+    assert diagnostics.json_number(value) is None
+
+
+@pytest.mark.parametrize("value", [0, -1.5, 2, 1e30])
+def test_json_number_passes_finite_values_through(value):
+    assert diagnostics.json_number(value) == pytest.approx(float(value))
+
+
+def test_json_number_preserves_none():
+    assert diagnostics.json_number(None) is None
+
+
+def _dumps(report):
+    return json.dumps(report, sort_keys=True, allow_nan=False, separators=(",", ":"))
+
+
+@pytest.mark.parametrize("builder", ["info", "doctor"])
+def test_reports_serialize_under_strict_json(builder):
+    """`allow_nan=False` is the assertion: a leaked NaN/Infinity raises."""
+    snap = _snapshot()
+    report = (diagnostics.info_report(snap, "s") if builder == "info"
+              else diagnostics.doctor_report(snap, "s", diagnostics.diagnose(snap)))
+    text = _dumps(report)
+    assert json.loads(text) == report
+    assert "NaN" not in text and "Infinity" not in text
+
+
+def test_reports_with_non_finite_data_still_serialize_strictly():
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    memory[0] = np.nan
+    memory[1] = np.inf
+    snap = _snapshot(memory=memory, best_fitness=float("nan"))
+    for report in (diagnostics.info_report(snap, "s"),
+                   diagnostics.doctor_report(snap, "s", diagnostics.diagnose(snap))):
+        text = _dumps(report)          # would raise if a non-finite leaked
+        assert "NaN" not in text and "Infinity" not in text
+    assert diagnostics.info_report(snap, "s")["best_fitness"] is None
+
+
+def test_source_is_the_only_intentionally_variable_field():
+    a = diagnostics.info_report(_snapshot(), "/one.npz")
+    b = diagnostics.info_report(_snapshot(), "/two.npz")
+    assert a["source"] != b["source"]
+    a.pop("source")
+    b.pop("source")
+    assert _dumps(a) == _dumps(b)
+
+
+def test_repeated_serialization_is_stable():
+    snap = _snapshot()
+    first = _dumps(diagnostics.doctor_report(snap, "s", diagnostics.diagnose(snap)))
+    second = _dumps(diagnostics.doctor_report(snap, "s", diagnostics.diagnose(snap)))
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Report schema
+# ---------------------------------------------------------------------------
+
+
+def test_info_report_schema():
+    report = diagnostics.info_report(_snapshot(), "/s.npz")
+    assert report["schema"] == diagnostics.REPORT_SCHEMA
+    assert report["kind"] == "info"
+    assert report["ok"] is True
+    assert report["source"] == "/s.npz"
+    assert report["shape"] == list(SHAPE)
+    assert report["total_cells"] == 2 * 3 * 4
+    assert report["generation"] == 7 and report["ca_step"] == 11
+    assert len(report["state_counts"]) == len(STATE_NAMES)
+    assert len(report["channels"]) == NUM_CHANNELS
+    assert [c["name"] for c in report["channels"]] == list(CHANNEL_NAMES)
+    assert [s["id"] for s in report["state_counts"]] == sorted(STATE_NAMES)
+
+
+def test_doctor_report_schema():
+    snap = _snapshot()
+    checks = diagnostics.diagnose(snap)
+    report = diagnostics.doctor_report(snap, "/s.npz", checks)
+    assert report["schema"] == diagnostics.REPORT_SCHEMA
+    assert report["kind"] == "doctor"
+    assert report["ok"] is True
+    assert [c["name"] for c in report["checks"]] == [c.name for c in checks]
+    assert report["summary"] == diagnostics.summarize(checks)
+    assert report["snapshot"]["shape"] == list(SHAPE)
+
+
+def test_doctor_report_ok_is_false_when_a_check_fails():
+    snap = _snapshot(generation=-1)
+    checks = diagnostics.diagnose(snap)
+    report = diagnostics.doctor_report(snap, "/s.npz", checks)
+    assert report["ok"] is False
+    assert report["summary"]["failed"] >= 1
+    assert any(c["ok"] is False for c in report["checks"])
+
+
+def test_report_values_are_ordinary_json_types():
+    snap = _snapshot()
+    report = diagnostics.doctor_report(snap, "/s.npz", diagnostics.diagnose(snap))
+
+    def walk(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                assert type(key) is str, f"non-str key {key!r}"
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+        else:
+            assert type(node) in (str, int, float, bool, type(None)), (
+                f"non-JSON value {node!r} of type {type(node).__name__}"
+            )
+
+    walk(report)
+
+
+# ---------------------------------------------------------------------------
+# Shared statistics -- one implementation, not two
+# ---------------------------------------------------------------------------
+
+
+def test_statistics_state_counts_sum_to_total_cells():
+    stats = diagnostics.snapshot_statistics(_snapshot())
+    assert sum(s["count"] for s in stats["state_counts"]) == stats["total_cells"]
+
+
+def test_statistics_match_snapshot_helpers():
+    """Parity with the domain object the human output has always used."""
+    snap = _snapshot()
+    stats = diagnostics.snapshot_statistics(snap)
+    assert stats["non_void_count"] == snap.non_void_count
+    for entry in stats["state_counts"]:
+        assert entry["count"] == snap.state_count(entry["id"])
+
+
+def test_channel_statistics_are_over_non_void_cells():
+    lattice = np.zeros(SHAPE, dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    memory = np.zeros((NUM_CHANNELS,) + SHAPE, dtype=np.float32)
+    memory[0] = 5.0            # everywhere
+    memory[0, 0, 0, 0] = 2.0   # the single non-void cell
+    stats = diagnostics.snapshot_statistics(_snapshot(lattice=lattice, memory=memory))
+    channel0 = stats["channels"][0]
+    assert channel0["populated"] is True
+    assert channel0["min"] == pytest.approx(2.0)
+    assert channel0["max"] == pytest.approx(2.0)
+
+
+def test_all_void_lattice_reports_unpopulated_channels():
+    lattice = np.zeros(SHAPE, dtype=np.uint8)
+    stats = diagnostics.snapshot_statistics(_snapshot(lattice=lattice))
+    for channel in stats["channels"]:
+        assert channel["populated"] is False
+        assert channel["min"] is None
+        assert channel["max"] is None
+        assert channel["mean"] is None
+
+
+# ---------------------------------------------------------------------------
+# Human formatting
+# ---------------------------------------------------------------------------
+
+
+def test_human_output_lists_every_check_in_order():
+    checks = diagnostics.diagnose(_snapshot())
+    lines = diagnostics.format_doctor(checks, "/s.npz")
+    body = [ln for ln in lines if ln.startswith("  [")]
+    assert len(body) == len(checks)
+    for line, check in zip(body, checks):
+        assert check.name in line
+        assert ("[PASS]" if check.ok else "[FAIL]") in line
+
+
+def test_human_output_ends_with_an_unambiguous_summary():
+    ok_lines = diagnostics.format_doctor(diagnostics.diagnose(_snapshot()), "/s")
+    assert ok_lines[-1].startswith("OK:")
+    bad_lines = diagnostics.format_doctor(
+        diagnostics.diagnose(_snapshot(generation=-1)), "/s"
+    )
+    assert bad_lines[-1].startswith("FAILED:")
+    assert "1 of" in bad_lines[-1]
+
+
+def test_human_output_reports_multiple_failures_together():
+    checks = diagnostics.diagnose(
+        _snapshot(generation=-1, ca_step=-1, best_fitness=float("nan"))
+    )
+    lines = diagnostics.format_doctor(checks, "/s")
+    assert sum(1 for ln in lines if "[FAIL]" in ln) == 3
+    assert lines[-1].startswith("FAILED: 3 of")
+
+
+def test_human_output_does_not_leak_payload_contents():
+    """Details name shapes, dtypes, counts and vocabulary -- never contents.
+
+    Driven through a snapshot that FAILS, because the failure branches are the
+    ones that interpolate data; a passing snapshot only ever renders fixed
+    success strings and would prove nothing.
+    """
+    memory = np.full((NUM_CHANNELS,) + SHAPE, 1234.5678, dtype=np.float32)
+    memory[0, 0, 0, 0] = np.nan                     # fails memory_values_finite
+    lattice = np.zeros(SHAPE, dtype=np.uint8)
+    lattice[0, 0, 0] = 77                           # fails lattice_states_known
+    lines = "\n".join(
+        diagnostics.format_doctor(
+            diagnostics.diagnose(_snapshot(lattice=lattice, memory=memory)), "/s.npz"
+        )
+    )
+    assert "1234.5" not in lines
+    assert "77" in lines, "the offending state id itself is vocabulary, and is named"
+
+
+def test_unknown_state_ids_are_capped_in_the_detail():
+    """A corrupt lattice must not turn a report into a dump of its own cells."""
+    lattice = np.arange(60, dtype=np.uint8).reshape(3, 4, 5)   # 55 unknown ids
+    check = _named(
+        diagnostics.diagnose(_snapshot(
+            lattice=lattice,
+            memory=np.zeros((NUM_CHANNELS, 3, 4, 5), dtype=np.float32),
+        ))
+    )["lattice_states_known"]
+    assert not check.ok
+    assert "..." in check.detail
+    assert "55 distinct" in check.detail
+    assert len(check.detail) < 200
+
+
+# ---------------------------------------------------------------------------
+# The report builders must survive every input the checks are meant to flag
+# ---------------------------------------------------------------------------
+
+
+def test_statistics_survive_a_memory_spatial_mismatch():
+    """Regression: masking a (4,4,4) channel with an (8,8,8) lattice mask
+    raises IndexError, so `doctor --json` used to die with a traceback and emit
+    no document on exactly the snapshot `memory_shape_matches_lattice` reports.
+    """
+    lattice = np.zeros((8, 8, 8), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    memory = np.zeros((NUM_CHANNELS, 4, 4, 4), dtype=np.float32)
+    snap = _snapshot(lattice=lattice, memory=memory)
+
+    stats = diagnostics.snapshot_statistics(snap)
+    assert [c["populated"] for c in stats["channels"]] == [False] * NUM_CHANNELS
+
+    checks = diagnostics.diagnose(snap)
+    assert not _named(checks)["memory_shape_matches_lattice"].ok
+    _dumps(diagnostics.doctor_report(snap, "/s.npz", checks))   # must not raise
+
+
+@pytest.mark.parametrize("channels", [1, 3, 5, 7])
+def test_statistics_survive_a_short_memory_grid(channels):
+    """Indexing channel 7 of a 3-channel grid raises IndexError.
+
+    All eight rows are still reported, so the JSON shape is the same for every
+    snapshot; the rows with no underlying channel are simply unpopulated.
+    """
+    memory = np.zeros((channels,) + SHAPE, dtype=np.float32)
+    snap = _snapshot(memory=memory)
+    stats = diagnostics.snapshot_statistics(snap)
+
+    populated = [c["populated"] for c in stats["channels"]]
+    assert len(populated) == NUM_CHANNELS
+    assert populated[:channels] == [True] * channels
+    assert populated[channels:] == [False] * (NUM_CHANNELS - channels)
+
+    _dumps(diagnostics.doctor_report(snap, "/s.npz", diagnostics.diagnose(snap)))
+
+
+def test_statistics_survive_a_non_array_memory_grid():
+    snap = _snapshot(memory=[1, 2, 3])
+    _dumps(diagnostics.doctor_report(snap, "/s.npz", diagnostics.diagnose(snap)))
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+def test_reports_survive_a_counter_that_is_not_json_serializable(field):
+    """`np.int64` fails the exact-int check; the report must still serialize."""
+    snap = _snapshot(**{field: np.int64(5)})
+    assert not _named(diagnostics.diagnose(snap))[f"{field}_non_negative_int"].ok
+    document = json.loads(_dumps(diagnostics.info_report(snap, "/s.npz")))
+    assert document[field] == 5
+
+
+@pytest.mark.parametrize("value", ["not-a-number", None, object()])
+def test_reports_survive_an_uncoercible_counter(value):
+    snap = _snapshot(generation=value)
+    assert diagnostics.info_report(snap, "/s")["generation"] is None
+    _dumps(diagnostics.info_report(snap, "/s"))
+
+
+def test_memory_shape_check_does_not_pass_on_a_non_three_d_lattice():
+    """Regression: with a rank-2 lattice of shape (8, 8), the naive expected
+    shape (8, 8, 8) matched a grid that is not 8 channels over the volume."""
+    lattice = np.zeros((8, 8), dtype=np.uint8)
+    memory = np.zeros((8, 8, 8), dtype=np.float32)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice, memory=memory)))
+    assert not checks["lattice_rank_is_three"].ok
+    assert not checks["memory_shape_matches_lattice"].ok
+
+
+# ---------------------------------------------------------------------------
+# Human formatters
+# ---------------------------------------------------------------------------
+
+
+def test_format_stat_renders_finite_values_unchanged():
+    assert diagnostics.format_stat(1.5) == "+1.5000"
+    assert diagnostics.format_stat(-0.25) == "-0.2500"
+
+
+def test_format_stat_renders_non_finite_without_raising():
+    """The JSON layer maps non-finite to None; the human table must cope."""
+    assert diagnostics.format_stat(None) == "non-finite"
+
+
+def test_format_percent_renders_none_without_raising():
+    assert diagnostics.format_percent(None).strip() == "n/a"
+    assert diagnostics.format_percent(12.5).strip() == "12.5"
+
+
+def test_json_scalar_keeps_exact_ints_and_nulls_the_rest():
+    assert diagnostics.json_scalar(5) == 5
+    assert type(diagnostics.json_scalar(5)) is int
+    assert diagnostics.json_scalar(float("nan")) is None
+    assert diagnostics.json_scalar("x") is None
+    assert diagnostics.json_scalar(None) is None
+
+
+def test_format_doctor_tolerates_an_empty_check_list():
+    assert diagnostics.format_doctor([], "/s")[-1].startswith("OK:")
+
+
+def test_diagnose_is_side_effect_free():
+    """Deterministic and non-mutating: the inputs are unchanged afterwards."""
+    snap = _snapshot()
+    lattice_before = snap.lattice.copy()
+    memory_before = snap.memory_grid.copy()
+    first = [(c.name, c.ok, c.detail) for c in diagnostics.diagnose(snap)]
+    second = [(c.name, c.ok, c.detail) for c in diagnostics.diagnose(snap)]
+    assert first == second
+    np.testing.assert_array_equal(snap.lattice, lattice_before)
+    np.testing.assert_array_equal(snap.memory_grid, memory_before)
+
+
+def test_diagnostics_module_references_no_renderer():
+    """Supplements -- does not replace -- the behavioural check in
+    tests/test_observatory_cli.py that `doctor` imports no renderer module."""
+    source = inspect.getsource(diagnostics)
+    for banned in ("scatter3d", "slicer", "dashboard", "animation",
+                   "matplotlib", "plotly", "pyplot"):
+        assert banned not in source, f"diagnostics references {banned}"

--- a/tests/test_observatory_diagnostics.py
+++ b/tests/test_observatory_diagnostics.py
@@ -693,3 +693,393 @@ def test_diagnostics_module_references_no_renderer():
     for banned in ("scatter3d", "slicer", "dashboard", "animation",
                    "matplotlib", "plotly", "pyplot"):
         assert banned not in source, f"diagnostics references {banned}"
+
+
+# ===========================================================================
+# Totality under hostile input
+#
+# The seam's whole promise is that a malformed runtime-contract value becomes
+# a FAILED CHECK, never a traceback. That promise was false: several wrong
+# dtypes reached `np.isfinite()`, `np.unique()` or `int()` and raised before
+# the check that exists to reject them could be reported.
+#
+# These assert TOTALITY, not specific verdicts: for every input the checks are
+# designed to reject, the whole pipeline -- diagnose, report construction,
+# strict serialization, human formatting -- must complete. Which checks fail
+# is asserted separately above; the claim here is that a report exists at all.
+# ===========================================================================
+
+
+class _Partial:
+    """A snapshot-shaped object with fields deliberately missing.
+
+    `diagnose()` reads its inputs with `getattr(..., None)`, so a library
+    caller can hand it an incomplete object. The report builders must accept
+    exactly what the checks accept.
+    """
+
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+
+def _raw(lattice, memory, generation=7, ca_step=11, best_fitness=0.5,
+         source="/x/snap.npz"):
+    """Build a snapshot with NO defaulting.
+
+    `_snapshot()` substitutes a valid array when it is handed `None`, which
+    would quietly turn the `non-array-none` cases into healthy snapshots and
+    make them prove nothing. Here `None` means None.
+    """
+    return ObservatorySnapshot(
+        lattice=lattice,
+        memory_grid=memory,
+        generation=generation,
+        ca_step=ca_step,
+        best_fitness=best_fitness,
+        source_path=source,
+    )
+
+
+def _hostile_lattices():
+    good = (2, 3, 4)
+    return [
+        ("uint8-valid", np.zeros(good, dtype=np.uint8)),
+        ("int8", np.zeros(good, dtype=np.int8)),
+        ("int16", np.zeros(good, dtype=np.int16)),
+        ("int32", np.zeros(good, dtype=np.int32)),
+        ("int64", np.zeros(good, dtype=np.int64)),
+        ("uint16", np.zeros(good, dtype=np.uint16)),
+        ("uint64", np.zeros(good, dtype=np.uint64)),
+        ("int8-negative", np.full(good, -3, dtype=np.int8)),
+        ("float32-integral", np.zeros(good, dtype=np.float32)),
+        ("float64-fractional", np.full(good, 0.5, dtype=np.float64)),
+        ("float-nan", np.full(good, np.nan, dtype=np.float64)),
+        ("float-posinf", np.full(good, np.inf, dtype=np.float64)),
+        ("float-neginf", np.full(good, -np.inf, dtype=np.float64)),
+        ("bool", np.zeros(good, dtype=bool)),
+        ("unicode", np.full(good, "x", dtype="<U5")),
+        ("bytes", np.full(good, b"x", dtype="S5")),
+        ("object-ints", np.array([[[1, 2], [3, 4]]], dtype=object)),
+        ("object-strings", np.array([[["a", "b"], ["c", "d"]]], dtype=object)),
+        # Jack's witness: elements that cannot be ordered against each other,
+        # so `np.unique()`'s sort raises.
+        ("object-mixed-unorderable", np.array([[["x", 1]]], dtype=object)),
+        ("object-none", np.array([[[None, None]]], dtype=object)),
+        ("complex64", np.zeros(good, dtype=np.complex64)),
+        ("complex128", np.zeros(good, dtype=np.complex128)),
+        ("datetime64", np.zeros(good, dtype="datetime64[s]")),
+        ("rank0", np.array(1, dtype=np.uint8)),
+        ("rank1", np.zeros((6,), dtype=np.uint8)),
+        ("rank2", np.zeros((3, 4), dtype=np.uint8)),
+        ("rank4", np.zeros((2, 2, 2, 2), dtype=np.uint8)),
+        ("zero-size", np.zeros((0, 3, 4), dtype=np.uint8)),
+        ("zero-size-all", np.zeros((0, 0, 0), dtype=np.uint8)),
+        ("unknown-states", np.full(good, 200, dtype=np.uint8)),
+        ("non-array-list", [[[1]]]),
+        ("non-array-none", None),
+        ("non-array-str", "lattice"),
+    ]
+
+
+def _hostile_memories():
+    good = (2, 3, 4)
+    ok_shape = (NUM_CHANNELS,) + good
+    return [
+        ("float32-valid", np.zeros(ok_shape, dtype=np.float32)),
+        ("float64", np.zeros(ok_shape, dtype=np.float64)),
+        ("float16", np.zeros(ok_shape, dtype=np.float16)),
+        ("int32", np.zeros(ok_shape, dtype=np.int32)),
+        ("uint8", np.zeros(ok_shape, dtype=np.uint8)),
+        ("bool", np.zeros(ok_shape, dtype=bool)),
+        ("complex64", np.zeros(ok_shape, dtype=np.complex64)),
+        ("complex128", np.zeros(ok_shape, dtype=np.complex128)),
+        ("datetime64", np.zeros(ok_shape, dtype="datetime64[s]")),
+        ("unicode", np.full(ok_shape, "x", dtype="<U5")),
+        ("bytes", np.full(ok_shape, b"x", dtype="S5")),
+        ("object-numbers", np.array([[[[1.0]]]], dtype=object)),
+        # Jack's witness: `np.isfinite()` raises TypeError on object dtype.
+        ("object-strings", np.array([[[["x"]]]], dtype=object)),
+        ("object-mixed", np.array([[[["x", 1.0]]]], dtype=object)),
+        ("object-none", np.array([[[[None]]]], dtype=object)),
+        ("nan", np.full(ok_shape, np.nan, dtype=np.float32)),
+        ("posinf", np.full(ok_shape, np.inf, dtype=np.float32)),
+        ("neginf", np.full(ok_shape, -np.inf, dtype=np.float32)),
+        ("zero-size", np.zeros((NUM_CHANNELS, 0, 3, 4), dtype=np.float32)),
+        ("rank0", np.array(1.0, dtype=np.float32)),
+        ("wrong-rank-3", np.zeros((NUM_CHANNELS, 3, 4), dtype=np.float32)),
+        ("wrong-rank-5", np.zeros((NUM_CHANNELS, 2, 3, 4, 1), dtype=np.float32)),
+        ("wrong-channels-3", np.zeros((3,) + good, dtype=np.float32)),
+        ("wrong-channels-9", np.zeros((9,) + good, dtype=np.float32)),
+        ("wrong-spatial", np.zeros((NUM_CHANNELS, 9, 9, 9), dtype=np.float32)),
+        ("non-array-list", [0.0]),
+        ("non-array-none", None),
+        ("non-array-str", "memory"),
+    ]
+
+
+class _Uncoercible:
+    """A hostile counter whose float conversion fails."""
+
+    def __float__(self):
+        raise ValueError("no float for you")
+
+
+def _hostile_metadata():
+    return [
+        ("int", 7),
+        ("zero", 0),
+        ("negative", -1),
+        ("bool-true", True),
+        ("bool-false", False),
+        ("float", 1.5),
+        ("float-nan", float("nan")),
+        ("float-inf", float("inf")),
+        ("float-neginf", float("-inf")),
+        ("str", "9"),
+        ("none", None),
+        ("np-int64", np.int64(5)),
+        ("np-float32", np.float32(1.5)),
+        ("np-bool", np.bool_(True)),
+        # `float()` raises OverflowError -- an ArithmeticError, so NOT caught
+        # by a (TypeError, ValueError) handler.
+        ("huge-int", 10 ** 400),
+        ("huge-negative-int", -(10 ** 400)),
+        ("complex", complex(1, 2)),
+        ("uncoercible", _Uncoercible()),
+        ("object", object()),
+        ("list", [1, 2]),
+    ]
+
+
+def _assert_total(snapshot, source="/x/snap.npz"):
+    """The seam must produce a complete, strict, deterministic report.
+
+    Asserts the whole promise at once: diagnose returns rather than raises,
+    all 13 checks are present in the established order, both report kinds
+    build, strict serialization succeeds, human formatting succeeds, and a
+    second run over the same input produces identical bytes.
+    """
+    checks = diagnostics.diagnose(snapshot)
+    assert len(checks) == 13
+    assert [c.name for c in checks] == [c.name for c in diagnostics.diagnose(snapshot)]
+    assert all(type(c.ok) is bool for c in checks), "check.ok must be a real bool"
+    assert all(type(c.detail) is str for c in checks)
+
+    report = diagnostics.doctor_report(snapshot, source, checks)
+    text = _dumps(report)                     # strict: allow_nan=False
+    assert json.loads(text) == report
+    assert "NaN" not in text and "Infinity" not in text
+
+    info = _dumps(diagnostics.info_report(snapshot, source))
+    assert "NaN" not in info and "Infinity" not in info
+
+    lines = diagnostics.format_doctor(checks, source)
+    assert lines[-1].startswith(("OK:", "FAILED:"))
+    assert len([ln for ln in lines if ln.startswith("  [")]) == 13
+
+    # Deterministic: byte-identical on a second pass over the same input.
+    assert _dumps(diagnostics.doctor_report(
+        snapshot, source, diagnostics.diagnose(snapshot))) == text
+    return checks, report, lines
+
+
+@pytest.mark.parametrize(
+    "lattice", [pytest.param(v, id=k) for k, v in _hostile_lattices()]
+)
+def test_diagnose_is_total_over_lattice_representations(lattice):
+    """Jack's witness among them: a mixed object lattice reached `np.unique()`
+    and raised TypeError before `lattice_dtype` could be reported failed."""
+    memory = np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=np.float32)
+    _assert_total(_raw(lattice, memory))
+
+
+@pytest.mark.parametrize(
+    "memory", [pytest.param(v, id=k) for k, v in _hostile_memories()]
+)
+def test_diagnose_is_total_over_memory_representations(memory):
+    """Jack's witness among them: an object-dtype grid reached `np.isfinite()`
+    and raised TypeError."""
+    lattice = np.zeros((2, 3, 4), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    _assert_total(_raw(lattice, memory))
+
+
+@pytest.mark.parametrize(
+    "value", [pytest.param(v, id=k) for k, v in _hostile_metadata()]
+)
+@pytest.mark.parametrize("field", ["generation", "ca_step", "best_fitness"])
+def test_diagnose_is_total_over_metadata(field, value):
+    """`float()` raises OverflowError for a huge int and TypeError for a
+    complex; neither may escape the checks or the report builders."""
+    _assert_total(_snapshot(**{field: value}))
+
+
+@pytest.mark.parametrize(
+    "lattice", [pytest.param(v, id=k) for k, v in _hostile_lattices()[:12]]
+)
+@pytest.mark.parametrize(
+    "memory", [pytest.param(v, id=k) for k, v in _hostile_memories()[:12]]
+)
+def test_diagnose_is_total_over_combined_hostility(lattice, memory):
+    """Malformed lattice and malformed memory together: no gate may depend on
+    the other side being well-formed."""
+    _assert_total(_raw(lattice, memory))
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {},
+        {"lattice": np.zeros((2, 3, 4), dtype=np.uint8)},
+        {"memory_grid": np.zeros((8, 2, 3, 4), dtype=np.float32)},
+        {"generation": 1, "ca_step": 2, "best_fitness": 0.5},
+    ],
+    ids=["nothing", "lattice-only", "memory-only", "metadata-only"],
+)
+def test_reports_survive_a_snapshot_with_missing_attributes(fields):
+    """`diagnose()` reads with `getattr(..., None)`, so it accepts an
+    incomplete object; the report builders must accept the same."""
+    _assert_total(_Partial(**fields))
+
+
+# --- the two reproduced blockers, named explicitly -------------------------
+
+
+def test_object_memory_grid_does_not_reach_isfinite():
+    """Reproducer: `np.isfinite(np.array([[[["x"]]]], dtype=object))` raises
+    TypeError. The finiteness check must report a failure instead."""
+    snap = _snapshot(memory=np.array([[[["x"]]]], dtype=object))
+    checks = _named(diagnostics.diagnose(snap))
+    assert not checks["memory_values_finite"].ok
+    assert not checks["memory_dtype"].ok
+
+
+def test_unorderable_object_lattice_does_not_reach_unique():
+    """Reproducer: `np.unique(np.array([[["x", 1]]], dtype=object))` sorts and
+    raises TypeError comparing str with int. `lattice_dtype` and
+    `lattice_states_known` must both be reported failed instead."""
+    snap = _snapshot(
+        lattice=np.array([[["x", 1]]], dtype=object),
+        memory=np.zeros((NUM_CHANNELS, 1, 1, 2), dtype=np.float32),
+    )
+    checks = _named(diagnostics.diagnose(snap))
+    assert not checks["lattice_dtype"].ok
+    assert not checks["lattice_states_known"].ok
+
+
+@pytest.mark.parametrize("dtype", ["<U5", "S5", "O", "complex128", "datetime64[s]"])
+def test_unsupported_lattice_dtype_never_passes_the_vocabulary_check(dtype):
+    """A skipped dependent evaluation is not a passing result: when a dtype is
+    unsafe to inspect, the vocabulary check reports failure, never success."""
+    lattice = np.zeros((2, 3, 4), dtype=dtype)
+    checks = _named(diagnostics.diagnose(_snapshot(lattice=lattice)))
+    assert not checks["lattice_dtype"].ok
+    assert not checks["lattice_states_known"].ok
+
+
+@pytest.mark.parametrize("dtype", ["<U5", "S5", "O", "complex128", "datetime64[s]"])
+def test_unsupported_memory_dtype_never_passes_the_finiteness_check(dtype):
+    memory = np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=dtype)
+    checks = _named(diagnostics.diagnose(_snapshot(memory=memory)))
+    assert not checks["memory_dtype"].ok
+    assert not checks["memory_values_finite"].ok
+
+
+def test_huge_integer_fitness_is_reported_not_raised():
+    """`float(10**400)` raises OverflowError, an ArithmeticError, so it is not
+    caught by a (TypeError, ValueError) handler."""
+    checks = _named(diagnostics.diagnose(_snapshot(best_fitness=10 ** 400)))
+    assert not checks["best_fitness_finite"].ok
+
+
+def test_huge_integer_counter_still_serializes_strictly():
+    snap = _snapshot(generation=10 ** 400)
+    assert not _named(diagnostics.diagnose(snap))["generation_non_negative_int"].ok
+    _dumps(diagnostics.info_report(snap, "/s"))
+
+
+def test_boolean_fitness_is_not_silently_treated_as_one_point_zero():
+    """`True` is not a fitness value. The check must fail, and the report must
+    not present it as the number 1.0."""
+    snap = _snapshot(best_fitness=True)
+    assert not _named(diagnostics.diagnose(snap))["best_fitness_finite"].ok
+    assert diagnostics.info_report(snap, "/s")["best_fitness"] is None
+
+
+def test_fractional_float_counter_is_not_silently_truncated():
+    snap = _snapshot(generation=2.7)
+    assert not _named(diagnostics.diagnose(snap))["generation_non_negative_int"].ok
+    assert diagnostics.info_report(snap, "/s")["generation"] != 2
+
+
+def test_hostile_inputs_are_not_modified():
+    """Side-effect freedom under hostile input, not merely healthy input."""
+    lattice = np.array([[["x", 1]]], dtype=object)
+    memory = np.array([[[["x"]]]], dtype=object)
+    lattice_before = lattice.tolist()
+    memory_before = memory.tolist()
+    _assert_total(_snapshot(lattice=lattice, memory=memory))
+    assert lattice.tolist() == lattice_before
+    assert memory.tolist() == memory_before
+
+
+@pytest.mark.parametrize(
+    "lattice", [pytest.param(v, id=k) for k, v in _hostile_lattices()]
+)
+def test_no_detail_grows_with_the_payload(lattice):
+    """No detail may grow with the data, however hostile or large."""
+    memory = np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=np.float32)
+    checks = diagnostics.diagnose(_raw(lattice, memory))
+    for check in checks:
+        assert len(check.detail) < 200, f"{check.name}: {check.detail[:80]}"
+
+
+# --- human output must not be forgeable ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "/x/a\nOK: all 13 checks passed.npz",
+        "/x/a\r\n  [PASS] lattice_is_array  forged.npz",
+        "/x/a\rFAILED: 0 of 13 checks did not pass.npz",
+        "/x/a\u2028  [PASS] forged.npz",
+        "/x/a\u2029  [PASS] forged.npz",
+        "/x/a\x85OK: all 13 checks passed.npz",
+        "/x/a\v  [PASS] forged.npz",
+        "/x/a\f  [PASS] forged.npz",
+        "/x/a\x1c  [PASS] forged.npz",
+        "/x/a\x1d  [PASS] forged.npz",
+        "/x/a\x1e  [PASS] forged.npz",
+    ],
+    ids=["lf", "crlf", "cr", "line-sep", "para-sep", "nel", "vtab",
+         "formfeed", "file-sep", "group-sep", "record-sep"],
+)
+def test_a_source_path_cannot_forge_report_lines(hostile):
+    """A pathname is untrusted data. Human `doctor` output must not let one
+    inject what looks like an extra check row or a second summary line.
+
+    `str.splitlines()` splits on more than \\n and \\r -- \\v, \\f, \\x1c-\\x1e,
+    \\x85, \\u2028 and \\u2029 all count -- so the header line is checked
+    against that full set, not just the obvious two.
+    """
+    checks = diagnostics.diagnose(_snapshot())
+    lines = diagnostics.format_doctor(checks, hostile)
+
+    assert len(lines[0].splitlines()) == 1, "header spans more than one line"
+    body = [ln for ln in lines if ln.startswith("  [")]
+    assert len(body) == 13, f"forged check rows: {len(body)}"
+    summaries = [ln for ln in lines if ln.startswith(("OK:", "FAILED:"))]
+    assert len(summaries) == 1, f"forged summary lines: {len(summaries)}"
+
+
+def test_json_mode_keeps_a_hostile_path_as_ordinary_escaped_data():
+    """JSON needs no sanitising -- ordinary escaping already makes the newline
+    inert -- but it must round-trip to exactly what was supplied."""
+    hostile = "/x/a\nOK: all 13 checks passed.npz"
+    report = diagnostics.doctor_report(
+        _snapshot(), hostile, diagnostics.diagnose(_snapshot())
+    )
+    text = _dumps(report)
+    assert "\n" not in text, "raw newline leaked into the JSON document"
+    assert json.loads(text)["source"] == hostile

--- a/tests/test_observatory_diagnostics.py
+++ b/tests/test_observatory_diagnostics.py
@@ -992,10 +992,30 @@ def test_huge_integer_fitness_is_reported_not_raised():
     assert not checks["best_fitness_finite"].ok
 
 
-def test_huge_integer_counter_still_serializes_strictly():
-    snap = _snapshot(generation=10 ** 400)
-    assert not _named(diagnostics.diagnose(snap))["generation_non_negative_int"].ok
-    _dumps(diagnostics.info_report(snap, "/s"))
+def test_huge_integer_counter_passes_and_is_reported_verbatim():
+    """A 401-digit integer IS a genuine non-negative integer, so the check
+    passes and the true value is emitted -- a Python int of any magnitude is a
+    legal JSON number. Forcing it through `float()` would raise OverflowError,
+    and rounding it would report a counter the snapshot does not have.
+
+    (My first draft of this test asserted the check should FAIL. Analysing the
+    contract showed that was wrong: nothing about the value violates
+    "non-negative integer", and failing it would have been an invented defect.)
+    """
+    huge = 10 ** 400
+    snap = _snapshot(generation=huge)
+    assert _named(diagnostics.diagnose(snap))["generation_non_negative_int"].ok
+    document = json.loads(_dumps(diagnostics.info_report(snap, "/s")))
+    assert document["generation"] == huge
+
+
+def test_a_counter_too_long_to_render_does_not_break_the_detail():
+    """`f"{n}"` raises ValueError past CPython's integer-to-string limit."""
+    snap = _snapshot(generation=10 ** 100000)
+    check = _named(diagnostics.diagnose(snap))["generation_non_negative_int"]
+    assert check.ok
+    assert len(check.detail) < 200
+    diagnostics.format_doctor(diagnostics.diagnose(snap), "/s")
 
 
 def test_boolean_fitness_is_not_silently_treated_as_one_point_zero():
@@ -1071,6 +1091,90 @@ def test_a_source_path_cannot_forge_report_lines(hostile):
     assert len(body) == 13, f"forged check rows: {len(body)}"
     summaries = [ln for ln in lines if ln.startswith(("OK:", "FAILED:"))]
     assert len(summaries) == 1, f"forged summary lines: {len(summaries)}"
+
+
+def test_a_hostile_detail_cannot_forge_report_rows():
+    """Details interpolate caller-supplied text too -- a structured dtype's
+    field names reach one -- so they are collapsed on the same basis."""
+    forged = "bad\n  [PASS] lattice_is_array  forged\nOK: all 13 checks passed."
+    lines = diagnostics.format_doctor([diagnostics.Check("n", False, forged)], "/s")
+    assert len([ln for ln in lines if ln.startswith("  [")]) == 1
+    assert len([ln for ln in lines if ln.startswith(("OK:", "FAILED:"))]) == 1
+
+
+def test_every_formatted_line_is_exactly_one_physical_line():
+    lines = diagnostics.format_doctor(diagnostics.diagnose(_snapshot()), "/s\n\nx")
+    for line in lines:
+        assert len(line.splitlines()) <= 1
+
+
+# --- statistics seam: unavailable, not fabricated ---------------------------
+
+
+@pytest.mark.parametrize("dtype", ["<U5", "S5", "datetime64[s]"])
+def test_uncountable_lattice_reports_null_counts_not_fabricated_zeros(dtype):
+    """`lattice > 0` raises TypeError for these dtypes. The rows must still be
+    present, reported as unavailable -- never as a fabricated count of 0,
+    which would read as a real measurement of an unreadable array."""
+    lattice = np.zeros((2, 3, 4), dtype=dtype)
+    stats = diagnostics.snapshot_statistics(_raw(
+        lattice, np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=np.float32)
+    ))
+    assert len(stats["state_counts"]) == len(STATE_NAMES)
+    assert all(entry["count"] is None for entry in stats["state_counts"])
+    assert all(entry["percent"] is None for entry in stats["state_counts"])
+    assert stats["non_void_count"] is None
+    assert all(c["populated"] is False for c in stats["channels"])
+
+
+@pytest.mark.parametrize("dtype", ["<U5", "S5", "complex128", "datetime64[s]"])
+def test_shape_matching_memory_of_a_wrong_dtype_is_not_aggregated(dtype):
+    """A shape-only gate let these through: `.min()`/`.max()` succeed and only
+    `float()` failed, one layer down inside `json_number`."""
+    lattice = np.zeros((2, 3, 4), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    memory = np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=dtype)
+    stats = diagnostics.snapshot_statistics(_raw(lattice, memory))
+    assert all(c["populated"] is False for c in stats["channels"])
+
+
+def test_rank_zero_lattice_does_not_index_a_scalar_channel():
+    """A rank-0 lattice paired with a rank-1 grid satisfied the old
+    `ndim + 1` gate, then indexed a numpy scalar and raised IndexError."""
+    snap = _raw(np.array(1, dtype=np.uint8), np.zeros((NUM_CHANNELS,),
+                                                      dtype=np.float32))
+    stats = diagnostics.snapshot_statistics(snap)
+    assert all(c["populated"] is False for c in stats["channels"])
+    _assert_total(snap)
+
+
+def test_statistics_key_set_is_invariant_across_hostile_inputs():
+    """The document shape must not depend on how broken the snapshot is."""
+    healthy = set(diagnostics.snapshot_statistics(_snapshot()))
+    for lattice in (None, "x", np.zeros((2, 2), dtype="<U5"), np.array(1)):
+        assert set(diagnostics.snapshot_statistics(_raw(lattice, None))) == healthy
+
+
+def test_healthy_statistics_are_unchanged_by_the_gating():
+    """The gates must not cost exactness on well-formed data."""
+    lattice = np.zeros((2, 3, 4), dtype=np.uint8)
+    lattice[0, 0, 0] = 1
+    lattice[1, 1, 1] = 2
+    memory = np.zeros((NUM_CHANNELS, 2, 3, 4), dtype=np.float32)
+    memory[0] = 2.5
+    stats = diagnostics.snapshot_statistics(_raw(lattice, memory))
+    assert stats["total_cells"] == 24
+    assert stats["non_void_count"] == 2
+    assert sum(e["count"] for e in stats["state_counts"]) == 24
+    assert stats["channels"][0]["populated"] is True
+    assert stats["channels"][0]["mean"] == pytest.approx(2.5)
+
+
+def test_format_count_preserves_the_established_columns():
+    assert diagnostics.format_count(1234, 8) == f"{1234:>8,}"
+    assert diagnostics.format_count(1234) == f"{1234:,}"
+    assert len(diagnostics.format_count(None, 8)) == 8
+    assert diagnostics.format_count(None).strip() == "n/a"
 
 
 def test_json_mode_keeps_a_hostile_path_as_ordinary_escaped_data():

--- a/tests/test_observatory_diagnostics.py
+++ b/tests/test_observatory_diagnostics.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import sys
 
 import pytest
 
@@ -844,6 +845,11 @@ def _hostile_metadata():
         # by a (TypeError, ValueError) handler.
         ("huge-int", 10 ** 400),
         ("huge-negative-int", -(10 ** 400)),
+        # Past CPython's int-to-str digit ceiling, so `str()`, `f"{n}"` and
+        # `json.dumps(n)` all raise ValueError. `_assert_total` serializes, so
+        # this row is what makes the matrix actually cover the defect.
+        ("oversized-int", 10 ** 100000),
+        ("oversized-negative-int", -(10 ** 100000)),
         ("complex", complex(1, 2)),
         ("uncoercible", _Uncoercible()),
         ("object", object()),
@@ -1009,13 +1015,99 @@ def test_huge_integer_counter_passes_and_is_reported_verbatim():
     assert document["generation"] == huge
 
 
-def test_a_counter_too_long_to_render_does_not_break_the_detail():
-    """`f"{n}"` raises ValueError past CPython's integer-to-string limit."""
-    snap = _snapshot(generation=10 ** 100000)
-    check = _named(diagnostics.diagnose(snap))["generation_non_negative_int"]
-    assert check.ok
+# ---------------------------------------------------------------------------
+# Oversized counters -- CPython's integer-to-string ceiling
+#
+# Past `sys.get_int_max_str_digits()` (4300 by default) `str(n)`, `f"{n}"` and
+# `json.dumps(n)` all raise ValueError. A counter of that magnitude therefore
+# has to be reported as unavailable rather than emitted verbatim, or the
+# report dies inside the serializer describing a snapshot it claimed was fine.
+#
+# `10**400` is 401 digits and stays comfortably inside the ceiling: it remains
+# a valid exact counter and must keep round-tripping verbatim. The boundary is
+# a JSON *text* limit, not a float limit, so it is deliberately not tied to
+# `sys.float_info.max`.
+# ---------------------------------------------------------------------------
+
+OVERSIZED = 10 ** 100000
+LARGE_BUT_SAFE = 10 ** 400
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+def test_large_but_representable_counter_stays_exact(field):
+    """The deliberately accepted case: 401 digits, well inside the ceiling."""
+    snap = _snapshot(**{field: LARGE_BUT_SAFE})
+    assert _named(diagnostics.diagnose(snap))[f"{field}_non_negative_int"].ok
+    document = json.loads(_dumps(diagnostics.info_report(snap, "/s")))
+    assert document[field] == LARGE_BUT_SAFE
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+def test_oversized_counter_fails_its_check_with_a_bounded_detail(field):
+    """A counter that cannot be rendered as decimal text is not a usable
+    counter. The detail must describe it without converting it."""
+    snap = _snapshot(**{field: OVERSIZED})
+    check = _named(diagnostics.diagnose(snap))[f"{field}_non_negative_int"]
+    assert not check.ok
     assert len(check.detail) < 200
-    diagnostics.format_doctor(diagnostics.diagnose(snap), "/s")
+    assert field in check.detail
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize("builder", ["info", "doctor"])
+def test_oversized_counter_serializes_as_null(field, builder):
+    """The defect: `json_scalar` returned the integer verbatim, so strict
+    serialization raised ValueError instead of producing the promised report.
+    """
+    snap = _snapshot(**{field: OVERSIZED})
+    report = (diagnostics.info_report(snap, "/s") if builder == "info"
+              else diagnostics.doctor_report(snap, "/s",
+                                             diagnostics.diagnose(snap)))
+    text = _dumps(report)                       # must not raise
+    document = json.loads(text)
+    value = document[field] if builder == "info" else document["snapshot"][field]
+    assert value is None
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step"])
+def test_oversized_counter_keeps_human_doctor_total(field):
+    snap = _snapshot(**{field: OVERSIZED})
+    lines = diagnostics.format_doctor(diagnostics.diagnose(snap), "/s")
+    assert lines[-1].startswith("FAILED:")
+    assert all(len(line.splitlines()) <= 1 for line in lines)
+
+
+def test_oversized_counter_renders_safely_in_the_human_table():
+    """`format_count` is what the human `info` table uses; it must not attempt
+    the decimal conversion that raises."""
+    rendered = diagnostics.format_count(OVERSIZED)
+    assert len(rendered) < 80
+    assert rendered.strip() != ""
+
+
+def test_ordinary_counter_formatting_is_unchanged():
+    """The guard must not disturb the established column layout."""
+    assert diagnostics.format_count(11) == "11"
+    assert diagnostics.format_count(1234567) == "1,234,567"
+    assert diagnostics.format_count(1234, 8) == f"{1234:>8,}"
+    assert diagnostics.format_count(LARGE_BUT_SAFE) == f"{LARGE_BUT_SAFE:,}"
+
+
+def test_the_representability_bound_is_a_json_text_bound_not_a_float_bound():
+    """Regression guard on the choice of bound. `10**400` exceeds
+    `sys.float_info.max` yet is perfectly representable as JSON text, so tying
+    the counter bound to the float ceiling would wrongly reject it."""
+    assert LARGE_BUT_SAFE > sys.float_info.max
+    assert diagnostics.json_scalar(LARGE_BUT_SAFE) == LARGE_BUT_SAFE
+    assert diagnostics.json_scalar(OVERSIZED) is None
+
+
+def test_diagnostics_does_not_mutate_the_global_digit_limit():
+    """The correction must not widen CPython's limit process-wide."""
+    before = sys.get_int_max_str_digits()
+    _dumps(diagnostics.info_report(_snapshot(generation=OVERSIZED), "/s"))
+    assert sys.get_int_max_str_digits() == before
+    assert "set_int_max_str_digits" not in inspect.getsource(diagnostics)
 
 
 def test_boolean_fitness_is_not_silently_treated_as_one_point_zero():

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -372,19 +372,24 @@ def _dispatch(args):
 
         stats = diagnostics.snapshot_statistics(snap)
         total = stats["total_cells"]
-        print(f"Source:     {snap.source_path}")
+        # `_one_line` on the path for the same reason the error lane uses it:
+        # a filename is untrusted data and must not forge extra output rows.
+        print(f"Source:     {_one_line(snap.source_path)}")
         print(f"Shape:      {snap.shape}")
         print(f"Generation: {snap.generation:,}")
         print(f"CA Step:    {snap.ca_step:,}")
         print(f"Fitness:    {snap.best_fitness:.4f}")
-        print(f"Non-void:   {stats['non_void_count']:,} / {total:,}")
+        print(f"Non-void:   {diagnostics.format_count(stats['non_void_count'])}"
+              f" / {diagnostics.format_count(total)}")
         print()
         # Rendered through the shared formatters: the statistics are JSON-safe,
-        # so a non-finite channel value arrives as None. Formatting None with a
-        # numeric spec raises, which would turn `info` on a snapshot carrying
-        # NaN into a traceback -- the very snapshot `doctor` exists to report.
+        # so a value that could not be computed arrives as None. Formatting
+        # None with a numeric spec raises, which would turn `info` on a
+        # snapshot carrying NaN into a traceback -- the very snapshot `doctor`
+        # exists to report.
         for entry in stats["state_counts"]:
-            print(f"  {entry['name']:12s}: {entry['count']:>8,} "
+            print(f"  {entry['name']:12s}: "
+                  f"{diagnostics.format_count(entry['count'], 8)} "
                   f"({diagnostics.format_percent(entry['percent'])}%)")
         print()
         for channel in stats["channels"]:

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -11,13 +11,15 @@ Usage:
     python -m vis.observatory channel <snapshot> <channel_index>
     python -m vis.observatory dashboard <snapshot>
     python -m vis.observatory animate <data_dir> [--max-frames 50]
-    python -m vis.observatory info <snapshot>
+    python -m vis.observatory info <snapshot> [--json]
+    python -m vis.observatory doctor <snapshot> [--json]
 """
 
 from __future__ import annotations
 
 import argparse
 import difflib
+import json
 import sys
 from pathlib import Path
 
@@ -30,9 +32,15 @@ from pathlib import Path
 #                 unknown flag, missing argument, out-of-range option value
 #   1  runtime -- an expected, actionable user error discovered while running:
 #                 unusable snapshot path or data, unusable animation directory,
-#                 slice level outside the selected axis
+#                 slice level outside the selected axis -- and, for `doctor`,
+#                 a snapshot that loaded but failed one or more diagnostics
 #
 # `--help` keeps argparse's conventional exit status 0.
+#
+# `doctor` is the one command that can return 1 after a fully successful load:
+# a completed diagnostic run with at least one failed requirement is a reported
+# result, not an error, so it prints its report normally (to stdout) and its
+# status alone tells a caller whether the snapshot is usable.
 #
 # Expected failures print ONE physical stderr line and no traceback. Unexpected
 # failures are deliberately NOT caught: only the narrow operations known to fail
@@ -129,6 +137,21 @@ def _suggest_command(parser, argv, commands):
     parser.error(
         f"unknown command {_one_line(token)!r}. Did you mean {matches[0]!r}?"
     )
+
+
+def _emit_json(report) -> None:
+    """Write exactly one JSON document to stdout, and nothing else.
+
+    ``allow_nan=False`` is a genuine assertion, not decoration: Python's
+    encoder otherwise emits the bare tokens ``NaN`` / ``Infinity``, which are
+    not valid JSON and break strict parsers. The report builders already map
+    every non-finite value to ``null``, so this raises only if that mapping is
+    ever missed -- a defect, which is exactly what should propagate.
+
+    ``sort_keys=True`` makes the byte output a function of the content alone,
+    so equivalent snapshots serialize identically.
+    """
+    print(json.dumps(report, sort_keys=True, allow_nan=False, separators=(",", ":")))
 
 
 def _validated_snapshot_path(raw: str) -> Path:
@@ -295,6 +318,17 @@ def main(argv=None):
     # ---- info: snapshot metadata ------------------------------------------
     p_info = sub.add_parser("info", help="Show snapshot metadata and statistics")
     p_info.add_argument("snapshot")
+    p_info.add_argument("--json", action="store_true",
+                        help="Emit one JSON document on stdout instead of text")
+
+    # ---- doctor: runtime-data-contract preflight ---------------------------
+    p_doctor = sub.add_parser(
+        "doctor",
+        help="Preflight a snapshot against the Observatory data contract",
+    )
+    p_doctor.add_argument("snapshot")
+    p_doctor.add_argument("--json", action="store_true",
+                          help="Emit one JSON document on stdout instead of text")
 
     if argv is None:
         argv = sys.argv[1:]
@@ -326,37 +360,57 @@ def _dispatch(args):
     if getattr(args, "data_dir", None) is not None:
         _validated_directory(args.data_dir)
 
-    # Lazy imports to keep CLI fast
-    from vis.observatory.constants import (
-        STATE_NAMES, CHANNEL_NAMES, SIGNAL_FIELD_CHANNEL, WARMTH_CHANNEL,
-        COMPUTE_AGE_CHANNEL,
-    )
-
     # ---- Dispatch ---------------------------------------------------------
 
     if args.command == "info":
         snap = _load_snapshot_checked(args.snapshot)
+        from vis.observatory import diagnostics
+
+        if args.json:
+            _emit_json(diagnostics.info_report(snap, str(snap.source_path)))
+            return 0
+
+        stats = diagnostics.snapshot_statistics(snap)
+        total = stats["total_cells"]
         print(f"Source:     {snap.source_path}")
         print(f"Shape:      {snap.shape}")
         print(f"Generation: {snap.generation:,}")
         print(f"CA Step:    {snap.ca_step:,}")
         print(f"Fitness:    {snap.best_fitness:.4f}")
-        print(f"Non-void:   {snap.non_void_count:,} / {int(__import__('numpy').prod(snap.shape)):,}")
+        print(f"Non-void:   {stats['non_void_count']:,} / {total:,}")
         print()
-        for sid, name in STATE_NAMES.items():
-            cnt = snap.state_count(sid)
-            pct = cnt / int(__import__('numpy').prod(snap.shape)) * 100
-            print(f"  {name:12s}: {cnt:>8,} ({pct:5.1f}%)")
+        # Rendered through the shared formatters: the statistics are JSON-safe,
+        # so a non-finite channel value arrives as None. Formatting None with a
+        # numeric spec raises, which would turn `info` on a snapshot carrying
+        # NaN into a traceback -- the very snapshot `doctor` exists to report.
+        for entry in stats["state_counts"]:
+            print(f"  {entry['name']:12s}: {entry['count']:>8,} "
+                  f"({diagnostics.format_percent(entry['percent'])}%)")
         print()
-        import numpy as _np
-        for ci, cname in enumerate(CHANNEL_NAMES):
-            ch = snap.channel(ci)
-            nonvoid = ch[snap.lattice > 0]
-            if len(nonvoid) > 0:
-                print(f"  Ch {ci} {cname:22s}: "
-                      f"min={nonvoid.min():+.4f}  max={nonvoid.max():+.4f}  "
-                      f"mean={nonvoid.mean():+.4f}")
+        for channel in stats["channels"]:
+            if not channel["populated"]:
+                continue
+            print(f"  Ch {channel['index']} {channel['name']:22s}: "
+                  f"min={diagnostics.format_stat(channel['min'])}  "
+                  f"max={diagnostics.format_stat(channel['max'])}  "
+                  f"mean={diagnostics.format_stat(channel['mean'])}")
         return 0
+
+    if args.command == "doctor":
+        # Preflight only: the snapshot is loaded through the ordinary public
+        # route and inspected. No renderer is imported, no window opens, no
+        # file is written.
+        snap = _load_snapshot_checked(args.snapshot)
+        from vis.observatory import diagnostics
+
+        checks = diagnostics.diagnose(snap)
+        source = str(snap.source_path)
+        if args.json:
+            _emit_json(diagnostics.doctor_report(snap, source, checks))
+        else:
+            for line in diagnostics.format_doctor(checks, source):
+                print(line)
+        return 0 if diagnostics.all_ok(checks) else 1
 
     if args.command == "slice":
         snap = _load_snapshot_checked(args.snapshot)

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -376,8 +376,12 @@ def _dispatch(args):
         # a filename is untrusted data and must not forge extra output rows.
         print(f"Source:     {_one_line(snap.source_path)}")
         print(f"Shape:      {snap.shape}")
-        print(f"Generation: {snap.generation:,}")
-        print(f"CA Step:    {snap.ca_step:,}")
+        # Through the shared formatter: `{:,}` raises ValueError on an integer
+        # past CPython's decimal-rendering ceiling, which the NPZ route can
+        # carry (it loads with allow_pickle=True and then calls int()).
+        # Ordinary counters render exactly as before.
+        print(f"Generation: {diagnostics.format_count(snap.generation)}")
+        print(f"CA Step:    {diagnostics.format_count(snap.ca_step)}")
         print(f"Fitness:    {snap.best_fitness:.4f}")
         print(f"Non-void:   {diagnostics.format_count(stats['non_void_count'])}"
               f" / {diagnostics.format_count(total)}")

--- a/vis/observatory/diagnostics.py
+++ b/vis/observatory/diagnostics.py
@@ -1,0 +1,452 @@
+"""Cosmic Observatory: snapshot diagnostics and machine-readable reporting.
+
+A deterministic, side-effect-free reporting seam. Nothing here renders, opens a
+window, touches the network, writes a file, reads a snapshot from disk or
+terminates the process — it takes an already-loaded ``ObservatorySnapshot`` and
+returns data. That is what makes it directly testable and what lets the CLI own
+exit statuses on its own.
+
+Two products:
+
+  * :func:`diagnose` — the ordered runtime-data-contract checks behind
+    ``python -m vis.observatory doctor``.
+  * :func:`snapshot_statistics` — the shared statistics both the human ``info``
+    output and ``info --json`` are built from, so the two cannot drift.
+
+Scope. These checks describe the Observatory's *runtime data contract*: the
+shapes, dtypes, vocabularies and finiteness every renderer and consumer in this
+package assumes. They are deliberately NOT scientific validity checks. An
+all-void lattice, an all-zero memory channel, a zero fitness and unusual but
+finite values are perfectly legal snapshots and are reported as passing.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from vis.observatory.constants import CHANNEL_NAMES, NUM_CHANNELS, STATE_NAMES
+
+# Bumped only when the emitted structure changes incompatibly.
+REPORT_SCHEMA = "utilityfog.observatory.report/1"
+
+LATTICE_RANK = 3
+LATTICE_DTYPE = np.uint8
+MEMORY_DTYPE = np.float32
+
+#: Sorted so the reported vocabulary is deterministic regardless of dict order.
+KNOWN_STATE_IDS: Tuple[int, ...] = tuple(sorted(STATE_NAMES))
+
+#: Suffix -> human name of the public load route, mirroring
+#: ``vis.observatory.loader.load_snapshot``'s dispatch. Kept as data so the
+#: report can name the route a source belongs to.
+LOAD_ROUTES: Dict[str, str] = {".npz": "npz", ".json": "portable-genome JSON"}
+
+#: Cap on how many unknown state ids a single ``detail`` string may name, so a
+#: corrupt lattice cannot turn a report into a dump of its own cell values.
+_MAX_REPORTED_STATE_IDS = 8
+
+
+@dataclass(frozen=True)
+class Check:
+    """One runtime-data-contract requirement and its outcome.
+
+    ``detail`` is a short, human-readable explanation. It never contains
+    payload contents -- only shapes, dtypes, counts and vocabulary members --
+    so a report can be pasted anywhere without leaking snapshot data.
+    """
+
+    name: str
+    ok: bool
+    detail: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "ok": self.ok, "detail": self.detail}
+
+
+# ---------------------------------------------------------------------------
+# JSON-safety helpers
+# ---------------------------------------------------------------------------
+
+
+def json_number(value: Any) -> Optional[float]:
+    """Return a JSON-safe float, or ``None`` for anything non-finite.
+
+    ``NaN``, ``Infinity`` and ``-Infinity`` have no representation in strict
+    JSON; Python's encoder emits the non-standard bare tokens ``NaN`` /
+    ``Infinity`` unless told otherwise. Mapping them to ``null`` here means the
+    document stays valid for every consumer, and the serializer can then run
+    with ``allow_nan=False`` as a genuine assertion rather than a formality.
+    """
+    if value is None:
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _is_exact_int(value: Any) -> bool:
+    """True only for a genuine Python ``int``.
+
+    ``bool`` is excluded because ``type(True) is bool``, and ``float`` because
+    ``2.0`` is not a generation counter. Both loader paths produce real ``int``
+    values (``int(...)`` for NPZ, the portable-genome counter guard for JSON),
+    so anything else means the snapshot was built by hand or by a defect.
+    """
+    return type(value) is int
+
+
+def _is_real_number(value: Any) -> bool:
+    return type(value) in (int, float)
+
+
+def json_scalar(value: Any) -> Any:
+    """JSON-safe rendering of a snapshot metadata scalar.
+
+    A genuine ``int`` is emitted as-is. Anything else is coerced through
+    :func:`json_number`, and anything that cannot be coerced becomes ``null``.
+
+    This is reporting, not error suppression: the value being unrepresentable
+    is itself a contract violation, and the corresponding check in
+    :func:`diagnose` already reports it as a failure. Without this, a report
+    *about* a broken counter would die inside the serializer instead of
+    describing what was wrong -- the report builder must survive every input
+    the checks are designed to flag.
+    """
+    if _is_exact_int(value):
+        return value
+    try:
+        return json_number(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def format_stat(value: Optional[float]) -> str:
+    """Fixed-width rendering of one statistic for the human ``info`` table.
+
+    ``None`` means the underlying value was non-finite: :func:`json_number`
+    maps NaN and +/-Infinity to ``None`` so the JSON document stays strictly
+    valid. The human table therefore says ``non-finite`` rather than being
+    handed ``None`` and dying on a numeric format specifier.
+    """
+    return f"{value:+.4f}" if value is not None else "non-finite"
+
+
+def format_percent(value: Optional[float]) -> str:
+    """As :func:`format_stat`, for the percentage column."""
+    return f"{value:5.1f}" if value is not None else "  n/a"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def diagnose(snapshot) -> List[Check]:
+    """Return the ordered runtime-data-contract checks for ``snapshot``.
+
+    The order is stable and does not depend on which checks pass, so two runs
+    over equivalent snapshots produce identical reports. Every check is
+    evaluated -- none short-circuits -- so a snapshot with several problems
+    reports all of them at once. A check whose precondition failed reports its
+    own failure rather than raising: for example, if the lattice is not an
+    array, the rank check fails with an explanatory detail instead of blowing
+    up on a missing attribute.
+    """
+    checks: List[Check] = []
+    lattice = getattr(snapshot, "lattice", None)
+    memory = getattr(snapshot, "memory_grid", None)
+
+    # Scope note, stated plainly because the name invites a stronger reading:
+    # this checks that the snapshot names a source belonging to one of the two
+    # public load routes -- it does NOT re-open the file. Re-reading it would
+    # be a side effect, and would prove nothing new inside `doctor`, which only
+    # reaches here after `load_snapshot()` has already succeeded. The row earns
+    # its place by making the report self-describing (a reader sees which route
+    # the data came from) and by catching a snapshot assembled in memory when
+    # `diagnose()` is used directly as a library call.
+    # Suffix comparison is case-SENSITIVE on purpose: `load_snapshot` compares
+    # `path.suffix == ".npz"` exactly, and `_validated_snapshot_path` rejects
+    # anything else before loading. Lower-casing here would report `RUN.NPZ` as
+    # loadable when the public route actually refuses it -- a check that fails
+    # open is worse than no check.
+    source = getattr(snapshot, "source_path", None)
+    suffix = Path(str(source)).suffix if source else ""
+    route = LOAD_ROUTES.get(suffix)
+    checks.append(Check(
+        "source_loadable",
+        route is not None,
+        f"source is a {route} snapshot" if route is not None
+        else (f"source suffix {suffix!r} is not a public load route "
+              f"({', '.join(sorted(LOAD_ROUTES))})" if source
+              else "snapshot carries no source path"),
+    ))
+
+    lattice_is_array = isinstance(lattice, np.ndarray)
+    checks.append(Check(
+        "lattice_is_array",
+        lattice_is_array,
+        "lattice is a NumPy array" if lattice_is_array
+        else f"lattice is {type(lattice).__name__}, expected numpy.ndarray",
+    ))
+
+    rank_ok = lattice_is_array and lattice.ndim == LATTICE_RANK
+    checks.append(Check(
+        "lattice_rank_is_three",
+        rank_ok,
+        f"lattice rank is {LATTICE_RANK}" if rank_ok
+        else (f"lattice rank is {lattice.ndim}, expected {LATTICE_RANK}"
+              if lattice_is_array else "lattice is not an array"),
+    ))
+
+    dims_ok = rank_ok and all(int(d) > 0 for d in lattice.shape)
+    checks.append(Check(
+        "lattice_dimensions_positive",
+        dims_ok,
+        f"lattice shape {tuple(int(d) for d in lattice.shape)}" if rank_ok and dims_ok
+        else (f"lattice shape {tuple(int(d) for d in lattice.shape)} has a "
+              "non-positive dimension" if rank_ok else "lattice rank is not 3"),
+    ))
+
+    lattice_dtype_ok = lattice_is_array and lattice.dtype == LATTICE_DTYPE
+    checks.append(Check(
+        "lattice_dtype",
+        lattice_dtype_ok,
+        f"lattice dtype is {np.dtype(LATTICE_DTYPE).name}" if lattice_dtype_ok
+        else (f"lattice dtype is {lattice.dtype}, expected "
+              f"{np.dtype(LATTICE_DTYPE).name}" if lattice_is_array
+              else "lattice is not an array"),
+    ))
+
+    if lattice_is_array and lattice.size:
+        present = sorted(int(v) for v in np.unique(lattice))
+        unknown = [v for v in present if v not in STATE_NAMES]
+        states_ok = not unknown
+        # Bounded on purpose. A uint8 lattice of arbitrary bytes yields up to
+        # 251 distinct unknown ids; listing them all would dump cell values
+        # into the report, which `Check.detail` promises never to do.
+        shown = ", ".join(str(v) for v in unknown[:_MAX_REPORTED_STATE_IDS])
+        if len(unknown) > _MAX_REPORTED_STATE_IDS:
+            shown += f", ... ({len(unknown)} distinct)"
+        detail = (
+            f"all state ids within {list(KNOWN_STATE_IDS)}" if states_ok
+            else f"state ids [{shown}] outside {list(KNOWN_STATE_IDS)}"
+        )
+    elif lattice_is_array:
+        states_ok, detail = True, "lattice is empty; no state ids to check"
+    else:
+        states_ok, detail = False, "lattice is not an array"
+    checks.append(Check("lattice_states_known", states_ok, detail))
+
+    memory_is_array = isinstance(memory, np.ndarray)
+    checks.append(Check(
+        "memory_is_array",
+        memory_is_array,
+        "memory grid is a NumPy array" if memory_is_array
+        else f"memory grid is {type(memory).__name__}, expected numpy.ndarray",
+    ))
+
+    # Gated on `rank_ok`, not merely on the lattice being an array: with a
+    # rank-2 lattice of shape (8, 8), `(NUM_CHANNELS,) + shape` is (8, 8, 8),
+    # which a genuinely wrong (8, 8, 8) memory grid would match -- the row
+    # would report PASS for a grid that is not 8 channels over the lattice
+    # volume. The expected shape is only meaningful once the rank is known.
+    if memory_is_array and rank_ok:
+        expected = (NUM_CHANNELS,) + tuple(int(d) for d in lattice.shape)
+        actual = tuple(int(d) for d in memory.shape)
+        shape_ok = actual == expected
+        detail = (f"memory shape {actual}" if shape_ok
+                  else f"memory shape {actual}, expected {expected}")
+    else:
+        shape_ok = False
+        detail = ("memory grid is not an array" if not memory_is_array
+                  else "lattice rank is not 3, so no memory shape is expected")
+    checks.append(Check("memory_shape_matches_lattice", shape_ok, detail))
+
+    memory_dtype_ok = memory_is_array and memory.dtype == MEMORY_DTYPE
+    checks.append(Check(
+        "memory_dtype",
+        memory_dtype_ok,
+        f"memory dtype is {np.dtype(MEMORY_DTYPE).name}" if memory_dtype_ok
+        else (f"memory dtype is {memory.dtype}, expected "
+              f"{np.dtype(MEMORY_DTYPE).name}" if memory_is_array
+              else "memory grid is not an array"),
+    ))
+
+    if memory_is_array and memory.size:
+        finite_mask = np.isfinite(memory)
+        non_finite = int(memory.size - int(np.count_nonzero(finite_mask)))
+        finite_ok = non_finite == 0
+        detail = ("all memory values are finite" if finite_ok
+                  else f"{non_finite} non-finite memory value(s)")
+    elif memory_is_array:
+        finite_ok, detail = True, "memory grid is empty; no values to check"
+    else:
+        finite_ok, detail = False, "memory grid is not an array"
+    checks.append(Check("memory_values_finite", finite_ok, detail))
+
+    for field in ("generation", "ca_step"):
+        value = getattr(snapshot, field, None)
+        ok = _is_exact_int(value) and value >= 0
+        if _is_exact_int(value):
+            detail = f"{field} is {value}" if ok else f"{field} is negative"
+        else:
+            detail = f"{field} is {type(value).__name__}, expected a non-negative int"
+        checks.append(Check(f"{field}_non_negative_int", ok, detail))
+
+    fitness = getattr(snapshot, "best_fitness", None)
+    if _is_real_number(fitness):
+        ok = math.isfinite(float(fitness))
+        detail = "best_fitness is finite" if ok else "best_fitness is not finite"
+    else:
+        ok = False
+        detail = f"best_fitness is {type(fitness).__name__}, expected a real number"
+    checks.append(Check("best_fitness_finite", ok, detail))
+
+    return checks
+
+
+def summarize(checks: List[Check]) -> Dict[str, int]:
+    """Counts for a completed diagnostic run."""
+    passed = sum(1 for c in checks if c.ok)
+    return {"total": len(checks), "passed": passed, "failed": len(checks) - passed}
+
+
+def all_ok(checks: List[Check]) -> bool:
+    return all(c.ok for c in checks)
+
+
+# ---------------------------------------------------------------------------
+# Shared statistics -- one implementation for human `info` and `info --json`
+# ---------------------------------------------------------------------------
+
+
+def snapshot_statistics(snapshot) -> Dict[str, Any]:
+    """Return the statistics both `info` renderings are built from.
+
+    Kept in one place deliberately: the human table and the JSON document
+    previously would have needed two subtly different implementations of the
+    same percentages and per-channel aggregates.
+
+    Channel aggregates are computed over NON-VOID cells only, matching the
+    established human output. A channel with no non-void cells is reported with
+    ``populated: false`` and ``null`` aggregates rather than being omitted, so
+    the JSON shape is the same for every snapshot; the human renderer skips
+    those rows exactly as it always has.
+    """
+    lattice = snapshot.lattice
+    shape = tuple(int(d) for d in lattice.shape)
+    total_cells = 1
+    for dim in shape:
+        total_cells *= dim
+    non_void_mask = lattice > 0
+
+    state_counts = []
+    for state_id in sorted(STATE_NAMES):
+        count = int(np.sum(lattice == state_id))
+        state_counts.append({
+            "id": int(state_id),
+            "name": STATE_NAMES[state_id],
+            "count": count,
+            "percent": json_number(count / total_cells * 100) if total_cells else None,
+        })
+
+    # A report must survive every input its own checks are designed to flag.
+    # `memory_grid[i][non_void_mask]` raises IndexError when the grid's spatial
+    # dimensions differ from the lattice, and again when the grid has fewer
+    # than eight channels -- precisely the snapshots `memory_shape_matches_
+    # lattice` exists to report. Without this gate, `doctor --json` died with a
+    # traceback and emitted no document at all on exactly those files, while
+    # human `doctor` reported them correctly.
+    memory = getattr(snapshot, "memory_grid", None)
+    channels_usable = (
+        isinstance(memory, np.ndarray)
+        and memory.ndim == lattice.ndim + 1
+        and tuple(int(d) for d in memory.shape[1:]) == shape
+    )
+
+    channels = []
+    for index, name in enumerate(CHANNEL_NAMES):
+        values = None
+        if channels_usable and index < int(memory.shape[0]):
+            selected = memory[index][non_void_mask]
+            if selected.size:
+                values = selected
+        channels.append({
+            "index": index,
+            "name": name,
+            "populated": values is not None,
+            "min": json_number(values.min()) if values is not None else None,
+            "max": json_number(values.max()) if values is not None else None,
+            "mean": json_number(values.mean()) if values is not None else None,
+        })
+
+    return {
+        "shape": list(shape),
+        "total_cells": total_cells,
+        "non_void_count": int(np.sum(non_void_mask)),
+        "generation": json_scalar(snapshot.generation),
+        "ca_step": json_scalar(snapshot.ca_step),
+        "best_fitness": json_number(snapshot.best_fitness)
+        if _is_real_number(snapshot.best_fitness) else None,
+        "state_counts": state_counts,
+        "channels": channels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reports
+# ---------------------------------------------------------------------------
+
+
+def info_report(snapshot, source: str) -> Dict[str, Any]:
+    """The `info --json` document."""
+    report = {
+        "schema": REPORT_SCHEMA,
+        "kind": "info",
+        "ok": True,
+        "source": source,
+    }
+    report.update(snapshot_statistics(snapshot))
+    return report
+
+
+def doctor_report(snapshot, source: str, checks: List[Check]) -> Dict[str, Any]:
+    """The `doctor --json` document."""
+    return {
+        "schema": REPORT_SCHEMA,
+        "kind": "doctor",
+        "ok": all_ok(checks),
+        "source": source,
+        "checks": [c.as_dict() for c in checks],
+        "summary": summarize(checks),
+        "snapshot": snapshot_statistics(snapshot),
+    }
+
+
+def format_doctor(checks: List[Check], source: str) -> List[str]:
+    """Human `doctor` output, as lines, in the stable check order.
+
+    Every check is listed whether it passed or failed, so a reader sees the
+    full contract rather than only what broke, and the closing line states the
+    verdict unambiguously.
+    """
+    lines = [f"Snapshot: {source}", ""]
+    width = max((len(c.name) for c in checks), default=0)
+    for check in checks:
+        mark = "PASS" if check.ok else "FAIL"
+        lines.append(f"  [{mark}] {check.name:<{width}}  {check.detail}")
+    counts = summarize(checks)
+    lines.append("")
+    if counts["failed"]:
+        lines.append(
+            f"FAILED: {counts['failed']} of {counts['total']} checks did not pass."
+        )
+    else:
+        lines.append(f"OK: all {counts['total']} checks passed.")
+    return lines

--- a/vis/observatory/diagnostics.py
+++ b/vis/observatory/diagnostics.py
@@ -59,6 +59,36 @@ _MAX_DETAIL_TOKEN = 60
 
 _FLOAT_MAX = sys.float_info.max
 
+#: ``log10(2)``, used to bound an integer's decimal length from its bit length.
+_LOG10_2 = math.log10(2)
+
+
+def _is_json_safe_int(value: int) -> bool:
+    """True when CPython can render ``value`` as decimal text.
+
+    CPython caps integer-to-string conversion (``sys.get_int_max_str_digits()``,
+    4300 by default). Past that ceiling ``str(n)``, ``f"{n}"`` and
+    ``json.dumps(n)`` all raise ``ValueError`` -- so an oversized counter
+    emitted verbatim would kill the serializer while the report was busy
+    asserting the counter was fine.
+
+    The ceiling is measured WITHOUT performing the conversion that raises:
+    ``int.bit_length()`` is exact, cheap and total, and ``digits <=
+    floor(bit_length * log10(2)) + 1`` bounds the decimal length from above.
+    The predicate therefore only admits values that are certainly renderable;
+    it may reject a borderline value that would in fact have fitted, which is
+    the safe direction. A limit of ``0`` means the cap is disabled.
+
+    This is a JSON *text* bound and is deliberately NOT ``_FLOAT_MAX``: a
+    401-digit integer such as ``10 ** 400`` far exceeds the float ceiling yet
+    is perfectly representable as a JSON number, and must keep round-tripping
+    exactly. The two bounds answer different questions.
+    """
+    limit = sys.get_int_max_str_digits()
+    if limit <= 0:
+        return True
+    return int(value.bit_length() * _LOG10_2) + 1 <= limit
+
 # --- dtype gating ----------------------------------------------------------
 #
 # `dtype.kind` characters: b bool, i signed int, u unsigned int, f float,
@@ -210,12 +240,17 @@ def json_scalar(value: Any) -> Any:
     the checks are designed to flag.
     """
     if _is_exact_int(value):
-        # Emitted verbatim, at any magnitude. A Python int of any size is a
-        # legal JSON number, and it is the true value; forcing it through
-        # float() would raise OverflowError above ~1.8e308 and would lose
-        # precision well before that. Reporting the real counter beats
-        # reporting a rounded one.
-        return value
+        # Emitted verbatim whenever the JSON encoder can actually write it.
+        # An exact int is the true value, and forcing it through float() would
+        # raise OverflowError above ~1.8e308 and lose precision well before
+        # that -- so a large counter such as 10**400 is reported exactly.
+        #
+        # The one exception is an integer past CPython's decimal-rendering
+        # ceiling: `json.dumps` would raise ValueError on it, so it is
+        # reported as null, matching how every other unavailable value in
+        # this module is represented. The corresponding check reports the
+        # failure, so nothing is silently lost.
+        return value if _is_json_safe_int(value) else None
     return json_number(value)
 
 
@@ -243,9 +278,17 @@ def format_count(value: Optional[int], width: int = 0) -> str:
     preserved exactly: ``width`` reproduces the previous ``{:>8,}`` for the
     per-state rows, and the default reproduces the unpadded ``{:,}`` used on
     the ``Non-void:`` line.
+
+    An integer past CPython's decimal-rendering ceiling is reported as
+    ``<too large>`` rather than formatted: ``{:,}`` on such a value raises
+    ``ValueError``, and rendering it in full would print a line the width of
+    the number. Counters reach this function through the human ``info`` table,
+    so the guard belongs here rather than at each call site.
     """
     if value is None:
         return "n/a".rjust(width)
+    if type(value) is int and not _is_json_safe_int(value):
+        return "<too large>".rjust(width)
     return f"{value:>{width},}" if width else f"{value:,}"
 
 
@@ -433,14 +476,19 @@ def diagnose(snapshot) -> List[Check]:
 
     for field in ("generation", "ca_step"):
         value = getattr(snapshot, field, None)
-        # `and` short-circuits, so `>= 0` only ever runs on a genuine int.
-        ok = _is_exact_int(value) and value >= 0
-        if _is_exact_int(value):
-            # `_clip` because `f"{value}"` raises ValueError past CPython's
-            # integer-to-string digit limit.
-            detail = f"{field} is {_clip(value)}" if ok else f"{field} is negative"
-        else:
+        if not _is_exact_int(value):
+            ok = False
             detail = f"{field} is {type(value).__name__}, expected a non-negative int"
+        elif value < 0:
+            ok, detail = False, f"{field} is negative"
+        elif not _is_json_safe_int(value):
+            # Described by bit length, never by converting it: `f"{value}"` is
+            # exactly the operation that raises for a value this large.
+            ok = False
+            detail = (f"{field} has {value.bit_length()} bits, too large to "
+                      "render as decimal text")
+        else:
+            ok, detail = True, f"{field} is {value}"
         checks.append(Check(f"{field}_non_negative_int", ok, detail))
 
     # `float(fitness)` is NOT called here. `_is_real_number` admits any Python

--- a/vis/observatory/diagnostics.py
+++ b/vis/observatory/diagnostics.py
@@ -23,6 +23,7 @@ finite values are perfectly legal snapshots and are reported as passing.
 from __future__ import annotations
 
 import math
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -50,6 +51,78 @@ LOAD_ROUTES: Dict[str, str] = {".npz": "npz", ".json": "portable-genome JSON"}
 #: corrupt lattice cannot turn a report into a dump of its own cell values.
 _MAX_REPORTED_STATE_IDS = 8
 
+#: Cap on any single interpolated token in a ``detail``. A structured dtype
+#: renders every one of its fields, a pathological suffix can be arbitrarily
+#: long, and ``f"{value}"`` on an integer past ~4300 digits raises ValueError
+#: outright. Capping keeps ``Check.detail``'s promise unconditional.
+_MAX_DETAIL_TOKEN = 60
+
+_FLOAT_MAX = sys.float_info.max
+
+# --- dtype gating ----------------------------------------------------------
+#
+# `dtype.kind` characters: b bool, i signed int, u unsigned int, f float,
+# c complex, m timedelta, M datetime, O object, S bytes, U unicode, V void.
+#
+# These two sets are the prerequisites for the only two value-inspecting
+# operations in this module. They are deliberately narrow: a check that cannot
+# be evaluated safely is reported as FAILED, never skipped into a pass.
+
+#: Kinds whose values can be enumerated and converted to `int` exactly.
+#: `np.unique()` sorts, and its sort raises for object dtype; `int()` then
+#: raises for unicode, bytes, complex, datetime and void. Float is excluded
+#: too, and that exclusion is load-bearing: `int(nan)` raises ValueError,
+#: `int(inf)` raises OverflowError, and `int(2.7)` would silently fabricate
+#: the valid state id 2 out of a value that is not a state id at all.
+_STATE_INSPECTABLE_KINDS = frozenset("biu")
+
+#: Kinds `np.isfinite()` accepts AND whose reductions yield real numbers.
+#: numpy also accepts complex, but complex is excluded because `float()` on a
+#: complex reduction raises TypeError one layer later, and because a complex
+#: memory grid violates the dtype contract regardless.
+_NUMERIC_KINDS = frozenset("biuf")
+
+
+def _clip(value: Any) -> str:
+    """Render one interpolated token, bounded and on a single line.
+
+    Everything a ``detail`` interpolates goes through here. Two reasons, both
+    demonstrated: a structured dtype's ``str()`` grows without limit and its
+    field names are caller-supplied text that may contain newlines, which would
+    forge report rows; and ``f"{n}"`` on a sufficiently large integer raises
+    ``ValueError`` under CPython's integer-to-string limit.
+    """
+    try:
+        text = str(value)
+    except ValueError:
+        # CPython's int->str digit limit. Narrow and named: the only operation
+        # guarded is this one conversion, for the one documented failure.
+        return "<unrenderable>"
+    text = " ".join(text.splitlines())
+    if len(text) > _MAX_DETAIL_TOKEN:
+        text = text[:_MAX_DETAIL_TOKEN] + "..."
+    return text
+
+
+def one_line(text: Any) -> str:
+    """Collapse anything ``str.splitlines()`` treats as a line boundary.
+
+    A source path is untrusted data: rendered verbatim into the human report it
+    can inject text that looks like an extra check row or a second summary
+    line, so a reader (or a grep) would see a verdict the run never reached.
+    The boundary set is wider than CR/LF -- ``\\v``, ``\\f``, ``\\x1c``-``\\x1e``,
+    ``\\x85``, ``\\u2028`` and ``\\u2029`` all split -- so `splitlines()` is used
+    rather than replacing the two obvious characters.
+
+    This matches ``cli._one_line`` exactly. The duplication is deliberate: this
+    module imports NumPy at module scope and the CLI must stay importable, and
+    usable for argparse errors, without paying that cost.
+
+    JSON output needs no equivalent: ordinary string escaping already makes
+    these characters inert, and the value must round-trip verbatim.
+    """
+    return " ".join(str(text).splitlines()).strip()
+
 
 @dataclass(frozen=True)
 class Check:
@@ -74,20 +147,38 @@ class Check:
 
 
 def json_number(value: Any) -> Optional[float]:
-    """Return a JSON-safe float, or ``None`` for anything non-finite.
+    """Return a JSON-safe float, or ``None`` for anything not finitely
+    representable as one.
 
     ``NaN``, ``Infinity`` and ``-Infinity`` have no representation in strict
     JSON; Python's encoder emits the non-standard bare tokens ``NaN`` /
     ``Infinity`` unless told otherwise. Mapping them to ``null`` here means the
     document stays valid for every consumer, and the serializer can then run
     with ``allow_nan=False`` as a genuine assertion rather than a formality.
+
+    Admission is POSITIVE rather than try/except: only the types this module
+    can convert exactly are converted at all. That matters because ``float()``
+    has three distinct failure modes here -- ``TypeError`` for a complex or an
+    arbitrary object, ``ValueError`` for a non-numeric string, and
+    ``OverflowError`` for an integer larger than ``sys.float_info.max``. The
+    last is an ``ArithmeticError``, so a ``(TypeError, ValueError)`` handler
+    would not have caught it, and ``math.isfinite()`` raises on the same value.
+    The magnitude test below compares an ``int`` against a ``float``, which
+    Python evaluates exactly and without conversion, so it cannot overflow.
+
+    ``bool`` is deliberately not admitted: ``True`` is not the number 1.0, and
+    silently reporting it as a fitness value would fabricate data.
     """
     if value is None:
         return None
-    number = float(value)
-    if not math.isfinite(number):
-        return None
-    return number
+    if type(value) is int:
+        if not -_FLOAT_MAX <= value <= _FLOAT_MAX:
+            return None
+        return float(value)
+    if isinstance(value, (float, np.floating, np.integer)):
+        number = float(value)          # np.integer maxes out far below float
+        return number if math.isfinite(number) else None
+    return None
 
 
 def _is_exact_int(value: Any) -> bool:
@@ -119,11 +210,13 @@ def json_scalar(value: Any) -> Any:
     the checks are designed to flag.
     """
     if _is_exact_int(value):
+        # Emitted verbatim, at any magnitude. A Python int of any size is a
+        # legal JSON number, and it is the true value; forcing it through
+        # float() would raise OverflowError above ~1.8e308 and would lose
+        # precision well before that. Reporting the real counter beats
+        # reporting a rounded one.
         return value
-    try:
-        return json_number(value)
-    except (TypeError, ValueError):
-        return None
+    return json_number(value)
 
 
 def format_stat(value: Optional[float]) -> str:
@@ -140,6 +233,20 @@ def format_stat(value: Optional[float]) -> str:
 def format_percent(value: Optional[float]) -> str:
     """As :func:`format_stat`, for the percentage column."""
     return f"{value:5.1f}" if value is not None else "  n/a"
+
+
+def format_count(value: Optional[int], width: int = 0) -> str:
+    """Fixed-width rendering of a count for the human ``info`` table.
+
+    ``None`` means the count could not be computed -- a lattice dtype the
+    statistics cannot compare against an integer. The existing column layout is
+    preserved exactly: ``width`` reproduces the previous ``{:>8,}`` for the
+    per-state rows, and the default reproduces the unpadded ``{:,}`` used on
+    the ``Non-void:`` line.
+    """
+    if value is None:
+        return "n/a".rjust(width)
+    return f"{value:>{width},}" if width else f"{value:,}"
 
 
 # ---------------------------------------------------------------------------
@@ -175,15 +282,19 @@ def diagnose(snapshot) -> List[Check]:
     # anything else before loading. Lower-casing here would report `RUN.NPZ` as
     # loadable when the public route actually refuses it -- a check that fails
     # open is worse than no check.
+    # `isinstance` before any truth test: `if source` on an ndarray raises
+    # ValueError ("truth value ... is ambiguous"), and on an arbitrary object
+    # `__bool__` can raise anything at all.
     source = getattr(snapshot, "source_path", None)
-    suffix = Path(str(source)).suffix if source else ""
+    has_source = isinstance(source, (str, Path)) and str(source) != ""
+    suffix = Path(str(source)).suffix if has_source else ""
     route = LOAD_ROUTES.get(suffix)
     checks.append(Check(
         "source_loadable",
         route is not None,
         f"source is a {route} snapshot" if route is not None
-        else (f"source suffix {suffix!r} is not a public load route "
-              f"({', '.join(sorted(LOAD_ROUTES))})" if source
+        else (f"source suffix {_clip(suffix)!r} is not a public load route "
+              f"({', '.join(sorted(LOAD_ROUTES))})" if has_source
               else "snapshot carries no source path"),
     ))
 
@@ -218,12 +329,25 @@ def diagnose(snapshot) -> List[Check]:
         "lattice_dtype",
         lattice_dtype_ok,
         f"lattice dtype is {np.dtype(LATTICE_DTYPE).name}" if lattice_dtype_ok
-        else (f"lattice dtype is {lattice.dtype}, expected "
+        else (f"lattice dtype is {_clip(lattice.dtype)}, expected "
               f"{np.dtype(LATTICE_DTYPE).name}" if lattice_is_array
               else "lattice is not an array"),
     ))
 
-    if lattice_is_array and lattice.size:
+    # Prerequisite gate. `np.unique()` sorts, and its sort raises TypeError on
+    # an object array whose elements cannot be ordered; `int(v)` then raises
+    # for unicode, bytes, complex, datetime, void, and for the NaN and +/-Inf
+    # a float array may carry. Inspecting values at all is therefore
+    # conditional on a dtype where both operations are total.
+    #
+    # When the gate closes, the check reports FAILURE, not success: a
+    # dependent evaluation that was deliberately not performed is not a pass.
+    # The dtype violation is already reported by `lattice_dtype` above, so the
+    # two rows agree rather than one silently fabricating a verdict.
+    lattice_inspectable = (
+        lattice_is_array and lattice.dtype.kind in _STATE_INSPECTABLE_KINDS
+    )
+    if lattice_inspectable and lattice.size:
         present = sorted(int(v) for v in np.unique(lattice))
         unknown = [v for v in present if v not in STATE_NAMES]
         states_ok = not unknown
@@ -237,8 +361,12 @@ def diagnose(snapshot) -> List[Check]:
             f"all state ids within {list(KNOWN_STATE_IDS)}" if states_ok
             else f"state ids [{shown}] outside {list(KNOWN_STATE_IDS)}"
         )
-    elif lattice_is_array:
+    elif lattice_inspectable:
         states_ok, detail = True, "lattice is empty; no state ids to check"
+    elif lattice_is_array:
+        states_ok = False
+        detail = (f"lattice dtype {_clip(lattice.dtype)} cannot be inspected "
+                  "for state ids")
     else:
         states_ok, detail = False, "lattice is not an array"
     checks.append(Check("lattice_states_known", states_ok, detail))
@@ -273,36 +401,59 @@ def diagnose(snapshot) -> List[Check]:
         "memory_dtype",
         memory_dtype_ok,
         f"memory dtype is {np.dtype(MEMORY_DTYPE).name}" if memory_dtype_ok
-        else (f"memory dtype is {memory.dtype}, expected "
+        else (f"memory dtype is {_clip(memory.dtype)}, expected "
               f"{np.dtype(MEMORY_DTYPE).name}" if memory_is_array
               else "memory grid is not an array"),
     ))
 
-    if memory_is_array and memory.size:
+    # Prerequisite gate. `np.isfinite()` raises TypeError for object, unicode,
+    # bytes, datetime64, timedelta64 and void dtypes -- for object it raises
+    # even when every element is a Python float, because the object loop looks
+    # for an `isfinite` method on the element. Complex is accepted by numpy but
+    # excluded here: it violates the dtype contract anyway, and its reductions
+    # would fail one layer later inside the statistics.
+    #
+    # As above, a closed gate reports FAILURE rather than skipping to a pass.
+    memory_numeric = memory_is_array and memory.dtype.kind in _NUMERIC_KINDS
+    if memory_numeric and memory.size:
         finite_mask = np.isfinite(memory)
         non_finite = int(memory.size - int(np.count_nonzero(finite_mask)))
         finite_ok = non_finite == 0
         detail = ("all memory values are finite" if finite_ok
                   else f"{non_finite} non-finite memory value(s)")
-    elif memory_is_array:
+    elif memory_numeric:
         finite_ok, detail = True, "memory grid is empty; no values to check"
+    elif memory_is_array:
+        finite_ok = False
+        detail = (f"memory dtype {_clip(memory.dtype)} cannot be inspected "
+                  "for finiteness")
     else:
         finite_ok, detail = False, "memory grid is not an array"
     checks.append(Check("memory_values_finite", finite_ok, detail))
 
     for field in ("generation", "ca_step"):
         value = getattr(snapshot, field, None)
+        # `and` short-circuits, so `>= 0` only ever runs on a genuine int.
         ok = _is_exact_int(value) and value >= 0
         if _is_exact_int(value):
-            detail = f"{field} is {value}" if ok else f"{field} is negative"
+            # `_clip` because `f"{value}"` raises ValueError past CPython's
+            # integer-to-string digit limit.
+            detail = f"{field} is {_clip(value)}" if ok else f"{field} is negative"
         else:
             detail = f"{field} is {type(value).__name__}, expected a non-negative int"
         checks.append(Check(f"{field}_non_negative_int", ok, detail))
 
+    # `float(fitness)` is NOT called here. `_is_real_number` admits any Python
+    # int, and `float(10**400)` raises OverflowError -- an ArithmeticError, so
+    # neither a TypeError nor a ValueError handler would catch it, and
+    # `math.isfinite()` raises on the same value. `json_number` performs the
+    # magnitude test by exact int/float comparison instead, which cannot
+    # overflow, and returns None for anything not finitely representable.
     fitness = getattr(snapshot, "best_fitness", None)
     if _is_real_number(fitness):
-        ok = math.isfinite(float(fitness))
-        detail = "best_fitness is finite" if ok else "best_fitness is not finite"
+        ok = json_number(fitness) is not None
+        detail = ("best_fitness is finite" if ok
+                  else "best_fitness is not a finite representable number")
     else:
         ok = False
         detail = f"best_fitness is {type(fitness).__name__}, expected a real number"
@@ -338,22 +489,49 @@ def snapshot_statistics(snapshot) -> Dict[str, Any]:
     ``populated: false`` and ``null`` aggregates rather than being omitted, so
     the JSON shape is the same for every snapshot; the human renderer skips
     those rows exactly as it always has.
+
+    Preconditions and totality boundary
+    -----------------------------------
+    NONE. This function is total over every input :func:`diagnose` accepts,
+    which is the contract that matters: :func:`doctor_report` embeds these
+    statistics, so any input the checks are designed to *report* must not make
+    the report itself unconstructible. It previously assumed strictly more than
+    ``diagnose`` guaranteed -- bare attribute access, an orderable lattice
+    dtype, and a memory dtype whose reductions are real numbers -- and raised
+    ``AttributeError``/``TypeError`` on inputs the checks were built to flag.
+
+    The key set is INVARIANT. When a statistic cannot be computed it is
+    reported as ``null`` and the row still appears; nothing is fabricated and
+    no invalid array is coerced into apparently valid scientific data. For a
+    healthy snapshot every value is exact, unchanged from before.
     """
-    lattice = snapshot.lattice
-    shape = tuple(int(d) for d in lattice.shape)
-    total_cells = 1
-    for dim in shape:
-        total_cells *= dim
-    non_void_mask = lattice > 0
+    # Read exactly as `diagnose` reads: a library caller may pass a partial or
+    # duck-typed object, and the two must accept the same inputs.
+    lattice = getattr(snapshot, "lattice", None)
+    memory = getattr(snapshot, "memory_grid", None)
+
+    lattice_is_array = isinstance(lattice, np.ndarray)
+    shape = tuple(int(d) for d in lattice.shape) if lattice_is_array else ()
+    # `size` rather than a product over `shape`: it is exact for a rank-0
+    # array, where the empty product would coincidentally also give 1 but for
+    # the wrong reason, and it is 0 for a non-array.
+    total_cells = int(lattice.size) if lattice_is_array else 0
+
+    # `lattice > 0` and `lattice == state_id` need an orderable numeric dtype.
+    # Unicode, bytes, object-holding-strings, datetime64 and void all raise
+    # TypeError on `>`; that is the dtype `lattice_dtype` already reports.
+    countable = lattice_is_array and lattice.dtype.kind in _NUMERIC_KINDS
+    non_void_mask = (lattice > 0) if countable else None
 
     state_counts = []
     for state_id in sorted(STATE_NAMES):
-        count = int(np.sum(lattice == state_id))
+        count = int(np.count_nonzero(lattice == state_id)) if countable else None
         state_counts.append({
             "id": int(state_id),
             "name": STATE_NAMES[state_id],
             "count": count,
-            "percent": json_number(count / total_cells * 100) if total_cells else None,
+            "percent": (json_number(count / total_cells * 100)
+                        if countable and total_cells else None),
         })
 
     # A report must survive every input its own checks are designed to flag.
@@ -363,9 +541,18 @@ def snapshot_statistics(snapshot) -> Dict[str, Any]:
     # lattice` exists to report. Without this gate, `doctor --json` died with a
     # traceback and emitted no document at all on exactly those files, while
     # human `doctor` reported them correctly.
-    memory = getattr(snapshot, "memory_grid", None)
+    #
+    # The dtype term is equally load-bearing and was the later discovery: for a
+    # SHAPE-MATCHING grid of unicode, bytes, complex or datetime64, `.min()`
+    # and `.max()` succeed and only `float()` fails one layer down, so a
+    # shape-only gate let a wrong dtype through to raise inside `json_number`.
+    # The rank term keeps a rank-0 lattice from pairing with a rank-1 grid and
+    # indexing a numpy scalar.
     channels_usable = (
-        isinstance(memory, np.ndarray)
+        countable
+        and lattice.ndim >= 1
+        and isinstance(memory, np.ndarray)
+        and memory.dtype.kind in _NUMERIC_KINDS
         and memory.ndim == lattice.ndim + 1
         and tuple(int(d) for d in memory.shape[1:]) == shape
     )
@@ -386,14 +573,17 @@ def snapshot_statistics(snapshot) -> Dict[str, Any]:
             "mean": json_number(values.mean()) if values is not None else None,
         })
 
+    fitness = getattr(snapshot, "best_fitness", None)
     return {
         "shape": list(shape),
         "total_cells": total_cells,
-        "non_void_count": int(np.sum(non_void_mask)),
-        "generation": json_scalar(snapshot.generation),
-        "ca_step": json_scalar(snapshot.ca_step),
-        "best_fitness": json_number(snapshot.best_fitness)
-        if _is_real_number(snapshot.best_fitness) else None,
+        "non_void_count": (int(np.count_nonzero(non_void_mask))
+                           if countable else None),
+        "generation": json_scalar(getattr(snapshot, "generation", None)),
+        "ca_step": json_scalar(getattr(snapshot, "ca_step", None)),
+        # Gated on the exact-type test, not merely passed to `json_number`, so
+        # a `bool` is reported as null rather than as the number 1.0.
+        "best_fitness": json_number(fitness) if _is_real_number(fitness) else None,
         "state_counts": state_counts,
         "channels": channels,
     }
@@ -435,12 +625,24 @@ def format_doctor(checks: List[Check], source: str) -> List[str]:
     Every check is listed whether it passed or failed, so a reader sees the
     full contract rather than only what broke, and the closing line states the
     verdict unambiguously.
+
+    Every returned element is exactly one physical line. The source path is
+    untrusted data -- on POSIX a filename may contain CR/LF, and even on
+    Windows it may contain U+0085, U+2028 or U+2029, all of which
+    ``str.splitlines()` treats as boundaries -- so rendered verbatim it could
+    inject a convincing extra ``[PASS]`` row or a second summary line and make
+    a reader, or a grep, see a verdict the run never reached. Details are
+    collapsed for the same reason: a structured dtype's field names reach a
+    detail as caller-supplied text.
+
+    The exit status was never at risk: `cli` computes it from `all_ok`, not
+    from this text. The integrity of the report a human reads is the point.
     """
-    lines = [f"Snapshot: {source}", ""]
+    lines = [f"Snapshot: {one_line(source)}", ""]
     width = max((len(c.name) for c in checks), default=0)
     for check in checks:
         mark = "PASS" if check.ok else "FAIL"
-        lines.append(f"  [{mark}] {check.name:<{width}}  {check.detail}")
+        lines.append(f"  [{mark}] {check.name:<{width}}  {one_line(check.detail)}")
     counts = summarize(checks)
     lines.append("")
     if counts["failed"]:


### PR DESCRIPTION
Refs #67

## Pins

| | |
|---|---|
| Base (`main`) | `c143cafe230016c3817aa2dc040f9b08da864a11` |
| Head | `03bb5813522e9563bd1f7c31286adb1e5df12ad2` |
| Branch | `feat/observatory-doctor-json-preflight` |
| Commits | 7 |

| Commit | |
|---|---|
| `ee8034e` | Observatory: add `doctor` preflight and deterministic JSON reporting |
| `96c05d8` | tests: failing-first adversarial totality matrix (**expected red**) |
| `38e1988` | Observatory: make the diagnostic seam total under hostile input |
| `7fcd10f` | tests: assert report-line structure, not substring occurrence |
| `1aa24b3` | Merge branch 'main' (synchronization) |
| `4fb452a` | tests: failing-first proof of the oversized-counter defect (**expected red**) |
| `03bb581` | Observatory: guard oversized counters before JSON serialization |

**Synchronized with `main`.** The original base was `5e61869d`; `main` advanced to `c143cafe` (merged #452 and #453) and has been merged in with an ordinary merge commit — no rebase, squash, amend or force-push. That advance touches only `experiments/tech_ledger/**`, verified by path and disjoint from all four files here, and the merge required no conflict resolution. All four package blobs are byte-identical across the synchronization (`diagnostics.py` `6850f06`, `cli.py` `b275889`, `test_observatory_diagnostics.py` `d29af25`, `test_observatory_cli.py` `12c586b`), so no production or test content was altered by it.

## Objective

The next issue-#67 tranche: a `doctor` subcommand that preflights whether a snapshot satisfies the Observatory **runtime data contract** without opening a renderer, plus deterministic machine-readable JSON for both `doctor` and the existing `info`.

## Ownership by layer

**`vis/observatory/diagnostics.py` (new)** owns validation semantics and report shape. Deterministic and side-effect-free: it takes an already-loaded snapshot and returns data. It does not render, open a window, touch the network, write a file, read from disk, or terminate the process.

**`vis/observatory/cli.py`** owns argument parsing, I/O and exit statuses only.

`vis/observatory/__init__.py` is **not** modified — `from vis.observatory import diagnostics` is an ordinary submodule import.

## Human contract

```
Snapshot: /path/to/snap.npz

  [PASS] source_loadable              source is a npz snapshot
  ...
  [FAIL] memory_values_finite         3 non-finite memory value(s)

FAILED: 1 of 13 checks did not pass.
```

Stable order, every check listed, one unambiguous closing line, all failures reported together. 13 checks: `source_loadable`, `lattice_is_array`, `lattice_rank_is_three`, `lattice_dimensions_positive`, `lattice_dtype`, `lattice_states_known`, `memory_is_array`, `memory_shape_matches_lattice`, `memory_dtype`, `memory_values_finite`, `generation_non_negative_int`, `ca_step_non_negative_int`, `best_fitness_finite`.

These describe the **runtime data contract**, not scientific validity. An all-void lattice, an all-zero channel, a zero fitness and unusual-but-finite values all pass.

Every returned line is exactly one physical line, and `Check.detail` names only shapes, dtypes, counts and vocabulary — never array contents, and never unbounded.

## JSON contract

One document on stdout, nothing else. Schema `utilityfog.observatory.report/1`.

- `doctor`: `schema`, `kind`, `ok`, `source`, `checks[]`, `summary`, `snapshot`.
- `info`: `schema`, `kind`, `ok`, `source`, plus the shared statistics inline.

Serialized with `sort_keys=True`, `allow_nan=False`, fixed separators. Non-finite values become `null` *before* serialization, so `allow_nan=False` is a real assertion. Only ordinary JSON types; no NumPy scalar reaches the document. Equivalent inputs are byte-identical apart from `source`, proven end-to-end over two distinct files. No report files are written (asserted against both the temp directory and the process's actual working directory).

**The key set is invariant.** A statistic that cannot be computed is reported as `null` with its row still present — never as a fabricated zero, which would read as a real measurement of an unreadable array.

## Exit contract

`0` loaded and all checks passed; `1` expected load failure **or** completed diagnostics with ≥1 failure; `2` argparse usage error; `--help` remains `0`. `doctor` is the one command that can return `1` after a successful load. Expected failures stay one stderr line with no traceback; unexpected defects propagate.

## Corrective run — totality under hostile input

Jack reproduced that the seam's central claim was false: several wrong-dtype arrays raised instead of becoming failed checks.

**Reproduction.** This seat has no local NumPy or pytest, so the adversarial matrix was landed first (`96c05d8`) and CI was used as the authoritative reproducer rather than an assertion of mine:

> **CI run 30930370213 — `115 failed, 3649 passed, 13 skipped`**

Distinct root causes reproduced, all now fixed by **prerequisite gating** — no `except Exception`, no bare handler, no broad suppression:

| # | Reproduced failure | Gate |
|---|---|---|
| 1 | `np.isfinite()` on object/unicode/bytes/datetime64/void → `TypeError`. For object it raises even when every element is a Python float, because the object loop looks for an `isfinite` *method*. **Jack's witness (a).** | `dtype.kind in "biuf"` |
| 2 | `np.unique()` sort → `TypeError` on unorderable objects; `int(v)` → `ValueError`/`OverflowError` for unicode, bytes, complex, datetime, and for NaN/±Inf in a float lattice. **Jack's witness (b).** | `dtype.kind in "biu"`, applied *before* `unique()` |
| 3 | `snapshot_statistics()` assumed more than `diagnose()` guarantees: bare attribute access → `AttributeError`; `lattice > 0` → `TypeError`; channels gated on shape alone, so a **shape-matching** grid of unicode/bytes/complex/datetime64 reached `.min()`/`.max()` (which succeed) and died in `float()` one layer down; a rank-0 lattice paired with a rank-1 grid → `IndexError`. | `getattr`, dtype and rank terms added to the gate |
| 4 | `float()` on a huge int → `OverflowError`, an `ArithmeticError` that the `(TypeError, ValueError)` handler never caught; `math.isfinite()` raises on the same value. | positive type admission + exact int/float magnitude comparison |
| 5 | A source path could **forge report lines** — a convincing extra `[PASS]` row and a second summary line, so a reader or a grep would see a verdict the run never reached. | `splitlines()` collapse on path *and* details |
| 6 | Unbounded detail tokens: a structured dtype renders every field (and its field names are caller-supplied text), and `f"{n}"` raises `ValueError` past CPython's integer-to-string limit. | all interpolated tokens clipped |

Because `doctor_report()` embeds the statistics, causes 3 and 4 produced **no JSON document at all** on exactly the snapshots the checks exist to report, while human `doctor` handled the same file correctly. That asymmetry is gone.

**A closed gate reports FAILURE, never a skipped pass** — a dependent evaluation deliberately not performed is not a result. Float is excluded from state inspection deliberately: `int(2.7)` would silently fabricate the valid state id `2` from a value that is not a state id at all. `bool` is not admitted as a number: `True` is not fitness `1.0`.

`snapshot_statistics()` now documents its preconditions explicitly: **none** — it is total over every input `diagnose()` accepts.

### Adversarial matrix

Lattice: uint8; int8/16/32/64; uint16/64; negative ints; float integral and fractional; float with NaN/±Inf; bool; unicode; bytes; object holding ints, strings, `None`, and mixed-unorderable; complex64/128; datetime64; rank 0/1/2/4; zero-size dimensions; unknown state ids; non-array (list/None/str); missing attribute.

Memory: float32/64/16; int32; uint8; bool; complex64/128; datetime64; unicode; bytes; object holding numbers, strings, mixed, `None`; NaN/±Inf; zero-size; rank-0; wrong rank; wrong channel count; wrong spatial shape; non-array; missing attribute.

Metadata: valid ints; zero; negative; bool; float; NaN/±Inf; str; `None`; `np.int64`/`np.float32`/`np.bool_`; ±10^400; complex; an object whose `__float__` raises; a bare object; a list.

Plus every combination of the first twelve lattices × first twelve memories, and snapshots missing attributes entirely. For each: `diagnose()` returns all 13 checks in order, `doctor_report()` builds, strict `allow_nan=False` serialization succeeds, `format_doctor()` succeeds, a second run is byte-identical, details stay bounded, and inputs are unmodified.

## Review round — oversized counters (Codex thread, `diagnostics.py:218`)

Reviewer `chatgpt-codex-connector` raised a **P2**: *"Guard oversized counters before JSON serialization."* Confirmed, reproduced and fixed.

**Root cause.** CPython caps integer-to-string conversion at `sys.get_int_max_str_digits()` (4300 by default). Past that ceiling `str(n)`, `f"{n}"` and `json.dumps(n)` all raise `ValueError`. `json_scalar` returned an exact `int` verbatim at any magnitude and the counter check *passed* it — so `info --json` and `doctor --json` raised inside the encoder while the report was asserting the counter was fine, and human `info` raised formatting the same value with `:,`.

**The suite missed it in two ways**, both closed: the metadata matrix's largest counter was `10**400` (401 digits, inside the ceiling), so `_assert_total`'s strict-serialization assertion never saw an oversized value; and the one `10**100000` test asserted only the bounded human detail and `format_doctor`, never serialization.

**Chosen bound — a JSON *text* bound, deliberately not `_FLOAT_MAX`.** `_is_json_safe_int()` decides admissibility **without performing the conversion that raises**: `int.bit_length()` is exact, cheap and total, and `digits ≤ floor(bit_length × log10(2)) + 1` bounds the decimal length from above. It admits only certainly-renderable values and errs toward rejection; a cap of `0` (disabled) admits everything. Verified sound across `10**0`–`10**100000`, tight at the boundary (4300 digits accepted, 4301 rejected).

`10**400` is far beyond `sys.float_info.max` yet perfectly representable as a JSON number — tying the counter bound to the float ceiling would have regressed it. It still passes its check and round-trips exactly; a regression test pins that distinction.

**Behaviour now:** a renderable exact int is emitted verbatim; an unrenderable one becomes `null` (the same representation this module already uses for every unavailable value, so keys and types stay stable); the `generation`/`ca_step` check fails with a bounded single-line detail describing the value by **bit length**, never by converting it; `format_count` renders `<too large>` so the human table cannot traceback or print a line the width of the number; and human `info` routes both counters through that formatter. Ordinary counter formatting is byte-identical — `{:,}` and `{:>8,}` as before.

No global `sys.set_int_max_str_digits()` mutation, no broad `except`, no bare handler, no blanket serializer catch.

**Reachability, stated precisely.** An ordinary portable-genome JSON file is **not** the route: CPython applies the same ceiling when *parsing*, so `json.load` rejects an over-limit decimal literal before the loader sees it (verified: `Exceeds the limit (4300 digits) for integer string conversion: value has 100001 digits`). The **NPZ route does** reach it — `load_npz` loads with `allow_pickle=True` and then calls `int(...)`, so a pickled Python int of any magnitude survives as a real `int`. A directly constructed snapshot is the other valid witness. The end-to-end tests use the NPZ route through `python -m vis.observatory`, not a patched loader.

**Receipts.** Failing-first `4fb452a` → CI run 30973748375: **`23 failed, 3794 passed, 13 skipped`**, every failure rooted in `ValueError: Exceeds the limit (4300 digits)`. Correction `03bb581` → CI run 30973967312: **`3817 passed, 13 skipped in 77.07s`**. No previously passing test was lost (3789 → 3817 = +28 new).

## Corrected limitation — an earlier body was wrong

The earlier body stated human `info` on a zero-size lattice "still crashes" with `TypeError`. **That was stale and is now removed.** It was true of the base (`ZeroDivisionError`), but the shared-statistics refactor already fixed it: the percentage becomes `None` and `format_percent` renders `n/a`. Verified end-to-end for shapes `(0,3,4)`, `(3,0,4)`, `(3,4,0)` and `(0,0,0)`: `info` exits **0**, `doctor` exits **1** reporting the zero dimension, and neither tracebacks in either output mode.

## Validation

| | |
|---|---|
| `py_compile` (all 4 files) | exit 0 |
| `git diff --check` | clean |
| Duplicate test names | none |
| Supporting probe, numpy-free seam | 74/74 pass |
| **pytest** | **NOT RUN LOCALLY** — no NumPy or pytest in this seat. CI is authoritative. |

No packages installed; the environment was not altered.

**Authoritative `verify-python` at head `03bb581`, run 30973967312: `3817 passed, 13 skipped in 77.07s`.** All checks SUCCESS: `agent-safety`, `verify-python`, `frontend-quality`.

Progression: 3276 (original base) → 3433 (`ee8034e`) → 115 failed/3649 passed (`96c05d8`, deliberate reproduction) → 2 failed/3787 passed (`38e1988`) → 3789 passed (`7fcd10f`) → 3789 passed (`1aa24b3`, post-synchronization) → 23 failed/3794 passed (`4fb452a`, deliberate reproduction) → **3817 passed (`03bb581`)**. Both reproduction commits are labelled as such; no previously passing test was lost at any step.

## Agent review

Three read-only lanes were commissioned against this head. Lane 3 (test-quality) was cut off by a session limit and, per instruction, **is not counted as evidence** — no finding from it is claimed below.

**Lane 1 — dtype/numeric totality.** Produced a full `INPUT → RAISES(line)` table and the `dtype.kind` safety matrix. Accepted in full; it is the direct source of gates 1, 2 and 4, and of the decision to exclude float from state inspection and complex from finiteness. Its point that `math.isfinite(10**400)` *also* raises — so the gate must not itself convert — is why the magnitude test is an exact int/float comparison.

**Lane 2 — statistics seam, reports, human output, leak.** Accepted in full: the `snapshot_statistics` totality boundary, the shape-only channel gate being insufficient against a shape-matching wrong dtype, the rank-0/rank-1 `IndexError`, the unbounded `{dtype}` and `{suffix!r}` tokens, and the concrete forged-pathname exploit. It also identified the stale zero-size limitation corrected above, and correctly noted that in my first forgery test only the header assertion was load-bearing — that test is now structural.

**Rejected / revised — one of my own.** My failing-first matrix asserted that a 10^400 `generation` should FAIL `generation_non_negative_int`. On analysis that was an invented defect: such a value *is* a genuine non-negative integer, and a Python int of any magnitude is a legal JSON number. The check now passes and the true value is emitted verbatim; rounding it through `float()` would report a counter the snapshot does not have. The test was corrected to assert that.

Two of my own assertions in `7fcd10f` were also wrong rather than the fix: they counted substring occurrences, but collapsing a hostile pathname makes the injected text inert on the header line rather than erasing it.

## Changed files

Exactly the authorized boundary; **+2722 / −24** across 4 files.

| File | + | − |
|---|---|---|
| `vis/observatory/diagnostics.py` (new) | 702 | 0 |
| `vis/observatory/cli.py` | 87 | 24 |
| `tests/test_observatory_diagnostics.py` (new) | 1281 | 0 |
| `tests/test_observatory_cli.py` | 652 | 0 |

No loader, renderer, CA-engine, portable-genome, package-initializer, schema, workflow, manifest, tech-ledger or handoff file is touched. Human `info` column layout is unchanged — `format_count` reproduces the previous `{:>8,}` and `{:,}` exactly, so the assertions in `tests/test_observatory.py` continue to hold.

## Open-PR overlap

**None.** Remaining open PRs are #443 (`.github/workflows/*`), #442 and #441 (`crates/uft_ca/Cargo.toml`) — all unassigned Dependabot automation, no shared path. #452 and #453 merged during this work and touched only `experiments/tech_ledger/**`; they are now part of this branch via the synchronization merge.

## Limitations and non-claims

- `source_loadable` **does not re-open the file.** It verifies the snapshot names a source belonging to a public load route and records which. Re-reading would be a side effect and would prove nothing inside `doctor`, which is only reached after `load_snapshot()` succeeded.
- Human output **collapses** line boundaries in paths and details; it does not erase the text. Injected content remains visible and inert on its line. Exit status was never at risk — `cli` computes it from `all_ok`, not from the text.
- JSON mode deliberately does **not** collapse: escaping already makes separators inert and the value must round-trip verbatim.
- A failed *load* emits **no JSON document** in `--json` mode — consistent with the exit taxonomy, but relevant to a consumer assuming a document on every invocation.
- Every hostile-dtype case is reachable only via `diagnose()` as a library call: both public loaders coerce with `.astype()`. The metadata cases are different — `load_genome` passes counters through from portable-genome JSON without coercion, so they are CLI-reachable.
- The checks are a data-contract preflight, not scientific validity.
- pytest was not run locally; all test claims rest on CI.

## Status

**Ready for review, open and unmerged.** Synchronized with `main` at `c143cafe`, which has not advanced since — no further synchronization was needed. Merge state CLEAN. Auto-merge not enabled and merging is not authorized under the current pass — the merge decision rests with the reviewer. Issue #67 not modified; #441–#443 untouched.
