### PR TITLE
Observatory: refuse pickle-backed NPZ snapshots

### DIFF
--- a/docs/OBSERVATORY_CLI_ERRORS.md
+++ b/docs/OBSERVATORY_CLI_ERRORS.md
@@ -309,10 +309,34 @@ no envelope. Absence of a matching line is how you tell them apart.
   contains an unpaired escape that strict parsers reject.
 - No traceback, and no unrestricted exception representation, is emitted.
 
-### Known limitation
+### Pickle-backed NPZ archives are refused
 
-`message` for `snapshot-unreadable` embeds the underlying decoder's text,
-which can include absolute paths and OS-localised strings. It is bounded and
-sanitised, but it is *not* a curated string. Treat `message` as untrusted
-human text — which rule 5 above already requires — and key automation off
-`code`.
+An `.npz` member of object dtype is stored as a pickle, so loading one with
+pickle enabled is arbitrary code execution by construction — and this route is
+reachable from a bare filename on the command line. The Observatory therefore
+opens every NPZ with `allow_pickle=False`.
+
+A snapshot carrying an object-dtype member is refused as an ordinary
+`snapshot-unreadable` input failure: exit status 1, one bounded human line or
+the version-1 envelope on stderr, empty stdout, no traceback.
+
+**This is deliberate, not a bug.** A pickle-backed legacy archive must be
+re-exported using numeric arrays. There is no flag, environment variable or
+compatibility mode to re-enable pickle, and no fallback retry — a compatibility
+escape hatch would reinstate exactly the execution path being removed. Ordinary
+snapshots are unaffected: they carry numeric arrays plus plain scalars, and
+legacy 3- and 5-channel numeric grids still migrate to eight channels as before.
+
+### Known limitations
+
+- **The pickle refusal is an object-array refusal, not whole-archive
+  validation.** No claim is made that an arbitrary `.npz` is safe or fully
+  validated. Decompression amplification, absurd declared shapes, hostile
+  member names and defects in NumPy's own header parsing are all out of scope.
+  What is guaranteed is narrower and precise: no member is ever handed to the
+  unpickler.
+- `message` for `snapshot-unreadable` embeds the underlying decoder's text,
+  which can include absolute paths and OS-localised strings. It is bounded and
+  sanitised, but it is *not* a curated string. Treat `message` as untrusted
+  human text — which rule 5 above already requires — and key automation off
+  `code`.

--- a/tests/test_observatory_cli.py
+++ b/tests/test_observatory_cli.py
@@ -1240,18 +1240,38 @@ def test_zero_size_lattice_does_not_crash_either_command(tmp_path, command, shap
                                  else "snapshot"] is not None
 
 
-# --- oversized counters through the genuine NPZ route ----------------------
+# --- oversized counters: the NPZ route is now closed -----------------------
 #
