### PR TITLE
fix(tech-ledger): correct TLV4-005 G boundary

### DIFF
--- a/experiments/tech_ledger/entries/TLV4-005.json
+++ b/experiments/tech_ledger/entries/TLV4-005.json
@@ -1,8 +1,9 @@
 {
  "classification_qualifiers": [
-  "F"
+  "F",
+  "G"
  ],
- "classification_rationale": "Established general-relativity method (B) with a hard caveat: the pseudotensor is coordinate-dependent, so only suitably integrated or asymptotic quantities are meaningful; reading local values as physical energy density, or citing them to support extraction or propulsion claims, is technically mismatched (F face).",
+ "classification_rationale": "Established general-relativity method (B): the Landau-Lifshitz pseudotensor and the Einstein-Landau-Lifshitz quadrupole formalism, anchored in directly inspected literature (Szabados, Living Rev. Relativity 7 (2004) 4 and Blanchet, Living Rev. Relativity 17 (2014) 2, Eqs. (4) and (9)-(13), both publisher-hosted review articles; Xulu, arXiv:hep-th/0308070, an author-manuscript thesis; access levels recorded in provenance). Hard caveat, directly sourced to Szabados and Xulu (Blanchet works in fixed harmonic coordinates and does not carry it): the pseudotensor is coordinate-dependent - pointwise components are never a coordinate-independent physical energy density and can be made to vanish at a point by coordinate choice, and integration in arbitrary coordinates does not by itself create an invariant; total energy-momentum is well defined at spatial infinity for asymptotically flat systems evaluated in quasi-Cartesian-type coordinates or as asymptotic quantities, total angular momentum only under stronger fall-off and parity conditions (with no generally accepted definition at null infinity); and this record does not exclude explicitly specified quasi-local constructions, whose pseudotensor superpotentials may be read as Hamiltonian boundary terms with fixed gauge and boundary conditions. Reading local values as physical energy density, or citing them to support extraction or propulsion claims, is technically mismatched (F face); the extraction-propulsion refusal is this record's own repository policy, not a source claim.",
  "entry_id": "TLV4-005",
  "implementation_disposition": "evidence-gated",
  "implementation_seam": "Numerical quadrupole-formula check against the analytic binary-inspiral leading order",
@@ -15,10 +16,10 @@
  "neutral_name": "Landau-Lifshitz gravitational pseudotensor calculations",
  "primary_classification": "B",
  "provenance": {
-  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates)",
-  "recorded_date": "2026-08-01",
+  "attributed_author": "Eighty Four (Kev-seat V4 technology audit, over Kev-supplied candidates); correction recorded by Eighty Four (Kev seat, 2026-08-05)",
+  "recorded_date": "2026-08-05",
   "source_kind": "user-supplied-audit",
-  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source",
+  "source_reference": "Kev-supplied V4 technology audit handback (Kev seat, 2026-08-01) -- unverified user-supplied audit, not a primary source -- corrected 2026-08-05 under strict primary-evidence rules: the record body derives from the original user-supplied audit and remains unverified; content claims rest only on directly inspected material - the publisher-hosted open-access review articles of Szabados (Living Rev. Relativity 7 (2004) 4) and Blanchet (Living Rev. Relativity 17 (2014) 2), both read in full, and the author-manuscript thesis of Xulu (arXiv:hep-th/0308070), read in full - source type and access level recorded as separate facts, and none of the three is a primary research paper; the quadrupole and binary-inspiral leading-order content is anchored in Blanchet Eqs. (4) and (9)-(13), with Peters, Phys. Rev. 136, B1224 (1964) and Peters-Mathews, Phys. Rev. 131, 435 (1963) carrying bibliographic identity only (not inspectable without bypass at audit time); the Landau-Lifshitz textbook carries bibliographic identity only, its attribution grounded via the inspected citations (Blanchet ref 285; Xulu ref 40; Szabados cites Goldberg 1958, not the textbook); the asymptotic-totals and angular-momentum conditions and the quasi-local rehabilitation are Szabados section 3.2.1-3.2.4, 3.3.1 and 11.3.4 direct statements; the extraction-propulsion refusal is this record's own repository policy; receipts in the TLV4-005 claim-atom and evidence dossier v3 (5425 bytes, sha256 d22eb6dac82de3bc7f7576e1ef29f0428b527bf341a66dda01b26c3d558d4bf3); G qualifier added; verification_status unchanged",
   "verification_status": "unverified"
  },
  "related_intake_ledger_entries": [],

