### PR TITLE
Observatory CLI: machine-readable error envelope (--error-format json)

### DIFF
--- a/docs/OBSERVATORY_CLI_ERRORS.md
+++ b/docs/OBSERVATORY_CLI_ERRORS.md
@@ -16,6 +16,12 @@ python -m vis.observatory [--error-format {human,json}] <command> ...
 subcommand. Placing it after the subcommand is itself a usage error, because
 the subcommand consumes everything that follows it.
 
+If the option is repeated, the last occurrence wins — argparse's ordinary
+behaviour. But if **any** occurrence carries an unrecognised value or is
+missing its value, the invocation cannot be parsed at all, and the refusal is
+reported in **human** form: a format that was never validly selected is not
+trusted to carry the refusal.
+
 | | `human` (default) | `json` |
 |---|---|---|
 | Stream | stderr | stderr |

--- a/docs/OBSERVATORY_CLI_ERRORS.md
+++ b/docs/OBSERVATORY_CLI_ERRORS.md
@@ -20,12 +20,38 @@ the subcommand consumes everything that follows it.
 |---|---|---|
 | Stream | stderr | stderr |
 | Shape | `cosmic-observatory: error: <message>` | one JSON object |
-| Lines | exactly one | exactly one |
+| Lines the CLI writes | exactly one | exactly one |
 | stdout | empty | empty |
 | Exit status | unchanged | unchanged |
 
-Human mode is byte-for-byte what it has always been. `--error-format human`
-and omitting the option produce identical output.
+`--error-format human` and omitting the option produce identical output, and
+human runtime-error prose, successful output and the exit statuses are all
+unchanged from before this option existed.
+
+The one thing that necessarily did change is the **help and usage displays**:
+they now list `--error-format {human,json}`, as any new option would.
+
+### The stderr contract, precisely
+
+The CLI guarantees what it writes. It does **not** own the stream.
+
+**Guaranteed:**
+
+- the expected-error path writes **exactly one** JSON envelope line, and
+  nothing else — no usage preamble, no traceback, no additional prose;
+- stdout is empty;
+- output is deterministic for identical inputs.
+
+**Not guaranteed:** that the envelope is the only thing on stderr, or that it
+is the final line. Python's `warnings` machinery, matplotlib, and the
+interpreter's own shutdown notices can write to stderr before or after the
+CLI does, and none of them are under its control.
+
+**So a consumer must locate the envelope rather than parse the whole stream:**
+scan stderr for a line that parses as a JSON object whose `schema` is
+`utilityfog.observatory.error/1`. If more than one is present — which can only
+happen when the stream carries output from something besides a single CLI
+invocation — use the **last** match.
 
 ## What is *not* affected
 
@@ -34,9 +60,9 @@ and omitting the option produce identical output.
 - **Successful output is unchanged.** `info --json` and `doctor --json` emit
   exactly the documents they always have, on stdout.
 - **Unexpected defects still propagate.** A programming error keeps its
-  traceback and is never dressed up as a user error. If the last line of
-  stderr does not parse as an envelope, an internal error occurred — do not
-  infer the envelope's presence from the exit status alone.
+  traceback and is never dressed up as a user error. If stderr carries no line
+  matching the error schema, an internal error occurred — do not infer the
+  envelope's presence from the exit status alone.
 
 ## Version-1 schema
 
@@ -73,8 +99,8 @@ Formatted for reading:
 | `exit_status` | integer | `2` or `1`. Restates the process status. |
 
 **Serialization.** Keys are sorted, separators are compact (`,` and `:`), the
-document is ASCII-escaped, and it is followed by one newline. Equivalent
-inputs produce byte-identical output.
+document is ASCII-escaped, and it occupies one physical line followed by one
+newline. Equivalent inputs produce byte-identical output.
 
 ASCII escaping is a correctness requirement, not a style choice. `U+2028`,
 `U+2029` and `U+0085` are legal unescaped in JSON strings but are line
@@ -95,9 +121,9 @@ applicable", never "unknown".
 |---|---|
 | `missing-command` | No subcommand was given. |
 | `unknown-command` | The subcommand is not recognised. |
-| `unknown-option` | An option is not recognised, or a value was given to a flag that takes none. |
-| `missing-argument` | A required argument was omitted. |
-| `invalid-argument-value` | An argument value failed validation (range, type, or choice). |
+| `unknown-option` | An option is not recognised, or a value was given to a flag that takes none (`--json=x`). |
+| `missing-argument` | A required argument was omitted, or an option was present without its value (`--save` with nothing after it). |
+| `invalid-argument-value` | A value *was* supplied and failed validation (range, type, or choice). |
 | `usage-error` | Fallback for any other usage failure. |
 
 ### `input` — the command line parsed but named something unusable (exit 1)
@@ -110,7 +136,14 @@ applicable", never "unknown".
 | `snapshot-unreadable` | The file exists but could not be decoded. |
 | `animation-directory-invalid` | The animation directory is missing, is not a directory, or holds no usable frames. |
 | `level-out-of-range` | A `--level` lies outside the selected axis. |
-| `input-error` | Fallback for any other expected runtime failure. |
+| `input-error` | Fallback for any other expected runtime failure — including a path the OS refused to examine at all. |
+
+The three specific `snapshot-*` path codes are reported only for a path
+**positively established** to be a directory, to be missing, or to have an
+unsupported suffix. When the operating system refuses to examine the path —
+a name past `NAME_MAX`, or one the filesystem rejects — nothing has been
+established about what kind of thing it is, so the honest `input-error`
+fallback is used rather than a code that would assert more than is known.
 
 `usage-error` and `input-error` are honest fallbacks. argparse's own messages
 are English prose that varies by Python version and may be localised, so
@@ -171,13 +204,28 @@ was 1".
 
 ### Shell
 
+Select the envelope line; do not parse the whole file.
+
 ```bash
-if ! out=$(python -m vis.observatory info "$SNAP" --json 2>err.json); then
-  code=$(jq -r .code < err.json)
-  case "$code" in
+SCHEMA=utilityfog.observatory.error/1
+
+if ! out=$(python -m vis.observatory info "$SNAP" --json 2>err.txt); then
+  # Keep only lines that are JSON objects carrying the error schema, and
+  # take the last. `-c` keeps each match on one line; `//empty` drops
+  # anything that is not an object.
+  envelope=$(jq -Rc --arg s "$SCHEMA" \
+    'fromjson? // empty | select(type == "object" and .schema == $s)' \
+    err.txt | tail -n 1)
+
+  if [ -z "$envelope" ]; then
+    echo "no error envelope found — internal error" >&2
+    exit 1
+  fi
+
+  case "$(printf '%s' "$envelope" | jq -r .code)" in
     snapshot-not-found)   echo "no such snapshot" ;;
     snapshot-unreadable)  echo "corrupt snapshot" ;;
-    *)                    echo "failed: $(jq -r .message < err.json)" ;;
+    *) printf '%s' "$envelope" | jq -r '"failed: " + .message' ;;
   esac
 fi
 ```
@@ -187,6 +235,31 @@ fi
 ```python
 import json
 import subprocess