-# Reachability note. An ordinary portable-genome JSON file is NOT the route:
-# CPython applies the same integer-string ceiling when PARSING, so `json.load`
-# rejects an over-limit decimal literal before the loader ever sees it. The
-# NPZ route does reach it -- `load_npz` uses `allow_pickle=True` and then
-# `int(...)`, so a pickled Python int of any magnitude survives as a real int.
-# A snapshot built directly in a library call is the other valid witness.
+# An oversized counter -- past CPython's integer-to-string ceiling -- had
+# exactly one NPZ route: an object-dtype member, i.e. a pickle. No numeric
+# NumPy dtype can represent 10**100000, so there is no pickle-free way to
+# construct one.
+#
+# The loader now opens archives with `allow_pickle=False`, which closes that
+# route deliberately. These tests therefore no longer assert that such a
+# snapshot LOADS and is diagnosed; they assert that it is REFUSED, before
+# diagnostics run, as an ordinary `snapshot-unreadable` input failure.
+#
+# Restoring the old assertions would mean restoring the unsafe pickle path,
+# so it is not an option. The oversized-counter DIAGNOSTICS contract is
+# unaffected and remains covered directly, in memory, by
+# tests/test_observatory_diagnostics.py -- which constructs the snapshot
+# through the library rather than through a file and needs no pickle. That
+# file is untouched by this change.
+#
+# An ordinary portable-genome JSON file was never the route either: CPython
+# applies the same ceiling when PARSING, so `json.load` rejects an over-limit
+# decimal literal before the loader sees it.
+
+ERROR_SCHEMA = "utilityfog.observatory.error/1"
 
 
-def _write_oversized_snapshot(path, field="generation"):
-    """A real .npz whose counter is a huge pickled Python int."""
+def _write_pickle_backed_counter(path, field="generation"):
+    """An .npz whose counter is an object-dtype (pickled) huge integer.
+
+    Written, not loaded: `np.savez` pickles on the way in, which is inert.
+    The loader must refuse it on the way out.
+    """
     lattice = np.zeros((2, 3, 4), dtype=np.uint8)
     lattice[0, 0, 0] = 1
     payload = {
@@ -1266,37 +1286,49 @@ def _write_oversized_snapshot(path, field="generation"):
     return str(path)
 
 
-@pytest.mark.parametrize("field", ["generation", "ca_step"])
-@pytest.mark.parametrize("argv_tail", [[], ["--json"]])
-def test_oversized_counter_does_not_traceback_in_info(tmp_path, field, argv_tail):
-    """Human `info` formats the counters directly with `:,`, which raises on a
-    value past the digit ceiling; `info --json` serialized it verbatim and
-    raised inside the encoder. Neither may traceback."""
-    path = _write_oversized_snapshot(tmp_path / f"big_{field}.npz", field)
-    proc = _run_module("info", path, *argv_tail)
-    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
-    assert proc.returncode == 0
-    if argv_tail:
-        assert json.loads(proc.stdout)[field] is None
+def _error_envelope(stderr):
+    """The envelope is the JSON line carrying the error schema."""
+    for line in stderr.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            document = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(document, dict) and document.get("schema") == ERROR_SCHEMA:
+            return document
+    return None
 
 
 @pytest.mark.parametrize("field", ["generation", "ca_step"])
+@pytest.mark.parametrize("command", ["info", "doctor"])
 @pytest.mark.parametrize("argv_tail", [[], ["--json"]])
-def test_oversized_counter_is_reported_by_doctor(tmp_path, field, argv_tail):
-    """`doctor` must report it as a failed check, not die describing it."""
-    path = _write_oversized_snapshot(tmp_path / f"big_{field}.npz", field)
-    proc = _run_module("doctor", path, *argv_tail)
-    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+def test_pickle_backed_counter_is_refused_before_diagnostics(
+    tmp_path, field, command, argv_tail
+):
+    """Refused at load, so no diagnostics run and no report is produced.
+
+    Both commands, both fields, both output modes: status 1, empty stdout,
+    no traceback, and in JSON mode a version-1 `snapshot-unreadable` envelope
+    on stderr.
+    """
+    path = _write_pickle_backed_counter(tmp_path / f"big_{field}.npz", field)
+    proc = _run_module(command, path, *argv_tail)
+
     assert proc.returncode == 1
+    assert proc.stdout == "", f"a report was produced: {proc.stdout[:200]!r}"
+    assert "Traceback (most recent call last)" not in proc.stderr, proc.stderr
+
     if argv_tail:
-        document = json.loads(proc.stdout)
-        assert document["ok"] is False
-        failed = [c["name"] for c in document["checks"] if not c["ok"]]
-        assert f"{field}_non_negative_int" in failed
-        assert document["snapshot"][field] is None
+        document = _error_envelope(proc.stderr)
+        assert document is not None, f"no envelope on stderr: {proc.stderr[:300]!r}"
+        assert document["code"] == "snapshot-unreadable"
+        assert document["category"] == "input"
+        assert document["exit_status"] == 1
     else:
-        assert f"{field}_non_negative_int" in proc.stdout
-        assert "[FAIL]" in proc.stdout
+        assert proc.stderr.startswith("cosmic-observatory: error: ")
+        assert len(proc.stderr.strip().splitlines()) == 1
 
 
 def test_ordinary_counters_still_render_normally(tmp_path):

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -820,11 +820,12 @@ def _pickle_backed_npz(tmp_path):
     return str(path)
 
 
-def test_pickle_backed_npz_is_a_bounded_human_error(cli, capsys, tmp_path):
-    cli.use_real_loader()
+def test_pickle_backed_npz_is_a_bounded_human_error(capsys, tmp_path):
+    """Driven through `main()` directly: this module never patches the loader,
+    so the real decode path runs."""
     target = _pickle_backed_npz(tmp_path)
 
-    assert cli.run(["info", target]) == 1
+    assert cli_mod.main(["info", target]) == 1
 
     captured = capsys.readouterr()
     assert captured.out == ""
@@ -842,12 +843,11 @@ def test_pickle_backed_npz_is_a_bounded_human_error(cli, capsys, tmp_path):
     ],
     ids=["global-flag", "auto-upgrade"],
 )