--- a/experiments/tech_ledger/tests/test_entries.py
+++ b/experiments/tech_ledger/tests/test_entries.py
@@ -116,7 +116,21 @@ def test_tlv4_005_landau_lifshitz_pseudotensor():
     entry = _load("TLV4-005")
     assert entry["entry_id"] == "TLV4-005"
     assert entry["primary_classification"] == "B"
-    assert entry["classification_qualifiers"] == ["F"]
+    assert entry["classification_qualifiers"] == ["F", "G"]
+    # Ruling pins (owner, 2026-08-05, corrected four-way scope): the
+    # caveat and the four-way scope are dossier-sourced; the pins carry
+    # polarity (non-exclusion, conditions), never bare vocabulary; the
+    # extraction-propulsion refusal is the record's own policy.
+    rationale = entry["classification_rationale"]
+    assert "the pseudotensor is coordinate-dependent" in rationale
+    assert "does not by itself create an invariant" in rationale
+    assert "does not exclude explicitly specified quasi-local constructions" in rationale
+    assert ("total angular momentum only under stronger fall-off and "
+            "parity conditions") in rationale
+    assert "this record's own repository policy, not a source claim" in rationale
+    assert "corrected 2026-08-05 under strict primary-evidence rules" in (
+        entry["provenance"]["source_reference"]
+    )
     assert entry["implementation_disposition"] == "evidence-gated"
     assert entry["status"] == "active"
     assert entry["implementation_seam"] == (


### PR DESCRIPTION
## What this PR does

Corrects the TLV4-005 (pseudotensor / Landau-Lifshitz energy localization) ledger entry's G-classification boundary and pins the corrected wording in the entry test. One ordinary commit; exactly two paths.

- **Base:** `1b800943d17ed7f497841a0a4650658ee21992e0` (live `main` at branch time; PR #451's Observatory merge)
- **Head:** `2241f564cb65b26d6b702048005fd04b5943e445` (single parent = base; one ordinary non-merge commit)
- **Paths (exactly two):** `experiments/tech_ledger/entries/TLV4-005.json` · `experiments/tech_ledger/tests/test_entries.py`
- **Diffstat:** 2 files changed, +21/−6 (entry 6/5, test 15/1)

## Byte receipts

| Artifact | Bytes | SHA-256 | Git blob |
|---|---|---|---|
| Baseline `TLV4-005.json` (on base) | 1,765 | `10d71a1d8dec425b6789749404d7cd1238766c8e8bf0b49f7a622f1ffcfceb26` | `08a4acc6552a129e9a85a6554b0683194a677606` |
| Candidate `TLV4-005.json` (this PR, installed by raw byte copy) | 4,526 | `bce754f2998031a3c5f9f967ea944f1ad803da5b26ec6ff88e30ed48765ad6fa` | `77f622cba8183d7492b37b659d69df68e7f263c2` |
| Finalized test patch (applied verbatim, not reconstructed) | 1,412 | `fdeacbadd17ae0806b4ef69b606dcf233ff05e24da6fcf637c6243ca786c0ea1` | `43da6ffe5b94d851a5787b04c946d5095cd7136a` |
| Final `test_entries.py` (result of the patch) | 16,728 | `76b9fca39f4d45496a517d13f43965cfa0b1d520595111d7b2f16e8dc23d584b` | `2f5f28cf35b4ce899849887d39285d29f05fc96d` |

**Receipt-erratum overlay (sealed local packet):** `TLV4_005_G_BOUNDARY_AND_CORRECTION_AUDIT_RECEIPT_ERRATUM_2026-08-05`, sealed by a 10-row `SHA256SUMS.txt` = 959 bytes / SHA-256 `b6f43ffbd410fcf79154d0baa6e615d64e2966c2686235d50058b5d7590cfe69`, re-verified 10/10 immediately before this branch was cut. That erratum corrected **descriptive receipt metadata only**: the prior receipt/constructor described "five ruling pins" where the patch actually carries **six** (the angular-momentum-conditions pin was omitted from the enumeration). The candidate and patch bytes were **byte-identical before and after** the erratum — regeneration from the corrected generator reproduced both outputs exactly (hashes above), and the corrected receipt differs from its predecessor in exactly one descriptive field (`route_G5_v2/pin_note`).

## The six-pin correction (what the test now pins)

The patch supersedes the qualifiers pin `["F"]` → `["F", "G"]` and adds six ruling pins:

1. **coordinate-dependence** (retention guard — the phrase pre-exists in the baseline rationale);
2. **no-invariant** (bites): integration in arbitrary coordinates "does not by itself create an invariant";
3. **quasi-local non-exclusion** (bites): the rationale "does not exclude explicitly specified quasi-local constructions";
4. **angular-momentum conditions** (bites): "total angular momentum only under stronger fall-off and parity conditions";
5. **policy marking** (bites): the extraction/propulsion refusal is "this record's own repository policy, not a source claim";
6. **provenance append** (bites): `provenance.source_reference` records "corrected 2026-08-05 under strict primary-evidence rules".

The pre-existing implementation-seam pin and coordinate-dependence-caveat warning pin are preserved verbatim.

## The corrected classification boundary (four-way distinction)

The rewritten rationale distinguishes four things the previous wording conflated:

1. **Pointwise pseudotensor components** are coordinate-dependent and never a coordinate-independent local energy density; they can be made to vanish at a point by coordinate choice.
2. **Integration in arbitrary coordinates** does not by itself create an invariant (Bauer's 1918 objection).
3. **Asymptotic totals** are meaningful under stated conditions: energy-momentum at spatial infinity for asymptotically flat systems in quasi-Cartesian-type coordinates, with **total angular momentum only under stronger fall-off and parity conditions**; there is no generally accepted definition at null infinity.
4. **Explicitly specified quasi-local constructions are not excluded** — their pseudotensor superpotentials **may** be read as quasi-local Hamiltonian boundary terms **with fixed gauge and boundary conditions** (conditional, hedged wording following the inspected source's own "rehabilitated" framing; this PR asserts no stronger claim).

## Source nomenclature and access (corrected)

- Szabados (Living Reviews in Relativity) and Blanchet (Living Reviews in Relativity) are **publisher-hosted review articles**, directly inspected in full text.
- Xulu is an **author-manuscript thesis** (arXiv), directly inspected.
- **None of these three is a primary-research paper**, and this PR does not describe them as such. Source **type** (review article / thesis) is distinct from the **access level achieved** (first-party full text in each case); the entry records both distinctly.

## Status honesty

- `provenance.verification_status` remains **`unverified`** — unchanged by this PR.
- The refusal to treat pseudotensor energy localization as a basis for extraction/propulsion claims is **this repository's own policy marking, not a claim attributed to any source**.
- Schema acceptance by the validator is a structural check only — it is **not scientific verification and not an endorsement** of the entry's content.

## Local verification receipts (this branch tree, current counts)

- Focused `experiments/tech_ledger/tests/test_entries.py` under `-W error`: **21 passed**.
- Complete Tech-Ledger lab under `-W error`: **96 passed, 8 skipped**.
- Reverse-quarantine guard (`tests/test_tech_ledger_reverse_quarantine.py`, `-W error`): **4 passed**.
- Full maintained battery (`python -m pytest tests/ -q`, plugins per CI): **3695 passed, 48 skipped, 0 failed**.
- Validator CLI over the complete entry directory: exit 0, **`entry_count = 20`**, **`total_entry_bytes = 39,368`**, canonical summary SHA-256 **`505cc05aeb847951b0133fab82ce879c9c1d8746bc2510052c4228c7349dfe66`**.
- Boundary checks: exactly two changed paths; `git diff --check` clean; no CR bytes and exactly one terminal LF in the entry; no schema/validator/workflow/README/other-entry change.

Draft on purpose: opened for audit, not for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