+
+ERROR_SCHEMA = "utilityfog.observatory.error/1"
+
+
+def find_envelope(stderr):
+    """Return the CLI's error envelope, or None if it did not emit one.
+
+    stderr is shared with the warnings machinery, matplotlib and the
+    interpreter's own shutdown notices, so the stream as a whole is not a
+    JSON document and its last line is not necessarily the envelope. Scan
+    for a JSON object carrying the error schema; take the last if several.
+    """
+    found = None
+    for line in stderr.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            document = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(document, dict) and document.get("schema") == ERROR_SCHEMA:
+            found = document
+    return found
+
 
 proc = subprocess.run(
     ["python", "-m", "vis.observatory", "--error-format", "json",
@@ -199,12 +272,16 @@ if proc.returncode == 0:
 elif proc.returncode == 1 and proc.stdout:
     report = json.loads(proc.stdout)          # ran; some checks failed
 else:
-    # The envelope is the LAST line of stderr: the warnings machinery and
-    # matplotlib share this stream and are not under the CLI's control.
-    line = [ln for ln in proc.stderr.splitlines() if ln.strip()][-1]
-    error = json.loads(line)
+    error = find_envelope(proc.stderr)
+    if error is None:
+        # No envelope means an internal error, not an expected failure.
+        raise SystemExit(f"observatory failed unexpectedly:\n{proc.stderr}")
     raise SystemExit(f"{error['code']}: {error['message']}")
 ```
+
+Note the last branch: **do not infer the envelope's presence from the exit
+status alone.** An unexpected defect also exits non-zero, with a traceback and
+no envelope. Absence of a matching line is how you tell them apart.
 
 ## Bounds and safety
 

--- a/docs/OBSERVATORY_CLI_ERRORS.md
+++ b/docs/OBSERVATORY_CLI_ERRORS.md
@@ -16,11 +16,21 @@ python -m vis.observatory [--error-format {human,json}] <command> ...
 subcommand. Placing it after the subcommand is itself a usage error, because
 the subcommand consumes everything that follows it.
 
-If the option is repeated, the last occurrence wins — argparse's ordinary
-behaviour. But if **any** occurrence carries an unrecognised value or is
-missing its value, the invocation cannot be parsed at all, and the refusal is
-reported in **human** form: a format that was never validly selected is not
-trusted to carry the refusal.
+Only occurrences **before the subcommand** count — everything from the command
+name onward belongs to that subcommand. A misplaced `--error-format` after the
+subcommand is a usage error, and it neither overrides nor supplies a global
+selection. So this still emits a JSON envelope, because JSON *was* validly
+selected before the subcommand:
+
+```
+--error-format json info snap.npz --error-format human   # JSON envelope, status 2
+```
+
+Within that prefix, if the option is repeated the last occurrence wins —
+argparse's ordinary behaviour. But if **any** prefix occurrence carries an
+unrecognised value or is missing its value, the invocation cannot be parsed at
+all, and the refusal is reported in **human** form: a format that was never
+validly selected is not trusted to carry the refusal.
 
 | | `human` (default) | `json` |
 |---|---|---|

--- a/docs/OBSERVATORY_CLI_ERRORS.md
+++ b/docs/OBSERVATORY_CLI_ERRORS.md
@@ -1,0 +1,225 @@
+# Observatory CLI — machine-readable error contract
+
+The Cosmic Observatory CLI (`python -m vis.observatory`) can report an
+**expected** failure either as human prose or as a single JSON object. This
+document specifies the JSON form, version 1.
+
+It describes only what is implemented today. Nothing here is a forward promise.
+
+## Two error modes
+
+```
+python -m vis.observatory [--error-format {human,json}] <command> ...
+```
+
+`--error-format` is a **global** option and must appear **before** the
+subcommand. Placing it after the subcommand is itself a usage error, because
+the subcommand consumes everything that follows it.
+
+| | `human` (default) | `json` |
+|---|---|---|
+| Stream | stderr | stderr |
+| Shape | `cosmic-observatory: error: <message>` | one JSON object |
+| Lines | exactly one | exactly one |
+| stdout | empty | empty |
+| Exit status | unchanged | unchanged |
+
+Human mode is byte-for-byte what it has always been. `--error-format human`
+and omitting the option produce identical output.
+
+## What is *not* affected
+
+- **`--help` is never an error.** Help stays human-readable on **stdout** with
+  exit status **0**, in both modes.
+- **Successful output is unchanged.** `info --json` and `doctor --json` emit
+  exactly the documents they always have, on stdout.
+- **Unexpected defects still propagate.** A programming error keeps its
+  traceback and is never dressed up as a user error. If the last line of
+  stderr does not parse as an envelope, an internal error occurred — do not
+  infer the envelope's presence from the exit status alone.
+
+## Version-1 schema
+
+```json
+{"argument":null,"category":"usage","code":"unknown-command","command":null,"exit_status":2,"message":"unknown command 'bod'. Did you mean 'body'?","ok":false,"schema":"utilityfog.observatory.error/1","suggestion":"Did you mean 'body'?"}
+```
+
+Formatted for reading:
+
+```json
+{
+  "schema": "utilityfog.observatory.error/1",
+  "ok": false,
+  "category": "usage",
+  "code": "unknown-command",
+  "message": "unknown command 'bod'. Did you mean 'body'?",
+  "suggestion": "Did you mean 'body'?",
+  "command": null,
+  "argument": null,
+  "exit_status": 2
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schema` | string | Always `utilityfog.observatory.error/1` in this version. |
+| `ok` | boolean | Always `false`. Present so the envelope is self-describing. |
+| `category` | string | `usage` or `input`. Fixes the exit status. |
+| `code` | string | Stable identifier from the vocabulary below. |
+| `message` | string | Human text. **Unstable — never parse it.** |
+| `suggestion` | string \| null | A suggested correction, when one exists. |
+| `command` | string \| null | The subcommand, when one was determined. |
+| `argument` | string \| null | The option or argument at fault, when known. |
+| `exit_status` | integer | `2` or `1`. Restates the process status. |
+
+**Serialization.** Keys are sorted, separators are compact (`,` and `:`), the
+document is ASCII-escaped, and it is followed by one newline. Equivalent
+inputs produce byte-identical output.
+
+ASCII escaping is a correctness requirement, not a style choice. `U+2028`,
+`U+2029` and `U+0085` are legal unescaped in JSON strings but are line
+boundaries to Python's `str.splitlines()` and to many log processors. Escaping
+them keeps the one-line guarantee true for a hostile filename.
+
+**Nullable fields are always present.** A field that vanishes when
+inapplicable forces consumers to branch on key existence; `null` means "not
+applicable", never "unknown".
+
+## Category and code vocabulary
+
+`category` fixes the exit status: `usage` → **2**, `input` → **1**.
+
+### `usage` — the command line could not be accepted (exit 2)
+
+| `code` | Raised when |
+|---|---|
+| `missing-command` | No subcommand was given. |
+| `unknown-command` | The subcommand is not recognised. |
+| `unknown-option` | An option is not recognised, or a value was given to a flag that takes none. |
+| `missing-argument` | A required argument was omitted. |
+| `invalid-argument-value` | An argument value failed validation (range, type, or choice). |
+| `usage-error` | Fallback for any other usage failure. |
+
+### `input` — the command line parsed but named something unusable (exit 1)
+
+| `code` | Raised when |
+|---|---|
+| `snapshot-not-found` | The snapshot path does not exist. |
+| `snapshot-wrong-path-kind` | A directory was given where a file is required. |
+| `snapshot-unsupported-suffix` | The suffix is not `.npz` or `.json`. |
+| `snapshot-unreadable` | The file exists but could not be decoded. |
+| `animation-directory-invalid` | The animation directory is missing, is not a directory, or holds no usable frames. |
+| `level-out-of-range` | A `--level` lies outside the selected axis. |
+| `input-error` | Fallback for any other expected runtime failure. |
+
+`usage-error` and `input-error` are honest fallbacks. argparse's own messages
+are English prose that varies by Python version and may be localised, so
+classification is deliberately conservative: an unrecognised shape is reported
+as a fallback rather than guessed into a specific code a consumer might trust.
+
+## `info --json` and `doctor --json`
+
+These commands already speak JSON on success, so they speak it on failure too
+— **even when `--error-format` was omitted**:
+
+```bash
+python -m vis.observatory info missing.npz --json     # envelope on stderr, status 1
+```
+
+The upgrade is scoped to those two commands. Every other subcommand stays
+human unless `--error-format json` is given explicitly, and an explicit
+`--error-format human` overrides the upgrade.
+
+The upgrade covers **runtime** failures (status 1). A *usage* error on those
+commands is reported in human form unless the global option was given, because
+at that point argparse has not confirmed `--json` was even valid in context.
+
+## A failed doctor check is not a CLI error
+
+This is the distinction most likely to trip a consumer, because both exit `1`.
+
+| | Failed `doctor` **check** | CLI **error** |
+|---|---|---|
+| Meaning | The snapshot loaded; the report says it violates the contract. | The command could not be carried out. |
+| Stream | **stdout** | **stderr** |
+| Shape | `utilityfog.observatory.report/1` | `utilityfog.observatory.error/1` |
+| stderr | empty | the envelope |
+| Exit status | 1 | 1 |
+
+A completed diagnostic run containing failures is a **result**, not an error.
+`ok: false` alone does not distinguish them — a failing doctor report also
+carries it. Use the **stream** or the **`schema`** value.
+
+Consequently the envelope is keyed on the error *type*, never on "the status
+was 1".
+
+## Forward compatibility
+
+1. `schema` is `utilityfog.observatory.error/1`. The trailing `/N` bumps only
+   for an incompatible structural change.
+2. New keys may be added at any time. **Ignore keys you do not recognise.**
+3. Existing keys are never removed, renamed or retyped within a version.
+4. Tolerate an unknown `code` by falling back to `category`; tolerate an
+   unknown `category` by falling back to the process exit status.
+5. `message` and `suggestion` are human text — unstable, possibly localised,
+   never to be parsed.
+6. Nullable fields are always present.
+7. The **process exit status is authoritative**; `exit_status` restates it for
+   readers who see the document detached from the process, such as a log line.
+
+## Consumer examples
+
+### Shell
+
+```bash
+if ! out=$(python -m vis.observatory info "$SNAP" --json 2>err.json); then
+  code=$(jq -r .code < err.json)
+  case "$code" in
+    snapshot-not-found)   echo "no such snapshot" ;;
+    snapshot-unreadable)  echo "corrupt snapshot" ;;
+    *)                    echo "failed: $(jq -r .message < err.json)" ;;
+  esac
+fi
+```
+
+### Python
+
+```python
+import json
+import subprocess
+
+proc = subprocess.run(
+    ["python", "-m", "vis.observatory", "--error-format", "json",
+     "doctor", snapshot],
+    capture_output=True, text=True,
+)
+
+if proc.returncode == 0:
+    report = json.loads(proc.stdout)          # all checks passed
+elif proc.returncode == 1 and proc.stdout:
+    report = json.loads(proc.stdout)          # ran; some checks failed
+else:
+    # The envelope is the LAST line of stderr: the warnings machinery and
+    # matplotlib share this stream and are not under the CLI's control.
+    line = [ln for ln in proc.stderr.splitlines() if ln.strip()][-1]
+    error = json.loads(line)
+    raise SystemExit(f"{error['code']}: {error['message']}")
+```
+
+## Bounds and safety
+
+- Every string field is collapsed to one line, forced to ASCII, and truncated
+  at 256 characters with a visible `...` marker. Truncation applies to field
+  **values**, never to the serialised document.
+- Lone surrogates — from a POSIX `surrogateescape` filename or an unpaired
+  UTF-16 unit on Windows — are rendered as literal text, so the document never
+  contains an unpaired escape that strict parsers reject.
+- No traceback, and no unrestricted exception representation, is emitted.
+
+### Known limitation
+
+`message` for `snapshot-unreadable` embeds the underlying decoder's text,
+which can include absolute paths and OS-localised strings. It is bounded and
+sanitised, but it is *not* a curated string. Treat `message` as untrusted
+human text — which rule 5 above already requires — and key automation off
+`code`.

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -26,6 +26,13 @@ from pathlib import Path
 
 import pytest
 
+# The Observatory package initializer imports `loader.py` and through it NumPy,
+# and sibling `vis` modules import matplotlib. Guarding BEFORE the package
+# import is what makes a missing optional stack a clean skip rather than a
+# hard collection error -- the same convention as tests/test_observatory_cli.py.
+pytest.importorskip("numpy")
+pytest.importorskip("matplotlib")
+
 from vis.observatory import cli as cli_mod
 from vis.observatory import cli_errors
 

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -1,0 +1,700 @@
+"""Machine-readable error contract for the Observatory CLI.
+
+Scope: the `--error-format json` envelope and the automatic upgrade for
+`info --json` / `doctor --json`. The envelope's own construction and
+sanitising live in `vis.observatory.cli_errors`; wiring, streams and exit
+statuses live in `vis.observatory.cli`.
+
+Two distinctions this module exists to pin down:
+
+  * A CLI *invocation* failure produces an envelope on stderr with an empty
+    stdout. A completed `doctor` run that merely contains failed checks is a
+    normal report on stdout with an empty stderr -- same exit status 1,
+    entirely different shape. The envelope is therefore keyed on the
+    `_UserError` type, never on "the status was 1".
+  * Human mode is unchanged and remains the default. The envelope is opt-in.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vis.observatory import cli as cli_mod
+from vis.observatory import cli_errors
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Everything `str.splitlines()` treats as a line boundary. The envelope must
+# survive every one of them on a single physical line.
+LINE_BREAKS = ["\n", "\r\n", "\r", "\v", "\f", "\x1c", "\x1d", "\x1e",
+               "\x85", " ", " "]
+
+REQUIRED_KEYS = {
+    "schema", "ok", "category", "code", "message",
+    "suggestion", "command", "argument", "exit_status",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _envelope_line(stderr):
+    """Return the envelope, which is the LAST line of stderr.
+
+    Deliberately not "stderr contains only the envelope". stderr is shared:
+    the warnings machinery, matplotlib and an interpreter shutdown notice can
+    all write there, none of them under this CLI's control. The enforceable
+    contract -- and the one consumers are told to rely on -- is that the
+    envelope is the final line and is itself exactly one physical line.
+    """
+    lines = [line for line in stderr.splitlines() if line.strip()]
+    assert lines, "no stderr output at all"
+    return lines[-1]
+
+
+def _only_envelope(capsys, expect_status=None):
+    """Assert stdout is empty and stderr's last line is one JSON envelope."""
+    captured = capsys.readouterr()
+    assert captured.out == "", f"stdout leaked: {captured.out[:200]!r}"
+    text = captured.err
+    # `endswith` rather than a newline count: `print` emits the platform
+    # terminator, so this is CRLF on Windows and LF on the CI runner.
+    assert text.endswith("\n")
+    line = _envelope_line(text)
+    assert len(line.splitlines()) == 1, "envelope must be one physical line"
+    document = json.loads(line)
+    assert isinstance(document, dict)
+    if expect_status is not None:
+        assert document["exit_status"] == expect_status
+    return document
+
+
+def _run_json(argv):
+    """Drive `main()` for an argv that must fail, returning (status, capsys).
+
+    Usage errors raise SystemExit; runtime errors return an int. Both are
+    normalised to a status so a single helper covers every category.
+    """
+    try:
+        return cli_mod.main(argv)
+    except SystemExit as exc:
+        return exc.code
+
+
+def _run_module(*args):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    env["MPLBACKEND"] = "Agg"
+    return subprocess.run(
+        [sys.executable, "-m", "vis.observatory", *args],
+        cwd=str(REPO_ROOT), env=env, capture_output=True, text=True, timeout=120,
+    )
+
+
+@pytest.fixture
+def snap(tmp_path):
+    """A path that passes validation but is not a loadable snapshot."""
+    path = tmp_path / "snap.npz"
+    path.write_bytes(b"not really an npz")
+    return str(path)
+
+
+# ===========================================================================
+# The module itself: standard library only, no rendering stack
+# ===========================================================================
+
+
+def test_cli_errors_imports_only_the_standard_library():
+    """Parsed from the source, so a lazy or conditional import cannot hide."""
+    source = Path(cli_errors.__file__).read_text(encoding="utf-8")
+    roots = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                roots.add(node.module.split(".")[0])
+            elif node.level:
+                pytest.fail(f"relative import in cli_errors: {ast.dump(node)}")
+    non_stdlib = roots - set(sys.stdlib_module_names)
+    assert non_stdlib == set(), f"non-stdlib imports: {sorted(non_stdlib)}"
+
+
+def test_cli_errors_references_no_renderer_or_numeric_stack():
+    source = Path(cli_errors.__file__).read_text(encoding="utf-8")
+    for banned in ("numpy", "matplotlib", "plotly", "scatter3d", "slicer",
+                   "dashboard", "animation", "diagnostics"):
+        assert banned not in source, f"cli_errors references {banned}"
+
+
+def test_cli_errors_loads_without_the_observatory_package():
+    """In a fresh interpreter, by file path, with no package import: the
+    module must come up without pulling NumPy or matplotlib."""
+    probe = (
+        "import importlib.util, sys;"
+        "spec = importlib.util.spec_from_file_location('ce', sys.argv[1]);"
+        "m = importlib.util.module_from_spec(spec);"
+        "spec.loader.exec_module(m);"
+        "assert 'numpy' not in sys.modules, 'numpy imported';"
+        "assert 'matplotlib' not in sys.modules, 'matplotlib imported';"
+        "print(m.ERROR_SCHEMA)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-I", "-c", probe, cli_errors.__file__],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == cli_errors.ERROR_SCHEMA
+
+
+# ===========================================================================
+# Vocabulary
+# ===========================================================================
+
+
+def test_category_vocabulary_is_closed():
+    assert cli_errors.CATEGORIES == frozenset({"usage", "input"})
+
+
+def test_every_code_maps_to_a_declared_category():
+    assert cli_errors.CODES, "the code vocabulary must not be empty"
+    for code, category in cli_errors.CODES.items():
+        assert category in cli_errors.CATEGORIES, f"{code} -> {category}"
+        assert code == code.lower()
+        assert " " not in code
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "missing-command", "unknown-command", "unknown-option",
+        "missing-argument", "invalid-argument-value",
+        "snapshot-not-found", "snapshot-wrong-path-kind",
+        "snapshot-unsupported-suffix", "snapshot-unreadable",
+        "animation-directory-invalid", "level-out-of-range",
+    ],
+)
+def test_required_codes_are_declared(code):
+    """The eleven cases the contract must name."""
+    assert code in cli_errors.CODES
+
+
+def test_usage_codes_are_status_two_and_input_codes_are_status_one():
+    for code, category in cli_errors.CODES.items():
+        expected = 2 if category == "usage" else 1
+        assert cli_errors.status_for(code) == expected, code
+
+
+# ===========================================================================
+# Envelope construction
+# ===========================================================================
+
+
+def _envelope(**kwargs):
+    kwargs.setdefault("code", "unknown-command")
+    kwargs.setdefault("message", "unknown command 'bod'")
+    return cli_errors.build_envelope(**kwargs)
+
+
+def test_envelope_has_exactly_the_documented_keys():
+    assert set(_envelope()) == REQUIRED_KEYS
+
+
+def test_envelope_fixed_fields():
+    document = _envelope()
+    assert document["schema"] == "utilityfog.observatory.error/1"
+    assert document["ok"] is False
+    assert document["category"] == "usage"
+    assert document["exit_status"] == 2
+
+
+def test_nullable_fields_are_present_rather_than_omitted():
+    document = _envelope()
+    for key in ("suggestion", "command", "argument"):
+        assert key in document
+        assert document[key] is None
+
+
+def test_envelope_values_are_ordinary_json_types():
+    document = _envelope(suggestion="Did you mean 'body'?", command="body",
+                         argument="--level")
+    for key, value in document.items():
+        assert type(key) is str
+        assert type(value) in (str, int, bool, type(None)), f"{key}={value!r}"
+
+
+def test_render_is_one_line_with_one_trailing_newline():
+    text = cli_errors.render(_envelope())
+    assert text.endswith("\n")
+    assert text.count("\n") == 1
+    assert len(text.strip().splitlines()) == 1
+
+
+def test_render_sorts_keys_and_uses_compact_separators():
+    text = cli_errors.render(_envelope()).rstrip("\n")
+    document = json.loads(text)
+    assert list(document) == sorted(REQUIRED_KEYS)
+    assert ", " not in text and '": ' not in text
+
+
+def test_render_is_ascii_escaped():
+    """`ensure_ascii=True` is what keeps the one-line contract true for a
+    hostile path: it escapes U+2028/U+2029 and every other separator that
+    `str.splitlines()` recognises but `json.dumps` would otherwise pass
+    through verbatim."""
+    text = cli_errors.render(_envelope(message="a b c\x85d"))
+    assert text.isascii()
+    assert len(text.strip().splitlines()) == 1
+
+
+@pytest.mark.parametrize("sep", LINE_BREAKS)
+def test_render_stays_one_line_for_every_separator(sep):
+    text = cli_errors.render(_envelope(message=f"before{sep}after"))
+    assert len(text.strip().splitlines()) == 1
+    assert text.count("\n") == 1
+
+
+def test_render_is_byte_stable():
+    a = cli_errors.render(_envelope(suggestion="s", command="c", argument="a"))
+    b = cli_errors.render(_envelope(suggestion="s", command="c", argument="a"))
+    assert a == b
+
+
+def test_render_emits_no_non_standard_tokens():
+    text = cli_errors.render(_envelope())
+    assert "NaN" not in text and "Infinity" not in text
+
+
+# --- bounding ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["message", "suggestion", "argument", "command"])
+def test_long_values_are_bounded_with_a_visible_marker(field):
+    document = _envelope(**{field: "x" * 100_000})
+    value = document[field]
+    assert len(value) <= cli_errors.MAX_FIELD_LENGTH + 8
+    assert value.endswith("..."), "truncation must be visible, not silent"
+
+
+def test_bounded_envelope_still_parses():
+    text = cli_errors.render(_envelope(message="y" * 100_000))
+    assert json.loads(text.rstrip("\n"))["message"].endswith("...")
+
+
+def test_short_values_are_not_altered():
+    assert _envelope(message="plain")["message"] == "plain"
+
+
+def test_quotes_and_backslashes_round_trip():
+    hostile = 'a"b\\c{}d'
+    document = json.loads(cli_errors.render(_envelope(message=hostile)))
+    assert document["message"] == hostile
+
+
+def test_envelope_never_contains_traceback_text():
+    document = _envelope(message="Traceback (most recent call last): boom")
+    assert "Traceback (most recent call last)" not in json.dumps(document)
+
+
+# ===========================================================================
+# CLI wiring: usage errors (status 2)
+# ===========================================================================
+
+
+USAGE_CASES = [
+    pytest.param([], "missing-command", id="missing-command"),
+    pytest.param(["zzzzzzzzzz"], "unknown-command", id="unknown-command-distant"),
+    pytest.param(["slize"], "unknown-command", id="unknown-command-close"),
+    pytest.param(["doctor"], "missing-argument", id="missing-argument"),
+]
+
+
+@pytest.mark.parametrize("tail, code", USAGE_CASES)
+def test_usage_errors_emit_an_envelope_with_status_two(capsys, tail, code):
+    assert _run_json(["--error-format", "json", *tail]) == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["category"] == "usage"
+    assert document["code"] == code
+
+
+def test_unknown_option_emits_an_envelope(capsys, snap):
+    assert _run_json(["--error-format", "json", "info", snap, "--nope"]) == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["code"] == "unknown-option"
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        ["slice", "S", "--channel", "99"],
+        ["slice", "S", "--channel", "abc"],
+        ["animate", "D", "--max-frames", "0"],
+        ["signal", "S", "--threshold", "-1"],
+        ["signal", "S", "--threshold", "nan"],
+    ],
+)
+def test_invalid_argument_values_emit_an_envelope(capsys, tmp_path, tail):
+    argv = ["--error-format", "json", *[
+        str(tmp_path / "s.npz") if t == "S" else
+        str(tmp_path) if t == "D" else t for t in tail]]
+    assert _run_json(argv) == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["code"] == "invalid-argument-value"
+
+
+def test_close_typo_carries_a_structured_suggestion(capsys):
+    assert _run_json(["--error-format", "json", "slize", "x.npz"]) == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["code"] == "unknown-command"
+    assert document["suggestion"] is not None
+    assert "slice" in document["suggestion"]
+
+
+def test_distant_typo_has_no_suggestion(capsys):
+    assert _run_json(["--error-format", "json", "zzzzzzzzzz", "x.npz"]) == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["suggestion"] is None
+
+
+def test_suggestion_survives_a_leading_global_option(capsys):
+    """Regression: `_first_command_token` skips tokens beginning with `-` but
+    had no notion of an option that consumes a value, so the flag's value
+    would be read as the subcommand and the did-you-mean feature lost."""
+    assert _run_json(["--error-format", "json", "slize", "x.npz"]) == 2
+    assert _only_envelope(capsys)["suggestion"] is not None
+
+
+def test_suggestion_survives_the_equals_form(capsys):
+    assert _run_json(["--error-format=json", "slize", "x.npz"]) == 2
+    assert _only_envelope(capsys)["suggestion"] is not None
+
+
+def test_suggestion_still_works_in_human_mode_with_the_flag_present(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "human", "slize", "x.npz"])
+    assert exc.value.code == 2
+    assert "did you mean" in capsys.readouterr().err.lower()
+
+
+# ===========================================================================
+# CLI wiring: runtime errors (status 1)
+# ===========================================================================
+
+
+def test_missing_snapshot_emits_an_envelope(capsys, tmp_path):
+    assert _run_json(["--error-format", "json", "info",
+                      str(tmp_path / "absent.npz")]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["category"] == "input"
+    assert document["code"] == "snapshot-not-found"
+
+
+def test_directory_where_snapshot_expected_emits_an_envelope(capsys, tmp_path):
+    assert _run_json(["--error-format", "json", "info", str(tmp_path)]) == 1
+    assert _only_envelope(capsys)["code"] == "snapshot-wrong-path-kind"
+
+
+def test_unsupported_suffix_emits_an_envelope(capsys, tmp_path):
+    path = tmp_path / "snap.txt"
+    path.write_text("x", encoding="utf-8")
+    assert _run_json(["--error-format", "json", "info", str(path)]) == 1
+    assert _only_envelope(capsys)["code"] == "snapshot-unsupported-suffix"
+
+
+def test_unreadable_snapshot_emits_an_envelope(capsys, snap):
+    assert _run_json(["--error-format", "json", "info", snap]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["code"] == "snapshot-unreadable"
+    assert "Traceback" not in json.dumps(document)
+
+
+@pytest.mark.parametrize("kind", ["missing", "not-a-directory"])
+def test_animation_directory_problems_emit_an_envelope(capsys, tmp_path, kind):
+    if kind == "missing":
+        target = tmp_path / "absent"
+    else:
+        target = tmp_path / "afile"
+        target.write_text("x", encoding="utf-8")
+    assert _run_json(["--error-format", "json", "animate", str(target)]) == 1
+    assert _only_envelope(capsys)["code"] == "animation-directory-invalid"
+
+
+# ===========================================================================
+# Human mode is unchanged and remains the default
+# ===========================================================================
+
+
+def test_human_is_the_default(capsys, tmp_path):
+    assert cli_mod.main(["info", str(tmp_path / "absent.npz")]) == 1
+    err = capsys.readouterr().err
+    assert err.startswith("cosmic-observatory: error: ")
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(err)
+
+
+def test_explicit_human_matches_the_default_byte_for_byte(capsys, tmp_path):
+    target = str(tmp_path / "absent.npz")
+    assert cli_mod.main(["info", target]) == 1
+    default = capsys.readouterr().err
+    assert cli_mod.main(["--error-format", "human", "info", target]) == 1
+    assert capsys.readouterr().err == default
+
+
+def test_human_error_is_still_one_line_for_a_hostile_path(capsys, tmp_path):
+    hostile = str(tmp_path / "we\rird\nname.npz")
+    assert cli_mod.main(["info", hostile]) == 1
+    err = capsys.readouterr().err
+    assert len(err.strip().splitlines()) == 1
+
+
+# ===========================================================================
+# Help stays human at status 0
+# ===========================================================================
+
+
+@pytest.mark.parametrize("argv", [
+    ["--error-format", "json", "--help"],
+    ["--error-format", "json", "slice", "--help"],
+    ["--error-format", "json", "--help", "slize"],
+])
+def test_help_stays_human_and_exits_zero(capsys, argv):
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(argv)
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() != ""
+    assert captured.err == ""
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(captured.out)
+
+
+def test_error_format_is_documented_in_help(capsys):
+    with pytest.raises(SystemExit):
+        cli_mod.main(["--help"])
+    out = capsys.readouterr().out
+    assert "--error-format" in out
+    assert "doctor" in out, "existing help content is preserved"
+
+
+def test_invalid_error_format_value_is_a_usage_error(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "yaml", "info", "x.npz"])
+    assert exc.value.code == 2
+
+
+def test_error_format_after_the_subcommand_is_a_usage_error(capsys, snap):
+    """Documented position is before the subcommand."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["info", snap, "--error-format", "json"])
+    assert exc.value.code == 2
+
+
+# ===========================================================================
+# Automatic envelope for `info --json` / `doctor --json`
+# ===========================================================================
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_commands_auto_upgrade_their_load_failures(capsys, command, snap):
+    """No global flag: a machine-oriented command must not answer a machine
+    consumer with human prose."""
+    assert cli_mod.main([command, snap, "--json"]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["schema"] == cli_errors.ERROR_SCHEMA
+    assert document["code"] == "snapshot-unreadable"
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_json_commands_stay_human_without_the_flag(capsys, command, snap):
+    assert cli_mod.main([command, snap]) == 1
+    err = capsys.readouterr().err
+    assert err.startswith("cosmic-observatory: error: ")
+
+
+def test_auto_upgrade_does_not_apply_to_other_subcommands(capsys, snap):
+    assert cli_mod.main(["slice", snap]) == 1
+    assert capsys.readouterr().err.startswith("cosmic-observatory: error: ")
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_explicit_human_overrides_the_auto_upgrade(capsys, command, snap):
+    assert cli_mod.main(["--error-format", "human", command, snap, "--json"]) == 1
+    assert capsys.readouterr().err.startswith("cosmic-observatory: error: ")
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_global_and_command_json_produce_exactly_one_envelope(capsys, command, snap):
+    assert cli_mod.main(["--error-format", "json", command, snap, "--json"]) == 1
+    _only_envelope(capsys, expect_status=1)
+
+
+# ===========================================================================
+# A failed doctor CHECK is a report, not a CLI error
+# ===========================================================================
+
+
+def _bad_check_snapshot(tmp_path):
+    np = pytest.importorskip("numpy")
+    lattice = np.zeros((2, 3, 4), dtype=np.uint8)
+    lattice[0, 0, 0] = 200                       # outside the vocabulary
+    path = tmp_path / "badcheck.npz"
+    np.savez(path, lattice=lattice,
+             memory_grid=np.zeros((8, 2, 3, 4), dtype=np.float32),
+             generation=7, ca_step=11, best_fitness=0.25)
+    return str(path)
+
+
+@pytest.mark.parametrize("prefix", [[], ["--error-format", "json"]])
+def test_failed_doctor_check_is_a_report_not_an_envelope(capsys, tmp_path, prefix):
+    """The distinction the whole contract rests on. Both are status 1: a
+    completed diagnostic run with failures is a reported result on stdout,
+    not a CLI invocation error. Keying the envelope on the status instead of
+    on the error type is exactly what this test refuses."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("matplotlib")
+    path = _bad_check_snapshot(tmp_path)
+    assert cli_mod.main([*prefix, "doctor", path]) == 1
+    captured = capsys.readouterr()
+    assert captured.err == "", "a failed check must not produce an error envelope"
+    assert "[FAIL]" in captured.out
+
+
+def test_failed_doctor_check_json_keeps_stderr_empty(capsys, tmp_path):
+    pytest.importorskip("numpy")
+    pytest.importorskip("matplotlib")
+    path = _bad_check_snapshot(tmp_path)
+    assert cli_mod.main(["doctor", path, "--json"]) == 1
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    document = json.loads(captured.out)
+    assert document["ok"] is False
+    assert document["kind"] == "doctor"
+
+
+def test_report_and_envelope_are_distinguishable_by_schema(capsys, tmp_path, snap):
+    """`ok: false` alone is not a discriminator -- a failing doctor report
+    also carries it. The schema id and the stream are."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("matplotlib")
+    assert cli_mod.main(["doctor", _bad_check_snapshot(tmp_path), "--json"]) == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert cli_mod.main(["doctor", snap, "--json"]) == 1
+    envelope = json.loads(_envelope_line(capsys.readouterr().err))
+
+    assert report["ok"] is False and envelope["ok"] is False
+    assert report["schema"] != envelope["schema"]
+    assert envelope["schema"] == cli_errors.ERROR_SCHEMA
+
+
+# ===========================================================================
+# Hostile input through the CLI
+# ===========================================================================
+
+
+@pytest.mark.parametrize("sep", LINE_BREAKS)
+def test_hostile_path_keeps_the_envelope_on_one_line(capsys, tmp_path, sep):
+    """The file is never created: a nonexistent path already reaches the
+    not-found lane, which is the message that carries the hostile text."""
+    hostile = f"{tmp_path}{os.sep}a{sep}b.npz"
+    assert _run_json(["--error-format", "json", "info", hostile]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["code"] == "snapshot-not-found"
+
+
+def test_hostile_path_cannot_forge_a_second_document(capsys, tmp_path):
+    forged = f'{tmp_path}{os.sep}a\n{{"ok":true}}\nb.npz'
+    assert _run_json(["--error-format", "json", "info", forged]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["ok"] is False
+
+
+def test_very_long_path_is_bounded(capsys, tmp_path):
+    long_path = f"{tmp_path}{os.sep}{'q' * 60000}.npz"
+    assert _run_json(["--error-format", "json", "info", long_path]) == 1
+    captured = capsys.readouterr()
+    assert len(captured.err) < 4096, "envelope must stay bounded"
+    json.loads(_envelope_line(captured.err))
+
+
+# ===========================================================================
+# Defect propagation must not widen
+# ===========================================================================
+
+
+class _Sentinel(Exception):
+    """A stand-in for a programming defect, not a user error."""
+
+
+def test_unexpected_defect_still_propagates_under_json(monkeypatch, snap):
+    from vis.observatory import loader as loader_mod
+
+    def _boom(_path):
+        raise _Sentinel("defect inside the loader")
+
+    monkeypatch.setattr(loader_mod, "load_snapshot", _boom)
+    with pytest.raises(_Sentinel, match="defect inside the loader"):
+        cli_mod.main(["--error-format", "json", "info", snap])
+
+
+@pytest.mark.parametrize("defect", [AttributeError, TypeError, RecursionError])
+def test_translated_error_set_never_covers_a_defect_class(defect):
+    """The refactor must not widen the boundary."""
+    translated = cli_mod._unreadable_input_errors()
+    assert not any(issubclass(defect, caught) for caught in translated)
+
+
+def test_no_envelope_is_emitted_for_an_unexpected_defect(monkeypatch, capsys, snap):
+    from vis.observatory import loader as loader_mod
+
+    monkeypatch.setattr(
+        loader_mod, "load_snapshot",
+        lambda _p: (_ for _ in ()).throw(_Sentinel("boom")),
+    )
+    with pytest.raises(_Sentinel):
+        cli_mod.main(["--error-format", "json", "info", snap])
+    assert capsys.readouterr().err == "", "a defect must not be dressed as a user error"
+
+
+# ===========================================================================
+# Public module route and stream identity
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "args, status",
+    [
+        (["--error-format", "json", "zzzzzzzzzz"], 2),
+        (["--error-format", "json", "info", "absent.npz"], 1),
+    ],
+)
+def test_envelope_reaches_real_stderr_with_the_right_status(args, status):
+    proc = _run_module(*args)
+    assert proc.returncode == status
+    assert proc.stdout == ""
+    document = json.loads(_envelope_line(proc.stderr))
+    assert document["exit_status"] == status
+    assert "Traceback (most recent call last)" not in proc.stderr
+
+
+def test_envelope_is_byte_stable_across_processes():
+    a = _run_module("--error-format", "json", "info", "absent.npz")
+    b = _run_module("--error-format", "json", "info", "absent.npz")
+    assert a.stderr == b.stderr
+    assert a.returncode == b.returncode
+
+
+def test_help_through_the_public_route_stays_human():
+    proc = _run_module("--error-format", "json", "--help")
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert "--error-format" in proc.stdout

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -613,7 +613,7 @@ def test_report_and_envelope_are_distinguishable_by_schema(capsys, tmp_path, sna
     report = json.loads(capsys.readouterr().out)
 
     assert cli_mod.main(["doctor", snap, "--json"]) == 1
-    envelope = json.loads(_envelope_line(capsys.readouterr().err))
+    envelope = _envelope_line(capsys.readouterr().err)
 
     assert report["ok"] is False and envelope["ok"] is False
     assert report["schema"] != envelope["schema"]
@@ -647,7 +647,7 @@ def test_very_long_path_is_bounded(capsys, tmp_path):
     assert _run_json(["--error-format", "json", "info", long_path]) == 1
     captured = capsys.readouterr()
     assert len(captured.err) < 4096, "envelope must stay bounded"
-    json.loads(_envelope_line(captured.err))
+    _envelope_line(captured.err)
 
 
 # ===========================================================================
@@ -705,7 +705,7 @@ def test_envelope_reaches_real_stderr_with_the_right_status(args, status):
     proc = _run_module(*args)
     assert proc.returncode == status
     assert proc.stdout == ""
-    document = json.loads(_envelope_line(proc.stderr))
+    document = _envelope_line(proc.stderr)
     assert document["exit_status"] == status
     assert "Traceback (most recent call last)" not in proc.stderr
 

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -130,9 +130,13 @@ def test_cli_errors_imports_only_the_standard_library():
 
 
 def test_cli_errors_references_no_renderer_or_numeric_stack():
+    """Bare words like "animation" and "dashboard" are legitimate vocabulary
+    here -- `animation-directory-invalid` is an error code -- so this scans for
+    module references rather than substrings. The AST walk above is the
+    authoritative import check; this supplements it."""
     source = Path(cli_errors.__file__).read_text(encoding="utf-8")
-    for banned in ("numpy", "matplotlib", "plotly", "scatter3d", "slicer",
-                   "dashboard", "animation", "diagnostics"):
+    for banned in ("numpy", "matplotlib", "plotly", "scatter3d",
+                   "vis.observatory.", "import vis"):
         assert banned not in source, f"cli_errors references {banned}"
 
 

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -160,6 +160,55 @@ def test_cli_errors_references_no_renderer_or_numeric_stack():
         assert banned not in source, f"cli_errors references {banned}"
 
 
+def test_optional_dependency_guards_precede_the_observatory_imports():
+    """Collection must SKIP, not error, when the optional numeric/rendering
+    stack is absent.
+
+    `from vis.observatory ...` executes `vis/observatory/__init__.py`, which
+    imports `loader.py` and then NumPy, so a bare top-level Observatory import
+    turns a skippable optional-dependency case into a hard collection error.
+    The established convention in `tests/test_observatory_cli.py` is to call
+    `pytest.importorskip` for numpy and matplotlib FIRST.
+
+    Asserted structurally against this module's own source, in statement
+    order, because the property is about import ordering at collection time --
+    which cannot be observed from inside a module that has already imported
+    successfully.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    guarded = []
+    first_observatory_import = None
+    for index, node in enumerate(tree.body):
+        if (isinstance(node, ast.ImportFrom) and node.module
+                and node.module.split(".")[0] == "vis"):
+            if first_observatory_import is None:
+                first_observatory_import = index
+        # `np = pytest.importorskip("numpy")` or a bare call statement.
+        call = None
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            call = node.value
+        elif (isinstance(node, ast.Assign) and isinstance(node.value, ast.Call)):
+            call = node.value
+        if call is None or not isinstance(call.func, ast.Attribute):
+            continue
+        if call.func.attr != "importorskip":
+            continue
+        if call.args and isinstance(call.args[0], ast.Constant):
+            guarded.append((index, call.args[0].value))
+
+    assert first_observatory_import is not None, "no vis.* import found"
+    names = {name for _, name in guarded}
+    assert "numpy" in names, "missing pytest.importorskip('numpy')"
+    assert "matplotlib" in names, "missing pytest.importorskip('matplotlib')"
+    for index, name in guarded:
+        if name in ("numpy", "matplotlib"):
+            assert index < first_observatory_import, (
+                f"importorskip({name!r}) must precede the first vis.* import"
+            )
+
+
 def test_cli_errors_loads_without_the_observatory_package():
     """In a fresh interpreter, by file path, with no package import: the
     module must come up without pulling NumPy or matplotlib."""
@@ -899,6 +948,87 @@ def test_a_failed_error_format_never_reaches_the_runtime_lane(capsys, flags, tmp
         cli_mod.main([*flags, "info", str(tmp_path / "absent.npz")])
     assert exc.value.code == 2
     assert not _envelopes_in(capsys.readouterr().err)
+
+
+# --- the scan covers the GLOBAL PREFIX only -------------------------------
+#
+# `--error-format` is a global option: it is only meaningful before the
+# subcommand, because the subparsers action consumes everything from the
+# command name onward. The pre-scan must therefore stop at the first
+# unconsumed non-option token -- the intended subcommand -- rather than
+# walking the whole argv and treating the subcommand's own arguments as
+# further global occurrences.
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        # A misplaced trailing option must not overwrite a valid prefix
+        # selection. argparse rejects the trailing option as a usage error,
+        # but the caller DID validly ask for JSON, so the refusal is JSON.
+        pytest.param(["--error-format", "json", "info", "s.npz",
+                      "--error-format", "human"], "json", id="json-prefix-human-trailing"),
+        pytest.param(["--error-format", "human", "info", "s.npz",
+                      "--error-format", "json"], "human", id="human-prefix-json-trailing"),
+        pytest.param(["--error-format=json", "info", "s.npz",
+                      "--error-format=human"], "json", id="equals-prefix-equals-trailing"),
+        pytest.param(["--error-f", "json", "info", "s.npz",
+                      "--error-format", "human"], "json", id="abbrev-prefix-trailing"),
+        # No valid prefix: a trailing misplaced option must not retroactively
+        # select anything.
+        pytest.param(["info", "s.npz", "--error-format", "json"],
+                     None, id="no-prefix-trailing-json"),
+        pytest.param(["info", "s.npz", "--error-format=json"],
+                     None, id="no-prefix-trailing-equals"),
+        pytest.param(["doctor", "s.npz", "--json", "--error-format", "json"],
+                     None, id="no-prefix-after-flags"),
+        # A trailing INVALID occurrence must not make the prefix sticky-human
+        # either: the scan never reaches it.
+        pytest.param(["--error-format", "json", "info", "s.npz",
+                      "--error-format", "yaml"], "json", id="valid-prefix-invalid-trailing"),
+        pytest.param(["--error-format", "json", "info", "s.npz",
+                      "--error-format"], "json", id="valid-prefix-dangling-trailing"),
+        # The subcommand's own options are never global occurrences.
+        pytest.param(["--error-format", "json", "slice", "s.npz",
+                      "--axis", "x", "--level", "3"], "json", id="subcommand-options-ignored"),
+        # Sticky failure still applies when it happens IN the prefix.
+        pytest.param(["--error-format", "yaml", "info", "s.npz",
+                      "--error-format", "json"], "human", id="invalid-prefix-trailing-valid"),
+    ],
+)
+def test_scanner_reads_only_the_global_prefix(argv, expected):
+    assert cli_mod._scan_error_format(argv) == expected
+
+
+def test_misplaced_trailing_option_still_yields_the_requested_json_envelope(capsys):
+    """The end-to-end shape of thread 1: argparse refuses the misplaced
+    trailing option, and because JSON was validly selected before the
+    subcommand, the refusal is a JSON envelope rather than prose."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "json", "info", "s.npz",
+                      "--error-format", "human"])
+    assert exc.value.code == 2
+    document = _only_envelope(capsys, expect_status=2)
+    assert document["category"] == "usage"
+
+
+def test_misplaced_trailing_option_keeps_human_when_human_was_selected(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "human", "info", "s.npz",
+                      "--error-format", "json"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert not _envelopes_in(captured.err)
+    assert "cosmic-observatory: error:" in captured.err
+
+
+def test_a_trailing_option_alone_selects_nothing(capsys):
+    """No valid global prefix, so the refusal stays human."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["info", "s.npz", "--error-format", "json"])
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert not _envelopes_in(captured.err)
 
 
 def test_all_valid_repeats_still_follow_last_wins(capsys, tmp_path):

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -47,32 +47,52 @@ REQUIRED_KEYS = {
 # ---------------------------------------------------------------------------
 
 
-def _envelope_line(stderr):
-    """Return the envelope, which is the LAST line of stderr.
+def _envelopes_in(stderr):
+    """Return every error envelope found on stderr, in order.
 
-    Deliberately not "stderr contains only the envelope". stderr is shared:
-    the warnings machinery, matplotlib and an interpreter shutdown notice can
-    all write there, none of them under this CLI's control. The enforceable
-    contract -- and the one consumers are told to rely on -- is that the
-    envelope is the final line and is itself exactly one physical line.
+    This is the enforceable contract, and it is deliberately weaker than
+    "stderr contains only the envelope" AND weaker than "the envelope is the
+    final line". stderr is shared: the warnings machinery, matplotlib and an
+    interpreter shutdown notice can all write there, before or after the CLI
+    does, and none of them are under this CLI's control.
+
+    What the CLI guarantees is that IT writes exactly one envelope line and no
+    other prose. What a consumer does is scan for a JSON line whose ``schema``
+    is the error schema, and -- if more than one is present, which can only
+    come from something other than a single CLI invocation -- take the last.
     """
-    lines = [line for line in stderr.splitlines() if line.strip()]
-    assert lines, "no stderr output at all"
-    return lines[-1]
+    found = []
+    for raw in stderr.splitlines():
+        line = raw.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            document = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(document, dict) and document.get("schema") == cli_errors.ERROR_SCHEMA:
+            found.append(document)
+    return found
+
+
+def _envelope_line(stderr):
+    """The single envelope a consumer should select from ``stderr``."""
+    found = _envelopes_in(stderr)
+    assert found, f"no error envelope on stderr: {stderr[:300]!r}"
+    return found[-1]
 
 
 def _only_envelope(capsys, expect_status=None):
-    """Assert stdout is empty and stderr's last line is one JSON envelope."""
+    """Assert stdout is empty and the CLI emitted exactly one envelope."""
     captured = capsys.readouterr()
     assert captured.out == "", f"stdout leaked: {captured.out[:200]!r}"
     text = captured.err
     # `endswith` rather than a newline count: `print` emits the platform
     # terminator, so this is CRLF on Windows and LF on the CI runner.
     assert text.endswith("\n")
-    line = _envelope_line(text)
-    assert len(line.splitlines()) == 1, "envelope must be one physical line"
-    document = json.loads(line)
-    assert isinstance(document, dict)
+    found = _envelopes_in(text)
+    assert len(found) == 1, f"expected exactly one envelope, got {len(found)}"
+    document = found[0]
     if expect_status is not None:
         assert document["exit_status"] == expect_status
     return document
@@ -702,3 +722,220 @@ def test_help_through_the_public_route_stays_human():
     assert proc.returncode == 0
     assert proc.stderr == ""
     assert "--error-format" in proc.stdout
+
+
+# ===========================================================================
+# Audit corrections
+# ===========================================================================
+
+
+# --- repeated global option: the scan must agree with argparse -------------
+#
+# argparse's ordinary behaviour is last-wins for a repeated option. The
+# pre-scan is a second reader of the same argv, so it must reach the same
+# answer -- otherwise the format the CLI *emits* disagrees with the format it
+# *parsed*, and which one you observe depends on whether the failure happened
+# before or after `parse_args`.
+
+
+@pytest.mark.parametrize(
+    "flags, expected",
+    [
+        (["--error-format", "json", "--error-format", "human"], "human"),
+        (["--error-format", "human", "--error-format", "json"], "json"),
+        (["--error-format=json", "--error-format=human"], "human"),
+        (["--error-format=human", "--error-format=json"], "json"),
+        (["--error-format", "json", "--error-format=human"], "human"),
+        (["--error-format=human", "--error-format", "json"], "json"),
+    ],
+)
+def test_repeated_error_format_follows_last_wins(capsys, tmp_path, flags, expected):
+    """Runtime lane: the emitted format must match the final selection."""
+    target = str(tmp_path / "absent.npz")
+    assert cli_mod.main([*flags, "info", target]) == 1
+    err = capsys.readouterr().err
+    if expected == "json":
+        assert _envelopes_in(err), "expected an envelope, got human prose"
+    else:
+        assert not _envelopes_in(err), "expected human prose, got an envelope"
+        assert err.startswith("cosmic-observatory: error: ")
+
+
+@pytest.mark.parametrize(
+    "flags, expected",
+    [
+        (["--error-format", "json", "--error-format", "human"], "human"),
+        (["--error-format", "human", "--error-format", "json"], "json"),
+    ],
+)
+def test_repeated_error_format_agrees_on_the_usage_lane(capsys, flags, expected):
+    """Usage lane: decided entirely by the pre-scan, so it is the lane that
+    exposes a scanner that disagrees with argparse."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main([*flags, "zzzzzzzzzz"])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert bool(_envelopes_in(err)) is (expected == "json")
+
+
+def test_the_scan_matches_what_argparse_parsed(capsys, tmp_path):
+    """Stated as an equality rather than a shape: whatever argparse records in
+    the namespace is what the emitter must have used."""
+    target = str(tmp_path / "absent.npz")
+    for flags in (["--error-format", "json", "--error-format", "human"],
+                  ["--error-format", "human", "--error-format", "json"]):
+        parsed = flags[-1] if "=" not in flags[-1] else flags[-1].split("=")[1]
+        cli_mod.main([*flags, "info", target])
+        err = capsys.readouterr().err
+        assert bool(_envelopes_in(err)) is (parsed == "json"), flags
+
+
+def test_an_invalid_repeat_does_not_select_a_format(capsys, tmp_path):
+    """A bad value is a usage error argparse is about to report; it must not
+    be accepted as a valid selection by the scanner either."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "json", "--error-format", "yaml",
+                      "info", str(tmp_path / "absent.npz")])
+    assert exc.value.code == 2
+
+
+# --- usage-code classification --------------------------------------------
+
+
+@pytest.mark.parametrize("tail", [["body", "S", "--save"], ["slice", "S", "--axis"]])
+def test_option_missing_its_value_is_missing_argument(capsys, tmp_path, tail):
+    """`--save` with nothing after it is a missing ARGUMENT, not an invalid
+    value: no value was supplied to be invalid."""
+    argv = ["--error-format", "json",
+            *[str(tmp_path / "s.npz") if t == "S" else t for t in tail]]
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(argv)
+    assert exc.value.code == 2
+    assert _only_envelope(capsys, expect_status=2)["code"] == "missing-argument"
+
+
+@pytest.mark.parametrize("command", ["info", "doctor"])
+def test_value_given_to_a_valueless_flag_is_unknown_option(capsys, tmp_path, command):
+    """`--json=value` supplies a value to a flag that takes none. The
+    documented vocabulary calls that `unknown-option`."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(["--error-format", "json", command,
+                      str(tmp_path / "s.npz"), "--json=value"])
+    assert exc.value.code == 2
+    assert _only_envelope(capsys, expect_status=2)["code"] == "unknown-option"
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        ["slice", "S", "--axis", "q"],          # invalid choice
+        ["channel", "S", "--mode", "nope"],     # invalid choice
+        ["slice", "S", "--channel", "99"],      # invalid typed value
+        ["slice", "S", "--level", "abc"],       # builtin int converter
+    ],
+)
+def test_invalid_choices_and_values_stay_invalid_argument_value(capsys, tmp_path, tail):
+    argv = ["--error-format", "json",
+            *[str(tmp_path / "s.npz") if t == "S" else t for t in tail]]
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main(argv)
+    assert exc.value.code == 2
+    assert _only_envelope(capsys)["code"] == "invalid-argument-value"
+
+
+def test_unrecognised_usage_shapes_fall_back_honestly():
+    """The fallback must exist and must be declared, so an unfamiliar argparse
+    message is reported honestly rather than guessed into a specific code."""
+    assert cli_errors.CODES["usage-error"] == "usage"
+    code, _ = cli_mod._classify_usage_error("something argparse has never said")
+    assert code == "usage-error"
+
+
+# --- unexaminable paths are not "wrong kind" ------------------------------
+
+
+def test_unexaminable_path_is_not_labelled_a_directory(capsys, tmp_path):
+    """The OS refused to examine the path, so nothing was established about
+    what kind of thing it is. Claiming `snapshot-wrong-path-kind` asserts it
+    IS a directory, which was never determined."""
+    long_path = f"{tmp_path}{os.sep}{'q' * 60000}.npz"
+    assert _run_json(["--error-format", "json", "info", long_path]) == 1
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["code"] == "input-error"
+    assert document["category"] == "input"
+
+
+def test_unexaminable_animation_directory_uses_the_fallback(capsys, tmp_path):
+    long_path = f"{tmp_path}{os.sep}{'q' * 60000}"
+    assert _run_json(["--error-format", "json", "animate", long_path]) == 1
+    assert _only_envelope(capsys, expect_status=1)["code"] == "input-error"
+
+
+def test_positively_established_path_kinds_keep_their_specific_codes(capsys, tmp_path):
+    """The fallback must not swallow the cases that ARE determined."""
+    cases = [
+        (str(tmp_path), "snapshot-wrong-path-kind"),
+        (str(tmp_path / "absent.npz"), "snapshot-not-found"),
+    ]
+    unsupported = tmp_path / "s.txt"
+    unsupported.write_text("x", encoding="utf-8")
+    cases.append((str(unsupported), "snapshot-unsupported-suffix"))
+
+    for target, expected in cases:
+        assert _run_json(["--error-format", "json", "info", target]) == 1
+        assert _only_envelope(capsys)["code"] == expected, target
+
+
+# --- stderr framing: a schema-bearing line, not "the last line" ------------
+
+
+def test_consumer_finds_the_envelope_behind_unrelated_stderr_prose(capsys, tmp_path):
+    """Unrelated diagnostics may share stderr. The consumer rule is "find the
+    JSON line whose schema is the error schema", not "read the whole stream"
+    and not "take the final line"."""
+    print("WARNING: some unrelated library noise", file=sys.stderr)
+    print("  continued on a second line", file=sys.stderr)
+
+    assert cli_mod.main(["--error-format", "json", "info",
+                         str(tmp_path / "absent.npz")]) == 1
+    err = capsys.readouterr().err
+
+    assert "unrelated library noise" in err, "the test's own noise must survive"
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(err)                       # the whole stream is not JSON
+
+    found = _envelopes_in(err)
+    assert len(found) == 1, "the CLI must contribute exactly one envelope"
+    assert found[0]["code"] == "snapshot-not-found"
+
+
+def test_the_cli_contributes_exactly_one_envelope_line(capsys, tmp_path):
+    assert cli_mod.main(["--error-format", "json", "info",
+                         str(tmp_path / "absent.npz")]) == 1
+    err = capsys.readouterr().err
+    json_lines = [ln for ln in err.splitlines() if ln.strip().startswith("{")]
+    assert len(json_lines) == 1
+
+
+def test_the_cli_writes_no_usage_preamble_or_prose_in_json_mode(capsys):
+    """The guarantee that survives the weakened framing contract: whatever
+    else shares stderr, the CLI itself adds no usage block and no prose."""
+    with pytest.raises(SystemExit):
+        cli_mod.main(["--error-format", "json", "zzzzzzzzzz"])
+    err = capsys.readouterr().err
+    assert "usage:" not in err
+    assert "cosmic-observatory: error:" not in err
+    assert "Traceback (most recent call last)" not in err
+    assert err.strip().startswith("{") and err.strip().endswith("}")
+
+
+def test_last_matching_envelope_wins_when_several_are_present():
+    """Selection rule, stated directly on the helper: several envelopes can
+    only come from something other than one CLI invocation, and the consumer
+    takes the last."""
+    first = cli_errors.format_error("snapshot-not-found", "first")
+    second = cli_errors.format_error("unknown-command", "second")
+    stream = f"noise\n{first}not json\n{second}trailing noise\n"
+    found = _envelopes_in(stream)
+    assert len(found) == 2
+    assert _envelope_line(stream)["code"] == "unknown-command"

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -799,6 +799,122 @@ def test_an_invalid_repeat_does_not_select_a_format(capsys, tmp_path):
     assert exc.value.code == 2
 
 
+# --- a failed occurrence is STICKY ----------------------------------------
+#
+# Last-wins is only meaningful when every occurrence is valid. argparse cannot
+# parse ANY of the invocations below, so the whole command line is refused --
+# and the scanner must reach the same conclusion. A later valid occurrence
+# must not launder an earlier invalid one into an accepted JSON selection, and
+# an earlier valid occurrence must not survive a later missing value.
+#
+# The rules, stated once:
+#   1. no occurrence            -> None
+#   2. all occurrences valid    -> the last one (argparse's ordinary result)
+#   3. ANY occurrence invalid or missing its value -> "human"
+#   4. separated, equals and supported abbreviated forms agree
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        # 1. absent
+        pytest.param([], None, id="absent"),
+        pytest.param(["info", "x.npz"], None, id="absent-with-command"),
+        # 2. all valid -> last wins
+        pytest.param(["--error-format", "json"], "json", id="single-json"),
+        pytest.param(["--error-format", "human"], "human", id="single-human"),
+        pytest.param(["--error-format", "json", "--error-format", "human"],
+                     "human", id="valid-valid-separated"),
+        pytest.param(["--error-format=human", "--error-format=json"],
+                     "json", id="valid-valid-equals"),
+        pytest.param(["--error-f", "json"], "json", id="abbreviated-valid"),
+        # 3. any failure is sticky
+        pytest.param(["--error-format", "yaml"], "human", id="single-invalid"),
+        pytest.param(["--error-format", "yaml", "--error-format", "json"],
+                     "human", id="invalid-then-valid-separated"),
+        pytest.param(["--error-format=yaml", "--error-format=json"],
+                     "human", id="invalid-then-valid-equals"),
+        pytest.param(["--error-format", "json", "--error-format", "yaml"],
+                     "human", id="valid-then-invalid-separated"),
+        pytest.param(["--error-format=json", "--error-format=yaml"],
+                     "human", id="valid-then-invalid-equals"),
+        pytest.param(["--error-format", "json", "--error-format"],
+                     "human", id="valid-then-missing-value"),
+        pytest.param(["--error-format=json", "--error-format"],
+                     "human", id="equals-then-missing-value"),
+        pytest.param(["--error-format"], "human", id="missing-value-alone"),
+        pytest.param(["--error-f", "yaml", "--error-format", "json"],
+                     "human", id="abbreviated-invalid-then-valid"),
+        pytest.param(["--error-f"], "human", id="abbreviated-missing-value"),
+        # 4. mixed forms
+        pytest.param(["--error-format=yaml", "--error-format", "json"],
+                     "human", id="equals-invalid-then-separated-valid"),
+        pytest.param(["--error-format", "json", "--error-format=yaml"],
+                     "human", id="separated-valid-then-equals-invalid"),
+    ],
+)
+def test_scanner_rules(argv, expected):
+    """The seam directly: every rule pinned on one table."""
+    assert cli_mod._scan_error_format(argv) == expected
+
+
+FAILED_SCAN_INVOCATIONS = [
+    pytest.param(["--error-format", "yaml", "--error-format", "json"],
+                 id="invalid-then-valid"),
+    pytest.param(["--error-format=yaml", "--error-format=json"],
+                 id="invalid-then-valid-equals"),
+    pytest.param(["--error-format", "json", "--error-format", "yaml"],
+                 id="valid-then-invalid"),
+    pytest.param(["--error-format=json", "--error-format=yaml"],
+                 id="valid-then-invalid-equals"),
+    pytest.param(["--error-format", "json", "--error-format"],
+                 id="valid-then-missing-value"),
+    pytest.param(["--error-format=json", "--error-format"],
+                 id="equals-then-missing-value"),
+    pytest.param(["--error-f", "yaml", "--error-format", "json"],
+                 id="abbreviated-invalid-then-valid"),
+]
+
+
+@pytest.mark.parametrize("flags", FAILED_SCAN_INVOCATIONS)
+def test_a_failed_error_format_is_refused_in_human_form(capsys, flags):
+    """End to end: argparse cannot parse any of these, so the refusal is a
+    status-2 usage error in HUMAN form -- a format that was never validly
+    selected must not be trusted to carry the refusal."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main([*flags, "info", "x.npz"])
+    assert exc.value.code == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert not _envelopes_in(captured.err), "refusal must not be a JSON envelope"
+    assert "cosmic-observatory: error:" in captured.err
+
+
+@pytest.mark.parametrize("flags", FAILED_SCAN_INVOCATIONS)
+def test_a_failed_error_format_never_reaches_the_runtime_lane(capsys, flags, tmp_path):
+    """The command never runs, so a runtime error cannot be reported either --
+    argparse refuses first, with status 2 rather than 1."""
+    with pytest.raises(SystemExit) as exc:
+        cli_mod.main([*flags, "info", str(tmp_path / "absent.npz")])
+    assert exc.value.code == 2
+    assert not _envelopes_in(capsys.readouterr().err)
+
+
+def test_all_valid_repeats_still_follow_last_wins(capsys, tmp_path):
+    """The correction must not damage the case that does parse."""
+    target = str(tmp_path / "absent.npz")
+    assert cli_mod.main(["--error-format", "human", "--error-format", "json",
+                         "info", target]) == 1
+    assert _envelopes_in(capsys.readouterr().err)
+
+    assert cli_mod.main(["--error-format", "json", "--error-format", "human",
+                         "info", target]) == 1
+    err = capsys.readouterr().err
+    assert not _envelopes_in(err)
+    assert err.startswith("cosmic-observatory: error: ")
+
+
 # --- usage-code classification --------------------------------------------
 
 

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -298,13 +298,33 @@ def _emit_json(report) -> None:
     print(json.dumps(report, sort_keys=True, allow_nan=False, separators=(",", ":")))
 
 
+def _examined(predicate, raw: str, code: str) -> bool:
+    """Run a filesystem predicate, translating a path the OS cannot examine.
+
+    `Path.exists()` and `Path.is_dir()` return False for an absent path, but
+    they RAISE for one the filesystem rejects outright -- a name past
+    NAME_MAX, or one containing a byte the filesystem forbids. `_ignore_error`
+    covers ENOENT/ENOTDIR/EBADF/ELOOP and nothing else, so ENAMETOOLONG and
+    EACCES propagate.
+
+    That is an expected input problem, not a defect: the user named something
+    unusable. Without this it escaped as a traceback on the status-1 lane,
+    which is exactly the class of failure this CLI's error contract exists to
+    make parseable.
+    """
+    try:
+        return predicate()
+    except OSError as exc:
+        raise _UserError(f"cannot examine path {raw}: {exc}", code) from exc
+
+
 def _validated_snapshot_path(raw: str) -> Path:
     """Check a snapshot argument is a supported, readable file before loading."""
     path = Path(raw)
     # Directory first: a bare directory has no suffix, so checking the suffix
     # ahead of this would report "unsupported format" for what is really a
     # wrong kind of path.
-    if path.is_dir():
+    if _examined(path.is_dir, raw, "snapshot-wrong-path-kind"):
         raise _UserError(
             f"snapshot path is a directory, not a file: {raw}",
             "snapshot-wrong-path-kind",
@@ -315,7 +335,7 @@ def _validated_snapshot_path(raw: str) -> Path:
             f"expected one of {', '.join(SUPPORTED_SNAPSHOT_SUFFIXES)}",
             "snapshot-unsupported-suffix",
         )
-    if not path.exists():
+    if not _examined(path.exists, raw, "snapshot-not-found"):
         raise _UserError(f"snapshot not found: {raw}", "snapshot-not-found")
     return path
 
@@ -323,11 +343,11 @@ def _validated_snapshot_path(raw: str) -> Path:
 def _validated_directory(raw: str) -> Path:
     """Check an animation argument is an existing, usable directory."""
     path = Path(raw)
-    if not path.exists():
+    if not _examined(path.exists, raw, "animation-directory-invalid"):
         raise _UserError(
             f"directory not found: {raw}", "animation-directory-invalid"
         )
-    if not path.is_dir():
+    if not _examined(path.is_dir, raw, "animation-directory-invalid"):
         raise _UserError(f"not a directory: {raw}", "animation-directory-invalid")
     return path
 

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -23,6 +23,8 @@ import json
 import sys
 from pathlib import Path
 
+from vis.observatory import cli_errors
+
 # ---------------------------------------------------------------------------
 # Error contract
 #
@@ -53,8 +55,37 @@ NUM_MEMORY_CHANNELS = 8
 _AXIS_INDEX = {"x": 0, "y": 1, "z": 2}
 
 
+#: Commands that already speak JSON on success, and therefore must speak it on
+#: failure too: answering `--json` with prose leaves a machine consumer with
+#: nothing to parse.
+_JSON_COMMANDS = frozenset({"info", "doctor"})
+
+_ERROR_FORMATS = ("human", "json")
+
+#: Global options that consume a following token. Kept as data because two
+#: separate pieces of logic must agree about it: the pre-scan below, and
+#: `_first_command_token`, which would otherwise mistake an option's VALUE for
+#: the subcommand.
+_VALUE_TAKING_GLOBAL_OPTIONS = ("--error-format",)
+
+#: The error format for the current `main()` call, or None when the global
+#: option was not supplied. Module scope because argparse discovers usage
+#: failures inside `parse_args`, before any namespace exists to carry it.
+_ERROR_FORMAT = None
+
+
 class _UserError(Exception):
-    """An expected, actionable user-facing failure (exit status 1)."""
+    """An expected, actionable user-facing failure (exit status 1).
+
+    Carries the machine-readable ``code`` from the raise site. Assigning it
+    there rather than deriving it from the message text is deliberate: message
+    wording is human prose that varies with the OS, the locale and the
+    library version, and must never be load-bearing.
+    """
+
+    def __init__(self, message, code="input-error"):
+        super().__init__(message)
+        self.code = code
 
 
 def _one_line(text: object) -> str:
@@ -107,15 +138,116 @@ def _non_negative_float(raw: str) -> float:
     return value
 
 
+def _is_value_taking_option(token: str) -> bool:
+    """True when ``token`` names a global option that consumes the next token.
+
+    Prefix matching mirrors argparse's own abbreviation support (``allow_abbrev``
+    defaults to True), so the pre-scan and the parser agree on what ``--error-f``
+    means rather than diverging on an abbreviation.
+    """
+    if "=" in token or not token.startswith("--") or len(token) <= 2:
+        return False
+    return any(name.startswith(token) for name in _VALUE_TAKING_GLOBAL_OPTIONS)
+
+
 def _first_command_token(argv):
-    """Return the first non-option token, i.e. the intended subcommand."""
+    """Return the first non-option token, i.e. the intended subcommand.
+
+    Skipping bare ``-``-prefixed tokens is not enough once a global option
+    takes a value: in ``--error-format json slize``, the value ``json`` is not
+    an option and would be returned as the intended subcommand, so the typo
+    ``slize`` would never be examined and the did-you-mean suggestion would be
+    silently lost.
+    """
+    skip_value = False
     for token in argv:
+        if skip_value:
+            skip_value = False
+            continue
         if token == "--":
             return None
         if token.startswith("-"):
+            skip_value = _is_value_taking_option(token)
             continue
         return token
     return None
+
+
+def _scan_error_format(argv):
+    """Read ``--error-format`` from argv before argparse runs.
+
+    Necessary, not merely convenient: argparse reports a usage failure from
+    inside ``parse_args``, so no parsed namespace exists yet at the moment the
+    format is needed. Returns ``None`` when the option is absent, which is what
+    lets an explicit ``--error-format human`` override the automatic upgrade
+    for ``info --json`` / ``doctor --json``.
+
+    An unrecognised value falls back to human: the request itself is a usage
+    error that argparse is about to report, and a format that was never validly
+    selected must not be trusted to carry the refusal.
+    """
+    expect_value = False
+    for token in argv:
+        if expect_value:
+            return token if token in _ERROR_FORMATS else "human"
+        if token == "--":
+            break
+        if token.startswith("--") and "=" in token:
+            name, _, value = token.partition("=")
+            if any(opt.startswith(name) for opt in _VALUE_TAKING_GLOBAL_OPTIONS):
+                return value if value in _ERROR_FORMATS else "human"
+            continue
+        if _is_value_taking_option(token):
+            expect_value = True
+    return None
+
+
+def _classify_usage_error(message):
+    """Map one argparse message to a (code, argument) pair.
+
+    argparse's text is English prose, gettext-wrapped and version-dependent, so
+    the anchors here are narrow and the fallback is honest: an unrecognised
+    shape becomes ``usage-error`` rather than being guessed into a more
+    specific code that a consumer might then rely on.
+    """
+    text = message or ""
+    if "the following arguments are required" in text:
+        required = text.split(":", 1)[-1]
+        if "command" in required:
+            return "missing-command", None
+        return "missing-argument", required.strip() or None
+    if text.startswith("unrecognized arguments"):
+        return "unknown-option", text.split(":", 1)[-1].strip() or None
+    if "invalid choice" in text:
+        if text.startswith("argument command"):
+            return "unknown-command", None
+        return "invalid-argument-value", text.split(":", 1)[0][9:].strip() or None
+    if text.startswith("argument "):
+        return "invalid-argument-value", text.split(":", 1)[0][9:].strip() or None
+    return "usage-error", None
+
+
+class _ObservatoryParser(argparse.ArgumentParser):
+    """An ArgumentParser that can report a usage failure as a JSON envelope.
+
+    Only ``error()`` is overridden. ``exit()`` and ``print_help()`` are left
+    alone on purpose: ``--help`` must stay human text on stdout at status 0
+    whatever the error format says.
+
+    ``add_subparsers`` defaults ``parser_class`` to ``type(self)``, so every
+    subparser inherits this behaviour -- which is what covers missing
+    positionals and every ``ArgumentTypeError`` from the custom converters,
+    since those are raised by the subparser rather than by this one.
+    """
+
+    def error(self, message):
+        if _ERROR_FORMAT != "json":
+            super().error(message)      # unchanged human behaviour
+        code, argument = _classify_usage_error(message)
+        sys.stderr.write(cli_errors.format_error(
+            code, message, argument=argument,
+        ))
+        sys.exit(2)
 
 
 def _suggest_command(parser, argv, commands):
@@ -131,12 +263,24 @@ def _suggest_command(parser, argv, commands):
     token = _first_command_token(argv)
     if token is None or token in commands:
         return
+    # Bound the token before difflib sees it: `get_close_matches` builds an
+    # index over the whole word before any cutoff applies, so a pathological
+    # argv value would be paid for in full. No real subcommand typo is this
+    # long, and `main(argv=[...])` is a supported entry point.
+    if len(token) > 64:
+        return
     matches = difflib.get_close_matches(token, commands, n=1, cutoff=0.6)
     if not matches:
         return
-    parser.error(
-        f"unknown command {_one_line(token)!r}. Did you mean {matches[0]!r}?"
-    )
+    suggestion = f"Did you mean {matches[0]!r}?"
+    message = f"unknown command {_one_line(token)!r}. {suggestion}"
+    if _ERROR_FORMAT == "json":
+        sys.stderr.write(cli_errors.format_error(
+            "unknown-command", message,
+            suggestion=suggestion, argument=token,
+        ))
+        sys.exit(2)
+    parser.error(message)
 
 
 def _emit_json(report) -> None:
@@ -161,14 +305,18 @@ def _validated_snapshot_path(raw: str) -> Path:
     # ahead of this would report "unsupported format" for what is really a
     # wrong kind of path.
     if path.is_dir():
-        raise _UserError(f"snapshot path is a directory, not a file: {raw}")
+        raise _UserError(
+            f"snapshot path is a directory, not a file: {raw}",
+            "snapshot-wrong-path-kind",
+        )
     if path.suffix not in SUPPORTED_SNAPSHOT_SUFFIXES:
         raise _UserError(
             f"unsupported snapshot format {path.suffix or '(none)'!r} for {raw}; "
-            f"expected one of {', '.join(SUPPORTED_SNAPSHOT_SUFFIXES)}"
+            f"expected one of {', '.join(SUPPORTED_SNAPSHOT_SUFFIXES)}",
+            "snapshot-unsupported-suffix",
         )
     if not path.exists():
-        raise _UserError(f"snapshot not found: {raw}")
+        raise _UserError(f"snapshot not found: {raw}", "snapshot-not-found")
     return path
 
 
@@ -176,9 +324,11 @@ def _validated_directory(raw: str) -> Path:
     """Check an animation argument is an existing, usable directory."""
     path = Path(raw)
     if not path.exists():
-        raise _UserError(f"directory not found: {raw}")
+        raise _UserError(
+            f"directory not found: {raw}", "animation-directory-invalid"
+        )
     if not path.is_dir():
-        raise _UserError(f"not a directory: {raw}")
+        raise _UserError(f"not a directory: {raw}", "animation-directory-invalid")
     return path
 
 
@@ -221,7 +371,9 @@ def _load_snapshot_checked(path):
     try:
         return load_snapshot(path)
     except _unreadable_input_errors() as exc:
-        raise _UserError(f"cannot read snapshot {path}: {exc}") from exc
+        raise _UserError(
+            f"cannot read snapshot {path}: {exc}", "snapshot-unreadable"
+        ) from exc
 
 
 def _validated_level(snapshot, axis: str, level):
@@ -239,15 +391,45 @@ def _validated_level(snapshot, axis: str, level):
     if not -extent <= level < extent:
         raise _UserError(
             f"level {level} is outside axis {axis!r} of size {extent} "
-            f"(valid range {-extent} to {extent - 1})"
+            f"(valid range {-extent} to {extent - 1})",
+            "level-out-of-range",
         )
     return level
 
 
+def _error_format_for(args) -> str:
+    """Resolve the error format for a failure that happened after parsing.
+
+    An explicit global option always wins. Absent one, a command that was
+    asked for JSON on success gets JSON on failure too -- answering `--json`
+    with prose is the gap this contract exists to close. The upgrade is scoped
+    to those commands; every other subcommand stays human.
+    """
+    if _ERROR_FORMAT is not None:
+        return _ERROR_FORMAT
+    if getattr(args, "command", None) in _JSON_COMMANDS and getattr(args, "json", False):
+        return "json"
+    return "human"
+
+
 def main(argv=None):
-    parser = argparse.ArgumentParser(
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Read before the parser is built: argparse reports usage failures from
+    # inside `parse_args`, so a namespace does not exist yet when the format
+    # is first needed.
+    global _ERROR_FORMAT
+    _ERROR_FORMAT = _scan_error_format(argv)
+
+    parser = _ObservatoryParser(
         prog="cosmic-observatory",
         description="Phase 8 Cosmic Observatory -- UtilityFog CA Visualization",
+    )
+    parser.add_argument(
+        "--error-format", choices=_ERROR_FORMATS, default="human",
+        help="How to report an expected failure. 'json' emits one error "
+             "envelope on stderr. Must appear before the subcommand.",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -330,8 +512,6 @@ def main(argv=None):
     p_doctor.add_argument("--json", action="store_true",
                           help="Emit one JSON document on stdout instead of text")
 
-    if argv is None:
-        argv = sys.argv[1:]
     _suggest_command(parser, argv, sorted(sub.choices))
 
     args = parser.parse_args(argv)
@@ -339,7 +519,14 @@ def main(argv=None):
     try:
         return _dispatch(args)
     except _UserError as exc:
-        print(f"{parser.prog}: error: {_one_line(exc)}", file=sys.stderr)
+        if _error_format_for(args) == "json":
+            # One write, terminator included, so nothing can interleave
+            # between the document and its newline.
+            sys.stderr.write(cli_errors.format_error(
+                exc.code, str(exc), command=getattr(args, "command", None),
+            ))
+        else:
+            print(f"{parser.prog}: error: {_one_line(exc)}", file=sys.stderr)
         return 1
 
 
@@ -539,7 +726,10 @@ def _dispatch(args):
         try:
             snapshots = load_snapshot_series(args.data_dir, max_count=args.max_frames)
         except _unreadable_input_errors() as exc:
-            raise _UserError(f"cannot animate {args.data_dir}: {exc}") from exc
+            raise _UserError(
+                f"cannot animate {args.data_dir}: {exc}",
+                "animation-directory-invalid",
+            ) from exc
 
         # Phase 2 -- rendering and saving. Deliberately OUTSIDE the translation
         # boundary: a failure here is a defect, not bad user input, and must

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -185,21 +185,31 @@ def _scan_error_format(argv):
     An unrecognised value falls back to human: the request itself is a usage
     error that argparse is about to report, and a format that was never validly
     selected must not be trusted to carry the refusal.
+
+    A repeated option follows argparse's ordinary LAST-WINS semantics. This
+    scan is a second reader of the same argv, so it has to reach the same
+    answer argparse will; returning the first occurrence instead would mean
+    the format the CLI emits disagrees with the format it parsed, and which
+    one a caller observed would depend on whether the failure happened before
+    or after ``parse_args``.
     """
+    selected = None
     expect_value = False
     for token in argv:
         if expect_value:
-            return token if token in _ERROR_FORMATS else "human"
+            expect_value = False
+            selected = token if token in _ERROR_FORMATS else "human"
+            continue
         if token == "--":
             break
         if token.startswith("--") and "=" in token:
             name, _, value = token.partition("=")
             if any(opt.startswith(name) for opt in _VALUE_TAKING_GLOBAL_OPTIONS):
-                return value if value in _ERROR_FORMATS else "human"
+                selected = value if value in _ERROR_FORMATS else "human"
             continue
         if _is_value_taking_option(token):
             expect_value = True
-    return None
+    return selected
 
 
 def _classify_usage_error(message):
@@ -218,12 +228,25 @@ def _classify_usage_error(message):
         return "missing-argument", required.strip() or None
     if text.startswith("unrecognized arguments"):
         return "unknown-option", text.split(":", 1)[-1].strip() or None
-    if "invalid choice" in text:
-        if text.startswith("argument command"):
-            return "unknown-command", None
-        return "invalid-argument-value", text.split(":", 1)[0][9:].strip() or None
     if text.startswith("argument "):
-        return "invalid-argument-value", text.split(":", 1)[0][9:].strip() or None
+        name, _, detail = text.partition(":")
+        argument = name[len("argument "):].strip() or None
+        # An invalid CHOICE of subcommand is an unknown command, not a bad
+        # value: `command` is the dest argparse gives the subparsers action.
+        if "invalid choice" in detail:
+            if argument == "command":
+                return "unknown-command", None
+            return "invalid-argument-value", argument
+        # The option was present but its value was not. Nothing was supplied
+        # to be invalid, so this is a missing argument.
+        if "expected" in detail and "argument" in detail:
+            return "missing-argument", argument
+        # A value was attached to a flag that takes none, e.g. `--json=x`.
+        if "ignored explicit argument" in detail:
+            return "unknown-option", argument
+        return "invalid-argument-value", argument
+    if "invalid choice" in text:
+        return "invalid-argument-value", None
     return "usage-error", None
 
 
@@ -298,7 +321,7 @@ def _emit_json(report) -> None:
     print(json.dumps(report, sort_keys=True, allow_nan=False, separators=(",", ":")))
 
 
-def _examined(predicate, raw: str, code: str) -> bool:
+def _examined(predicate, raw: str) -> bool:
     """Run a filesystem predicate, translating a path the OS cannot examine.
 
     `Path.exists()` and `Path.is_dir()` return False for an absent path, but
@@ -309,13 +332,23 @@ def _examined(predicate, raw: str, code: str) -> bool:
 
     That is an expected input problem, not a defect: the user named something
     unusable. Without this it escaped as a traceback on the status-1 lane,
-    which is exactly the class of failure this CLI's error contract exists to
-    make parseable.
+    which is exactly the class of failure this contract exists to make
+    parseable.
+
+    The code is always the honest ``input-error`` fallback. When the OS
+    refuses to look at a path, NOTHING has been established about what kind of
+    thing it is -- so reporting `snapshot-wrong-path-kind` would assert it is
+    a directory, and `snapshot-not-found` would assert it is absent, neither
+    of which was determined. The specific codes stay reserved for paths
+    positively established to be a directory, missing, or of an unsupported
+    suffix.
     """
     try:
         return predicate()
     except OSError as exc:
-        raise _UserError(f"cannot examine path {raw}: {exc}", code) from exc
+        raise _UserError(
+            f"cannot examine path {raw}: {exc}", "input-error"
+        ) from exc
 
 
 def _validated_snapshot_path(raw: str) -> Path:
@@ -324,7 +357,7 @@ def _validated_snapshot_path(raw: str) -> Path:
     # Directory first: a bare directory has no suffix, so checking the suffix
     # ahead of this would report "unsupported format" for what is really a
     # wrong kind of path.
-    if _examined(path.is_dir, raw, "snapshot-wrong-path-kind"):
+    if _examined(path.is_dir, raw):
         raise _UserError(
             f"snapshot path is a directory, not a file: {raw}",
             "snapshot-wrong-path-kind",
@@ -335,7 +368,7 @@ def _validated_snapshot_path(raw: str) -> Path:
             f"expected one of {', '.join(SUPPORTED_SNAPSHOT_SUFFIXES)}",
             "snapshot-unsupported-suffix",
         )
-    if not _examined(path.exists, raw, "snapshot-not-found"):
+    if not _examined(path.exists, raw):
         raise _UserError(f"snapshot not found: {raw}", "snapshot-not-found")
     return path
 
@@ -343,11 +376,11 @@ def _validated_snapshot_path(raw: str) -> Path:
 def _validated_directory(raw: str) -> Path:
     """Check an animation argument is an existing, usable directory."""
     path = Path(raw)
-    if not _examined(path.exists, raw, "animation-directory-invalid"):
+    if not _examined(path.exists, raw):
         raise _UserError(
             f"directory not found: {raw}", "animation-directory-invalid"
         )
-    if not _examined(path.is_dir, raw, "animation-directory-invalid"):
+    if not _examined(path.is_dir, raw):
         raise _UserError(f"not a directory: {raw}", "animation-directory-invalid")
     return path
 

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -182,34 +182,51 @@ def _scan_error_format(argv):
     lets an explicit ``--error-format human`` override the automatic upgrade
     for ``info --json`` / ``doctor --json``.
 
-    An unrecognised value falls back to human: the request itself is a usage
-    error that argparse is about to report, and a format that was never validly
-    selected must not be trusted to carry the refusal.
+    The rules, in full:
 
-    A repeated option follows argparse's ordinary LAST-WINS semantics. This
-    scan is a second reader of the same argv, so it has to reach the same
-    answer argparse will; returning the first occurrence instead would mean
-    the format the CLI emits disagrees with the format it parsed, and which
-    one a caller observed would depend on whether the failure happened before
-    or after ``parse_args``.
+    1. No occurrence -> ``None``.
+    2. Every occurrence valid -> the LAST one, matching argparse's ordinary
+       repeated-option semantics. This scan is a second reader of the same
+       argv and has to reach the same answer argparse will; returning the
+       first occurrence instead would mean the format the CLI emits disagrees
+       with the format it parsed, and which a caller observed would depend on
+       whether the failure happened before or after ``parse_args``.
+    3. ANY occurrence carrying an invalid value, or lacking its value
+       entirely, makes the result ``human`` -- and that is STICKY. argparse
+       cannot parse such a command line at all, so the whole invocation is
+       refused; a later valid occurrence must not launder an earlier invalid
+       one into an accepted JSON selection, and an earlier valid occurrence
+       must not survive a later missing value. A format that was never
+       validly selected must not be trusted to carry the refusal.
+    4. Separated, equals and supported abbreviated forms all agree.
     """
     selected = None
+    failed = False
     expect_value = False
     for token in argv:
         if expect_value:
             expect_value = False
-            selected = token if token in _ERROR_FORMATS else "human"
+            if token in _ERROR_FORMATS:
+                selected = token
+            else:
+                failed = True
             continue
         if token == "--":
             break
         if token.startswith("--") and "=" in token:
             name, _, value = token.partition("=")
             if any(opt.startswith(name) for opt in _VALUE_TAKING_GLOBAL_OPTIONS):
-                selected = value if value in _ERROR_FORMATS else "human"
+                if value in _ERROR_FORMATS:
+                    selected = value
+                else:
+                    failed = True
             continue
         if _is_value_taking_option(token):
             expect_value = True
-    return selected
+    if expect_value:
+        # The option was the final token, so its value never arrived.
+        failed = True
+    return "human" if failed else selected
 
 
 def _classify_usage_error(message):

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -199,6 +199,19 @@ def _scan_error_format(argv):
        must not survive a later missing value. A format that was never
        validly selected must not be trusted to carry the refusal.
     4. Separated, equals and supported abbreviated forms all agree.
+
+    Only the GLOBAL PREFIX is scanned. ``--error-format`` is a global option
+    and is only meaningful before the subcommand, because the subparsers
+    action consumes everything from the command name onward. So the scan stops
+    at the first unconsumed non-option token -- the intended subcommand --
+    rather than walking the whole argv.
+
+    Without that stop, ``--error-format json info snap.npz --error-format
+    human`` overwrote the selection from the subcommand's own arguments.
+    argparse refuses the misplaced trailing option as a usage error, but the
+    caller HAD validly asked for JSON, so the refusal must be a JSON envelope.
+    Conversely a trailing occurrence must never retroactively select a format
+    when no valid one appeared in the prefix.
     """
     selected = None
     failed = False
@@ -212,6 +225,9 @@ def _scan_error_format(argv):
                 failed = True
             continue
         if token == "--":
+            break
+        if not token.startswith("-"):
+            # The subcommand. Everything after it belongs to the subparser.
             break
         if token.startswith("--") and "=" in token:
             name, _, value = token.partition("=")

--- a/vis/observatory/cli_errors.py
+++ b/vis/observatory/cli_errors.py
@@ -98,6 +98,13 @@ MAX_FIELD_LENGTH = 256
 
 _TRUNCATION_MARKER = "..."
 
+#: Redacted rather than merely bounded. An exception's text can carry a
+#: formatted traceback (a nested error, a subprocess's captured output), and
+#: the contract promises no traceback ever reaches a consumer. Replacing the
+#: marker leaves visible evidence that something was removed.
+_TRACEBACK_MARKER = "Traceback (most recent call last)"
+_TRACEBACK_REDACTION = "[traceback removed]"
+
 
 def category_for(code: str) -> str:
     """Return the category a code belongs to."""
@@ -139,6 +146,7 @@ def sanitize(value: Any) -> Optional[str]:
     if value is None:
         return None
     text = " ".join(str(value).splitlines()).strip()
+    text = text.replace(_TRACEBACK_MARKER, _TRACEBACK_REDACTION)
     text = text.encode("ascii", "backslashreplace").decode("ascii")
     if len(text) > MAX_FIELD_LENGTH:
         text = text[:MAX_FIELD_LENGTH] + _TRUNCATION_MARKER

--- a/vis/observatory/cli_errors.py
+++ b/vis/observatory/cli_errors.py
@@ -1,0 +1,209 @@
+"""Cosmic Observatory: the machine-readable CLI error contract.
+
+A caller that asks for JSON should never be answered with prose. The
+Observatory's machine-oriented commands already emit strict documents on
+success; this module supplies the matching shape for an expected *failure*,
+so an automated consumer has something to parse on every outcome.
+
+Deliberately standard-library-only and free of any rendering, NumPy or
+visualization import. Two reasons, both load-bearing: the error path must
+stay usable when the reason for failing is that an optional dependency is
+missing, and the module must remain importable in isolation so its purity can
+be tested from a bare interpreter.
+
+Nothing here reads or writes a file, touches the network, or terminates the
+process. It takes already-classified facts and returns text; the CLI owns
+streams and exit statuses.
+
+Contract summary
+----------------
+An expected failure emits one JSON object, on one physical line, on stderr:
+
+    {"argument":null,"category":"usage","code":"unknown-command",...}
+
+Keys are sorted, separators are compact, and the document is ASCII-escaped.
+That last point is not cosmetic -- see :func:`render`.
+
+Forward compatibility, for consumers
+------------------------------------
+1. ``schema`` is ``utilityfog.observatory.error/1``. The trailing ``/N`` is
+   bumped only for an incompatible structural change.
+2. New keys may be added at any time. Ignore keys you do not recognise.
+3. Existing keys are never removed, renamed or retyped within a version.
+4. Tolerate an unknown ``code`` by falling back to ``category``; tolerate an
+   unknown ``category`` by falling back to the process exit status.
+5. ``message`` and ``suggestion`` are human text. They are unstable, may be
+   localised by the underlying OS, and must never be parsed.
+6. Nullable fields are always present. ``null`` means "not applicable", never
+   "unknown".
+7. The process exit status is authoritative; ``exit_status`` restates it for
+   readers who see the document detached from the process, such as a log line.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+#: Bumped only when the emitted structure changes incompatibly.
+ERROR_SCHEMA = "utilityfog.observatory.error/1"
+
+CATEGORY_USAGE = "usage"
+CATEGORY_INPUT = "input"
+
+#: The closed set of categories. A category fixes the exit status.
+CATEGORIES = frozenset({CATEGORY_USAGE, CATEGORY_INPUT})
+
+#: Exit status per category. Single source of truth: callers pass a code,
+#: never a status, so the body and the process can never disagree.
+_STATUS_BY_CATEGORY = {CATEGORY_USAGE: 2, CATEGORY_INPUT: 1}
+
+#: The closed initial code vocabulary, mapped to its category.
+#:
+#: `usage` codes describe a command line the CLI could not accept at all;
+#: `input` codes describe a command line that parsed but named something the
+#: CLI could not use. That split is exactly the existing exit taxonomy, so the
+#: vocabulary adds names to established behaviour rather than new behaviour.
+CODES: Dict[str, str] = {
+    # -- usage (status 2) ---------------------------------------------------
+    "missing-command": CATEGORY_USAGE,
+    "unknown-command": CATEGORY_USAGE,
+    "unknown-option": CATEGORY_USAGE,
+    "missing-argument": CATEGORY_USAGE,
+    "invalid-argument-value": CATEGORY_USAGE,
+    # Fallback. argparse's own messages are English prose that varies by
+    # Python version and may be localised, so classification is deliberately
+    # conservative: an unrecognised usage failure is reported honestly as
+    # `usage-error` rather than guessed into a more specific code.
+    "usage-error": CATEGORY_USAGE,
+    # -- input (status 1) ---------------------------------------------------
+    "snapshot-not-found": CATEGORY_INPUT,
+    "snapshot-wrong-path-kind": CATEGORY_INPUT,
+    "snapshot-unsupported-suffix": CATEGORY_INPUT,
+    "snapshot-unreadable": CATEGORY_INPUT,
+    "animation-directory-invalid": CATEGORY_INPUT,
+    "level-out-of-range": CATEGORY_INPUT,
+    # Fallback for an expected runtime failure with no more specific code.
+    "input-error": CATEGORY_INPUT,
+}
+
+#: Cap on any single string field, applied after sanitising.
+#:
+#: Three routes can hand this module an unbounded value: argparse echoes the
+#: raw argv token in an invalid-value message, a filesystem path is
+#: caller-controlled, and an exception's own text can be arbitrarily long.
+#: Truncation is visible rather than silent, and is applied to field VALUES --
+#: never to the serialised document, which would destroy parseability.
+MAX_FIELD_LENGTH = 256
+
+_TRUNCATION_MARKER = "..."
+
+
+def category_for(code: str) -> str:
+    """Return the category a code belongs to."""
+    try:
+        return CODES[code]
+    except KeyError:
+        raise KeyError(f"unknown error code {code!r}") from None
+
+
+def status_for(code: str) -> int:
+    """Return the exit status a code implies."""
+    return _STATUS_BY_CATEGORY[category_for(code)]
+
+
+def sanitize(value: Any) -> Optional[str]:
+    """Return ``value`` as one bounded, single-line, ASCII-safe string.
+
+    ``None`` passes through, because a nullable field stays null rather than
+    becoming the text ``"None"``.
+
+    Three transformations, in this order and for distinct reasons:
+
+    1. **Collapse line boundaries.** ``str.splitlines()`` splits on far more
+       than CR and LF -- ``\\v``, ``\\f``, ``\\x1c``-``\\x1e``, ``\\x85``,
+       ``\\u2028`` and ``\\u2029`` all count. A caller-supplied path
+       containing any of them could otherwise forge an extra line, and a
+       line-oriented consumer would read a document the CLI never emitted.
+       JSON escaping alone is not a substitute: it neutralises ``\\x00``-
+       ``\\x1f`` unconditionally, but ``\\x85`` and ``\\u2028`` only under
+       ASCII escaping. Collapsing here means the guarantee does not depend on
+       a serializer flag.
+    2. **Force ASCII.** A lone surrogate -- from a POSIX ``surrogateescape``
+       filename or an unpaired UTF-16 unit on Windows -- would otherwise be
+       emitted as an unpaired ``\\udcff`` escape, which is invalid JSON that
+       strict parsers reject. Encoding with ``backslashreplace`` turns it into
+       literal text before the serializer ever sees it.
+    3. **Bound the length**, with a visible marker.
+    """
+    if value is None:
+        return None
+    text = " ".join(str(value).splitlines()).strip()
+    text = text.encode("ascii", "backslashreplace").decode("ascii")
+    if len(text) > MAX_FIELD_LENGTH:
+        text = text[:MAX_FIELD_LENGTH] + _TRUNCATION_MARKER
+    return text
+
+
+def build_envelope(
+    code: str,
+    message: Any,
+    suggestion: Any = None,
+    command: Any = None,
+    argument: Any = None,
+) -> Dict[str, Any]:
+    """Return the envelope for one expected failure.
+
+    ``category`` and ``exit_status`` are derived from ``code`` rather than
+    passed in, so the two can never contradict each other or the process.
+
+    Every nullable field is present in the result. A field that disappears
+    when inapplicable forces consumers to branch on key existence; ``null``
+    lets them read one shape every time.
+    """
+    return {
+        "schema": ERROR_SCHEMA,
+        "ok": False,
+        "category": category_for(code),
+        "code": code,
+        "message": sanitize(message),
+        "suggestion": sanitize(suggestion),
+        "command": sanitize(command),
+        "argument": sanitize(argument),
+        "exit_status": status_for(code),
+    }
+
+
+def render(envelope: Dict[str, Any]) -> str:
+    """Serialize an envelope to the exact text written to stderr.
+
+    ``sort_keys=True`` makes the bytes a function of the content alone, so two
+    runs over equivalent inputs agree regardless of construction path.
+    ``allow_nan=False`` is an assertion rather than decoration: this module
+    never produces a non-finite value, so it fires only on a defect.
+
+    ``ensure_ascii`` is left at its default ``True`` **deliberately**. With it
+    off, ``json.dumps`` passes U+2028, U+2029 and U+0085 through unescaped --
+    legal JSON, but every one of them is a line boundary to
+    ``str.splitlines()``, which would break the single-line contract for any
+    consumer reading stderr line by line. :func:`sanitize` already removes
+    them, so this is defence in depth; do not "improve" it by turning
+    ``ensure_ascii`` off to keep paths readable.
+
+    The trailing newline is part of the contract and is included here, so the
+    caller performs exactly one write.
+    """
+    return json.dumps(
+        envelope, sort_keys=True, allow_nan=False, separators=(",", ":")
+    ) + "\n"
+
+
+def format_error(
+    code: str,
+    message: Any,
+    suggestion: Any = None,
+    command: Any = None,
+    argument: Any = None,
+) -> str:
+    """Build and render in one step -- the CLI's usual entry point."""
+    return render(build_envelope(code, message, suggestion, command, argument))


### PR DESCRIPTION
Advances #67

Not `Closes` — issue #67 is a broader CLI-UX epic. This tranche closes one named limitation from it: a machine-oriented command could answer a machine consumer with human prose.

## Pins

| | |
|---|---|
| Base (`main`) | `779cedb6d5e3d8abb4a5e7da0b517f01d1686fb8` |
| Head | `294fa38f12308c1a4d7ba7ded35d001fca2076ea` |
| Branch | `feat/observatory-cli-error-envelope` |
| Commits | 10 |

**Synchronized with `main`.** The original base was `1b800943`; `main` advanced to `779cedb6` (merged #454, touching only `experiments/tech_ledger/**`) and has been merged in with an ordinary merge commit — no rebase, squash, amend or force-push, and no conflict resolution required. All four package blobs are byte-identical across the synchronization.

| Commit | |
|---|---|
| `7ef13cf` | tests: failing-first contract (**expected red**) |
| `659a900` | Observatory: machine-readable CLI error envelope |
| `64b972d` | Observatory: redact tracebacks and translate unexaminable paths |
| `cd4fdbf` | tests: failing regressions for the audit findings (**expected red**) |
| `dc0a4d4` | Observatory: correct scanner precedence, usage codes, path classification |
| `5718616` | Merge branch 'main' (synchronization) |
| `1e8b4ed` | tests: failing regressions for the sticky-scanner edge (**expected red**) |
| `5a6d28b` | Observatory: a failed `--error-format` occurrence is sticky |
| `641ca21` | tests: failing regressions for the two Codex threads (**expected red**) |
| `294fa38` | Observatory: scan only the global prefix; guard optional deps at collection |

`main` was re-read after each correction and remains `779cedb6`, so no further synchronization was needed. One synchronization merge was performed in total.

## Audit round

Jack's audit of `64b972d` found four defects. All are corrected, each reproduced by a failing test first.

| # | Defect | Correction |
|---|---|---|
| 1 | **Repeated `--error-format` disagreed with argparse.** argparse is last-wins; the pre-scan returned the *first* occurrence, so `--error-format json --error-format human` parsed to human but emitted JSON — and which you observed depended on whether the failure was before or after `parse_args`. | Scan now follows last-wins across separated, equals, abbreviated and mixed forms. See the follow-up round below for the invalid/incomplete cases. |
| 2 | **Usage codes mis-classified.** An option present without its value (`--save`) was reported `invalid-argument-value` — but nothing was supplied to be invalid. A value attached to a valueless flag (`--json=x`) likewise. | `expected N argument(s)` → `missing-argument`; `ignored explicit argument` → `unknown-option`. Invalid choices and invalid typed values keep `invalid-argument-value`; the honest `usage-error` fallback is unchanged. |
| 3 | **An unexaminable path was labelled a directory.** When the OS refuses to examine a path, nothing is established about what kind of thing it is, yet the code claimed `snapshot-wrong-path-kind`. | Now the honest `input-error` fallback. No new code minted. The three specific `snapshot-*` codes stay reserved for a path *positively established* to be a directory, missing, or of an unsupported suffix. |
| 4 | **The stderr framing contract was unenforceable.** "The envelope is the last line" cannot be guaranteed — unrelated diagnostics may follow as easily as precede. | Replaced by the schema-line contract, in tests, code and docs. |

### Corrected stderr contract

**Guaranteed:** the expected-error path writes **exactly one** envelope line and nothing else — no usage preamble, no traceback, no prose; stdout is empty; output is deterministic.

**Not guaranteed:** that the envelope is the only thing on stderr, or that it is the final line.

**Consumer rule:** scan stderr for a JSON line whose `schema` is `utilityfog.observatory.error/1`; if several are present, use the last. Absence of a match means an internal error — do not infer the envelope's presence from the exit status alone. Both the shell and Python examples in the docs now do exactly this.

No exception catching was broadened and no warnings were suppressed globally.

## Follow-up round — a failed scanner occurrence is sticky

> **Erratum.** At `5718616` this body and the `dc0a4d4` commit message claimed *"an invalid value in any position still falls back to human"*. **That was incomplete.** It held only when the invalid occurrence was the **last** one. `_scan_error_format()` tracked the last *selection*, so a failed occurrence could be overwritten:
>
> ```
> --error-format yaml --error-format json      scanned as "json"
> --error-format json --error-format           scanned as "json"
> ```
>
> argparse can parse neither — an invalid choice in the first, an option with no value in the second — so the whole command line is refused, and the scanner has to agree. A later valid occurrence must not launder an earlier invalid one into an accepted JSON selection, and an earlier valid occurrence must not survive a later missing value.

**Corrected rule, in full:**

1. No occurrence → `None`.
2. Every occurrence valid → the **last** one, argparse's ordinary semantics.
3. **Any** occurrence with an invalid value, or lacking its value → `human`, and that is **sticky**.
4. Separated, equals and supported abbreviated forms all agree.

The correction is one sticky flag plus an end-of-argv check for an option left without its value. No redesign of the argparse integration, no broadened exception handling, and the all-valid last-wins path is untouched — re-asserted by tests so the fix could not have been made by simply disabling last-wins.

A failed invocation is refused with **status 2, human stderr, no JSON envelope, empty stdout**, and never reaches the runtime lane.

## Codex review round — both threads resolved

Two P2 findings on the ready PR. Both confirmed, reproduced by failing tests first, and corrected in `294fa38`.

**1 — `vis/observatory/cli.py`: stop scanning after the subcommand.** The pre-scan walked the whole argv, so it treated the subcommand's own arguments as further global occurrences. `--error-format json info snap.npz --error-format human` had its selection overwritten to human before argparse refused the misplaced trailing option — a caller who validly asked for JSON got prose.

`--error-format` is global and is only meaningful before the subcommand, because the subparsers action consumes everything from the command name onward. The scan now stops at the first unconsumed non-option token. One `break`.

```
--error-format json info snap.npz --error-format human   ->  JSON envelope, status 2
--error-format human info snap.npz --error-format json   ->  human prose,   status 2
info snap.npz --error-format json                        ->  human (no valid prefix)
```

A trailing occurrence can no longer retroactively select a format, and subcommand options such as `--axis`/`--level` are ignored entirely. Last-wins, sticky-human, the separated/equals/abbreviated forms and unknown-command suggestions are all preserved and re-asserted, so the fix could not have been made by weakening them. The documented semantics are aligned.

**2 — `tests/test_observatory_cli_errors.py`: optional-dependency collection.** The module imported `from vis.observatory ...` at top level with no guard, so collecting it without the optional numeric/rendering stack executed `vis/observatory/__init__.py` → `loader.py` → `numpy` and failed hard instead of skipping. `pytest.importorskip` for numpy and matplotlib now precedes those imports, matching `tests/test_observatory_cli.py`. Package initialization is unchanged, and the bare-interpreter subprocess test proving `cli_errors.py` is standard-library-only is retained — that claim is about the module in isolation.

Pinned by `test_optional_dependency_guards_precede_the_observatory_imports`, which asserts the ordering structurally against this module's own source: the property is about import ordering at *collection* time, which cannot be observed from inside a module that already imported successfully.

## The gap

`info --json` and `doctor --json` emit a strict document on success. An expected *load* failure left the caller with `cosmic-observatory: error: …` on stderr and nothing to parse. A consumer asking for JSON got prose.

## What is added

A global `--error-format {human,json}`, positioned **before** the subcommand, default `human`. On an expected failure in JSON mode, stderr carries one envelope and stdout stays empty; exit statuses are unchanged (2 usage, 1 runtime).

```json
{
  "schema": "utilityfog.observatory.error/1",
  "ok": false,
  "category": "usage",
  "code": "unknown-command",
  "message": "unknown command 'bod'. Did you mean 'body'?",
  "suggestion": "Did you mean 'body'?",
  "command": null,
  "argument": null,
  "exit_status": 2
}
```

Serialized with sorted keys, compact separators, ASCII-escaped, one trailing newline. Nullable fields are always present.

**Closed vocabulary.** `usage` (exit 2): `missing-command`, `unknown-command`, `unknown-option`, `missing-argument`, `invalid-argument-value`, `usage-error`. `input` (exit 1): `snapshot-not-found`, `snapshot-wrong-path-kind`, `snapshot-unsupported-suffix`, `snapshot-unreadable`, `animation-directory-invalid`, `level-out-of-range`, `input-error`. That covers all eleven cases the contract names; the two `*-error` entries are honest fallbacks.

**Automatic upgrade.** `info --json` and `doctor --json` use the envelope for runtime failures even without the global flag. An explicit `--error-format human` overrides it. The upgrade does not extend to other subcommands.

**A failed doctor check is not a CLI error.** Both exit 1, but a completed diagnostic run with failures is a *report* on stdout with empty stderr, carrying `utilityfog.observatory.report/1`. The envelope is keyed on the error **type**, never on "the status was 1" — and there is a test that fails if that is ever reversed.

## Ownership by layer

**`vis/observatory/cli_errors.py`** (new) owns the envelope: schema constant, vocabulary, sanitising, serialization. Standard-library only, with no rendering, NumPy or visualization import — so the error path stays usable when the reason for failing *is* a missing optional dependency, and purity is testable from a bare interpreter. It reads and writes nothing and never terminates the process.

**`vis/observatory/cli.py`** owns streams, exit statuses and classification.

## Design points worth review

- **`--error-format` is pre-scanned from argv** before the parser is built. Not an optimisation: argparse reports usage failures from inside `parse_args`, so no namespace exists yet when the format is needed. The scan returns `None` when absent, which is what lets an explicit `human` override the auto-upgrade. Prefix matching mirrors argparse's own `allow_abbrev`, so scan and parser agree on `--error-f`.
- **`_ObservatoryParser` overrides `error()` only.** `exit()` and `print_help()` are untouched, so `--help` stays human on stdout at status 0. `add_subparsers` defaults `parser_class` to `type(self)`, so all eleven subparsers inherit it — which is what covers missing positionals and every `ArgumentTypeError` from the custom converters, since those are raised by the subparser rather than the top parser.
- **`_UserError` carries its code from the raise site.** Deriving a code from message text would make human prose load-bearing, and that text is version-dependent and may be localised.
- **`_first_command_token` now skips a value-taking option's value.** A latent regression this flag would otherwise introduce: in `--error-format json slize`, `json` would have been read as the intended subcommand and the did-you-mean suggestion silently lost. Regression test included.
- **argparse messages are classified with narrow anchors** and an honest fallback rather than guessed into a specific code a consumer might rely on.
- **difflib is length-bounded** before it indexes the token: `get_close_matches` builds its index over the whole word before any cutoff applies, and `main(argv=[…])` is a supported entry point.

## Failing-first evidence

`7ef13cf` (tests only) → **CI run 30978985450: `1 error`** — collection aborted with `ImportError: cannot import name 'cli_errors'`, the module not yet existing. Collection-level rather than 59 individual failures, because the import is at module scope; recorded as-is rather than dressed up.

`659a900` (implementation) → **CI run 30979398049: `3 failed, 3924 passed, 13 skipped`**. All three diagnosed and fixed in `64b972d`:

| Failure | Cause | Disposition |
|---|---|---|
| `test_very_long_path_is_bounded` | `OSError` at `pathlib.py:840` on a 60000-character name. `Path.exists()`/`is_dir()` return False for an absent path but **raise** for one the filesystem rejects; `_ignore_error` covers ENOENT/ENOTDIR/EBADF/ELOOP only, so ENAMETOOLONG and EACCES propagate. | **Production fix.** Pre-existing, but squarely on the path being contracted — an expected input problem landing as a traceback on the status-1 lane. `_examined()` translates it, narrowly and only around the predicate call. |
| `test_envelope_never_contains_traceback_text` | `sanitize()` bounded but did not redact. An exception's own text can carry a formatted traceback. | **Production fix.** The marker is replaced, leaving visible evidence. |
| `test_cli_errors_references_no_renderer_or_numeric_stack` | My test banned the bare word `animation`, which legitimately appears in the code `animation-directory-invalid`. | **Test fix.** Narrowed to module references; the AST import walk remains the authoritative stdlib-only check. |

My test was wrong in the third; the production code was wrong in the first two.

## Validation and receipts

| | |
|---|---|
| `py_compile` (all changed Python) | exit 0 |
| `git diff --check` | clean |
| Duplicate test names | none |
| **pytest** | **NOT RUN LOCALLY** — this seat has no NumPy or pytest. CI is authoritative. |

No packages were installed and the environment was not altered.

**Authoritative — `pull_request`-event CI run `30994201527`, `verify-python` job `92267245994`: `4002 passed, 13 skipped in 62.45s`.** All checks SUCCESS at the final head.

Progression across the whole run:

| Head | Result |
|---|---|
| `1b800943` (base) | 3789 passed |
| `7ef13cf` | 1 error — collection `ImportError`, deliberate |
| `659a900` | 3 failed / 3924 passed |
| `64b972d` | 3927 passed |
| `cd4fdbf` | **19 failed / 3934 passed** — deliberate, the audit regressions |
| `dc0a4d4` | 3953 passed |
| `5718616` (synchronized) | 3953 passed |
| `1e8b4ed` | **14 failed / 3973 passed** — deliberate, the sticky-scanner regressions |
| `5a6d28b` | 3987 passed |
| `641ca21` | **13 failed / 3989 passed** — deliberate, the Codex-thread regressions |
| `294fa38` (final) | **4002 passed, 13 skipped** |

No previously passing test was lost at any step. The count is unchanged across the synchronization.

A revision of this body before `5718616` called push-event run `30979690481` "authoritative". That was wrong — the PR-event job is the authoritative one, and the receipt above is that job at the final head.

## Changed files

Four files, **+2026 / −21**. The authorized boundary permitted a fifth (`tests/test_observatory_cli.py`); it was not needed — no existing assertion required adjustment.

| File | + | − |
|---|---|---|
| `tests/test_observatory_cli_errors.py` (new) | 1194 | 0 |
| `docs/OBSERVATORY_CLI_ERRORS.md` (new) | 318 | 0 |
| `vis/observatory/cli.py` | 297 | 21 |
| `vis/observatory/cli_errors.py` (new) | 217 | 0 |

No workflow, dependency, packaging, policy, ledger, Rust or unrelated documentation file is touched. No package entry point invented.

## Compatibility

- Human mode is the default; `--error-format human` and omitting it produce identical stderr, and human runtime-error prose, successful output and exit statuses are unchanged. The one thing that necessarily *did* change is the **help and usage displays**, which now list `--error-format {human,json}` as any new option would.
- `--help` stays human on stdout at status 0 in both modes.
- Successful `info --json` / `doctor --json` documents are untouched.
- The exit taxonomy (0/1/2) is unchanged.
- Unexpected defects still propagate with their tracebacks; the translated-exception set was not widened, and there is a test asserting no envelope is emitted for a defect.
- `python -m vis.observatory` is preserved; `__main__.py` is not modified.

## Security notes

- Every field is collapsed to one line (covering the full `str.splitlines()` set, not just CR/LF), forced to ASCII, traceback-redacted, then truncated at 256 chars with a visible marker.
- `ensure_ascii` is left at its default `True` **deliberately**: with it off, `json.dumps` passes U+2028/U+2029/U+0085 through unescaped — legal JSON, but line boundaries to `splitlines()`. `sanitize()` already removes them; the encoder setting is defence in depth. A comment says so, so it is not "improved" later.
- Lone surrogates become literal text, so the document never contains an unpaired escape that strict parsers reject.
- Nothing here reads or writes a file or touches the network.

## Limitations and non-claims

- **The CLI writes exactly one envelope line; it does not own the stream.** Unrelated diagnostics may appear before or after it, so neither "stderr contains only the envelope" nor "the envelope is the last line" is enforceable. Consumers locate the schema-bearing line; the tests and docs both state it that way, and a test proves selection still works with unrelated prose ahead of the envelope.
- **`message` for `snapshot-unreadable` embeds the decoder's own text**, which can include absolute paths and OS-localised strings. Bounded, sanitised and traceback-redacted, but not curated. Documented as untrusted human text; automation keys off `code`.
- **Separately worth a ticket, deliberately not touched here:** `loader.py` calls `np.load(..., allow_pickle=True)`, so a hostile `.npz` can execute code during load and control an exception's `__str__`. That is a loader concern outside this boundary; `scripts/dandelion.py` already uses `allow_pickle=False`, so there is precedent for fixing it.
- **Auto-upgrade covers runtime failures only.** A *usage* error on `info --json` stays human unless the global flag is given, because at that point argparse has not confirmed `--json` was valid in context.
- **Framing is asserted with `endswith("\n")` + `splitlines()`, not a newline count** — `print` emits the platform terminator, so the byte is CRLF on Windows.
- Issue #67 remains open; this does not complete it.
- pytest was not run locally; all test claims rest on CI.

## Status

**Ready for review, open and unmerged.** Synchronized with `main` at `779cedb6`; merge state CLEAN, zero behind. Auto-merge not enabled and merging is not authorized under the current pass — the merge decision rests with the reviewer. Both Codex review threads are resolved. Issue #67 not modified; #441–#443 and #456 untouched.