-def test_pickle_backed_npz_emits_the_error_envelope(cli, capsys, tmp_path,
+def test_pickle_backed_npz_emits_the_error_envelope(capsys, tmp_path,
                                                     argv_prefix, tail):
-    cli.use_real_loader()
     target = _pickle_backed_npz(tmp_path)
 
-    assert cli.run([*argv_prefix, "info", target, *tail]) == 1
+    assert cli_mod.main([*argv_prefix, "info", target, *tail]) == 1
 
     document = _only_envelope(capsys, expect_status=1)
     assert document["code"] == "snapshot-unreadable"

--- a/tests/test_observatory_cli_errors.py
+++ b/tests/test_observatory_cli_errors.py
@@ -781,6 +781,99 @@ def test_help_through_the_public_route_stays_human():
 
 
 # ===========================================================================
+# A pickle-backed NPZ is an ordinary `snapshot-unreadable` input failure
+#
+# The loader refuses object-dtype members rather than unpickling them. At the
+# CLI boundary that must land on the established status-1 lane -- not as a
+# traceback, and not with the payload's representation leaking into the
+# message.
+# ===========================================================================
+
+
+_PICKLE_MARKER = "CLI_PICKLE_PAYLOAD_EXECUTED"
+
+
+def _touch_cli_marker(directory: str) -> str:
+    """Inert stand-in for a payload; writes one file inside pytest's tmp_path."""
+    marker = Path(directory) / _PICKLE_MARKER
+    marker.write_text("executed", encoding="utf-8")
+    return str(marker)
+
+
+class _CliPayloadOnUnpickle:
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_touch_cli_marker, (self._directory,))
+
+
+def _pickle_backed_npz(tmp_path):
+    np = pytest.importorskip("numpy")
+    path = tmp_path / "pickled.npz"
+    np.savez(
+        path,
+        lattice=np.array([_CliPayloadOnUnpickle(tmp_path)], dtype=object),
+        memory_grid=np.zeros((8, 2, 3, 4), dtype=np.float32),
+        generation=7, ca_step=11, best_fitness=0.25,
+    )
+    return str(path)
+
+
+def test_pickle_backed_npz_is_a_bounded_human_error(cli, capsys, tmp_path):
+    cli.use_real_loader()
+    target = _pickle_backed_npz(tmp_path)
+
+    assert cli.run(["info", target]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert len(captured.err.strip().splitlines()) == 1
+    assert "Traceback (most recent call last)" not in captured.err
+    assert captured.err.startswith("cosmic-observatory: error: ")
+    assert not (tmp_path / _PICKLE_MARKER).exists(), "the payload executed"
+
+
+@pytest.mark.parametrize(
+    "argv_prefix, tail",
+    [
+        (["--error-format", "json"], []),
+        ([], ["--json"]),
+    ],
+    ids=["global-flag", "auto-upgrade"],
+)
+def test_pickle_backed_npz_emits_the_error_envelope(cli, capsys, tmp_path,
+                                                    argv_prefix, tail):
+    cli.use_real_loader()
+    target = _pickle_backed_npz(tmp_path)
+
+    assert cli.run([*argv_prefix, "info", target, *tail]) == 1
+
+    document = _only_envelope(capsys, expect_status=1)
+    assert document["code"] == "snapshot-unreadable"
+    assert document["category"] == "input"
+    assert not (tmp_path / _PICKLE_MARKER).exists(), "the payload executed"
+
+    # The refusal names the mechanism, not the payload's repr.
+    serialized = json.dumps(document)
+    assert "Traceback" not in serialized
+    assert "_CliPayloadOnUnpickle" not in serialized
+
+
+def test_pickle_refusal_through_the_public_module_route(tmp_path):
+    """End to end, through a real process rather than the fixture."""
+    pytest.importorskip("numpy")
+    target = _pickle_backed_npz(tmp_path)
+    proc = _run_module("--error-format", "json", "doctor", target)
+
+    assert proc.returncode == 1
+    assert proc.stdout == ""
+    assert "Traceback (most recent call last)" not in proc.stderr
+    assert _envelope_line(proc.stderr)["code"] == "snapshot-unreadable"
+    assert not (tmp_path / _PICKLE_MARKER).exists(), "the payload executed"
+
+
+# ===========================================================================
 # Audit corrections
 # ===========================================================================
 

--- a/tests/test_observatory_loader.py
+++ b/tests/test_observatory_loader.py
@@ -188,14 +188,21 @@ def test_dtype_conversions_are_preserved():
     assert snapshot.memory_grid.dtype == np.float32
 
 
-def test_np_load_receives_str_path_and_allow_pickle():
+def test_np_load_receives_str_path_and_allow_pickle_false():
+    """`allow_pickle=False` is passed EXPLICITLY.
+
+    NumPy's default is already False, but relying on a default would make the
+    security property invisible at the call site and silently reversible by an
+    upstream change. The exact-dict comparison is what stops a fallback retry
+    or an extra flag being added without a test noticing.
+    """
     archive = _FakeArchive(_contents())
     _, load_mock = _load(archive, path=Path("/fake/dir/v070_gen7.npz"))
     assert load_mock.call_count == 1
     args, kwargs = load_mock.call_args
     assert args == (str(Path("/fake/dir/v070_gen7.npz")),)
     assert type(args[0]) is str
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_metadata_defaults_are_preserved_when_keys_are_absent():

--- a/tests/test_observatory_loader_security.py
+++ b/tests/test_observatory_loader_security.py
@@ -219,10 +219,15 @@ def test_loader_never_enables_pickle_anywhere(tmp_path):
 
 
 def test_no_pickle_enabling_escape_hatch_exists():
-    """No flag, environment variable or compatibility mode may re-enable it."""
+    """No flag, environment variable or compatibility mode may re-enable it.
+
+    Tokens are precise rather than substrings: a bare ``environ`` also matches
+    the ordinary English word "environment", which the docstring legitimately
+    uses when explaining that there is no environment override.
+    """
     source = Path(inspect.getsourcefile(loader)).read_text(encoding="utf-8")
     for banned in ("allow_pickle=True", "ALLOW_PICKLE", "allow-pickle",
-                   "getenv", "environ"):
+                   "os.getenv", "os.environ", "environ["):
         assert banned not in source, f"loader references {banned}"
 
 

--- a/tests/test_observatory_loader_security.py
+++ b/tests/test_observatory_loader_security.py
@@ -1,0 +1,362 @@
+"""Observatory NPZ loading refuses pickle.
+
+`np.load(..., allow_pickle=True)` hands an untrusted archive to the unpickler,
+and unpickling is arbitrary code execution by construction. This module proves
+the Observatory's NPZ route refuses object-dtype members instead, using a
+harmless payload that would leave a marker file if it were ever invoked.
+
+Scope of the claim, stated once and honestly: this is an **object-array
+refusal**, not whole-archive validation. Nothing here claims resistance to
+decompression amplification, absurd declared shapes, hostile member names or
+defects in NumPy's own header parsing. The same wording is used by
+`scripts/dandelion.py`, which made this change first (PR #432).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+# The Observatory package initializer imports `loader.py` and through it NumPy.
+# Guard before the package import so a missing optional stack is a clean skip.
+np = pytest.importorskip("numpy")
+
+from vis.observatory import loader
+
+NUM_CHANNELS = 8
+SHAPE = (2, 3, 4)
+
+#: Written only if a pickle payload is actually executed. Its absence after a
+#: load attempt is the proof that nothing ran.
+MARKER_NAME = "PICKLE_PAYLOAD_EXECUTED"
+
+
+def _create_marker(directory: str) -> str:
+    """Stand in for a malicious pickle payload.
+
+    Deliberately inert: it writes one small file inside the directory pytest
+    already owns and cleans up, and returns. A real payload would call
+    something far less pleasant -- the point is that the reduction is invoked
+    at all, not what it does.
+
+    Module scope is required: pickle stores a module-qualified reference, so a
+    function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / MARKER_NAME
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadOnUnpickle:
+    """An object whose reduction calls :func:`_create_marker` when unpickled.
+
+    `__reduce__` is evaluated at PICKLE time and merely records the callable
+    and its arguments; the call happens at UNPICKLE time. So writing this into
+    an archive is safe, and only loading it with pickle enabled would fire.
+    """
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker, (self._directory,))
+
+
+def _payload_array(directory):
+    """A 1-element object array carrying the payload."""
+    return np.array([_PayloadOnUnpickle(directory)], dtype=object)
+
+
+def _lattice():
+    return np.zeros(SHAPE, dtype=np.uint8)
+
+
+def _grid(channels=NUM_CHANNELS):
+    return np.zeros((channels,) + SHAPE, dtype=np.float32)
+
+
+def _write(path, **members):
+    """Write an NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": _lattice(),
+        "memory_grid": _grid(),
+        "generation": 7,
+        "ca_step": 11,
+        "best_fitness": 0.25,
+    }
+    payload.update(members)
+    np.savez(path, **payload)
+    return str(path) if str(path).endswith(".npz") else f"{path}.npz"
+
+
+def _marker(tmp_path):
+    return tmp_path / MARKER_NAME
+
+
+# ---------------------------------------------------------------------------
+# The payload fixture is real: it fires when pickle is enabled
+# ---------------------------------------------------------------------------
+
+
+def test_the_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """A control on the other tests. If this did not fire, every "marker is
+    absent" assertion below would be vacuous -- they would pass against a
+    payload that never worked in the first place.
+
+    This deliberately calls `np.load` directly with pickle ENABLED. It does not
+    go through the Observatory loader, and it is the only place in the suite
+    that does so.
+    """
+    archive = _write(tmp_path / "control.npz", lattice=_payload_array(tmp_path))
+    assert not _marker(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+# ---------------------------------------------------------------------------
+# Required arrays
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid"])
+def test_object_payload_in_a_required_array_is_refused(tmp_path, field):
+    archive = _write(tmp_path / f"{field}.npz", **{field: _payload_array(tmp_path)})
+
+    with pytest.raises(ValueError) as excinfo:
+        loader.load_npz(archive)
+
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker(tmp_path).exists(), "the pickle payload executed"
+
+
+# ---------------------------------------------------------------------------
+# Recognized metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step", "best_fitness"])
+def test_object_payload_in_recognized_metadata_is_refused(tmp_path, field):
+    """`.get(key, default)` decodes the member when the key is present, so a
+    metadata field is just as much an execution site as a required array."""
+    archive = _write(tmp_path / f"{field}.npz", **{field: _payload_array(tmp_path)})
+
+    with pytest.raises(ValueError) as excinfo:
+        loader.load_npz(archive)
+
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker(tmp_path).exists(), "the pickle payload executed"
+
+
+@pytest.mark.parametrize("field", ["generation", "ca_step", "best_fitness"])
+def test_object_bearing_structured_metadata_is_refused(tmp_path, field):
+    """A structured dtype can hide an object field, so `kind == 'O'` alone is
+    not the test -- NumPy's own refusal covers `dtype.hasobject`."""
+    structured = np.empty((1,), dtype=[("payload", "O"), ("n", "i4")])
+    structured["payload"][0] = _PayloadOnUnpickle(tmp_path)
+    structured["n"][0] = 1
+    archive = _write(tmp_path / f"struct_{field}.npz", **{field: structured})
+
+    with pytest.raises(ValueError):
+        loader.load_npz(archive)
+
+    assert not _marker(tmp_path).exists(), "the pickle payload executed"
+
+
+# ---------------------------------------------------------------------------
+# Unreferenced members
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreferenced_hostile_member_is_never_deserialized(tmp_path):
+    """NumPy's NPZ access is lazy: a member is decoded only when read. An extra
+    member the Observatory never asks for is therefore ignored, not executed.
+
+    The snapshot itself is well-formed, so this must LOAD successfully -- an
+    unreferenced member is not grounds for refusal.
+    """
+    archive = _write(tmp_path / "extra.npz", unreferenced=_payload_array(tmp_path))
+
+    snapshot = loader.load_npz(archive)
+
+    assert snapshot.lattice.dtype == np.uint8
+    assert snapshot.memory_grid.dtype == np.float32
+    assert not _marker(tmp_path).exists(), "an unread member was deserialized"
+
+
+# ---------------------------------------------------------------------------
+# No escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_loader_never_enables_pickle_anywhere(tmp_path):
+    """Parsed, not grepped: every `np.load` call in the loader must pass
+    `allow_pickle=False` explicitly. A bare call inherits NumPy's default,
+    which is False today but is not a contract this module should rely on.
+    """
+    source = Path(inspect.getsourcefile(loader)).read_text(encoding="utf-8")
+    calls = 0
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name != "load":
+            continue
+        calls += 1
+        keywords = {kw.arg: kw.value for kw in node.keywords}
+        assert "allow_pickle" in keywords, "np.load must set allow_pickle explicitly"
+        value = keywords["allow_pickle"]
+        assert isinstance(value, ast.Constant) and value.value is False, (
+            "allow_pickle must be the literal False, not a variable or flag"
+        )
+    assert calls >= 1, "no np.load call found in the loader"
+
+
+def test_no_pickle_enabling_escape_hatch_exists():
+    """No flag, environment variable or compatibility mode may re-enable it."""
+    source = Path(inspect.getsourcefile(loader)).read_text(encoding="utf-8")
+    for banned in ("allow_pickle=True", "ALLOW_PICKLE", "allow-pickle",
+                   "getenv", "environ"):
+        assert banned not in source, f"loader references {banned}"
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    """A fallback retry would defeat the whole change. The refusal must be
+    terminal: exactly one archive open, and no second attempt."""
+    archive = _write(tmp_path / "retry.npz", lattice=_payload_array(tmp_path))
+
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(loader.np, "load", _recording_load)
+
+    with pytest.raises(ValueError):
+        loader.load_npz(archive)
+
+    assert calls == [False], f"expected exactly one pickle-free open, got {calls}"
+    assert not _marker(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# Archive closure on refusal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
+def test_the_archive_is_closed_when_a_member_is_refused(tmp_path, field):
+    """The refusal happens at member access, inside the context. The handle
+    must still be released -- on Windows a retained handle blocks deleting or
+    rotating the snapshot."""
+    target = tmp_path / f"closed_{field}.npz"
+    archive = _write(target, **{field: _payload_array(tmp_path)})
+
+    with pytest.raises(ValueError):
+        loader.load_npz(archive)
+
+    # If the handle leaked, this raises PermissionError on Windows.
+    Path(archive).unlink()
+    assert not Path(archive).exists()
+
+
+# ---------------------------------------------------------------------------
+# Numeric compatibility is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_a_numeric_snapshot_still_loads_and_converts(tmp_path):
+    archive = _write(
+        tmp_path / "numeric.npz",
+        lattice=np.ones(SHAPE, dtype=np.int32),
+        memory_grid=np.ones((NUM_CHANNELS,) + SHAPE, dtype=np.float64),
+        generation=np.int64(5),
+        ca_step=np.int64(6),
+        best_fitness=np.float32(0.5),
+    )
+    snapshot = loader.load_npz(archive)
+    assert snapshot.lattice.dtype == np.uint8
+    assert snapshot.memory_grid.dtype == np.float32
+    assert snapshot.generation == 5 and type(snapshot.generation) is int
+    assert snapshot.ca_step == 6 and type(snapshot.ca_step) is int
+    assert snapshot.best_fitness == pytest.approx(0.5)
+    assert type(snapshot.best_fitness) is float
+
+
+def test_metadata_defaults_survive(tmp_path):
+    path = tmp_path / "bare.npz"
+    np.savez(path, lattice=_lattice(), memory_grid=_grid())
+    snapshot = loader.load_npz(str(path))
+    assert (snapshot.generation, snapshot.ca_step, snapshot.best_fitness) == (0, 0, 0.0)
+
+
+@pytest.mark.parametrize("channels", [3, 5])
+def test_legacy_numeric_grids_still_migrate_to_eight_channels(tmp_path, channels):
+    archive = _write(tmp_path / f"legacy{channels}.npz", memory_grid=_grid(channels))
+    snapshot = loader.load_npz(archive)
+    assert snapshot.memory_grid.shape == (NUM_CHANNELS,) + SHAPE
+    assert snapshot.memory_grid.dtype == np.float32
+
+
+def test_load_snapshot_inherits_the_refusal(tmp_path):
+    """The public dispatch route, not just `load_npz` directly."""
+    archive = _write(tmp_path / "dispatch.npz", lattice=_payload_array(tmp_path))
+    with pytest.raises(ValueError):
+        loader.load_snapshot(archive)
+    assert not _marker(tmp_path).exists()
+
+
+def test_series_loading_inherits_the_refusal(tmp_path):
+    """One hostile member in a series must not execute, and the archives
+    already opened must be closed before the failure propagates."""
+    series = tmp_path / "series"
+    series.mkdir()
+    np.savez(series / "v070_000.npz", lattice=_lattice(), memory_grid=_grid())
+    np.savez(series / "v070_001.npz", lattice=_payload_array(tmp_path),
+             memory_grid=_grid())
+
+    with pytest.raises(ValueError):
+        loader.load_snapshot_series(str(series))
+
+    assert not _marker(tmp_path).exists()
+    for member in sorted(series.glob("*.npz")):
+        member.unlink()          # raises if a handle leaked
+
+
+def test_a_clean_series_still_loads(tmp_path):
+    series = tmp_path / "clean"
+    series.mkdir()
+    for index in range(2):
+        np.savez(series / f"v070_{index:03d}.npz",
+                 lattice=_lattice(), memory_grid=_grid(), generation=index)
+    snapshots = loader.load_snapshot_series(str(series))
+    assert len(snapshots) == 2
+    assert [s.generation for s in snapshots] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Established failure modes are unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_required_key_still_raises_keyerror(tmp_path):
+    path = tmp_path / "nokeys.npz"
+    np.savez(path, memory_grid=_grid())
+    with pytest.raises(KeyError):
+        loader.load_npz(str(path))
+
+
+def test_a_corrupt_archive_still_raises(tmp_path):
+    path = tmp_path / "corrupt.npz"
+    path.write_bytes(b"not an npz at all")
+    with pytest.raises(Exception) as excinfo:
+        loader.load_npz(str(path))
+    assert not isinstance(excinfo.value, AssertionError)

--- a/tests/test_observatory_loader_security.py
+++ b/tests/test_observatory_loader_security.py
@@ -153,18 +153,63 @@ def test_object_payload_in_recognized_metadata_is_refused(tmp_path, field):
     assert not _marker(tmp_path).exists(), "the pickle payload executed"
 
 
+def _structured_payload(directory):
+    """A structured dtype hiding the payload in an object field."""
+    structured = np.empty((1,), dtype=[("payload", "O"), ("n", "i4")])
+    structured["payload"][0] = _PayloadOnUnpickle(directory)
+    structured["n"][0] = 1
+    return structured
+
+
+def test_the_structured_payload_also_fires_when_pickle_is_enabled(tmp_path):
+    """Control for the structured variant specifically.
+
+    The plain object-array payload has its own control above, but a structured
+    dtype takes a different path through NumPy's descriptor handling. Without
+    this, the structured refusal test's "marker is absent" assertion could pass
+    against a payload that was never live in that shape.
+    """
+    archive = _write(tmp_path / "struct_control.npz",
+                     generation=_structured_payload(tmp_path))
+    assert not _marker(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["generation"]
+
+    assert _marker(tmp_path).exists(), "the structured payload is inert; fix it"
+
+
 @pytest.mark.parametrize("field", ["generation", "ca_step", "best_fitness"])
 def test_object_bearing_structured_metadata_is_refused(tmp_path, field):
     """A structured dtype can hide an object field, so `kind == 'O'` alone is
     not the test -- NumPy's own refusal covers `dtype.hasobject`."""
-    structured = np.empty((1,), dtype=[("payload", "O"), ("n", "i4")])
-    structured["payload"][0] = _PayloadOnUnpickle(tmp_path)
-    structured["n"][0] = 1
-    archive = _write(tmp_path / f"struct_{field}.npz", **{field: structured})
+    archive = _write(tmp_path / f"struct_{field}.npz",
+                     **{field: _structured_payload(tmp_path)})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         loader.load_npz(archive)
 
+    # Assert the SPECIFIC refusal: a bare `ValueError` would also be satisfied
+    # by an unrelated failure elsewhere in the load path.
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker(tmp_path).exists(), "the pickle payload executed"
+
+
+def test_a_compressed_archive_is_refused_the_same_way(tmp_path):
+    """Real producers use `np.savez_compressed`, so the hostile fixture should
+    exercise that shape too rather than only the uncompressed one."""
+    path = tmp_path / "compressed.npz"
+    np.savez_compressed(
+        path,
+        lattice=_payload_array(tmp_path),
+        memory_grid=_grid(),
+        generation=7, ca_step=11, best_fitness=0.25,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        loader.load_npz(str(path))
+
+    assert "allow_pickle=False" in str(excinfo.value)
     assert not _marker(tmp_path).exists(), "the pickle payload executed"
 
 

--- a/vis/observatory/cli.py
+++ b/vis/observatory/cli.py
@@ -424,9 +424,19 @@ def _unreadable_input_errors():
     Deliberately assembled rather than replaced by a bare ``except Exception``:
     the tuple is what separates a bad *file* from a bad *program*. NumPy signals
     a damaged archive in several unrelated ways -- an empty file raises
-    ``EOFError``, non-archive bytes fall through to the pickle path and raise
-    ``UnpicklingError``, a corrupt member raises ``BadZipFile`` or ``zlib.error``
-    -- and none of those derive from ``OSError`` or ``ValueError``.
+    ``EOFError``, a corrupt member raises ``BadZipFile`` or ``zlib.error`` --
+    and neither of those derives from ``OSError`` or ``ValueError``.
+
+    The Observatory loader now opens archives with ``allow_pickle=False``, so
+    non-archive bytes and pickle-backed members are refused BEFORE any
+    unpickling, normally as ``ValueError``. That refusal is already covered by
+    ``ValueError`` below.
+
+    ``pickle.UnpicklingError`` is retained conservatively: this tuple is shared
+    by every input-translation site, and keeping it costs nothing. Its presence
+    describes what would be *translated* if it ever arrived -- it does not
+    enable, authorise or imply pickle anywhere. Nothing in this package
+    unpickles.
     """
     import pickle
     import zlib
@@ -650,8 +660,12 @@ def _dispatch(args):
         print(f"Source:     {_one_line(snap.source_path)}")
         print(f"Shape:      {snap.shape}")
         # Through the shared formatter: `{:,}` raises ValueError on an integer
-        # past CPython's decimal-rendering ceiling, which the NPZ route can
-        # carry (it loads with allow_pickle=True and then calls int()).
+        # past CPython's decimal-rendering ceiling. That value can still arrive
+        # by DIRECT LIBRARY CONSTRUCTION -- a snapshot assembled in memory is a
+        # supported seam -- so the formatter's robustness remains necessary.
+        # It can no longer arrive through the NPZ route: an integer that large
+        # has only an object-array representation, and the loader refuses those
+        # with `allow_pickle=False` before anything reaches formatting.
         # Ordinary counters render exactly as before.
         print(f"Generation: {diagnostics.format_count(snap.generation)}")
         print(f"CA Step:    {diagnostics.format_count(snap.ca_step)}")

--- a/vis/observatory/loader.py
+++ b/vis/observatory/loader.py
@@ -126,15 +126,44 @@ def load_npz(path: str | Path) -> ObservatorySnapshot:
     closed deterministically before any of that later work begins. Extraction
     failures are not caught, translated or suppressed: a missing key or a failing
     metadata conversion propagates exactly as before, and the `with` block still
-    closes the archive on the way out. `str(path)`, `allow_pickle=True`, the
-    `0` / `0` / `0.0` metadata defaults and the `int()` / `float()` conversions
-    are preserved verbatim.
+    closes the archive on the way out. `str(path)`, the `0` / `0` / `0.0`
+    metadata defaults and the `int()` / `float()` conversions are preserved
+    verbatim.
 
-    The claim is archive resource lifetime relative to extraction — not an
-    indefinitely accumulating descriptor leak, and not snapshot validation.
+    ``allow_pickle=False`` -- no pickle, ever
+    ----------------------------------------
+    An NPZ member of object dtype is stored as a pickle, so loading one with
+    pickle enabled is arbitrary code execution by construction. This route is
+    reachable from a bare filename on the command line, so the archive is
+    opened with ``allow_pickle=False`` and NumPy refuses such a member with a
+    ``ValueError`` instead of unpickling it. That refusal is already in the
+    CLI's translated-input set, so it surfaces as an ordinary
+    ``snapshot-unreadable`` failure rather than a traceback.
+
+    Passed EXPLICITLY although NumPy's default is already ``False``: relying on
+    the default would make the property invisible at the call site and
+    silently reversible by an upstream change. There is deliberately no
+    fallback retry, no flag and no environment override -- a compatibility
+    escape hatch would reinstate exactly the execution path being removed.
+
+    No legitimate producer in this repository is affected. Snapshots carry
+    numeric arrays plus plain scalars, and the same decision was already taken
+    for `scripts/dandelion.py` (PR #432) and for the nextness, calibration,
+    engine-resume and replicate loaders.
+
+    The claim is an OBJECT-ARRAY REFUSAL, not whole-archive validation: nothing
+    here resists decompression amplification, absurd declared shapes, hostile
+    member names or defects in NumPy's own header parsing. A pickle-backed
+    legacy archive is refused by design and must be re-exported with numeric
+    arrays.
+
+    The other claim is archive resource lifetime relative to extraction — not
+    an indefinitely accumulating descriptor leak, and not snapshot validation.
+    Both hold on refusal too: the member is decoded inside the ``with`` block,
+    so the handle is released whether extraction succeeds or is refused.
     """
     path = Path(path)
-    with np.load(str(path), allow_pickle=True) as snap:
+    with np.load(str(path), allow_pickle=False) as snap:
         lattice = snap["lattice"]
         memory_grid = snap["memory_grid"]
         generation = int(snap.get("generation", 0))


### PR DESCRIPTION
Security-hardening follow-up to PR #455. Related context: issue #67 remains a broader CLI-UX epic and is not completed by this PR.

## Pins

| | |
|---|---|
| Base (`main`) | `a5476d752a57d7d5aef4d35fe896a154e70339f4` |
| Head | `b88197e263d26b90fd5874a452f1e8c28e80b688` |
| Branch | `security/observatory-npz-pickle-free` |
| Original base | `be349b7a` (before synchronization) |

| Commit | |
|---|---|
| `9fa91eb` | tests: failing-first proof (**deliberate red**) |
| `e8ddfa8` | Observatory: refuse pickle-backed NPZ snapshots |
| `70d4377` | tests: make the escape-hatch scan use precise tokens |
| `e5e81a5` | Merge branch 'main' (synchronization) |
| `fc2a71a` | tests: align oversized-counter route with pickle refusal |
| `a1ebc1c` | tests: strengthen the structured-payload and compressed-archive proofs |
| `b88197e` | docs(observatory): align CLI comments with pickle refusal |

Synchronized once with `main` at `a5476d75` (merged #456, `experiments/tech_ledger/README.md` only, +29/−1, file-disjoint). All five package blobs verified byte-identical across the merge.

## The threat

An `.npz` member of object dtype is stored as a **pickle**. `vis/observatory/loader.py` opened every archive with `allow_pickle=True`, so unpickling — arbitrary code execution by construction — happened on a path reachable from a bare filename on the command line:

```
python -m vis.observatory info hostile.npz
```

The loader now passes `allow_pickle=False`, so NumPy refuses such a member with a `ValueError` instead of executing it.

Passed **explicitly** although NumPy's default is already `False`: relying on a default makes the property invisible at the call site and silently reversible upstream. There is no fallback retry, no flag and no environment override — a compatibility escape hatch would reinstate exactly the execution path being removed.

## Compatibility decision

**No legitimate producer in this repository is affected.**

- The canonical producer `scripts/run_v070_engine.py:223` writes ndarrays plus plain Python scalars.
- `scripts/ca/replicate.py:601` writes ndarrays.
- **Six loaders here were already pickle-free** — `scripts/dandelion.py:229` (#432), `nextness_observer`, `nextness_calibration`, `run_v070_engine`, `ca/replicate`, `workstream_b_profile_predicates`. The Observatory was the holdout, not a special case.

**A pickle-backed legacy archive is refused by design** and must be re-exported with numeric arrays. This is documented as deliberate, not a bug.

Everything else is untouched: metadata defaults, the `int()`/`float()` conversions, the `uint8`/`float32` casts, the legacy 3/5→8-channel migration and its `ImportError` zero-padding fallback, `load_snapshot` dispatch and `load_snapshot_series`. Portable-genome JSON is unaffected — it decodes base64, never `np.load`.

The refusal is a `ValueError`, already in the CLI's `_unreadable_input_errors()` tuple, so it surfaces as an ordinary `snapshot-unreadable` input failure — exit 1, one bounded human line or the version-1 envelope on stderr, empty stdout, no traceback. **No CLI change was needed.**

## Invalidated historical witness — disclosed

PR #451 established the oversized-counter contract (a `generation` past CPython's integer-to-string ceiling) and documented its NPZ reachability as: *"the NPZ route does reach it — `load_npz` uses `allow_pickle=True` and then `int(...)`."*

That was true, and this change **deliberately closes it**. An oversized counter had exactly one NPZ route: an object-dtype member, i.e. a pickle. No numeric NumPy dtype can represent `10**100000`, so there is no pickle-free way to construct one. Restoring the old assertions would mean restoring the unsafe path.

`tests/test_observatory_cli.py` therefore now asserts what is actually true — such a snapshot is **refused before diagnostics run**, both fields × both commands × both output modes, status 1, empty stdout, no traceback, bounded human line or `snapshot-unreadable` envelope. `test_ordinary_counters_still_render_normally` is preserved unchanged.

**The oversized-counter diagnostics contract is not lost.** It remains covered directly, in memory, by `tests/test_observatory_diagnostics.py` — which builds the snapshot through the library rather than through a file and needs no pickle (`test_oversized_counter_fails_its_check_with_a_bounded_detail`, `test_oversized_counter_serializes_as_null`, `test_oversized_counter_keeps_human_doctor_total`, `test_large_but_representable_counter_stays_exact`). **That file is deliberately untouched by this PR.**

## Failing-first evidence

`9fa91eb` (tests only) → CI run **31021578651**: **`16 failed, 4012 passed, 13 skipped, 3 errors`**.

The proof is a harmless payload: a module-level class whose `__reduce__` returns `(_create_marker, (tmp_path,))`. `__reduce__` runs at *pickle* time and only records the callable, so writing the archive is inert; the call happens at *unpickle* time. If the loader unpickles it, one marker file appears inside pytest's own temporary directory. Nothing hostile is constructed and nothing escapes `tmp_path`.

`test_the_payload_fixture_actually_fires_when_pickle_is_enabled` is the control — it loads with `allow_pickle=True` directly, the only place in the suite that does, and asserts the marker **does** appear. Without it every "marker is absent" assertion would be vacuous.

A second control covers the structured-dtype variant specifically, since it takes a different path through NumPy's descriptor handling.

## Coverage

Hostile payload in: each required array (`lattice`, `memory_grid`); each recognized metadata field (`.get(key, default)` decodes a present key just as `__getitem__` does); an object-bearing **structured** dtype, which a `kind == 'O'` check would miss; a **compressed** archive, matching what real producers write; and an **unreferenced extra member**, which must stay ignored rather than executed and must not make a well-formed snapshot fail.

Plus: archive closure on refusal (asserted by unlinking afterwards — a leaked handle raises on Windows); no fallback retry (every `np.load` call recorded, asserted `== [False]`); no environment/flag escape hatch (AST-parsed, requiring the literal `False`); `load_snapshot` and `load_snapshot_series` inheriting the refusal; numeric compatibility — dtype conversion, metadata defaults, NumPy-scalar metadata, legacy 3/5-channel migration; and the established missing-key and corrupt-archive behaviour.

At the CLI: human and JSON refusal, in-process and through the real `python -m vis.observatory` route.

## Receipts

| | |
|---|---|
| Deliberate red | run `31021578651` — `16 failed, 4012 passed, 13 skipped, 3 errors` |
| Boundary-correction red | run `31022300445` — 8 failed, all in `tests/test_observatory_cli.py` |
| Branch/push (informational) | run `31061701553`, job `92490827472` — 4033 passed |
| PR-event at `a1ebc1c` | run `31061904069`, job `92491419876` — `4033 passed, 13 skipped in 82.29s` |
| **Final authoritative (PR-event, head `b88197e`)** | run **`31066838751`**, `verify-python` job **`92506209720`** — **`4033 passed, 13 skipped in 68.02s`** |

*An earlier revision of this body named the push-event run `31061701553` as "Final". That was wrong — the PR-event job is authoritative, and the row above is that job at the current head.*

All checks green. `py_compile` on every changed Python file exit 0; `git diff --check` clean; no duplicate test names. **pytest is not runnable in this seat** (no NumPy/pytest); nothing was installed; CI is authoritative.

## Changed files — exactly seven, **+665 / −54**

| File | + | − |
|---|---|---|
| `tests/test_observatory_loader_security.py` (new) | 412 | 0 |
| `tests/test_observatory_cli_errors.py` | 93 | 0 |
| `tests/test_observatory_cli.py` | 65 | 33 |
| `vis/observatory/loader.py` | 36 | 7 |
| `docs/OBSERVATORY_CLI_ERRORS.md` | 31 | 7 |
| `vis/observatory/cli.py` | 19 | 5 |
| `tests/test_observatory_loader.py` | 9 | 2 |

Two boundary expansions, both approved after the package stopped rather than widening on its own: `tests/test_observatory_cli.py` (the obsolete oversized-counter NPZ block) and `vis/observatory/cli.py` (**comment/docstring only** — verified by comparing the AST of both revisions with docstrings stripped: identical, so no executable behaviour, import, exception tuple or control flow changed).

## Review findings

Two read-only reviews were run on the final diff. Three findings were accepted and fixed in `a1ebc1c`: the structured-dtype refusal asserted only a bare `ValueError`; the structured payload had no "fires" control; and no hostile fixture used `savez_compressed`.

**Corrected in `b88197e`** — both flagged independently by the two lanes, both now fixed after the boundary was expanded to include `vis/observatory/cli.py` for comments only:

1. The human `info` counter comment claimed the NPZ route can carry an oversized integer "because it loads with `allow_pickle=True`". It now states the truth: such a value can still arrive by **direct library construction** — a supported in-memory seam, so the formatter's robustness remains necessary — but no longer through the NPZ route, because an integer that large has only an object-array representation and the loader refuses those before formatting.
2. `_unreadable_input_errors()` claimed non-archive bytes "fall through to the pickle path and raise `UnpicklingError`". They are now refused before any unpickling, normally as `ValueError`. `pickle.UnpicklingError` **remains in the tuple, unchanged and conservative**; the docstring now makes explicit that its presence describes what would be *translated* if it arrived and does **not** enable, authorise or imply pickle anywhere.

**Still disclosed, deliberately not implemented here — separate future work:**

3. **Other pickle-enabled load sites remain**, several CLI-reachable from a bare filename: `scripts/portable_genome.py:733`, `scripts/acoustic_map.py:347`, `scripts/geometry_daemon.py:71`, `scripts/gpu_benchmark.py:108`, `scripts/lucid_server.py:51`, `scripts/medusa_api.py:103`. `portable_genome.py` is notable because the Observatory imports from that module. This PR makes no repo-wide claim.
4. A *numeric* `.npy` renamed to `.npz` makes `np.load` return an ndarray, so the `with` statement raises `TypeError` — not in the translated tuple, so it tracebacks rather than producing the bounded line. **Pre-existing**, unrelated to pickle, and outside the boundary. (The object-dtype variant of this is safe: `ValueError`, translated correctly.)

## Known limitations

**This is an object-array refusal, not whole-archive validation.** No claim is made that an arbitrary `.npz` is safe or fully validated. Decompression amplification, absurd declared shapes, hostile member names and defects in NumPy's own header parsing are all out of scope. What is guaranteed is narrower and precise: **no member is ever handed to the unpickler.** The same wording is used by `scripts/dandelion.py`, which made this change first.

## Final status

**Merged** as `feba238c579d7f7efec4204069d4ece48a1a50c1` at `2026-08-06T06:50:45Z`. Live `main` equals that merge commit. Auto-merge was never enabled; the remote branch was automatically deleted by the repository’s existing setting.

Issue #67 experienced an unintended status transition caused by the former opening-line wording and was restored to **OPEN** under explicit authorization. Its content, comments, labels, milestone and assignees were not changed. PRs #441–#443 remained untouched.


