### PR TITLE
Snapshot consumers: refuse pickle-backed NPZ members

### DIFF
--- a/scripts/acoustic_map.py
+++ b/scripts/acoustic_map.py
@@ -334,8 +334,19 @@ def run_acoustic_diagnostic(snapshot_path: str, num_steps: int = 200):
     Extraction is not guarded: a missing key or a failing ``int()`` conversion
     propagates exactly as before, and the ``with`` block still closes the archive
     on the way out. The ``snapshot_path`` argument is passed to ``np.load``
-    unchanged (no path conversion is introduced) and ``allow_pickle=True`` is
-    preserved verbatim.
+    unchanged (no path conversion is introduced).
+
+    ``allow_pickle=False`` -- an object-dtype member is stored as a pickle, so
+    loading one with pickle enabled is arbitrary code execution. The snapshot
+    path here comes straight from ``sys.argv``, so NumPy now refuses such a
+    member with a ``ValueError`` rather than unpickling it. Passed explicitly
+    although it is already NumPy's default, because relying on a default makes
+    the property invisible at the call site and silently reversible upstream.
+    There is deliberately no fallback retry and no override.
+
+    That refusal is an OBJECT-MEMBER REFUSAL, not whole-archive validation:
+    nothing here resists decompression amplification, absurd declared shapes,
+    hostile member names or defects in NumPy's own header parsing.
 
     The claim is archive resource lifetime relative to extraction — not an
     indefinitely accumulating descriptor leak, not snapshot validation, and
@@ -344,7 +355,7 @@ def run_acoustic_diagnostic(snapshot_path: str, num_steps: int = 200):
     from scripts.continuous_evolution_ca import step_ca_lattice, load_rule_spec, init_memory_grid
 
     print(f"Loading snapshot: {snapshot_path}")
-    with np.load(snapshot_path, allow_pickle=True) as snap:
+    with np.load(snapshot_path, allow_pickle=False) as snap:
         lattice = snap["lattice"]
         memory_grid = snap["memory_grid"]
         gen = int(snap["generation"])

--- a/scripts/geometry_daemon.py
+++ b/scripts/geometry_daemon.py
@@ -63,12 +63,23 @@ def _load_snapshot(path):
     or a failing `int()` conversion propagates exactly as before, and the `with`
     block still closes the archive on the way out.
 
-    `allow_pickle=True` and the `str(path)` conversion are preserved verbatim;
-    changing that policy is out of scope. The claim here is archive resource
-    lifetime only — not snapshot validation, archive security, deterministic
-    export or atomic output.
+    The `str(path)` conversion is preserved verbatim.
+
+    `allow_pickle=False` — an object-dtype member is stored as a pickle, so
+    loading one with pickle enabled is arbitrary code execution. This daemon
+    loads unattended from a watched directory, so a file dropped into `data/`
+    would be unpickled with nobody present; NumPy now refuses such a member
+    with a `ValueError` instead. Passed explicitly although it is already
+    NumPy's default, because relying on a default makes the property invisible
+    at the call site and silently reversible upstream. There is deliberately
+    no fallback retry and no override.
+
+    The claim here is an OBJECT-MEMBER REFUSAL plus archive resource lifetime
+    — not snapshot validation, whole-archive security, deterministic export or
+    atomic output. Nothing here resists decompression amplification, absurd
+    declared shapes, hostile member names or NumPy header defects.
     """
-    with np.load(str(path), allow_pickle=True) as snap:
+    with np.load(str(path), allow_pickle=False) as snap:
         state = snap["lattice"]
         memory_grid = snap["memory_grid"]
         generation = int(snap["generation"])

--- a/scripts/gpu_benchmark.py
+++ b/scripts/gpu_benchmark.py
@@ -98,14 +98,25 @@ def _load_snapshot(snapshot_path):
     Extraction is not guarded: a missing key or a failing `int()` conversion
     propagates exactly as before, and the `with` block still closes the archive
     on the way out. The supplied `snapshot_path` object is passed to `np.load`
-    unchanged (no path conversion introduced) and `allow_pickle=True` is
-    preserved verbatim.
+    unchanged (no path conversion introduced).
+
+    `allow_pickle=False` — an object-dtype member is stored as a pickle, so
+    loading one with pickle enabled is arbitrary code execution. `--snapshot`
+    is forwarded here straight from argparse, so NumPy now refuses such a
+    member with a `ValueError` rather than unpickling it. Passed explicitly
+    although it is already NumPy's default, because relying on a default makes
+    the property invisible at the call site and silently reversible upstream.
+    There is deliberately no fallback retry and no override.
+
+    That refusal is an OBJECT-MEMBER REFUSAL, not whole-archive validation:
+    nothing here resists decompression amplification, absurd declared shapes,
+    hostile member names or defects in NumPy's own header parsing.
 
     The claim is archive resource lifetime relative to extraction — not an
     indefinitely accumulating descriptor leak, not snapshot validation, and
     nothing about the benchmark mathematics or timing methodology.
     """
-    with np.load(snapshot_path, allow_pickle=True) as snap:
+    with np.load(snapshot_path, allow_pickle=False) as snap:
         lattice = snap["lattice"]
         memory_grid = snap["memory_grid"]
         generation = int(snap["generation"])

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -14,6 +14,7 @@ The server:
 """
 
 import asyncio
+import contextlib
 import json
 import glob
 import time
@@ -72,12 +73,23 @@ def extract_render_data(snap_path):
     still open. Closure is explicit, not left to garbage collection, and it
     holds on refusal too because the members are read inside the block.
 
+    Ownership is CONDITIONAL because ``np.load`` returns two different kinds of
+    thing. A zip archive yields an ``NpzFile``, which owns an operating-system
+    handle and needs that deterministic close. A ``.npy`` yields a plain
+    ndarray (or a memmap), which owns no handle and has no context-manager
+    protocol; wrapping it in ``nullcontext`` lets it reach the same
+    ``snap['lattice']`` subscript that has always been where a non-archive
+    input fails. The archive gains closure without the array losing its
+    established exception.
+
     The claim is an OBJECT-MEMBER REFUSAL and archive resource lifetime -- not
     whole-archive validation. Nothing here resists decompression
     amplification, absurd declared shapes, hostile member names or defects in
     NumPy's own header parsing.
     """
-    with np.load(snap_path, allow_pickle=False) as snap:
+    loaded = np.load(snap_path, allow_pickle=False)
+    owner = contextlib.nullcontext(loaded) if isinstance(loaded, np.ndarray) else loaded
+    with owner as snap:
         state = snap['lattice']
         mg = snap['memory_grid']
         gen = int(snap['generation'])

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -54,9 +54,10 @@ def extract_render_data(snap_path):
     ---------------------------------------------------------
     An NPZ member of object dtype is stored as a pickle, so loading one with
     pickle enabled is arbitrary code execution by construction. This function
-    is reached from a watched directory every poll AND on every client
-    connect, so an archive dropped into ``data/`` would be unpickled without
-    anyone asking. NumPy now refuses such a member with a ``ValueError``
+    is reached on every client connect, and from the watched directory
+    whenever the newest snapshot's path or mtime CHANGES -- not on every poll,
+    which only re-checks. Either way an archive dropped into ``data/`` would be
+    unpickled without anyone asking. NumPy now refuses such a member with a ``ValueError``
     instead.
 
     Passed EXPLICITLY although NumPy's default is already ``False``: relying
@@ -76,11 +77,17 @@ def extract_render_data(snap_path):
     Ownership is CONDITIONAL because ``np.load`` returns two different kinds of
     thing. A zip archive yields an ``NpzFile``, which owns an operating-system
     handle and needs that deterministic close. A ``.npy`` yields a plain
-    ndarray (or a memmap), which owns no handle and has no context-manager
-    protocol; wrapping it in ``nullcontext`` lets it reach the same
-    ``snap['lattice']`` subscript that has always been where a non-archive
-    input fails. The archive gains closure without the array losing its
-    established exception.
+    ndarray, which owns no handle and has no context-manager protocol; wrapping
+    it in ``nullcontext`` lets it reach the same ``snap['lattice']`` subscript
+    that has always been where a NUMERIC non-archive input fails. The archive
+    gains closure without the array losing its established exception.
+
+    Two limits on that, stated rather than implied. An OBJECT-dtype ``.npy``
+    now fails earlier, at ``np.load`` itself, because pickle is refused before
+    anything is returned -- that is the intended change, not a preserved one.
+    And ``np.load`` returns a ``memmap`` only when passed ``mmap_mode``, which
+    this call site never does; a memmap WOULD own a mapping and would not be
+    closed by this branch, so the argument list here is load-bearing.
 
     The claim is an OBJECT-MEMBER REFUSAL and archive resource lifetime -- not
     whole-archive validation. Nothing here resists decompression

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -49,8 +49,8 @@ def find_latest_snapshot(data_dir):
 def extract_render_data(snap_path):
     """Extract cell positions, states, and ages from a snapshot.
 
-    ``allow_pickle=False`` -- no pickle, ever
-    ----------------------------------------
+    ``allow_pickle=False`` -- no pickled member is ever loaded
+    ---------------------------------------------------------
     An NPZ member of object dtype is stored as a pickle, so loading one with
     pickle enabled is arbitrary code execution by construction. This function
     is reached from a watched directory every poll AND on every client

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -47,11 +47,40 @@ def find_latest_snapshot(data_dir):
 
 
 def extract_render_data(snap_path):
-    """Extract cell positions, states, and ages from a snapshot."""
-    snap = np.load(snap_path, allow_pickle=True)
-    state = snap['lattice']
-    mg = snap['memory_grid']
-    gen = int(snap['generation'])
+    """Extract cell positions, states, and ages from a snapshot.
+
+    ``allow_pickle=False`` -- no pickle, ever
+    ----------------------------------------
+    An NPZ member of object dtype is stored as a pickle, so loading one with
+    pickle enabled is arbitrary code execution by construction. This function
+    is reached from a watched directory every poll AND on every client
+    connect, so an archive dropped into ``data/`` would be unpickled without
+    anyone asking. NumPy now refuses such a member with a ``ValueError``
+    instead.
+
+    Passed EXPLICITLY although NumPy's default is already ``False``: relying
+    on the default would make the property invisible at the call site and
+    silently reversible by an upstream change. There is deliberately no
+    fallback retry and no override.
+
+    Archive lifetime
+    ----------------
+    The three values are materialised inside the ``with`` block and the
+    archive is closed before any downstream work begins -- including the
+    ``state.shape[0]`` inspection, the non-void search and the per-cell loop,
+    which previously ran for up to ``MAX_CELLS`` iterations with the handle
+    still open. Closure is explicit, not left to garbage collection, and it
+    holds on refusal too because the members are read inside the block.
+
+    The claim is an OBJECT-MEMBER REFUSAL and archive resource lifetime -- not
+    whole-archive validation. Nothing here resists decompression
+    amplification, absurd declared shapes, hostile member names or defects in
+    NumPy's own header parsing.
+    """
+    with np.load(snap_path, allow_pickle=False) as snap:
+        state = snap['lattice']
+        mg = snap['memory_grid']
+        gen = int(snap['generation'])
 
     n = state.shape[0]
 

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -92,15 +92,29 @@ def _load_snapshot(path):
 
     Extraction is not guarded: a missing key or a failing ``int()`` / ``float()``
     conversion propagates exactly as before, and the ``with`` block still closes
-    the archive on the way out. ``str(path)``, ``allow_pickle=True``, the
-    required-key semantics, the extraction order, both conversions and the tuple
-    order are preserved verbatim.
+    the archive on the way out. ``str(path)``, the required-key semantics, the
+    extraction order, both conversions and the tuple order are preserved
+    verbatim.
+
+    ``allow_pickle=False`` -- an object-dtype member is stored as a pickle, so
+    loading one with pickle enabled is arbitrary code execution. This helper
+    backs four unauthenticated GET routes on a service that binds
+    ``0.0.0.0``, so anyone able to place a file in ``data/`` could have had it
+    unpickled by the next request. NumPy now refuses such a member with a
+    ``ValueError`` instead. Passed explicitly although it is already NumPy's
+    default, because relying on a default makes the property invisible at the
+    call site and silently reversible upstream. There is deliberately no
+    fallback retry and no override.
+
+    That refusal is an OBJECT-MEMBER REFUSAL, not whole-archive validation:
+    nothing here resists decompression amplification, absurd declared shapes,
+    hostile member names or defects in NumPy's own header parsing.
 
     The claim is archive resource lifetime relative to extraction — not an
     indefinitely accumulating descriptor leak, not snapshot validation, endpoint
     totality, API authentication or atomic file access.
     """
-    with np.load(str(path), allow_pickle=True) as snap:
+    with np.load(str(path), allow_pickle=False) as snap:
         lattice = snap["lattice"]
         memory_grid = snap["memory_grid"]
         generation = int(snap["generation"])

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -1090,20 +1090,21 @@ __all__ += [  # type: ignore[misc]
 #
 # Boundaries enforced here:
 #
-#   • Snapshot loading uses ``allow_pickle=False``. An NPZ member of object
-#     dtype is stored as a pickle, so loading one with pickle enabled is
-#     arbitrary code execution by construction; NumPy refuses such a member
-#     with a ``ValueError`` instead. The reads in this chunk already pass
-#     ``False`` (see ``_is_valid_snapshot_npz`` and ``process_snapshot``).
+#   • Snapshot loading passes ``allow_pickle=False``. An NPZ member of
+#     object dtype is stored as a pickle, so loading one with pickle enabled
+#     is arbitrary code execution by construction; NumPy refuses such a
+#     member with a ``ValueError`` instead. Both reads in this chunk already
+#     pass ``False`` -- ``_is_valid_snapshot_npz`` and ``load_snapshot``,
+#     which is the one ``process_snapshot`` calls and is also exported in
+#     ``__all__``, so it is reachable on its own.
 #
-#     This comment previously said the opposite -- that loading used
-#     ``allow_pickle=True`` because Medusa's own ``np.savez`` artefacts
-#     include pickled metadata, that Phase 16's medusa_api used the same
-#     flag, and that engine files are trusted. All three were wrong: this
-#     file's own loads pass ``False``, medusa_api now does too, and no
-#     producer in this repository emits an object-dtype member -- the
-#     engine writes ndarrays and plain scalars, and ``meta_json`` is a
-#     ``<U`` string, not an object.
+#     This comment previously asserted the opposite: that loading enabled
+#     pickle because Medusa's own ``np.savez`` artefacts include pickled
+#     metadata, that Phase 16's medusa_api used the same setting, and that
+#     engine files are trusted. All three were wrong. This file's own loads
+#     pass ``False``; medusa_api now does too; and no producer in this
+#     repository emits an object-dtype member -- the engine writes ndarrays
+#     and plain scalars, and ``meta_json`` is a ``<U`` string, not an object.
 #
 #     What is claimed is OBJECT-MEMBER REFUSAL, not whole-archive
 #     validation: nothing here resists decompression amplification, absurd
@@ -1149,11 +1150,22 @@ def _is_valid_snapshot_npz(path: pathlib.Path) -> bool:
 
     What this predicate does NOT do is reject an object-bearing archive.
     ``NpzFile.files`` reads the zip's central directory only; it decodes no
-    member, so ``allow_pickle=False`` has nothing to refuse at listing time
+    member, so ``allow_pickle=False`` has nothing to refuse at listing time,
     and an archive carrying a pickled member whose three required keys are
-    present is reported valid here. Refusal happens later, at the
-    pickle-free member access in ``process_snapshot``, which is where the
-    ``ValueError`` is raised.
+    present is reported valid here.
+
+    Where the refusal then lands depends on WHICH member is pickled, and
+    ``load_snapshot`` treats the two cases differently:
+
+      • a pickled REQUIRED key (``lattice``, ``memory_grid``,
+        ``generation``) raises ``ValueError`` out of ``load_snapshot``;
+      • a pickled OPTIONAL key is caught there and skipped silently, so the
+        load succeeds with that key absent from ``meta`` and NOTHING
+        propagates.
+
+    Either way the pickle is never executed, which is the property that
+    matters. But "the archive is refused" would be too strong: for an
+    optional member it is accepted minus one key.
 
     That is an object-member refusal, not whole-archive validation: this
     predicate is a cheap key-presence check and claims nothing more.
@@ -1167,9 +1179,11 @@ def _is_valid_snapshot_npz(path: pathlib.Path) -> bool:
         with np.load(str(path), allow_pickle=False) as snap:
             return _REQUIRED_SNAPSHOT_KEYS.issubset(set(snap.files))
     except Exception:
-        # Catch broadly: malformed zip, missing file, permissions,
-        # pickled-payload-refused, future numpy quirks. Any failure
-        # is "this is not a valid Medusa snapshot."
+        # Catch broadly: malformed zip, missing file, permissions, future
+        # numpy quirks. Any failure is "this is not a valid Medusa snapshot."
+        # Deliberately NOT listed: a refused pickled payload. Listing keys
+        # decodes no member, so nothing is refused at this point -- see the
+        # docstring above.
         return False
 
 

--- a/scripts/nextness_observer.py
+++ b/scripts/nextness_observer.py
@@ -1090,11 +1090,26 @@ __all__ += [  # type: ignore[misc]
 #
 # Boundaries enforced here:
 #
-#   • Snapshot loading uses ``allow_pickle=True`` because Medusa's own
-#     ``np.savez`` artefacts include pickled metadata (Phase 16's
-#     medusa_api uses the same flag). We trust the engine's own files.
-#     Loading non-Medusa .npz files is not in scope; the function only
-#     accepts paths that match the configured snapshot glob.
+#   • Snapshot loading uses ``allow_pickle=False``. An NPZ member of object
+#     dtype is stored as a pickle, so loading one with pickle enabled is
+#     arbitrary code execution by construction; NumPy refuses such a member
+#     with a ``ValueError`` instead. The reads in this chunk already pass
+#     ``False`` (see ``_is_valid_snapshot_npz`` and ``process_snapshot``).
+#
+#     This comment previously said the opposite -- that loading used
+#     ``allow_pickle=True`` because Medusa's own ``np.savez`` artefacts
+#     include pickled metadata, that Phase 16's medusa_api used the same
+#     flag, and that engine files are trusted. All three were wrong: this
+#     file's own loads pass ``False``, medusa_api now does too, and no
+#     producer in this repository emits an object-dtype member -- the
+#     engine writes ndarrays and plain scalars, and ``meta_json`` is a
+#     ``<U`` string, not an object.
+#
+#     What is claimed is OBJECT-MEMBER REFUSAL, not whole-archive
+#     validation: nothing here resists decompression amplification, absurd
+#     declared shapes, hostile member names or defects in NumPy's own header
+#     parsing. Loading non-Medusa .npz files remains out of scope; the
+#     function only accepts paths that match the configured snapshot glob.
 #
 #   • Writes are restricted to ``config.log_directory`` and its parent
 #     must already exist (we create the leaf log dir, never the scaffold).
@@ -1129,9 +1144,19 @@ def _is_valid_snapshot_npz(path: pathlib.Path) -> bool:
     data — ``NpzFile.files`` reads only the zip's central directory, so
     this stays in the milliseconds range even for tens of MB.
 
-    Any failure mode — missing keys, malformed zip, I/O error, pickled
-    payload that ``allow_pickle=False`` refuses to materialize at
-    file-listing time — yields ``False``. The function never raises.
+    Any failure mode — missing keys, malformed zip, I/O error — yields
+    ``False``. The function never raises.
+
+    What this predicate does NOT do is reject an object-bearing archive.
+    ``NpzFile.files`` reads the zip's central directory only; it decodes no
+    member, so ``allow_pickle=False`` has nothing to refuse at listing time
+    and an archive carrying a pickled member whose three required keys are
+    present is reported valid here. Refusal happens later, at the
+    pickle-free member access in ``process_snapshot``, which is where the
+    ``ValueError`` is raised.
+
+    That is an object-member refusal, not whole-archive validation: this
+    predicate is a cheap key-presence check and claims nothing more.
 
     Per issue #139 finding (a): replaces the previous file-size
     threshold, which was structurally wrong (real snapshots range from

--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -742,7 +742,8 @@ if __name__ == "__main__":
             #
             # The context manager closes the archive before `export_genome`
             # begins -- deterministically, not left to garbage collection.
-            # Every member is materialised inside the block, so the base64
+            # Every member this CLI reads is materialised inside the block
+            # (an unread member is never touched at all), so the base64
             # encoding downstream reads real in-memory arrays.
             with np.load(args.snapshot, allow_pickle=False) as snap:
                 lattice, memory_grid = snap["lattice"], snap["memory_grid"]

--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -730,10 +730,24 @@ if __name__ == "__main__":
         gen = ca_step_count = 0
         best_fit = 0.0
         if args.snapshot:
-            snap = np.load(args.snapshot, allow_pickle=True)
-            lattice, memory_grid = snap["lattice"], snap["memory_grid"]
-            gen, ca_step_count = int(snap.get("generation", 0)), int(snap.get("ca_step", 0))
-            best_fit = float(snap.get("best_fitness", 0.0))
+            # An NPZ member of object dtype IS a pickle, so loading one with
+            # pickle enabled is arbitrary code execution by construction, and
+            # this path takes its archive straight from the command line.
+            # NumPy now refuses such a member with a ValueError instead of
+            # reconstructing it. `allow_pickle=False` is passed EXPLICITLY
+            # although it is already NumPy's default: a default makes the
+            # property invisible at the call site and silently reversible by an
+            # upstream change. There is no fallback retry and no override.
+            # This is an object-member refusal, not archive validation.
+            #
+            # The context manager closes the archive before `export_genome`
+            # begins -- deterministically, not left to garbage collection.
+            # Every member is materialised inside the block, so the base64
+            # encoding downstream reads real in-memory arrays.
+            with np.load(args.snapshot, allow_pickle=False) as snap:
+                lattice, memory_grid = snap["lattice"], snap["memory_grid"]
+                gen, ca_step_count = int(snap.get("generation", 0)), int(snap.get("ca_step", 0))
+                best_fit = float(snap.get("best_fitness", 0.0))
         path = export_genome(args.output, rule_spec=rule_spec, generation=gen,
                              ca_step=ca_step_count, best_fitness=best_fit,
                              lattice=lattice, memory_grid=memory_grid,

--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import contextlib
 import json
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -740,12 +741,23 @@ if __name__ == "__main__":
             # upstream change. There is no fallback retry and no override.
             # This is an object-member refusal, not archive validation.
             #
-            # The context manager closes the archive before `export_genome`
-            # begins -- deterministically, not left to garbage collection.
-            # Every member this CLI reads is materialised inside the block
-            # (an unread member is never touched at all), so the base64
-            # encoding downstream reads real in-memory arrays.
-            with np.load(args.snapshot, allow_pickle=False) as snap:
+            # Ownership is CONDITIONAL because `np.load` returns two different
+            # kinds of thing. A zip archive yields an `NpzFile`, which owns an
+            # operating-system handle and must be closed deterministically
+            # before `export_genome` begins rather than left to garbage
+            # collection. A `.npy` yields a plain ndarray (or a memmap), which
+            # owns no handle and has no context-manager protocol; wrapping it
+            # in `nullcontext` lets it reach the same `snap["lattice"]`
+            # subscript that has always been where a non-archive input fails,
+            # so the archive gains closure without the array losing its
+            # established exception.
+            #
+            # Every member this CLI reads is materialised inside the block (an
+            # unread member is never touched at all), so the base64 encoding
+            # downstream reads real in-memory arrays.
+            loaded = np.load(args.snapshot, allow_pickle=False)
+            owner = contextlib.nullcontext(loaded) if isinstance(loaded, np.ndarray) else loaded
+            with owner as snap:
                 lattice, memory_grid = snap["lattice"], snap["memory_grid"]
                 gen, ca_step_count = int(snap.get("generation", 0)), int(snap.get("ca_step", 0))
                 best_fit = float(snap.get("best_fitness", 0.0))

--- a/scripts/portable_genome.py
+++ b/scripts/portable_genome.py
@@ -745,12 +745,20 @@ if __name__ == "__main__":
             # kinds of thing. A zip archive yields an `NpzFile`, which owns an
             # operating-system handle and must be closed deterministically
             # before `export_genome` begins rather than left to garbage
-            # collection. A `.npy` yields a plain ndarray (or a memmap), which
-            # owns no handle and has no context-manager protocol; wrapping it
-            # in `nullcontext` lets it reach the same `snap["lattice"]`
-            # subscript that has always been where a non-archive input fails,
-            # so the archive gains closure without the array losing its
+            # collection. A `.npy` yields a plain ndarray, which owns no handle
+            # and has no context-manager protocol; wrapping it in
+            # `nullcontext` lets it reach the same `snap["lattice"]` subscript
+            # that has always been where a NUMERIC non-archive input fails, so
+            # the archive gains closure without the array losing its
             # established exception.
+            #
+            # Two limits, stated rather than implied. An OBJECT-dtype `.npy`
+            # now fails earlier, at `np.load` itself, because pickle is refused
+            # before anything is returned -- that is the intended change, not a
+            # preserved one. And `np.load` returns a `memmap` only when passed
+            # `mmap_mode`, which this call site never does; a memmap WOULD own a
+            # mapping and would NOT be closed by the ndarray branch, so the
+            # argument list here is load-bearing.
             #
             # Every member this CLI reads is materialised inside the block (an
             # unread member is never touched at all), so the base64 encoding

--- a/tests/test_acoustic_map_snapshot_loader.py
+++ b/tests/test_acoustic_map_snapshot_loader.py
@@ -15,7 +15,8 @@ before any post-extraction work begins.
 No real simulation, engine, GPU kernel, snapshot or heatmap is involved: the
 engine's lazy import is served by a scoped `sys.modules` stand-in (restored
 afterwards), `AcousticMap` is replaced by a recorder, and `np.load` returns a
-closure-recording fake. Nothing is written anywhere.
+closure-recording fake. The pickle-refusal tests appended at the end DO
+write real NPZ archives, but only inside pytest's own `tmp_path`.
 
 Scope is archive resource lifetime relative to extraction — not snapshot
 validation, archive security, the acoustic mathematics or whole-diagnostic
@@ -514,6 +515,20 @@ def _write_snapshot_am(path, compressed=False, **members):
     return str(path)
 
 
+def _engine_stub_installed():
+    """Serve `run_acoustic_diagnostic`'s function-local engine import.
+
+    That import happens at `acoustic_map.py:355`, BEFORE the `np.load` at
+    :358, so a hostile-archive test would otherwise pull in the real engine
+    and contradict this module's "no real engine" claim.
+    """
+    stub = types.ModuleType(_ENGINE_MODULE)
+    stub.step_ca_lattice = lambda *a, **k: None
+    stub.load_rule_spec = lambda *a, **k: {}
+    stub.init_memory_grid = lambda *a, **k: None
+    return mock.patch.dict(sys.modules, {_ENGINE_MODULE: stub})
+
+
 def test_am_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     """Control. Without it, every "marker is absent" assertion below could
     pass against a payload that never worked. This is the only place in this
@@ -534,7 +549,7 @@ def test_object_payload_is_refused_by_the_diagnostic(tmp_path, field):
     archive = _write_snapshot_am(
         tmp_path / f"{field}.npz", **{field: _payload_array_am(tmp_path)}
     )
-    with pytest.raises(ValueError) as excinfo:
+    with _engine_stub_installed(), pytest.raises(ValueError) as excinfo:
         acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
     assert "allow_pickle=False" in str(excinfo.value)
     assert not _marker_am(tmp_path).exists(), "the pickle payload executed"
@@ -552,7 +567,8 @@ def test_no_diagnostic_seam_runs_after_a_refusal(tmp_path):
         def __init__(self, *a, **k):
             built.append(1)
 
-    with mock.patch.object(acoustic_map, "AcousticMap", _RecordingMap):
+    with _engine_stub_installed(), \
+         mock.patch.object(acoustic_map, "AcousticMap", _RecordingMap):
         with pytest.raises(ValueError):
             acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
 
@@ -572,7 +588,7 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
         return real_load(*args, **kwargs)
 
     monkeypatch.setattr(acoustic_map.np, "load", _recording_load)
-    with pytest.raises(ValueError):
+    with _engine_stub_installed(), pytest.raises(ValueError):
         acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
     assert calls == [False], f"expected one pickle-free open, got {calls}"
 
@@ -592,7 +608,7 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
         return handle
 
     monkeypatch.setattr(acoustic_map.np, "load", _tracking_load)
-    with pytest.raises(ValueError):
+    with _engine_stub_installed(), pytest.raises(ValueError):
         acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
 
     assert len(opened) == 1

--- a/tests/test_acoustic_map_snapshot_loader.py
+++ b/tests/test_acoustic_map_snapshot_loader.py
@@ -208,7 +208,7 @@ def test_generation_is_an_exact_builtin_int():
     assert generation == 4242
 
 
-def test_np_load_receives_the_original_path_and_allow_pickle():
+def test_np_load_receives_the_original_path_and_allow_pickle_false():
     """No path conversion is introduced: the very object passed in is forwarded."""
     path = Path("/fake/dir/v070_gen7.npz")
     _, _, _, load_mock = _run(num_steps=0, snapshot_path=path)
@@ -216,7 +216,7 @@ def test_np_load_receives_the_original_path_and_allow_pickle():
     args, kwargs = load_mock.call_args
     assert args == (path,)
     assert args[0] is path  # not str(path), not a re-wrapped Path
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_extraction_order_is_preserved():
@@ -455,3 +455,146 @@ def test_engine_module_stub_was_scoped_and_restored():
     before = sys.modules.get(_ENGINE_MODULE)
     _run(num_steps=0)
     assert sys.modules.get(_ENGINE_MODULE) is before
+
+
+# ===========================================================================
+# Pickle refusal -- acoustic_map must never unpickle an NPZ member
+#
+# An object-dtype member is stored as a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The payload below is
+# harmless: its reduction writes ONE marker file inside pytest's own tmp_path
+# and returns. `__reduce__` runs at PICKLE time and only records the callable,
+# so writing the archive is inert; the call would happen at UNPICKLE time.
+#
+# Scope: an object-member refusal, NOT whole-archive validation.
+# ===========================================================================
+
+_AM_MARKER = "ACOUSTIC_PAYLOAD_EXECUTED"
+
+
+def _create_marker_am(directory: str) -> str:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required -- pickle stores a module-qualified reference, so
+    a function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / _AM_MARKER
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadAm:
+    """Its reduction calls the marker writer when unpickled."""
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker_am, (self._directory,))
+
+
+def _payload_array_am(directory):
+    return np.array([_PayloadAm(directory)], dtype=object)
+
+
+def _marker_am(tmp_path):
+    return tmp_path / _AM_MARKER
+
+
+def _write_snapshot_am(path, compressed=False, **members):
+    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "generation": 7,
+    }
+    payload.update(members)
+    writer = np.savez_compressed if compressed else np.savez
+    writer(path, **payload)
+    return str(path)
+
+
+def test_am_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Control. Without it, every "marker is absent" assertion below could
+    pass against a payload that never worked. This is the only place in this
+    module that enables pickle."""
+    archive = _write_snapshot_am(
+        tmp_path / "control.npz", lattice=_payload_array_am(tmp_path)
+    )
+    assert not _marker_am(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker_am(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
+def test_object_payload_is_refused_by_the_diagnostic(tmp_path, field):
+    archive = _write_snapshot_am(
+        tmp_path / f"{field}.npz", **{field: _payload_array_am(tmp_path)}
+    )
+    with pytest.raises(ValueError) as excinfo:
+        acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_am(tmp_path).exists(), "the pickle payload executed"
+
+
+def test_no_diagnostic_seam_runs_after_a_refusal(tmp_path):
+    """The refusal precedes every engine seam, so nothing is stepped and no
+    heatmap is written into the repository."""
+    archive = _write_snapshot_am(
+        tmp_path / "hostile.npz", lattice=_payload_array_am(tmp_path)
+    )
+    built = []
+
+    class _RecordingMap:
+        def __init__(self, *a, **k):
+            built.append(1)
+
+    with mock.patch.object(acoustic_map, "AcousticMap", _RecordingMap):
+        with pytest.raises(ValueError):
+            acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
+
+    assert built == [], "a diagnostic seam ran after the refusal"
+    assert not _marker_am(tmp_path).exists()
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    archive = _write_snapshot_am(
+        tmp_path / "retry.npz", lattice=_payload_array_am(tmp_path)
+    )
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(acoustic_map.np, "load", _recording_load)
+    with pytest.raises(ValueError):
+        acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
+    assert calls == [False], f"expected one pickle-free open, got {calls}"
+
+
+def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+    """Real-object introspection rather than unlink: POSIX unlink succeeds
+    with descriptors outstanding, so it proves nothing on the Linux runner."""
+    archive = _write_snapshot_am(
+        tmp_path / "closed.npz", lattice=_payload_array_am(tmp_path)
+    )
+    real_load = np.load
+    opened = []
+
+    def _tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(acoustic_map.np, "load", _tracking_load)
+    with pytest.raises(ValueError):
+        acoustic_map.run_acoustic_diagnostic(archive, num_steps=0)
+
+    assert len(opened) == 1
+    handle = opened[0]
+    assert handle.fid is None or getattr(handle.fid, "closed", True)

--- a/tests/test_acoustic_map_snapshot_loader.py
+++ b/tests/test_acoustic_map_snapshot_loader.py
@@ -597,4 +597,4 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
 
     assert len(opened) == 1
     handle = opened[0]
-    assert handle.fid is None or getattr(handle.fid, "closed", True)
+    assert handle.fid is None or handle.fid.closed

--- a/tests/test_acoustic_map_snapshot_loader.py
+++ b/tests/test_acoustic_map_snapshot_loader.py
@@ -19,7 +19,7 @@ closure-recording fake. The pickle-refusal tests appended at the end DO
 write real NPZ archives, but only inside pytest's own `tmp_path`.
 
 Scope is archive resource lifetime relative to extraction — not snapshot
-validation, archive security, the acoustic mathematics or whole-diagnostic
+validation, whole-archive validation, the acoustic mathematics or whole-diagnostic
 correctness.
 """
 
@@ -613,4 +613,8 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
 
     assert len(opened) == 1
     handle = opened[0]
-    assert handle.fid is None or handle.fid.closed
+    # `zip` is the primary witness: `close()` drops it unconditionally,
+    # whereas `fid` is a CLASS attribute defaulting to None and is only set
+    # on the instance when np.load owned the file. Asserting `fid is None`
+    # alone would therefore pass on a handle that was never closed at all.
+    assert handle.zip is None and (handle.fid is None or handle.fid.closed)

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -27,6 +27,7 @@ import ast
 from pathlib import Path
 from unittest import mock
 
+import numpy as np
 import pytest
 
 # `scripts/geometry_daemon.py` runs `GEO_DIR.mkdir(parents=True, exist_ok=True)`

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -19,8 +19,9 @@ at the end write real NPZ archives there), and the module's import-time
 `GEO_DIR.mkdir(...)` is isolated
 so the repository's real `data/geometry` directory is never created or modified.
 
-Scope is `.npz` archive resource lifetime only — not snapshot validation, archive
-security, deterministic export, atomic output or whole-daemon correctness.
+Scope is `.npz` archive resource lifetime and object-member refusal — not
+snapshot validation, whole-archive validation, deterministic export, atomic
+output or whole-daemon correctness.
 """
 
 from __future__ import annotations
@@ -591,7 +592,12 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         geometry_daemon._load_snapshot(archive)
     assert len(opened) == 1
-    assert opened[0].fid is None or opened[0].fid.closed
+    # `zip` is the primary witness: `close()` drops it unconditionally,
+    # whereas `fid` is a CLASS attribute defaulting to None, so asserting
+    # on it alone would pass on a handle that was never closed at all.
+    assert opened[0].zip is None and (
+        opened[0].fid is None or opened[0].fid.closed
+    )
 
 
 def test_a_numeric_snapshot_still_loads_unchanged(tmp_path):

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -589,7 +589,7 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         geometry_daemon._load_snapshot(archive)
     assert len(opened) == 1
-    assert opened[0].fid is None or getattr(opened[0].fid, "closed", True)
+    assert opened[0].fid is None or opened[0].fid.closed
 
 
 def test_a_numeric_snapshot_still_loads_unchanged(tmp_path):

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -512,8 +512,8 @@ def _write_snapshot_gd(path, compressed=False, **members):
 
 def test_gd_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     """Control. Without it, every "marker is absent" assertion below could
-    pass against a payload that never worked. This is the only place in this
-    module that enables pickle."""
+    pass against a payload that never worked. Pickle is enabled here and in the
+    compressed-archive control below, and nowhere else in this module."""
     archive = _write_snapshot_gd(
         tmp_path / "control.npz", lattice=_payload_array_gd(tmp_path)
     )

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -14,7 +14,9 @@ Nothing here touches a real snapshot, engine, printer, STL generation or
 long-running daemon: `np.load` is replaced at the module boundary with a fake
 archive that records context entry/exit and closure, the three exporters are
 recorders, and the clock is deterministic. No `.npz`, CSV, JSON, STL or PNG is
-written anywhere, and the module's import-time `GEO_DIR.mkdir(...)` is isolated
+written outside pytest's own `tmp_path` (the pickle-refusal tests appended
+at the end write real NPZ archives there), and the module's import-time
+`GEO_DIR.mkdir(...)` is isolated
 so the repository's real `data/geometry` directory is never created or modified.
 
 Scope is `.npz` archive resource lifetime only — not snapshot validation, archive

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -133,7 +133,7 @@ def test_helper_calls_np_load_with_the_same_path_conversion_and_allow_pickle():
     args, kwargs = loader.call_args
     assert args == (str(Path("/fake/dir/v070_gen42.npz")),)
     assert type(args[0]) is str
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_helper_enters_the_archive_context_exactly_once():
@@ -342,7 +342,7 @@ def test_daemon_cycle_loads_with_the_preserved_call_shape(tmp_path):
     assert loader.call_count == 1
     args, kwargs = loader.call_args
     assert args == (str(snapshot),)
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_daemon_cycle_keeps_the_snapshot_glob_pattern(tmp_path):
@@ -447,3 +447,153 @@ def test_once_path_uses_the_helper():
     main_block = main_blocks[0]
     assert len(_helper_calls(main_block)) == 1
     assert _np_load_calls(main_block) == []
+
+
+# ===========================================================================
+# Pickle refusal -- geometry_daemon must never unpickle an NPZ member
+#
+# An object-dtype member is stored as a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The payload below is
+# harmless: its reduction writes ONE marker file inside pytest's own tmp_path
+# and returns. `__reduce__` runs at PICKLE time and only records the callable,
+# so writing the archive is inert; the call would happen at UNPICKLE time.
+#
+# Scope: an object-member refusal, NOT whole-archive validation.
+# ===========================================================================
+
+_GD_MARKER = "GEOMETRY_PAYLOAD_EXECUTED"
+
+
+def _create_marker_gd(directory: str) -> str:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required -- pickle stores a module-qualified reference, so
+    a function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / _GD_MARKER
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadGd:
+    """Its reduction calls the marker writer when unpickled."""
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker_gd, (self._directory,))
+
+
+def _payload_array_gd(directory):
+    return np.array([_PayloadGd(directory)], dtype=object)
+
+
+def _marker_gd(tmp_path):
+    return tmp_path / _GD_MARKER
+
+
+def _write_snapshot_gd(path, compressed=False, **members):
+    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "generation": 7,
+    }
+    payload.update(members)
+    writer = np.savez_compressed if compressed else np.savez
+    writer(path, **payload)
+    return str(path)
+
+
+def test_gd_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Control. Without it, every "marker is absent" assertion below could
+    pass against a payload that never worked. This is the only place in this
+    module that enables pickle."""
+    archive = _write_snapshot_gd(
+        tmp_path / "control.npz", lattice=_payload_array_gd(tmp_path)
+    )
+    assert not _marker_gd(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker_gd(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
+def test_object_payload_is_refused_by_the_helper(tmp_path, field):
+    archive = _write_snapshot_gd(
+        tmp_path / f"{field}.npz", **{field: _payload_array_gd(tmp_path)}
+    )
+    with pytest.raises(ValueError) as excinfo:
+        geometry_daemon._load_snapshot(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_gd(tmp_path).exists(), "the pickle payload executed"
+
+
+def test_a_compressed_hostile_archive_is_refused_the_same_way(tmp_path):
+    """Real producers use `np.savez_compressed`, so the hostile fixture
+    exercises that shape too rather than only the uncompressed one."""
+    archive = _write_snapshot_gd(
+        tmp_path / "compressed.npz", compressed=True,
+        lattice=_payload_array_gd(tmp_path),
+    )
+    with pytest.raises(ValueError) as excinfo:
+        geometry_daemon._load_snapshot(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_gd(tmp_path).exists()
+
+
+def test_the_compressed_payload_also_fires_when_pickle_is_enabled(tmp_path):
+    archive = _write_snapshot_gd(
+        tmp_path / "cc.npz", compressed=True,
+        lattice=_payload_array_gd(tmp_path),
+    )
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+    assert _marker_gd(tmp_path).exists(), "the compressed payload is inert"
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    archive = _write_snapshot_gd(
+        tmp_path / "retry.npz", lattice=_payload_array_gd(tmp_path)
+    )
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(geometry_daemon.np, "load", _recording_load)
+    with pytest.raises(ValueError):
+        geometry_daemon._load_snapshot(archive)
+    assert calls == [False]
+
+
+def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+    archive = _write_snapshot_gd(
+        tmp_path / "closed.npz", lattice=_payload_array_gd(tmp_path)
+    )
+    real_load = np.load
+    opened = []
+
+    def _tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(geometry_daemon.np, "load", _tracking_load)
+    with pytest.raises(ValueError):
+        geometry_daemon._load_snapshot(archive)
+    assert len(opened) == 1
+    assert opened[0].fid is None or getattr(opened[0].fid, "closed", True)
+
+
+def test_a_numeric_snapshot_still_loads_unchanged(tmp_path):
+    archive = _write_snapshot_gd(tmp_path / "clean.npz", generation=np.int64(12))
+    state, grid, generation = geometry_daemon._load_snapshot(archive)
+    assert state.shape == (2, 2, 2)
+    assert grid.shape == (8, 2, 2, 2)
+    assert generation == 12 and type(generation) is int

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -17,7 +17,9 @@ No real benchmark, engine, GPU kernel, snapshot or persistent output is used:
 `scripts.continuous_evolution_ca` is replaced by a scoped stand-in (the
 production module imports it at load time), `benchmark_component` is a
 deterministic recorder rather than a timing loop, arrays are 2x2x2, and
-`np.load` returns a closure-recording fake. Nothing is written anywhere.
+`np.load` returns a closure-recording fake. The pickle-refusal tests
+appended at the end DO write real NPZ archives, but only inside pytest's
+own `tmp_path`.
 
 Scope is archive resource lifetime relative to extraction — not snapshot
 validation, benchmark mathematics, timing methodology, or the separate question

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -151,7 +151,7 @@ def test_generation_is_an_exact_builtin_int():
     assert generation == 4242
 
 
-def test_np_load_receives_the_original_path_object_and_allow_pickle():
+def test_np_load_receives_the_original_path_object_and_allow_pickle_false():
     """No path conversion is introduced: the very object passed in is forwarded."""
     path = Path("/fake/dir/v070_gen7.npz")
     _, load_mock = _load(_FakeArchive(_contents()), path=path)
@@ -159,7 +159,7 @@ def test_np_load_receives_the_original_path_object_and_allow_pickle():
     args, kwargs = load_mock.call_args
     assert args == (path,)
     assert args[0] is path
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_extraction_order_is_preserved():
@@ -494,3 +494,125 @@ def test_no_real_engine_gpu_or_benchmark_was_executed(capsys):
     assert all(entry["name"].endswith("(CPU)") for entry in rec.components)
     assert not any("(GPU)" in entry["name"] for entry in rec.components)
     assert len(rec.measured) == 3  # each measured callable invoked exactly once
+
+
+# ===========================================================================
+# Pickle refusal -- gpu_benchmark must never unpickle an NPZ member
+#
+# An object-dtype member is stored as a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The payload below is
+# harmless: its reduction writes ONE marker file inside pytest's own tmp_path
+# and returns. `__reduce__` runs at PICKLE time and only records the callable,
+# so writing the archive is inert; the call would happen at UNPICKLE time.
+#
+# Scope: an object-member refusal, NOT whole-archive validation.
+# ===========================================================================
+
+_GB_MARKER = "GPU_PAYLOAD_EXECUTED"
+
+
+def _create_marker_gb(directory: str) -> str:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required -- pickle stores a module-qualified reference, so
+    a function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / _GB_MARKER
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadGb:
+    """Its reduction calls the marker writer when unpickled."""
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker_gb, (self._directory,))
+
+
+def _payload_array_gb(directory):
+    return np.array([_PayloadGb(directory)], dtype=object)
+
+
+def _marker_gb(tmp_path):
+    return tmp_path / _GB_MARKER
+
+
+def _write_snapshot_gb(path, compressed=False, **members):
+    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "generation": 7,
+    }
+    payload.update(members)
+    writer = np.savez_compressed if compressed else np.savez
+    writer(path, **payload)
+    return str(path)
+
+
+def test_gb_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Control. Without it, every "marker is absent" assertion below could
+    pass against a payload that never worked. This is the only place in this
+    module that enables pickle."""
+    archive = _write_snapshot_gb(
+        tmp_path / "control.npz", lattice=_payload_array_gb(tmp_path)
+    )
+    assert not _marker_gb(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker_gb(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
+def test_object_payload_is_refused_by_the_helper(tmp_path, field):
+    archive = _write_snapshot_gb(
+        tmp_path / f"{field}.npz", **{field: _payload_array_gb(tmp_path)}
+    )
+    with pytest.raises(ValueError) as excinfo:
+        gpu_benchmark._load_snapshot(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_gb(tmp_path).exists(), "the pickle payload executed"
+
+
+def test_run_benchmarks_refuses_before_any_benchmark_runs(tmp_path):
+    """The refusal happens inside the loader, so no warmup, no timing loop and
+    no GPU branch is ever entered."""
+    archive = _write_snapshot_gb(
+        tmp_path / "hostile.npz", lattice=_payload_array_gb(tmp_path)
+    )
+    ran = []
+    with mock.patch.object(gpu_benchmark, "benchmark_component",
+                           lambda *a, **k: ran.append(1)):
+        with pytest.raises(ValueError):
+            gpu_benchmark.run_benchmarks(archive, num_steps=1)
+    assert ran == [], "a benchmark ran after the refusal"
+    assert not _marker_gb(tmp_path).exists()
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    archive = _write_snapshot_gb(
+        tmp_path / "retry.npz", lattice=_payload_array_gb(tmp_path)
+    )
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(gpu_benchmark.np, "load", _recording_load)
+    with pytest.raises(ValueError):
+        gpu_benchmark._load_snapshot(archive)
+    assert calls == [False]
+
+
+def test_a_numeric_snapshot_still_loads_and_converts(tmp_path):
+    archive = _write_snapshot_gb(tmp_path / "clean.npz", generation=np.int64(9))
+    lattice, grid, generation = gpu_benchmark._load_snapshot(archive)
+    assert lattice.dtype == np.uint8 and grid.dtype == np.float32
+    assert generation == 9 and type(generation) is int

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -524,6 +524,50 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
     assert calls == [False]
 
 
+def _legacy_npy_error_class_ls():
+    """The exception class an ordinary numeric `.npy` produced BEFORE this branch.
+
+    Derived, never hard-coded. At the base commit `extract_render_data` did
+    `snap = np.load(...)` and then immediately `snap['lattice']`. For a non-zip
+    input `np.load` returns a plain ndarray rather than an `NpzFile`, so the
+    legacy failure is whatever a constant-string subscript on an ndarray raises
+    in the installed NumPy.
+    """
+    probe = np.zeros(2)
+    try:
+        probe["lattice"]
+    except Exception as exc:  # noqa: BLE001 - the class IS the thing under test
+        return type(exc)
+    raise AssertionError(
+        "a constant-string subscript on a plain ndarray no longer raises; "
+        "the legacy contract this test pins no longer exists"
+    )
+
+
+@requires_numpy
+def test_a_numeric_npy_still_fails_exactly_as_it_did_before(tmp_path, monkeypatch):
+    """`extract_render_data` gained its first `with` on this branch.
+
+    An `NpzFile` needs deterministic ownership; an ndarray does not. Conditional
+    ownership keeps the archive closing while leaving a `.npy` to fail at the
+    same `snap['lattice']` subscript it always did -- and nothing downstream may
+    run, which `np.argwhere` witnesses because it is the first call after the
+    extraction.
+    """
+    not_an_archive = tmp_path / "snapshot.npy"
+    np.save(not_an_archive, np.zeros((2, 2, 2), dtype=np.uint8))
+
+    reached = []
+    monkeypatch.setattr(
+        lucid_server.np, "argwhere", lambda *a, **k: reached.append("argwhere")
+    )
+
+    with pytest.raises(_legacy_npy_error_class_ls()):
+        lucid_server.extract_render_data(str(not_an_archive))
+
+    assert reached == [], "downstream processing ran on a non-archive input"
+
+
 @requires_numpy
 def test_a_numeric_snapshot_still_produces_cells_and_metrics(tmp_path):
     archive = _write_snapshot_ls(tmp_path / "clean.npz", generation=np.int64(5))

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -12,7 +12,8 @@ as it already did for syntactically invalid JSON.
 
 Everything here runs in-process against the real coroutine driven by a
 controlled asynchronous fake socket: no real WebSocket, no browser, no network,
-no snapshot files and no NumPy data.
+no snapshot files outside pytest's own `tmp_path` (the pickle-refusal
+tests appended at the end write real NPZ archives there).
 
 Scope is top-level JSON shape in `handle_client` only — not whole-server,
 whole-WebSocket, authentication, authorization or payload-schema totality.
@@ -335,8 +336,22 @@ def test_initial_snapshot_failure_does_not_block_message_handling(monkeypatch):
     assert websocket.delivered == ["null", PING]
     assert len(_pongs(websocket)) == 1
 
-import numpy as np
 from pathlib import Path
+
+# This module deliberately runs without NumPy (see `_optional_dependency_stubs`
+# above): the malformed-frame contract must execute in ordinary maintained CI
+# rather than being skipped away behind an optional dependency. The pickle
+# tests below DO need real NumPy, so it is imported defensively and only those
+# tests are skipped when it is absent -- importing it unconditionally would
+# fail collection of this whole file, taking the 330 lines above with it.
+try:
+    import numpy as np
+    _HAVE_NUMPY = True
+except ImportError:  # pragma: no cover - exercised only in a bare environment
+    np = None
+    _HAVE_NUMPY = False
+
+requires_numpy = pytest.mark.skipif(not _HAVE_NUMPY, reason="numpy not installed")
 
 
 # ===========================================================================
@@ -396,6 +411,7 @@ def _write_snapshot_ls(path, compressed=False, **members):
     return str(path)
 
 
+@requires_numpy
 def test_ls_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     """Control. Without it, every "marker is absent" assertion below could
     pass against a payload that never worked. This is the only place in this
@@ -411,6 +427,7 @@ def test_ls_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     assert _marker_ls(tmp_path).exists(), "the payload fixture is inert; fix it"
 
 
+@requires_numpy
 @pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
 def test_object_payload_is_refused_by_extract_render_data(tmp_path, field):
     archive = _write_snapshot_ls(
@@ -429,6 +446,7 @@ def _structured_payload_ls(directory):
     return structured
 
 
+@requires_numpy
 def test_the_structured_payload_also_fires_when_pickle_is_enabled(tmp_path):
     """A structured dtype takes a different path through NumPy's descriptor
     handling than a plain object array, so it needs its own control."""
@@ -440,6 +458,7 @@ def test_the_structured_payload_also_fires_when_pickle_is_enabled(tmp_path):
     assert _marker_ls(tmp_path).exists(), "the structured payload is inert"
 
 
+@requires_numpy
 def test_an_object_bearing_structured_dtype_is_refused(tmp_path):
     """`kind == 'O'` alone would miss this; NumPy's refusal covers
     `dtype.hasobject`."""
@@ -452,6 +471,7 @@ def test_an_object_bearing_structured_dtype_is_refused(tmp_path):
     assert not _marker_ls(tmp_path).exists()
 
 
+@requires_numpy
 def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
     """`extract_render_data` had no context manager: the handle was held open
     across up to MAX_CELLS iterations of per-cell work. `np.argwhere` is the
@@ -481,6 +501,7 @@ def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
     assert observed == [True], "the archive was still open during cell iteration"
 
 
+@requires_numpy
 def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
     archive = _write_snapshot_ls(
         tmp_path / "retry.npz", lattice=_payload_array_ls(tmp_path)
@@ -498,6 +519,7 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
     assert calls == [False]
 
 
+@requires_numpy
 def test_a_numeric_snapshot_still_produces_cells_and_metrics(tmp_path):
     archive = _write_snapshot_ls(tmp_path / "clean.npz", generation=np.int64(5))
     data = lucid_server.extract_render_data(archive)

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -470,7 +470,7 @@ def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
 
     def _watching_argwhere(*args, **kwargs):
         handle = opened[0]
-        observed.append(handle.fid is None or getattr(handle.fid, "closed", True))
+        observed.append(handle.fid is None or handle.fid.closed)
         return real_argwhere(*args, **kwargs)
 
     monkeypatch.setattr(lucid_server.np, "load", _tracking_load)

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -334,3 +334,174 @@ def test_initial_snapshot_failure_does_not_block_message_handling(monkeypatch):
     asyncio.run(lucid_server.handle_client(websocket))
     assert websocket.delivered == ["null", PING]
     assert len(_pongs(websocket)) == 1
+
+import numpy as np
+from pathlib import Path
+
+
+# ===========================================================================
+# Pickle refusal -- lucid_server must never unpickle an NPZ member
+#
+# An object-dtype member is stored as a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The payload below is
+# harmless: its reduction writes ONE marker file inside pytest's own tmp_path
+# and returns. `__reduce__` runs at PICKLE time and only records the callable,
+# so writing the archive is inert; the call would happen at UNPICKLE time.
+#
+# Scope: an object-member refusal, NOT whole-archive validation.
+# ===========================================================================
+
+_LS_MARKER = "LUCID_PAYLOAD_EXECUTED"
+
+
+def _create_marker_ls(directory: str) -> str:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required -- pickle stores a module-qualified reference, so
+    a function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / _LS_MARKER
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadLs:
+    """Its reduction calls the marker writer when unpickled."""
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker_ls, (self._directory,))
+
+
+def _payload_array_ls(directory):
+    return np.array([_PayloadLs(directory)], dtype=object)
+
+
+def _marker_ls(tmp_path):
+    return tmp_path / _LS_MARKER
+
+
+def _write_snapshot_ls(path, compressed=False, **members):
+    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": np.ones((4, 4, 4), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 4, 4, 4), dtype=np.float32),
+        "generation": 7,
+    }
+    payload.update(members)
+    writer = np.savez_compressed if compressed else np.savez
+    writer(path, **payload)
+    return str(path)
+
+
+def test_ls_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Control. Without it, every "marker is absent" assertion below could
+    pass against a payload that never worked. This is the only place in this
+    module that enables pickle."""
+    archive = _write_snapshot_ls(
+        tmp_path / "control.npz", lattice=_payload_array_ls(tmp_path)
+    )
+    assert not _marker_ls(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker_ls(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+@pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
+def test_object_payload_is_refused_by_extract_render_data(tmp_path, field):
+    archive = _write_snapshot_ls(
+        tmp_path / f"{field}.npz", **{field: _payload_array_ls(tmp_path)}
+    )
+    with pytest.raises(ValueError) as excinfo:
+        lucid_server.extract_render_data(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_ls(tmp_path).exists(), "the pickle payload executed"
+
+
+def _structured_payload_ls(directory):
+    structured = np.empty((1,), dtype=[("payload", "O"), ("n", "i4")])
+    structured["payload"][0] = _PayloadLs(directory)
+    structured["n"][0] = 1
+    return structured
+
+
+def test_the_structured_payload_also_fires_when_pickle_is_enabled(tmp_path):
+    """A structured dtype takes a different path through NumPy's descriptor
+    handling than a plain object array, so it needs its own control."""
+    archive = _write_snapshot_ls(
+        tmp_path / "sc.npz", generation=_structured_payload_ls(tmp_path)
+    )
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["generation"]
+    assert _marker_ls(tmp_path).exists(), "the structured payload is inert"
+
+
+def test_an_object_bearing_structured_dtype_is_refused(tmp_path):
+    """`kind == 'O'` alone would miss this; NumPy's refusal covers
+    `dtype.hasobject`."""
+    archive = _write_snapshot_ls(
+        tmp_path / "struct.npz", generation=_structured_payload_ls(tmp_path)
+    )
+    with pytest.raises(ValueError) as excinfo:
+        lucid_server.extract_render_data(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_ls(tmp_path).exists()
+
+
+def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
+    """`extract_render_data` had no context manager: the handle was held open
+    across up to MAX_CELLS iterations of per-cell work. `np.argwhere` is the
+    first downstream call, so it is the ordering witness."""
+    archive = _write_snapshot_ls(tmp_path / "clean.npz")
+    real_load = np.load
+    opened = []
+
+    def _tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    observed = []
+    real_argwhere = np.argwhere
+
+    def _watching_argwhere(*args, **kwargs):
+        handle = opened[0]
+        observed.append(handle.fid is None or getattr(handle.fid, "closed", True))
+        return real_argwhere(*args, **kwargs)
+
+    monkeypatch.setattr(lucid_server.np, "load", _tracking_load)
+    monkeypatch.setattr(lucid_server.np, "argwhere", _watching_argwhere)
+
+    lucid_server.extract_render_data(archive)
+
+    assert observed == [True], "the archive was still open during cell iteration"
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    archive = _write_snapshot_ls(
+        tmp_path / "retry.npz", lattice=_payload_array_ls(tmp_path)
+    )
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(lucid_server.np, "load", _recording_load)
+    with pytest.raises(ValueError):
+        lucid_server.extract_render_data(archive)
+    assert calls == [False]
+
+
+def test_a_numeric_snapshot_still_produces_cells_and_metrics(tmp_path):
+    archive = _write_snapshot_ls(tmp_path / "clean.npz", generation=np.int64(5))
+    data = lucid_server.extract_render_data(archive)
+    assert set(data) == {"cells", "metrics"}
+    assert data["metrics"]["generation"] == 5
+    assert type(data["metrics"]["generation"]) is int
+    assert data["cells"], "a fully non-void lattice must yield cells"

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -417,8 +417,8 @@ def _write_snapshot_ls(path, compressed=False, **members):
 @requires_numpy
 def test_ls_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     """Control. Without it, every "marker is absent" assertion below could
-    pass against a payload that never worked. This is the only place in this
-    module that enables pickle."""
+    pass against a payload that never worked. Pickle is enabled here and in the
+    structured-dtype control below, and nowhere else in this module."""
     archive = _write_snapshot_ls(
         tmp_path / "control.npz", lattice=_payload_array_ls(tmp_path)
     )
@@ -504,6 +504,35 @@ def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
     lucid_server.extract_render_data(archive)
 
     assert observed == [True], "the archive was still open during cell iteration"
+
+
+@requires_numpy
+def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+    """Closure on the exceptional path, witnessed on the real `NpzFile`.
+
+    The docstring claims closure "holds on refusal too because the members are
+    read inside the block". This file's ownership is conditional now, so that
+    claim is newest here and is witnessed rather than asserted.
+    """
+    archive = _write_snapshot_ls(
+        tmp_path / "refused.npz", lattice=_payload_array_ls(tmp_path)
+    )
+    opened = []
+    real_load = np.load
+
+    def tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(lucid_server.np, "load", tracking_load)
+    with pytest.raises(ValueError):
+        lucid_server.extract_render_data(str(archive))
+
+    assert len(opened) == 1, "the archive was never opened"
+    # `close()` drops `zip` unconditionally; `fid` is a class attribute
+    # defaulting to None and cannot carry this claim alone.
+    assert opened[0].zip is None, "the archive survived the refusal"
 
 
 @requires_numpy

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -10,13 +10,16 @@ ignored. Construction now accepts only an exact built-in `dict` and silently
 ignores every other decoded shape, continuing to read later messages exactly
 as it already did for syntactically invalid JSON.
 
-Everything here runs in-process against the real coroutine driven by a
-controlled asynchronous fake socket: no real WebSocket, no browser, no network,
-no snapshot files outside pytest's own `tmp_path` (the pickle-refusal
-tests appended at the end write real NPZ archives there).
+The malformed-frame tests run in-process against the real coroutine driven by
+a controlled asynchronous fake socket; the pickle-refusal tests appended at
+the end call `extract_render_data` directly, with no coroutine and no fake
+socket. Neither uses a real WebSocket, browser or network, and neither writes
+a snapshot file outside pytest's own `tmp_path`.
 
-Scope is top-level JSON shape in `handle_client` only — not whole-server,
-whole-WebSocket, authentication, authorization or payload-schema totality.
+Scope is top-level JSON shape in `handle_client`, plus `extract_render_data`'s
+object-member refusal and archive lifetime — not whole-server, whole-WebSocket,
+whole-archive validation, authentication, authorization or payload-schema
+totality.
 """
 
 from __future__ import annotations
@@ -490,7 +493,9 @@ def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
 
     def _watching_argwhere(*args, **kwargs):
         handle = opened[0]
-        observed.append(handle.fid is None or handle.fid.closed)
+        # `close()` drops `zip` unconditionally; `fid` is a class attribute
+        # defaulting to None, so it cannot carry this claim on its own.
+        observed.append(handle.zip is None)
         return real_argwhere(*args, **kwargs)
 
     monkeypatch.setattr(lucid_server.np, "load", _tracking_load)

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -544,6 +544,25 @@ def _legacy_npy_error_class_ls():
     )
 
 
+#: The exact legacy class, named rather than only derived, so the contract is
+#: readable without running anything. Cross-checked against a live probe below.
+_LEGACY_NPY_ERROR_LS = IndexError
+
+
+@requires_numpy
+def test_the_named_legacy_npy_class_is_what_numpy_actually_raises():
+    """Keeps the named class and the derived one from drifting apart."""
+    derived = _legacy_npy_error_class_ls()
+    assert derived is _LEGACY_NPY_ERROR_LS, (
+        f"the legacy class is actually {derived.__name__}, not "
+        f"{_LEGACY_NPY_ERROR_LS.__name__}; update _LEGACY_NPY_ERROR_LS"
+    )
+    # Non-vacuity: the regression raised TypeError from the context-manager
+    # protocol. If the legacy class were TypeError too, this suite could not
+    # tell the broken state from the correct one.
+    assert derived is not TypeError
+
+
 @requires_numpy
 def test_a_numeric_npy_still_fails_exactly_as_it_did_before(tmp_path, monkeypatch):
     """`extract_render_data` gained its first `with` on this branch.

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -19,7 +19,7 @@ replaced by a closure-recording fake, and the one endpoint witness uses Flask's
 in-process test client.
 
 Scope is archive resource lifetime relative to extraction — not snapshot
-validation, archive security, endpoint totality, API authentication, atomic file
+validation, whole-archive validation, endpoint totality, API authentication, atomic file
 access or whole-server correctness.
 """
 
@@ -505,8 +505,11 @@ def test_ma_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
     "field", ["lattice", "memory_grid", "generation", "best_fitness"]
 )
 def test_object_payload_is_refused_by_the_helper(tmp_path, field):
-    """`best_fitness` is unique to this module -- it is the only loader of the
-    six that reads a fourth member."""
+    """Four members, `best_fitness` among them.
+
+    This was the widest loader of the six until the export CLI joined them:
+    `scripts/portable_genome.py` reads five, three of those through `.get`.
+    """
     archive = _write_snapshot_ma(
         tmp_path / f"{field}.npz", **{field: _payload_array_ma(tmp_path)}
     )
@@ -549,7 +552,12 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         medusa_api._load_snapshot(archive)
     assert len(opened) == 1
-    assert opened[0].fid is None or opened[0].fid.closed
+    # `zip` is the primary witness: `close()` drops it unconditionally,
+    # whereas `fid` is a CLASS attribute defaulting to None, so asserting
+    # on it alone would pass on a handle that was never closed at all.
+    assert opened[0].zip is None and (
+        opened[0].fid is None or opened[0].fid.closed
+    )
 
 
 def test_a_numeric_snapshot_still_loads_all_four_values(tmp_path):

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -549,7 +549,7 @@ def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         medusa_api._load_snapshot(archive)
     assert len(opened) == 1
-    assert opened[0].fid is None or getattr(opened[0].fid, "closed", True)
+    assert opened[0].fid is None or opened[0].fid.closed
 
 
 def test_a_numeric_snapshot_still_loads_all_four_values(tmp_path):

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -191,7 +191,7 @@ def test_extraction_order_is_preserved():
     assert archive.lookups == ["lattice", "memory_grid", "generation", "best_fitness"]
 
 
-def test_np_load_receives_str_path_and_allow_pickle():
+def test_np_load_receives_str_path_and_allow_pickle_false():
     archive = _FakeArchive(_contents())
     path = _FakeSnapshotPath("v070_gen42.npz")
     _, load_mock = _load(archive, path=path)
@@ -199,7 +199,7 @@ def test_np_load_receives_str_path_and_allow_pickle():
     args, kwargs = load_mock.call_args
     assert args == (str(path),)
     assert type(args[0]) is str
-    assert kwargs == {"allow_pickle": True}
+    assert kwargs == {"allow_pickle": False}
 
 
 def test_returned_arrays_keep_their_dtypes():
@@ -426,3 +426,137 @@ def test_all_four_endpoints_still_use_the_shared_helper():
             if isinstance(node, ast.FunctionDef) and node.name == name
         )
         assert _np_load_calls(function) == []  # each goes through the helper only
+
+
+# ===========================================================================
+# Pickle refusal -- medusa_api must never unpickle an NPZ member
+#
+# An object-dtype member is stored as a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The payload below is
+# harmless: its reduction writes ONE marker file inside pytest's own tmp_path
+# and returns. `__reduce__` runs at PICKLE time and only records the callable,
+# so writing the archive is inert; the call would happen at UNPICKLE time.
+#
+# Scope: an object-member refusal, NOT whole-archive validation.
+# ===========================================================================
+
+_MA_MARKER = "MEDUSA_PAYLOAD_EXECUTED"
+
+
+def _create_marker_ma(directory: str) -> str:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required -- pickle stores a module-qualified reference, so
+    a function defined inside a test body could not be resolved at load time.
+    """
+    marker = Path(directory) / _MA_MARKER
+    marker.write_text("payload executed", encoding="utf-8")
+    return str(marker)
+
+
+class _PayloadMa:
+    """Its reduction calls the marker writer when unpickled."""
+
+    def __init__(self, directory):
+        self._directory = str(directory)
+
+    def __reduce__(self):
+        return (_create_marker_ma, (self._directory,))
+
+
+def _payload_array_ma(directory):
+    return np.array([_PayloadMa(directory)], dtype=object)
+
+
+def _marker_ma(tmp_path):
+    return tmp_path / _MA_MARKER
+
+
+def _write_snapshot_ma(path, compressed=False, **members):
+    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    payload = {
+        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "generation": 7,
+        "best_fitness": 0.5,
+    }
+    payload.update(members)
+    writer = np.savez_compressed if compressed else np.savez
+    writer(path, **payload)
+    return str(path)
+
+
+def test_ma_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Control. Without it, every "marker is absent" assertion below could
+    pass against a payload that never worked. This is the only place in this
+    module that enables pickle."""
+    archive = _write_snapshot_ma(
+        tmp_path / "control.npz", lattice=_payload_array_ma(tmp_path)
+    )
+    assert not _marker_ma(tmp_path).exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert _marker_ma(tmp_path).exists(), "the payload fixture is inert; fix it"
+
+
+@pytest.mark.parametrize(
+    "field", ["lattice", "memory_grid", "generation", "best_fitness"]
+)
+def test_object_payload_is_refused_by_the_helper(tmp_path, field):
+    """`best_fitness` is unique to this module -- it is the only loader of the
+    six that reads a fourth member."""
+    archive = _write_snapshot_ma(
+        tmp_path / f"{field}.npz", **{field: _payload_array_ma(tmp_path)}
+    )
+    with pytest.raises(ValueError) as excinfo:
+        medusa_api._load_snapshot(archive)
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not _marker_ma(tmp_path).exists(), "the pickle payload executed"
+
+
+def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+    archive = _write_snapshot_ma(
+        tmp_path / "retry.npz", lattice=_payload_array_ma(tmp_path)
+    )
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(medusa_api.np, "load", _recording_load)
+    with pytest.raises(ValueError):
+        medusa_api._load_snapshot(archive)
+    assert calls == [False]
+
+
+def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+    archive = _write_snapshot_ma(
+        tmp_path / "closed.npz", lattice=_payload_array_ma(tmp_path)
+    )
+    real_load = np.load
+    opened = []
+
+    def _tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(medusa_api.np, "load", _tracking_load)
+    with pytest.raises(ValueError):
+        medusa_api._load_snapshot(archive)
+    assert len(opened) == 1
+    assert opened[0].fid is None or getattr(opened[0].fid, "closed", True)
+
+
+def test_a_numeric_snapshot_still_loads_all_four_values(tmp_path):
+    archive = _write_snapshot_ma(
+        tmp_path / "clean.npz", generation=np.int64(3), best_fitness=np.float32(0.25)
+    )
+    lattice, grid, generation, fitness = medusa_api._load_snapshot(archive)
+    assert lattice.dtype == np.uint8 and grid.dtype == np.float32
+    assert generation == 3 and type(generation) is int
+    assert fitness == pytest.approx(0.25) and type(fitness) is float

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1321,6 +1321,60 @@ def _cli_main_block() -> ast.Module:
     return ast.Module(body=blocks[0].body, type_ignores=[])
 
 
+def _member_accesses(node, name):
+    """Every constant-string member access on ``name`` inside ``node``.
+
+    Returns ``(lineno, col_offset, member)`` triples so callers can restore
+    source order -- ``ast.walk`` does not preserve it, and two of the CLI's
+    accesses share a line.
+
+    Both access forms are covered: ``snap["x"]`` and ``snap.get("x", default)``.
+    """
+    found = []
+    for child in ast.walk(node):
+        member = None
+        if (isinstance(child, ast.Subscript)
+                and isinstance(child.value, ast.Name) and child.value.id == name
+                and isinstance(child.slice, ast.Constant)
+                and isinstance(child.slice.value, str)):
+            member = child.slice.value
+        elif (isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr == "get"
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == name
+                and child.args and isinstance(child.args[0], ast.Constant)
+                and isinstance(child.args[0].value, str)):
+            member = child.args[0].value
+        if member is not None:
+            found.append((child.lineno, child.col_offset, member))
+    return found
+
+
+def _cli_snapshot_with():
+    """The ``with`` in the export CLI that owns the loaded snapshot.
+
+    Selected by BEHAVIOUR, not position. The ``__main__`` body also contains
+    ``with open(args.rule_file, "rb") as f:``, so "the only ``with``" was never
+    a safe way to find this one -- it silently selects the TOML handle. The
+    snapshot block is identified as the one whose bound name is dereferenced
+    with constant-string members, and exactly one must match.
+    """
+    block = _cli_main_block()
+    candidates = []
+    for node in ast.walk(block):
+        if not isinstance(node, ast.With):
+            continue
+        target = node.items[0].optional_vars
+        if isinstance(target, ast.Name) and _member_accesses(node, target.id):
+            candidates.append(node)
+    assert len(candidates) == 1, (
+        "expected exactly one `with` dereferencing constant-string snapshot "
+        f"members in the export CLI, found {len(candidates)}"
+    )
+    return candidates[0]
+
+
 def _run_export_cli(monkeypatch, rule_file, snapshot, output, *extra) -> None:
     """Execute the real ``__main__`` body in-process.
 
@@ -1414,15 +1468,14 @@ def test_export_cli_routes_the_snapshot_through_conditional_ownership():
     rather than only to a test run.
     """
     block = _cli_main_block()
-    owning = [node for node in ast.walk(block) if isinstance(node, ast.With)]
-    assert len(owning) == 1, "the export CLI no longer has exactly one `with`"
+    owning = _cli_snapshot_with()
     assert any(
         isinstance(node, ast.Attribute) and node.attr == "nullcontext"
         for node in ast.walk(block)
     ), "the snapshot is not routed through contextlib.nullcontext"
     inside = {
         node.func.id
-        for node in ast.walk(owning[0])
+        for node in ast.walk(owning)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
     assert "export_genome" not in inside, (
@@ -1644,6 +1697,36 @@ def _legacy_npy_error_class():
         "a constant-string subscript on a plain ndarray no longer raises; "
         "the legacy contract this test pins no longer exists"
     )
+
+
+#: The exact legacy class, named rather than only derived, because a reviewer
+#: should be able to read the contract without running anything. It is
+#: cross-checked against a live probe below, so the name cannot rot silently.
+_LEGACY_NPY_ERROR = IndexError
+
+
+def test_the_named_legacy_npy_class_is_what_numpy_actually_raises():
+    """Keeps the named class and the derived one from drifting apart.
+
+    If NumPy ever changes what a constant-string subscript on a plain ndarray
+    raises, this fails and names the real class rather than letting the
+    documented contract quietly become fiction.
+    """
+    derived = _legacy_npy_error_class()
+    assert derived is _LEGACY_NPY_ERROR, (
+        f"the legacy class is actually {derived.__name__}, not "
+        f"{_LEGACY_NPY_ERROR.__name__}; update _LEGACY_NPY_ERROR"
+    )
+
+
+def test_the_legacy_class_is_distinguishable_from_the_regression():
+    """Non-vacuity: the two outcomes this test suite separates must differ.
+
+    The regression raised ``TypeError`` from the context-manager protocol. If
+    the legacy class were also ``TypeError``, every assertion below would pass
+    in both the broken and the correct state and prove nothing.
+    """
+    assert _legacy_npy_error_class() is not TypeError
 
 
 def test_a_numeric_npy_still_fails_exactly_as_it_did_before(monkeypatch, tmp_path):

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -28,12 +28,14 @@ Reachability is checked on two separate surfaces:
 from __future__ import annotations
 
 import ast
+import base64
 import inspect
 import json
 import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import scripts.portable_genome as pg
@@ -1207,9 +1209,177 @@ def test_export_genome_untouched_by_this_package():
     assert {"_load_transition_table", "_load_stochastic_config"} <= called
 
 
-def test_export_cli_snapshot_path_unchanged():
-    # Deliberately out of scope for this package: the export CLI still loads a
-    # snapshot exactly as before.
+# ===========================================================================
+# Export-CLI snapshot loading: no pickled member is ever loaded
+#
+# An NPZ member of object dtype IS a pickle, so loading one with pickle
+# enabled is arbitrary code execution by construction. The export CLI reads a
+# snapshot supplied on the command line, so the payload below is harmless: its
+# reduction writes ONE marker file inside pytest's own tmp_path and returns.
+# `__reduce__` runs at PICKLE time and only records the callable, so writing
+# the archive is inert; the call would happen at UNPICKLE time, which is the
+# event under test.
+#
+# Two surfaces, matching this module's existing DIRECT/PUBLIC split:
+#   * IN-PROCESS -- the module's real `__main__` body, lifted from the live
+#     source, so load counting, archive lifetime and call ordering can be
+#     observed on the real objects.
+#   * PUBLIC -- `python -m scripts.portable_genome export`, which proves the
+#     shipped entry point refuses too.
+#
+# Scope: an OBJECT-MEMBER REFUSAL, not whole-archive validation. Nothing here
+# claims resistance to decompression amplification, absurd declared shapes,
+# hostile member names or defects in NumPy's own header parsing.
+# ===========================================================================
+
+_PG_MARKER = "PORTABLE_GENOME_PAYLOAD_EXECUTED"
+
+#: Every member the export CLI actually dereferences, in the CLI's own order.
+#: `generation`, `ca_step` and `best_fitness` are reached through `.get`, which
+#: routes through `NpzFile.__getitem__` whenever the key is present -- a `.get`
+#: default does NOT make a member safe, and each is covered here for that
+#: reason.
+_CLI_MEMBERS = ("lattice", "memory_grid", "generation", "ca_step", "best_fitness")
+
+
+def _create_marker_pg(directory: str) -> int:
+    """Stand in for a malicious payload; deliberately inert.
+
+    Module scope is required: pickle stores a module-qualified reference, so
+    this has to be importable by name at unpickle time.
+
+    Returns ``0`` so a pickle-enabled load carries on through the CLI's
+    ``int()``/``float()`` casts instead of dying on incidental type noise. That
+    keeps the failing-first evidence pointed at the real defect -- the payload
+    ran -- rather than at a cast that happened to blow up first.
+    """
+    Path(directory, _PG_MARKER).write_text("executed", encoding="utf-8")
+    return 0
+
+
+class _PayloadPG:
+    """An object whose reduction calls :func:`_create_marker_pg`."""
+
+    def __init__(self, directory: str) -> None:
+        self._directory = directory
+
+    def __reduce__(self):
+        return (_create_marker_pg, (self._directory,))
+
+
+def _payload_member_pg(directory) -> "np.ndarray":
+    """A 0-d object-dtype member -- i.e. a pickle inside the archive."""
+    return np.array(_PayloadPG(str(directory)), dtype=object)
+
+
+def _numeric_members_pg(generation=7, ca_step=42, best_fitness=0.125) -> dict:
+    """A legitimate snapshot: ndarrays and plain numeric scalars, no objects."""
+    return {
+        "lattice": np.arange(8, dtype=np.uint8).reshape(2, 2, 2),
+        "memory_grid": np.zeros((pg.MEMORY_CHANNELS, 2, 2, 2), dtype=np.float32),
+        "generation": np.int64(generation),
+        "ca_step": np.int64(ca_step),
+        "best_fitness": np.float64(best_fitness),
+    }
+
+
+def _write_snapshot_pg(tmp_path, members) -> Path:
+    archive = tmp_path / "snapshot.npz"
+    np.savez(archive, **members)
+    return archive
+
+
+def _minimal_rule_file(tmp_path) -> Path:
+    """An empty rule spec.
+
+    Every configuration loader reached by ``export_genome`` defaults cleanly on
+    an absent ``params`` section, so this keeps the evidence pointed at
+    snapshot loading rather than at rule parsing.
+    """
+    rule_file = tmp_path / "rule.toml"
+    rule_file.write_text("", encoding="utf-8")
+    return rule_file
+
+
+def _cli_main_block() -> ast.Module:
+    """The module's real ``if __name__ == "__main__":`` body, lifted live.
+
+    Lifted from the installed source rather than reimplemented, so these tests
+    cannot drift away from what ``python -m scripts.portable_genome`` actually
+    runs. The single-block assertion is what keeps the lift honest.
+    """
+    tree = _module_tree()
+    blocks = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "__name__"
+    ]
+    assert len(blocks) == 1, "portable_genome no longer has exactly one __main__ block"
+    return ast.Module(body=blocks[0].body, type_ignores=[])
+
+
+def _run_export_cli(monkeypatch, rule_file, snapshot, output, *extra) -> None:
+    """Execute the real ``__main__`` body in-process.
+
+    It runs against a COPY of the module's own globals, so ``export_genome``
+    and ``np`` are the real objects and any monkeypatch applied BEFORE this
+    call is visible to the CLI. Nothing long-running is started: the export
+    branch parses one TOML file, reads one archive and writes one JSON file.
+    """
+    argv = [
+        "portable_genome.py", "export",
+        "--rule-file", str(rule_file),
+        "--snapshot", str(snapshot),
+        "--output", str(output),
+        *extra,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    namespace = dict(pg.__dict__)
+    namespace["__name__"] = "__main__"
+    exec(compile(_cli_main_block(), "<portable_genome __main__>", "exec"), namespace)
+
+
+def _export_cli_subprocess(rule_file, snapshot, output, *extra):
+    """Run the PUBLIC export CLI exactly as an operator would."""
+    return subprocess.run(
+        [
+            sys.executable, "-m", "scripts.portable_genome", "export",
+            "--rule-file", str(rule_file),
+            "--snapshot", str(snapshot),
+            "--output", str(output),
+            *extra,
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _archive_is_open(handle) -> bool:
+    """True while the NPZ archive still owns operating-system resources.
+
+    Reads the real ``NpzFile``: ``close()`` drops both ``zip`` and ``fid`` to
+    ``None``. Deliberately NOT written with a ``getattr(..., default)`` --
+    a default is precisely what makes a closure assertion pass on an object
+    that was never observed at all.
+    """
+    return handle.zip is not None
+
+
+# --- static contract -------------------------------------------------------
+
+
+def test_export_cli_snapshot_load_is_pickle_free():
+    """Supersedes ``test_export_cli_snapshot_path_unchanged``.
+
+    That test pinned the export CLI to ``allow_pickle=True`` and described the
+    loader as deliberately out of scope. It is in scope now: the pin asserted
+    the insecure behaviour, so it has been replaced by an assertion of the
+    intended secure contract rather than merely deleted.
+    """
     tree = _module_tree()
     loads = [
         node
@@ -1224,4 +1394,238 @@ def test_export_cli_snapshot_path_unchanged():
     keywords = {kw.arg: kw.value for kw in loads[0].keywords}
     assert set(keywords) == {"allow_pickle"}
     assert isinstance(keywords["allow_pickle"], ast.Constant)
-    assert keywords["allow_pickle"].value is True
+    assert keywords["allow_pickle"].value is False
+
+
+def test_export_cli_owns_the_archive_through_a_context_manager():
+    """The load is a ``with`` subject, and ``export_genome`` is outside it.
+
+    The dynamic proof lives in
+    ``test_the_archive_is_closed_before_export_genome_begins``; this is the
+    structural half, and it is what makes the ordering visible to a reader of
+    the source rather than only to a test run.
+    """
+    tree = _module_tree()
+    owning = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.With)
+        and any(
+            isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Attribute)
+            and item.context_expr.func.attr == "load"
+            for item in node.items
+        )
+    ]
+    assert len(owning) == 1, "the export CLI's np.load is not owned by a `with`"
+    inside = {
+        node.func.id
+        for node in ast.walk(owning[0])
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "export_genome" not in inside, (
+        "export_genome is called while the archive is still open"
+    )
+
+
+# --- the payload really does execute when pickle is enabled ----------------
+
+
+def test_pg_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
+    """Positive control.
+
+    Without this, every "marker absent" assertion below would be vacuous: a
+    payload that never fires proves nothing about a loader that refuses it.
+    """
+    archive = _write_snapshot_pg(tmp_path, {"lattice": _payload_member_pg(tmp_path)})
+    marker = tmp_path / _PG_MARKER
+    assert not marker.exists()
+
+    with np.load(archive, allow_pickle=True) as snap:
+        snap["lattice"]
+
+    assert marker.exists(), "the payload did not fire; the refusal tests are vacuous"
+
+
+# --- refusal ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("member", _CLI_MEMBERS)
+def test_every_member_the_cli_touches_is_refused(monkeypatch, tmp_path, member):
+    """Each of the five members the CLI dereferences, carrying the payload.
+
+    The last three are reached through ``.get`` with a default. That default
+    only applies to an ABSENT key -- a present key still decodes -- so they are
+    covered exactly like the two direct subscripts.
+    """
+    members = _numeric_members_pg()
+    members[member] = _payload_member_pg(tmp_path)
+    archive = _write_snapshot_pg(tmp_path, members)
+    output = tmp_path / "genome.json"
+    marker = tmp_path / _PG_MARKER
+
+    with pytest.raises(ValueError) as excinfo:
+        _run_export_cli(monkeypatch, _minimal_rule_file(tmp_path), archive, output)
+
+    assert "allow_pickle=False" in str(excinfo.value)
+    assert not marker.exists(), "the payload executed"
+    assert not output.exists(), "a genome was written from a refused snapshot"
+
+
+def test_the_public_export_cli_refuses_a_pickled_member(tmp_path):
+    """The shipped entry point, run as an operator would run it.
+
+    Marker absence is deliberately NOT asserted here: the payload's reduction
+    names a callable in THIS test module, which a fresh interpreter would fail
+    to import, so an absent marker in a subprocess would prove nothing either
+    way. What this surface proves is that the real console entry point refuses
+    and writes no genome. The in-process tests above own the marker evidence.
+    """
+    archive = _write_snapshot_pg(
+        tmp_path, {**_numeric_members_pg(), "lattice": _payload_member_pg(tmp_path)}
+    )
+    output = tmp_path / "genome.json"
+
+    result = _export_cli_subprocess(_minimal_rule_file(tmp_path), archive, output)
+
+    assert result.returncode != 0
+    assert "allow_pickle=False" in result.stderr
+    assert not output.exists()
+
+
+def test_the_cli_loads_once_and_never_retries_with_pickle_enabled(monkeypatch, tmp_path):
+    """A refusal must be final.
+
+    A fallback retry would restore the vulnerability while leaving every other
+    assertion in this file green, so the argument every load was made with is
+    recorded and the whole sequence is asserted -- not just the first call.
+    """
+    archive = _write_snapshot_pg(
+        tmp_path, {**_numeric_members_pg(), "lattice": _payload_member_pg(tmp_path)}
+    )
+    calls = []
+    real_load = np.load
+
+    def recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle", "<absent>"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(np, "load", recording_load)
+    with pytest.raises(ValueError):
+        _run_export_cli(
+            monkeypatch, _minimal_rule_file(tmp_path), archive, tmp_path / "genome.json"
+        )
+
+    assert calls == [False], f"expected exactly one pickle-free load, got {calls}"
+
+
+# --- archive lifetime ------------------------------------------------------
+
+
+def test_the_archive_is_closed_before_export_genome_begins(monkeypatch, tmp_path):
+    """Deterministic closure, observed on the real ``NpzFile``.
+
+    Non-vacuity is enforced from both ends. The archive is recorded as GENUINELY
+    OPEN at load time, and ``export_genome`` is recorded as GENUINELY REACHED --
+    both are asserted before the closure claim, so "closed" can never be
+    satisfied by an observation that never happened.
+    """
+    archive = _write_snapshot_pg(tmp_path, _numeric_members_pg())
+    seen = {}
+    real_load = np.load
+    real_export = pg.export_genome
+
+    def watching_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        seen["handle"] = handle
+        seen["open_at_load"] = _archive_is_open(handle)
+        return handle
+
+    def watching_export(*args, **kwargs):
+        seen["open_at_export"] = _archive_is_open(seen["handle"])
+        seen["fid_at_export"] = seen["handle"].fid
+        return real_export(*args, **kwargs)
+
+    monkeypatch.setattr(np, "load", watching_load)
+    monkeypatch.setattr(pg, "export_genome", watching_export)
+    _run_export_cli(
+        monkeypatch, _minimal_rule_file(tmp_path), archive, tmp_path / "genome.json"
+    )
+
+    assert seen.get("open_at_load") is True, "the archive was never observed open"
+    assert "open_at_export" in seen, "export_genome was never reached"
+    assert seen["open_at_export"] is False, "export_genome ran with the archive open"
+    assert seen["fid_at_export"] is None, "the file descriptor was still held"
+
+
+# --- compatibility ---------------------------------------------------------
+
+
+def test_a_numeric_snapshot_still_exports_its_counters(monkeypatch, tmp_path):
+    """Generation, CA step and best fitness survive the refusal change."""
+    archive = _write_snapshot_pg(tmp_path, _numeric_members_pg())
+    output = tmp_path / "genome.json"
+
+    _run_export_cli(monkeypatch, _minimal_rule_file(tmp_path), archive, output)
+
+    metadata = json.loads(output.read_text(encoding="utf-8"))["metadata"]
+    assert metadata["source_generation"] == 7
+    assert metadata["source_ca_step"] == 42
+    assert metadata["best_fitness"] == 0.125
+
+
+def test_absent_optional_members_still_fall_back_to_their_defaults(monkeypatch, tmp_path):
+    """The `.get` defaults are untouched: an ABSENT key still yields 0/0/0.0."""
+    archive = _write_snapshot_pg(
+        tmp_path,
+        {
+            "lattice": np.arange(8, dtype=np.uint8).reshape(2, 2, 2),
+            "memory_grid": np.zeros((pg.MEMORY_CHANNELS, 2, 2, 2), dtype=np.float32),
+        },
+    )
+    output = tmp_path / "genome.json"
+
+    _run_export_cli(monkeypatch, _minimal_rule_file(tmp_path), archive, output)
+
+    metadata = json.loads(output.read_text(encoding="utf-8"))["metadata"]
+    assert metadata["source_generation"] == 0
+    assert metadata["source_ca_step"] == 0
+    assert metadata["best_fitness"] == 0.0
+
+
+def test_the_epigenetic_payload_still_exports_intact(monkeypatch, tmp_path):
+    """The arrays outlive the archive.
+
+    ``export_genome`` base64-encodes ``lattice`` and ``memory_grid`` AFTER the
+    archive is closed, so decoding them to their exact byte lengths and values
+    is what proves closure did not truncate or invalidate the data.
+    """
+    archive = _write_snapshot_pg(tmp_path, _numeric_members_pg())
+    output = tmp_path / "genome.json"
+
+    _run_export_cli(
+        monkeypatch,
+        _minimal_rule_file(tmp_path),
+        archive,
+        output,
+        "--include-epigenetic",
+    )
+
+    epi = json.loads(output.read_text(encoding="utf-8"))["epigenetic_snapshot"]
+    assert epi["included"] is True
+    assert epi["lattice_shape"] == [2, 2, 2]
+    assert epi["snapshot_generation"] == 7
+    assert epi["snapshot_ca_step"] == 42
+    assert base64.b64decode(epi["lattice_b64"]) == bytes(range(8))
+    assert len(base64.b64decode(epi["memory_grid_b64"])) == pg.MEMORY_CHANNELS * 8 * 4
+
+
+def test_without_the_flag_the_epigenetic_section_stays_excluded(monkeypatch, tmp_path):
+    """Established export semantics: the flag, not the snapshot, decides."""
+    archive = _write_snapshot_pg(tmp_path, _numeric_members_pg())
+    output = tmp_path / "genome.json"
+
+    _run_export_cli(monkeypatch, _minimal_rule_file(tmp_path), archive, output)
+
+    genome = json.loads(output.read_text(encoding="utf-8"))
+    assert genome["epigenetic_snapshot"] == {"included": False}

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1325,8 +1325,8 @@ def _member_accesses(node, name):
     """Every constant-string member access on ``name`` inside ``node``.
 
     Returns ``(lineno, col_offset, member)`` triples so callers can restore
-    source order -- ``ast.walk`` does not preserve it, and two of the CLI's
-    accesses share a line.
+    source order -- ``ast.walk`` does not preserve it, and the CLI packs two
+    accesses onto each of two lines, so ``lineno`` alone is not enough.
 
     Both access forms are covered: ``snap["x"]`` and ``snap.get("x", default)``.
     """
@@ -1405,12 +1405,37 @@ def _cli_snapshot_members():
     return tuple(ordered)
 
 
+def _derive_cli_members():
+    """Derive at import WITHOUT letting a failure take out the file.
+
+    ``_cli_snapshot_members`` asserts loudly, and it has to -- a derivation
+    that quietly returned ``()`` would parametrise zero refusal cases in
+    silence. But it is called at module scope, where a raised assertion is a
+    COLLECTION ERROR for all ~70 tests here, most of which are the
+    configuration-shape totality package and have nothing to do with snapshot
+    loading. This module's sibling `tests/test_lucid_server.py` refuses an
+    unconditional numpy import for exactly that reason.
+
+    So the failure is captured rather than raised, reported by its own test,
+    and coverage falls back to the reviewed contract -- never to nothing.
+    """
+    try:
+        return _cli_snapshot_members(), None
+    except AssertionError as exc:
+        return (), exc
+
+
+_DERIVED_CLI_MEMBERS, _CLI_DERIVATION_ERROR = _derive_cli_members()
+
 #: Every member the export CLI actually dereferences, in the CLI's own order,
 #: DERIVED from the live source rather than transcribed. `generation`,
 #: `ca_step` and `best_fitness` are reached through `.get`, which routes
 #: through `NpzFile.__getitem__` whenever the key is present -- a `.get`
 #: default does NOT make a member safe, and each is covered for that reason.
-_CLI_MEMBERS = _cli_snapshot_members()
+#:
+#: Falls back to the reviewed contract if the derivation could not run, so the
+#: refusal parametrisation never silently empties.
+_CLI_MEMBERS = _DERIVED_CLI_MEMBERS or _EXPECTED_CLI_MEMBERS
 
 
 def _run_export_cli(monkeypatch, rule_file, snapshot, output, *extra) -> None:
@@ -1498,10 +1523,24 @@ def test_the_derived_cli_members_match_the_reviewed_contract():
     is exactly the kind of change that should stop a reviewer rather than slip
     through under a green suite.
     """
-    assert _CLI_MEMBERS == _EXPECTED_CLI_MEMBERS, (
-        f"the export CLI now dereferences {_CLI_MEMBERS}, not "
-        f"{_EXPECTED_CLI_MEMBERS}. The refusal tests already cover the new set; "
-        "confirm the change is intended and update _EXPECTED_CLI_MEMBERS."
+    assert _DERIVED_CLI_MEMBERS == _EXPECTED_CLI_MEMBERS, (
+        f"the export CLI now dereferences {_DERIVED_CLI_MEMBERS}, not "
+        f"{_EXPECTED_CLI_MEMBERS}. Before editing the constant, check the "
+        "DERIVATION against the CLI: if a member is read through an alias or a "
+        "computed key it will be under-reported here, and copying a short "
+        "tuple into the constant would bake that gap in permanently."
+    )
+
+
+def test_the_cli_member_derivation_actually_ran():
+    """The fallback must never pass for a broken derivation.
+
+    `_CLI_MEMBERS` falls back to the reviewed contract so the refusal tests
+    keep running, which means a failed derivation would otherwise be invisible.
+    This is where it surfaces.
+    """
+    assert _CLI_DERIVATION_ERROR is None, (
+        f"the export CLI member derivation failed: {_CLI_DERIVATION_ERROR}"
     )
 
 
@@ -1529,10 +1568,10 @@ def test_export_cli_routes_the_snapshot_through_conditional_ownership():
 
     The context expression is deliberately NOT ``np.load(...)`` itself.
     ``np.load`` returns an ``NpzFile`` for a zip archive but a plain ndarray
-    (or a memmap) for a ``.npy``, and an ndarray has no context-manager
-    protocol. Only the non-archive case is wrapped in ``nullcontext``: the NPZ
-    keeps deterministic closure, and a ``.npy`` still fails exactly where it
-    always did, at the first constant-string subscript.
+    for a ``.npy``, and an ndarray has no context-manager protocol. Only the
+    non-archive case is wrapped in ``nullcontext``: the NPZ keeps deterministic
+    closure, and a numeric ``.npy`` still fails exactly where it always did, at
+    the first constant-string subscript.
 
     The dynamic halves live in
     ``test_the_archive_is_closed_before_export_genome_begins`` and
@@ -1542,6 +1581,20 @@ def test_export_cli_routes_the_snapshot_through_conditional_ownership():
     """
     block = _cli_main_block()
     owning = _cli_snapshot_with()
+
+    # Assert the docstring's actual claim: the `with` subject is a NAME, not
+    # the load call. Checking only that the token `nullcontext` appears
+    # somewhere in the block would still pass if the code were rewritten as
+    # `with np.load(...) as snap:` beside a dead nullcontext reference.
+    context_expr = owning.items[0].context_expr
+    assert not (
+        isinstance(context_expr, ast.Call)
+        and isinstance(context_expr.func, ast.Attribute)
+        and context_expr.func.attr == "load"
+    ), "the `with` subject is np.load(...) itself; a .npy would fail on entry"
+    assert isinstance(context_expr, ast.Name), (
+        "the `with` subject is no longer the conditionally-owned name"
+    )
     assert any(
         isinstance(node, ast.Attribute) and node.attr == "nullcontext"
         for node in ast.walk(block)
@@ -1691,6 +1744,35 @@ def test_the_archive_is_closed_before_export_genome_begins(monkeypatch, tmp_path
 # --- compatibility ---------------------------------------------------------
 
 
+def test_the_real_archive_is_closed_after_a_refusal(monkeypatch, tmp_path):
+    """Closure must hold on the exceptional path, not only the happy one.
+
+    The prose claims the archive closes "on a refusal raised mid extraction"
+    because the members are read inside the block. This is the file where that
+    claim is newest -- ownership here is conditional -- so it is witnessed
+    rather than asserted, on the real `NpzFile`.
+    """
+    archive = _write_snapshot_pg(
+        tmp_path, {**_numeric_members_pg(), "lattice": _payload_member_pg(tmp_path)}
+    )
+    opened = []
+    real_load = np.load
+
+    def tracking_load(*args, **kwargs):
+        handle = real_load(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(np, "load", tracking_load)
+    with pytest.raises(ValueError):
+        _run_export_cli(
+            monkeypatch, _minimal_rule_file(tmp_path), archive, tmp_path / "g.json"
+        )
+
+    assert len(opened) == 1, "the archive was never opened"
+    assert _archive_is_open(opened[0]) is False, "the archive survived the refusal"
+
+
 def test_a_numeric_snapshot_still_exports_its_counters(monkeypatch, tmp_path):
     """Generation, CA step and best fitness survive the refusal change."""
     archive = _write_snapshot_pg(tmp_path, _numeric_members_pg())
@@ -1815,11 +1897,20 @@ def test_a_numeric_npy_still_fails_exactly_as_it_did_before(monkeypatch, tmp_pat
     np.save(not_an_archive, np.arange(8, dtype=np.uint8))
     output = tmp_path / "genome.json"
 
+    # `IndexError` is a common class, so the absence of an output file does not
+    # by itself prove the failure happened at the subscript. A sentinel on
+    # `export_genome` -- the first thing after the extraction -- pins it.
+    reached = []
+    monkeypatch.setattr(
+        pg, "export_genome", lambda *a, **k: reached.append("export_genome")
+    )
+
     with pytest.raises(_legacy_npy_error_class()):
         _run_export_cli(
             monkeypatch, _minimal_rule_file(tmp_path), not_an_archive, output
         )
 
+    assert reached == [], "export_genome ran on a non-archive input"
     assert not output.exists()
 
 

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1397,27 +1397,29 @@ def test_export_cli_snapshot_load_is_pickle_free():
     assert keywords["allow_pickle"].value is False
 
 
-def test_export_cli_owns_the_archive_through_a_context_manager():
-    """The load is a ``with`` subject, and ``export_genome`` is outside it.
+def test_export_cli_routes_the_snapshot_through_conditional_ownership():
+    """The loaded object is owned by a ``with``; ``export_genome`` is outside it.
 
-    The dynamic proof lives in
-    ``test_the_archive_is_closed_before_export_genome_begins``; this is the
-    structural half, and it is what makes the ordering visible to a reader of
-    the source rather than only to a test run.
+    The context expression is deliberately NOT ``np.load(...)`` itself.
+    ``np.load`` returns an ``NpzFile`` for a zip archive but a plain ndarray
+    (or a memmap) for a ``.npy``, and an ndarray has no context-manager
+    protocol. Only the non-archive case is wrapped in ``nullcontext``: the NPZ
+    keeps deterministic closure, and a ``.npy`` still fails exactly where it
+    always did, at the first constant-string subscript.
+
+    The dynamic halves live in
+    ``test_the_archive_is_closed_before_export_genome_begins`` and
+    ``test_a_numeric_npy_still_fails_exactly_as_it_did_before``; this is the
+    structural half, which makes the ordering visible to a reader of the source
+    rather than only to a test run.
     """
-    tree = _module_tree()
-    owning = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.With)
-        and any(
-            isinstance(item.context_expr, ast.Call)
-            and isinstance(item.context_expr.func, ast.Attribute)
-            and item.context_expr.func.attr == "load"
-            for item in node.items
-        )
-    ]
-    assert len(owning) == 1, "the export CLI's np.load is not owned by a `with`"
+    block = _cli_main_block()
+    owning = [node for node in ast.walk(block) if isinstance(node, ast.With)]
+    assert len(owning) == 1, "the export CLI no longer has exactly one `with`"
+    assert any(
+        isinstance(node, ast.Attribute) and node.attr == "nullcontext"
+        for node in ast.walk(block)
+    ), "the snapshot is not routed through contextlib.nullcontext"
     inside = {
         node.func.id
         for node in ast.walk(owning[0])
@@ -1622,26 +1624,42 @@ def test_the_epigenetic_payload_still_exports_intact(monkeypatch, tmp_path):
     assert len(base64.b64decode(epi["memory_grid_b64"])) == pg.MEMORY_CHANNELS * 8 * 4
 
 
-def test_a_non_npz_snapshot_now_fails_at_the_context_manager(monkeypatch, tmp_path):
-    """A DISCLOSED CONSEQUENCE of giving the archive deterministic closure.
+def _legacy_npy_error_class():
+    """The exception class an ordinary numeric ``.npy`` produced BEFORE this branch.
 
-    ``np.load`` on a file that is not a zip returns a plain ndarray, which has
-    no context-manager protocol. Before the ``with``, a ``.npy`` passed to
-    ``--snapshot`` got as far as ``snap["lattice"]`` and failed there with an
-    indexing error; it now fails one statement earlier with a different
-    exception type.
+    Derived, never hard-coded. At the base commit the export CLI did
+    ``snap = np.load(...)`` and then immediately ``snap["lattice"]``. For a
+    non-zip input ``np.load`` returns a plain ndarray rather than an
+    ``NpzFile``, so the legacy failure is whatever a constant-string subscript
+    on an ndarray raises in the installed NumPy. Reproducing that exact
+    operation here pins the contract to real behaviour instead of to a
+    remembered class name, and cannot drift if NumPy changes it.
+    """
+    probe = np.zeros(2)
+    try:
+        probe["lattice"]
+    except Exception as exc:  # noqa: BLE001 - the class IS the thing under test
+        return type(exc)
+    raise AssertionError(
+        "a constant-string subscript on a plain ndarray no longer raises; "
+        "the legacy contract this test pins no longer exists"
+    )
 
-    Closing the archive before ``export_genome`` and preserving the exception
-    behaviour cannot both hold for a non-zip input. Closure was the explicit
-    requirement, so the consequence is pinned here as a stated contract rather
-    than left as a silent change. What is unchanged: the exception still
-    propagates uncaught, the exit is still non-zero, and no genome is written.
+
+def test_a_numeric_npy_still_fails_exactly_as_it_did_before(monkeypatch, tmp_path):
+    """Deterministic NPZ closure must not cost the legacy ``.npy`` failure.
+
+    An ``NpzFile`` owns an operating-system handle and needs deterministic
+    ownership; an ndarray owns nothing and needs none. Conditional ownership
+    gives the archive its ``with`` while leaving a ``.npy`` to reach the same
+    subscript that failed at the base commit -- same exception class, no
+    output, no downstream work.
     """
     not_an_archive = tmp_path / "snapshot.npy"
     np.save(not_an_archive, np.arange(8, dtype=np.uint8))
     output = tmp_path / "genome.json"
 
-    with pytest.raises((TypeError, AttributeError)):
+    with pytest.raises(_legacy_npy_error_class()):
         _run_export_cli(
             monkeypatch, _minimal_rule_file(tmp_path), not_an_archive, output
         )

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1475,11 +1475,13 @@ def test_every_member_the_cli_touches_is_refused(monkeypatch, tmp_path, member):
 def test_the_public_export_cli_refuses_a_pickled_member(tmp_path):
     """The shipped entry point, run as an operator would run it.
 
-    Marker absence is deliberately NOT asserted here: the payload's reduction
-    names a callable in THIS test module, which a fresh interpreter would fail
-    to import, so an absent marker in a subprocess would prove nothing either
-    way. What this surface proves is that the real console entry point refuses
-    and writes no genome. The in-process tests above own the marker evidence.
+    Marker absence is deliberately NOT asserted here, and would be the wrong
+    evidence on this surface whatever the import layout happens to be: the
+    payload's reduction names a callable in THIS test module, so an absent
+    marker in a subprocess is explained just as well by the child failing to
+    import it as by the loader refusing it. What this surface proves is that
+    the real console entry point refuses and writes no genome. The in-process
+    tests above own the marker evidence unconditionally.
     """
     archive = _write_snapshot_pg(
         tmp_path, {**_numeric_members_pg(), "lattice": _payload_member_pg(tmp_path)}
@@ -1618,6 +1620,33 @@ def test_the_epigenetic_payload_still_exports_intact(monkeypatch, tmp_path):
     assert epi["snapshot_ca_step"] == 42
     assert base64.b64decode(epi["lattice_b64"]) == bytes(range(8))
     assert len(base64.b64decode(epi["memory_grid_b64"])) == pg.MEMORY_CHANNELS * 8 * 4
+
+
+def test_a_non_npz_snapshot_now_fails_at_the_context_manager(monkeypatch, tmp_path):
+    """A DISCLOSED CONSEQUENCE of giving the archive deterministic closure.
+
+    ``np.load`` on a file that is not a zip returns a plain ndarray, which has
+    no context-manager protocol. Before the ``with``, a ``.npy`` passed to
+    ``--snapshot`` got as far as ``snap["lattice"]`` and failed there with an
+    indexing error; it now fails one statement earlier with a different
+    exception type.
+
+    Closing the archive before ``export_genome`` and preserving the exception
+    behaviour cannot both hold for a non-zip input. Closure was the explicit
+    requirement, so the consequence is pinned here as a stated contract rather
+    than left as a silent change. What is unchanged: the exception still
+    propagates uncaught, the exit is still non-zero, and no genome is written.
+    """
+    not_an_archive = tmp_path / "snapshot.npy"
+    np.save(not_an_archive, np.arange(8, dtype=np.uint8))
+    output = tmp_path / "genome.json"
+
+    with pytest.raises((TypeError, AttributeError)):
+        _run_export_cli(
+            monkeypatch, _minimal_rule_file(tmp_path), not_an_archive, output
+        )
+
+    assert not output.exists()
 
 
 def test_without_the_flag_the_epigenetic_section_stays_excluded(monkeypatch, tmp_path):

--- a/tests/test_portable_genome_config_shapes.py
+++ b/tests/test_portable_genome_config_shapes.py
@@ -1234,12 +1234,12 @@ def test_export_genome_untouched_by_this_package():
 
 _PG_MARKER = "PORTABLE_GENOME_PAYLOAD_EXECUTED"
 
-#: Every member the export CLI actually dereferences, in the CLI's own order.
-#: `generation`, `ca_step` and `best_fitness` are reached through `.get`, which
-#: routes through `NpzFile.__getitem__` whenever the key is present -- a `.get`
-#: default does NOT make a member safe, and each is covered here for that
-#: reason.
-_CLI_MEMBERS = ("lattice", "memory_grid", "generation", "ca_step", "best_fitness")
+#: The member list the CLI is expected to dereference today. This is a REVIEW
+#: ALARM, not the source of coverage: `_CLI_MEMBERS` below is derived from the
+#: real CLI, so a new member is covered automatically, and
+#: `test_the_derived_cli_members_match_the_reviewed_contract` then fails to say
+#: the contract moved and wants looking at.
+_EXPECTED_CLI_MEMBERS = ("lattice", "memory_grid", "generation", "ca_step", "best_fitness")
 
 
 def _create_marker_pg(directory: str) -> int:
@@ -1375,6 +1375,44 @@ def _cli_snapshot_with():
     return candidates[0]
 
 
+def _cli_snapshot_members():
+    """Derive, from the real export CLI, every snapshot member it dereferences.
+
+    Narrowly scoped on purpose: it reads only the ``with`` block that owns the
+    snapshot, only names bound by that block, and only CONSTANT-string members.
+    A dynamically computed key would not be seen -- the CLI has none, and
+    inventing broad matching to cover a case that does not exist would trade a
+    true narrow claim for a false wide one.
+
+    Source order is preserved so the parametrised refusal test reads in the
+    same order the CLI dereferences, which is also the order in which a refusal
+    wins when several members are hostile at once.
+
+    The assertions inside deliberately fail LOUDLY at import. A derivation that
+    quietly returned ``()`` on a restructured CLI would parametrise zero cases
+    and every refusal test would vanish while the suite stayed green.
+    """
+    with_node = _cli_snapshot_with()
+    name = with_node.items[0].optional_vars.id
+
+    ordered, seen = [], set()
+    for _lineno, _col, member in sorted(_member_accesses(with_node, name)):
+        if member not in seen:
+            seen.add(member)
+            ordered.append(member)
+
+    assert ordered, "no constant-string snapshot members found in the export CLI"
+    return tuple(ordered)
+
+
+#: Every member the export CLI actually dereferences, in the CLI's own order,
+#: DERIVED from the live source rather than transcribed. `generation`,
+#: `ca_step` and `best_fitness` are reached through `.get`, which routes
+#: through `NpzFile.__getitem__` whenever the key is present -- a `.get`
+#: default does NOT make a member safe, and each is covered for that reason.
+_CLI_MEMBERS = _cli_snapshot_members()
+
+
 def _run_export_cli(monkeypatch, rule_file, snapshot, output, *extra) -> None:
     """Execute the real ``__main__`` body in-process.
 
@@ -1449,6 +1487,41 @@ def test_export_cli_snapshot_load_is_pickle_free():
     assert set(keywords) == {"allow_pickle"}
     assert isinstance(keywords["allow_pickle"], ast.Constant)
     assert keywords["allow_pickle"].value is False
+
+
+def test_the_derived_cli_members_match_the_reviewed_contract():
+    """Automatic coverage expansion, plus an explicit alarm when it expands.
+
+    Coverage comes from the derivation, so a sixth member added to the CLI is
+    refused-tested the moment it appears -- no one has to remember to update a
+    list. This test then fails, on purpose, because a changed snapshot contract
+    is exactly the kind of change that should stop a reviewer rather than slip
+    through under a green suite.
+    """
+    assert _CLI_MEMBERS == _EXPECTED_CLI_MEMBERS, (
+        f"the export CLI now dereferences {_CLI_MEMBERS}, not "
+        f"{_EXPECTED_CLI_MEMBERS}. The refusal tests already cover the new set; "
+        "confirm the change is intended and update _EXPECTED_CLI_MEMBERS."
+    )
+
+
+def test_the_member_derivation_can_actually_see_a_member():
+    """Non-vacuity for the derivation itself.
+
+    `_member_accesses` returning nothing would empty the parametrisation, and
+    an empty parametrisation is silent. Feeding it a block written in both
+    access forms proves it still reads them, and that it ignores a member
+    accessed on some OTHER name.
+    """
+    planted = ast.parse(
+        "with owner as snap:\n"
+        "    a = snap['lattice']\n"
+        "    b = snap.get('generation', 0)\n"
+        "    c = other['ignored']\n"
+        "    d = snap[key]\n"
+    )
+    found = [member for _l, _c, member in sorted(_member_accesses(planted, "snap"))]
+    assert found == ["lattice", "generation"]
 
 
 def test_export_cli_routes_the_snapshot_through_conditional_ownership():

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -41,27 +41,57 @@ TARGETS = (
 #: (`assert keywords["allow_pickle"].value is True`), which lies outside this
 #: package's authorized file boundary. Converting that loader requires
 #: updating that assertion, so it is left for a separate authorized pass
-#: rather than silently widening scope here. The repo-wide sweep below
-#: therefore records it as the single known exception, by exact path, so it
-#: cannot be forgotten and no OTHER regression can hide behind it.
-KNOWN_PENDING = ("scripts/portable_genome.py",)
+#: rather than silently widening scope here.
+#:
+#: Keyed to an exact COUNT, not just a path. Exempting the whole file would
+#: let a SECOND pickle-enabled `np.load` be added there and hide behind the
+#: exemption; requiring the count to stay at exactly one closes that.
+KNOWN_PENDING = {"scripts/portable_genome.py": 1}
+
+#: Directories the repo-wide sweep must cover. Asserted to exist, because
+#: `Path.rglob` on a missing directory yields nothing silently -- renaming one
+#: would otherwise narrow the sweep without any test noticing.
+SWEPT_DIRS = ("scripts", "vis")
 
 
 def _np_load_calls(tree):
-    """Return every ``np.load(...)`` call in ``tree``.
+    """Return every NumPy ``load`` call in ``tree``.
 
-    Deliberately np-qualified. A bare ``attr == "load"`` filter would also
+    Deliberately NumPy-qualified. A bare ``attr == "load"`` filter would also
     match `json.load` (`medusa_api.py`) and `tomli.load`
     (`portable_genome.py`), which live in these same files and would make the
     policy fail spuriously. Working from the AST also means the docstrings
     that mention ``np.load(...)`` in prose are correctly ignored.
+
+    Both spellings are matched -- ``np.load`` / ``numpy.load`` via an
+    attribute, and a bare ``load`` bound by ``from numpy import load``. The
+    repo-wide sweep has no per-file "is `np` numpy?" backstop, so a new module
+    written in either of the other two styles would otherwise slip past it.
     """
-    return [
-        node for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute) and node.func.attr == "load"
-        and isinstance(node.func.value, ast.Name) and node.func.value.id == "np"
-    ]
+    aliases = {"np", "numpy"}
+    bare_load_imported = any(
+        isinstance(node, ast.ImportFrom) and node.module == "numpy"
+        and any(a.name == "load" for a in node.names)
+        for node in ast.walk(tree)
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "numpy":
+                    aliases.add(alias.asname or "numpy")
+
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (isinstance(func, ast.Attribute) and func.attr == "load"
+                and isinstance(func.value, ast.Name) and func.value.id in aliases):
+            found.append(node)
+        elif (bare_load_imported and isinstance(func, ast.Name)
+                and func.id == "load"):
+            found.append(node)
+    return found
 
 
 def _assert_pickle_free(rel, tree):
@@ -112,41 +142,46 @@ def test_no_pickle_enabling_escape_hatch_exists(rel):
         assert banned not in source, f"{rel} references {banned}"
 
 
+def _unguarded_load_counts():
+    """Map each swept file to how many NumPy loads lack literal False."""
+    counts = {}
+    for name in SWEPT_DIRS:
+        directory = _REPO_ROOT / name
+        assert directory.is_dir(), (
+            f"{name}/ is missing -- the sweep would silently cover nothing"
+        )
+        for path in sorted(directory.rglob("*.py")):
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            for call in _np_load_calls(ast.parse(path.read_text(encoding="utf-8"))):
+                keywords = {kw.arg: kw.value for kw in call.keywords}
+                value = keywords.get("allow_pickle")
+                if not (isinstance(value, ast.Constant) and value.value is False):
+                    counts[rel] = counts.get(rel, 0) + 1
+    return counts
+
+
 def test_no_unguarded_np_load_survives_under_scripts_or_vis():
     """Rename-proof sweep. `TARGETS` can go stale; this cannot.
 
-    It also catches a seventh loader appearing later. The single known
-    exception is listed by exact path so it is impossible to forget and
-    impossible for another regression to hide behind.
+    It also catches a seventh loader appearing later. The known exception is
+    matched on an exact COUNT, so a second pickle-enabled load added to the
+    exempt file is still caught.
     """
-    offenders = []
-    for path in sorted([*(_REPO_ROOT / "scripts").rglob("*.py"),
-                        *(_REPO_ROOT / "vis").rglob("*.py")]):
-        rel = path.relative_to(_REPO_ROOT).as_posix()
-        for call in _np_load_calls(ast.parse(path.read_text(encoding="utf-8"))):
-            keywords = {kw.arg: kw.value for kw in call.keywords}
-            value = keywords.get("allow_pickle")
-            if not (isinstance(value, ast.Constant) and value.value is False):
-                offenders.append(rel)
-
-    unexpected = sorted(set(offenders) - set(KNOWN_PENDING))
-    assert unexpected == [], (
-        f"np.load without literal allow_pickle=False: {unexpected}"
+    counts = _unguarded_load_counts()
+    unexpected = {
+        rel: n for rel, n in counts.items() if KNOWN_PENDING.get(rel) != n
+    }
+    assert unexpected == {}, (
+        "NumPy load without literal allow_pickle=False (path -> count): "
+        f"{unexpected}"
     )
 
 
 def test_the_known_pending_exception_is_still_real():
     """If `portable_genome` is ever converted, this fails and the exception
     must be deleted -- so the list cannot rot into a permanent blind spot."""
-    still_pending = []
-    for rel in KNOWN_PENDING:
-        tree = ast.parse((_REPO_ROOT / rel).read_text(encoding="utf-8"))
-        for call in _np_load_calls(tree):
-            keywords = {kw.arg: kw.value for kw in call.keywords}
-            value = keywords.get("allow_pickle")
-            if not (isinstance(value, ast.Constant) and value.value is False):
-                still_pending.append(rel)
-    assert sorted(set(still_pending)) == sorted(KNOWN_PENDING), (
-        "a KNOWN_PENDING module is now pickle-free -- remove it from the list "
-        "and add it to TARGETS"
+    counts = _unguarded_load_counts()
+    assert {rel: counts.get(rel, 0) for rel in KNOWN_PENDING} == KNOWN_PENDING, (
+        "a KNOWN_PENDING module changed -- if it is now pickle-free, remove it "
+        "from KNOWN_PENDING and add it to TARGETS"
     )

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -32,21 +32,18 @@ TARGETS = (
     "scripts/gpu_benchmark.py",
     "scripts/lucid_server.py",
     "scripts/medusa_api.py",
+    "scripts/portable_genome.py",
 )
 
-#: `scripts/portable_genome.py` is deliberately ABSENT from TARGETS.
+#: There is deliberately NO exemption list. An earlier revision of this module
+#: carried `KNOWN_PENDING`, holding `scripts/portable_genome.py` back because
+#: its loader was pinned to `allow_pickle=True` by an AST assertion in a file
+#: outside that package's authorized boundary. That assertion now asserts the
+#: secure contract instead, the loader is converted, and the exemption has been
+#: removed rather than left behind as a dormant hole -- an exemption mechanism
+#: that no longer exempts anything is an invitation to reuse it.
 #:
-#: Its `np.load` is pinned to `allow_pickle=True` by an AST assertion in
-#: `tests/test_portable_genome_config_shapes.py::test_export_cli_snapshot_path_unchanged`
-#: (`assert keywords["allow_pickle"].value is True`), which lies outside this
-#: package's authorized file boundary. Converting that loader requires
-#: updating that assertion, so it is left for a separate authorized pass
-#: rather than silently widening scope here.
-#:
-#: Keyed to an exact COUNT, not just a path. Exempting the whole file would
-#: let a SECOND pickle-enabled `np.load` be added there and hide behind the
-#: exemption; requiring the count to stay at exactly one closes that.
-KNOWN_PENDING = {"scripts/portable_genome.py": 1}
+#: The sweep below therefore requires ZERO unguarded NumPy loads.
 
 #: Directories the repo-wide sweep must cover. Asserted to exist, because
 #: `Path.rglob` on a missing directory yields nothing silently -- renaming one
@@ -163,25 +160,36 @@ def _unguarded_load_counts():
 def test_no_unguarded_np_load_survives_under_scripts_or_vis():
     """Rename-proof sweep. `TARGETS` can go stale; this cannot.
 
-    It also catches a seventh loader appearing later. The known exception is
-    matched on an exact COUNT, so a second pickle-enabled load added to the
-    exempt file is still caught.
+    It also catches a seventh loader appearing later. There is no exemption
+    list to consult and no count to keep in step: the requirement is simply
+    zero.
     """
     counts = _unguarded_load_counts()
-    unexpected = {
-        rel: n for rel, n in counts.items() if KNOWN_PENDING.get(rel) != n
-    }
-    assert unexpected == {}, (
+    assert counts == {}, (
         "NumPy load without literal allow_pickle=False (path -> count): "
-        f"{unexpected}"
+        f"{counts}"
     )
 
 
-def test_the_known_pending_exception_is_still_real():
-    """If `portable_genome` is ever converted, this fails and the exception
-    must be deleted -- so the list cannot rot into a permanent blind spot."""
-    counts = _unguarded_load_counts()
-    assert {rel: counts.get(rel, 0) for rel in KNOWN_PENDING} == KNOWN_PENDING, (
-        "a KNOWN_PENDING module changed -- if it is now pickle-free, remove it "
-        "from KNOWN_PENDING and add it to TARGETS"
+def test_the_sweep_can_actually_see_a_pickle_enabled_load(tmp_path):
+    """Non-vacuity guard for the sweep above.
+
+    `test_no_unguarded_np_load_survives_under_scripts_or_vis` now asserts an
+    empty dict, and an empty dict is exactly what a broken matcher returns.
+    Feeding `_np_load_calls` a module that really does enable pickle proves the
+    detector still detects, so a green sweep means "nothing found" rather than
+    "nothing looked for".
+    """
+    hostile = ast.parse(
+        "import numpy as np\n"
+        "import numpy as _alias\n"
+        "from numpy import load\n"
+        "np.load('a.npz', allow_pickle=True)\n"
+        "_alias.load('b.npz')\n"
+        "load('c.npz', allow_pickle=True)\n"
+        "import json\n"
+        "json.load(open('d.json'))\n"
     )
+    calls = _np_load_calls(hostile)
+    # Three NumPy loads caught across all three spellings; `json.load` ignored.
+    assert len(calls) == 3

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -1,0 +1,152 @@
+"""Cross-module policy: snapshot loaders must not unpickle.
+
+An NPZ member of object dtype is stored as a pickle, so loading one with
+pickle enabled is arbitrary code execution by construction. This module is the
+repository-wide gate: every covered loader must pass the literal
+``allow_pickle=False``, explicitly.
+
+Explicit rather than relying on NumPy's default -- which is already ``False`` --
+because a default makes the property invisible at the call site and silently
+reversible by an upstream change.
+
+Scope note, stated once and honestly: this is an OBJECT-MEMBER REFUSAL, not
+whole-archive validation. Nothing here claims resistance to decompression
+amplification, absurd declared shapes, hostile member names or defects in
+NumPy's own header parsing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Modules whose NPZ loader is covered by the pickle-free policy.
+#: Renaming or moving one of these is a deliberate change: update this tuple.
+TARGETS = (
+    "scripts/acoustic_map.py",
+    "scripts/geometry_daemon.py",
+    "scripts/gpu_benchmark.py",
+    "scripts/lucid_server.py",
+    "scripts/medusa_api.py",
+)
+
+#: `scripts/portable_genome.py` is deliberately ABSENT from TARGETS.
+#:
+#: Its `np.load` is pinned to `allow_pickle=True` by an AST assertion in
+#: `tests/test_portable_genome_config_shapes.py::test_export_cli_snapshot_path_unchanged`
+#: (`assert keywords["allow_pickle"].value is True`), which lies outside this
+#: package's authorized file boundary. Converting that loader requires
+#: updating that assertion, so it is left for a separate authorized pass
+#: rather than silently widening scope here. The repo-wide sweep below
+#: therefore records it as the single known exception, by exact path, so it
+#: cannot be forgotten and no OTHER regression can hide behind it.
+KNOWN_PENDING = ("scripts/portable_genome.py",)
+
+
+def _np_load_calls(tree):
+    """Return every ``np.load(...)`` call in ``tree``.
+
+    Deliberately np-qualified. A bare ``attr == "load"`` filter would also
+    match `json.load` (`medusa_api.py`) and `tomli.load`
+    (`portable_genome.py`), which live in these same files and would make the
+    policy fail spuriously. Working from the AST also means the docstrings
+    that mention ``np.load(...)`` in prose are correctly ignored.
+    """
+    return [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute) and node.func.attr == "load"
+        and isinstance(node.func.value, ast.Name) and node.func.value.id == "np"
+    ]
+
+
+def _assert_pickle_free(rel, tree):
+    calls = _np_load_calls(tree)
+    # Non-vacuity: a covered file that has lost its np.load has moved its
+    # loader elsewhere, which is an API change, not a silent pass.
+    assert calls, f"{rel}: no np.load found -- the loader moved; update TARGETS"
+    for call in calls:
+        keywords = {kw.arg: kw.value for kw in call.keywords}
+        assert "allow_pickle" in keywords, (
+            f"{rel}:{call.lineno} np.load must set allow_pickle explicitly; "
+            "a bare call inherits NumPy's default, which is not a contract"
+        )
+        value = keywords["allow_pickle"]
+        assert isinstance(value, ast.Constant) and value.value is False, (
+            f"{rel}:{call.lineno} allow_pickle must be the literal False, "
+            f"not {ast.dump(value)}"
+        )
+
+
+@pytest.mark.parametrize("rel", TARGETS)
+def test_every_targeted_np_load_is_pickle_free(rel):
+    path = _REPO_ROOT / rel
+    assert path.is_file(), f"{rel} is missing -- the target list is stale"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+
+    # `np` really is numpy in this file, so the matcher means what it says.
+    assert any(
+        isinstance(node, ast.Import)
+        and any(a.name == "numpy" and a.asname == "np" for a in node.names)
+        for node in ast.walk(tree)
+    ), f"{rel}: `np` is not bound to numpy"
+
+    _assert_pickle_free(rel, tree)
+
+
+@pytest.mark.parametrize("rel", TARGETS)
+def test_no_pickle_enabling_escape_hatch_exists(rel):
+    """No flag or compatibility mode may re-enable pickle.
+
+    Tokens are precise. `os.environ` is NOT banned here: `medusa_api.py` reads
+    `MEDUSA_EVENT_BUS_DISABLED` legitimately, and `gpu_accelerator` manipulates
+    the environment for unrelated reasons. Only pickle-specific constructions
+    are forbidden.
+    """
+    source = (_REPO_ROOT / rel).read_text(encoding="utf-8")
+    for banned in ("allow_pickle=True", "ALLOW_PICKLE", "allow-pickle"):
+        assert banned not in source, f"{rel} references {banned}"
+
+
+def test_no_unguarded_np_load_survives_under_scripts_or_vis():
+    """Rename-proof sweep. `TARGETS` can go stale; this cannot.
+
+    It also catches a seventh loader appearing later. The single known
+    exception is listed by exact path so it is impossible to forget and
+    impossible for another regression to hide behind.
+    """
+    offenders = []
+    for path in sorted([*(_REPO_ROOT / "scripts").rglob("*.py"),
+                        *(_REPO_ROOT / "vis").rglob("*.py")]):
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        for call in _np_load_calls(ast.parse(path.read_text(encoding="utf-8"))):
+            keywords = {kw.arg: kw.value for kw in call.keywords}
+            value = keywords.get("allow_pickle")
+            if not (isinstance(value, ast.Constant) and value.value is False):
+                offenders.append(rel)
+
+    unexpected = sorted(set(offenders) - set(KNOWN_PENDING))
+    assert unexpected == [], (
+        f"np.load without literal allow_pickle=False: {unexpected}"
+    )
+
+
+def test_the_known_pending_exception_is_still_real():
+    """If `portable_genome` is ever converted, this fails and the exception
+    must be deleted -- so the list cannot rot into a permanent blind spot."""
+    still_pending = []
+    for rel in KNOWN_PENDING:
+        tree = ast.parse((_REPO_ROOT / rel).read_text(encoding="utf-8"))
+        for call in _np_load_calls(tree):
+            keywords = {kw.arg: kw.value for kw in call.keywords}
+            value = keywords.get("allow_pickle")
+            if not (isinstance(value, ast.Constant) and value.value is False):
+                still_pending.append(rel)
+    assert sorted(set(still_pending)) == sorted(KNOWN_PENDING), (
+        "a KNOWN_PENDING module is now pickle-free -- remove it from the list "
+        "and add it to TARGETS"
+    )

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -137,6 +137,25 @@ def _np_load_calls(tree):
     return found
 
 
+#: Callees that accept ``allow_pickle`` POSITIONALLY, and at which index.
+#: NumPy signatures:
+#:     np.load(file, mmap_mode=None, allow_pickle=False, ...)
+#:     NpzFile(fid, own_fid=False, allow_pickle=False, ...)
+#:     read_array(fp, allow_pickle=False, pickle_kwargs=None, ...)
+#:
+#: A positional ``True`` in one of those slots enables pickle while naming no
+#: keyword at all, so neither the keyword branch below nor the token scan can
+#: see it. `NpzFile` and `read_array` are exactly the two doors the argument
+#: matcher exists to guard, and both were reachable this way.
+#:
+#: Keyed on the bare callee name, so it is deliberately CONSERVATIVE: an
+#: unrelated `something.load(a, b, c)` would be flagged too. Over-matching is
+#: the safe direction for a gate like this, and it costs nothing today --
+#: nothing under the swept directories passes enough positional arguments to
+#: reach any of these slots.
+_POSITIONAL_ALLOW_PICKLE = {"load": 2, "NpzFile": 2, "read_array": 1}
+
+
 def _pickle_enabling_calls(tree):
     """Calls that ask for pickle through a STATICALLY READABLE argument.
 
@@ -149,15 +168,23 @@ def _pickle_enabling_calls(tree):
     EXACTLY what is enforced, and nothing wider:
 
     * an explicit ``allow_pickle=`` keyword whose value is not the literal
-      ``False``, on a call to anything;
+      ``False``, on a call to ANYTHING -- including one reached through an
+      object attribute, one wrapped in ``functools.partial``, and one whose
+      value is a computed name rather than a constant. A non-literal value is
+      treated as enabling precisely because it cannot be read;
     * ``**{"allow_pickle": ...}`` where the mapping is a LITERAL dict with a
-      constant key.
+      constant key;
+    * a POSITIONAL ``allow_pickle`` on the small set of callees in
+      ``_POSITIONAL_ALLOW_PICKLE``, whose signatures accept it by position.
 
-    NOT enforced, and not claimed: any route where the argument is not
-    statically readable -- ``**kwargs`` forwarded from elsewhere, a dict built
-    at runtime, a name whose value is computed, ``functools.partial``, or a
-    call reached through an object attribute. This is a static gate over
-    literal source, not a proof that pickle can never be requested.
+    NOT enforced, and not claimed: a route where the argument is not
+    statically readable at all -- ``**kwargs`` forwarded from another
+    function, or a mapping built at runtime and expanded by name. For a
+    ``load``-named callee those are still caught by the *unguarded* sweep,
+    which requires a readable literal ``False``; for any other callee they are
+    a genuine blind spot. Nor is a positional ``allow_pickle`` on a callee
+    outside that set seen. This is a static gate over literal source, not a
+    proof that pickle can never be requested.
 
     Being AST rather than substring, it is not fooled by ``allow_pickle = True``
     with spaces, which the token scan below misses.
@@ -166,23 +193,40 @@ def _pickle_enabling_calls(tree):
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
+        enabling = False
         for keyword in node.keywords:
             if keyword.arg == "allow_pickle":
                 if not (isinstance(keyword.value, ast.Constant)
                         and keyword.value.value is False):
-                    found.append(node)
+                    enabling = True
                     break
             elif keyword.arg is None and isinstance(keyword.value, ast.Dict):
                 # `**{...}`. Only a literal mapping can be read; anything else
                 # is out of scope and deliberately not guessed at.
-                enabling = any(
+                if any(
                     isinstance(key, ast.Constant) and key.value == "allow_pickle"
                     and not (isinstance(value, ast.Constant) and value.value is False)
                     for key, value in zip(keyword.value.keys, keyword.value.values)
-                )
-                if enabling:
-                    found.append(node)
+                ):
+                    enabling = True
                     break
+
+        if not enabling:
+            func = node.func
+            name = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name)
+                else None
+            )
+            index = _POSITIONAL_ALLOW_PICKLE.get(name)
+            if index is not None and len(node.args) > index:
+                value = node.args[index]
+                enabling = not (
+                    isinstance(value, ast.Constant) and value.value is False
+                )
+
+        if enabling:
+            found.append(node)
     return found
 
 
@@ -292,19 +336,25 @@ _PLANTED_MODULE = (
     "np.lib.npyio.NpzFile(fh, allow_pickle = True)\n"  # not `load` at all
     "np.lib.format.read_array(fh, allow_pickle=True)\n"  # nor is this
     "np.load('g.npz', **{'allow_pickle': True})\n"    # literal dict expansion
+    "np.lib.format.read_array(fh, True)\n"            # POSITIONAL allow_pickle
+    "np.lib.npyio.NpzFile(fh, False, True)\n"         # POSITIONAL, third slot
+    "np.load('h.npz', allow_pickle=False)\n"          # GUARDED negative control
     "import json\n"
     "json.load(open('f.json'))\n"                     # must be ignored
 )
 
-#: Reaching `_np_load_calls`: the five `load`-named spellings plus the literal
-#: dict expansion, which is a `load` call whose keyword is not readable as
-#: `False` and so counts as unguarded. The `NpzFile` and `read_array`
-#: constructors are not `load` calls and are caught only by the argument-based
-#: matcher. `json.load` is caught by neither.
+#: Total `load`-named calls the name matcher finds, guarded or not.
+_PLANTED_LOADS = 7
+#: How many of those lack a readable literal `False`. Deliberately DIFFERENT
+#: from `_PLANTED_LOADS`: the planted module carries one guarded load, so a
+#: single constant cannot satisfy both and a classification that stopped
+#: discriminating could not pass. `NpzFile` and `read_array` are not `load`
+#: calls and are invisible to this matcher by design.
 _PLANTED_UNGUARDED = 6
-#: Every call whose `allow_pickle` is statically readable and not `False`,
-#: including the whitespaced `NpzFile`, `read_array`, and the `**{...}` form.
-_PLANTED_ENABLING = 7
+#: Every call whose `allow_pickle` is statically readable and not `False`:
+#: the whitespaced `NpzFile`, `read_array`, the `**{...}` form and both
+#: positional spellings, but NOT the guarded control.
+_PLANTED_ENABLING = 9
 
 
 def test_no_unguarded_np_load_survives_under_scripts_or_vis():
@@ -331,9 +381,11 @@ def test_no_call_under_scripts_or_vis_asks_for_pickle():
     any name, request pickle through a statically readable argument.
 
     Static gate, stated exactly: it reads explicit ``allow_pickle=`` keywords
-    and literal ``**{...}`` mappings. It does not resolve forwarded
-    ``**kwargs``, runtime-built mappings or computed values, and does not claim
-    to.
+    (on any callee, including attribute-reached and ``partial``-wrapped ones,
+    and treating a non-literal value as enabling), literal ``**{...}``
+    mappings, and positional ``allow_pickle`` on the callees listed in
+    ``_POSITIONAL_ALLOW_PICKLE``. It does not resolve forwarded ``**kwargs`` or
+    mappings built at runtime, and does not claim to.
     """
     _, enabling = _sweep()
     assert enabling == {}, (
@@ -351,7 +403,7 @@ def test_the_matchers_can_actually_see_a_pickle_enabled_load():
     found" rather than "nothing looked for".
     """
     tree = ast.parse(_PLANTED_MODULE)
-    assert len(_np_load_calls(tree)) == _PLANTED_UNGUARDED
+    assert len(_np_load_calls(tree)) == _PLANTED_LOADS
     assert len(_pickle_enabling_calls(tree)) == _PLANTED_ENABLING
 
 

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -138,27 +138,51 @@ def _np_load_calls(tree):
 
 
 def _pickle_enabling_calls(tree):
-    """Every call that ASKS for pickle, whatever the callee is called.
+    """Calls that ask for pickle through a STATICALLY READABLE argument.
 
-    ``np.load`` is not the only door. ``np.lib.npyio.NpzFile(fh,
-    allow_pickle=True)`` and ``np.lib.format.read_array(fh,
-    allow_pickle=True)`` reach the same unpickling code and are structurally
-    invisible to any matcher keyed on the callee's NAME. Keying on the ARGUMENT
-    instead catches every spelling, including ones that do not exist yet.
+    Keyed on the argument rather than the callee, so it does not depend on
+    guessing a name. ``np.load`` is not the only door: ``np.lib.npyio.NpzFile(
+    fh, allow_pickle=True)`` and ``np.lib.format.read_array(fh,
+    allow_pickle=True)`` reach the same unpickling code and are invisible to
+    any matcher keyed on the callee's name.
 
-    Being AST rather than substring, it is also not fooled by
-    ``allow_pickle = True`` with spaces, which the token scan below misses.
+    EXACTLY what is enforced, and nothing wider:
+
+    * an explicit ``allow_pickle=`` keyword whose value is not the literal
+      ``False``, on a call to anything;
+    * ``**{"allow_pickle": ...}`` where the mapping is a LITERAL dict with a
+      constant key.
+
+    NOT enforced, and not claimed: any route where the argument is not
+    statically readable -- ``**kwargs`` forwarded from elsewhere, a dict built
+    at runtime, a name whose value is computed, ``functools.partial``, or a
+    call reached through an object attribute. This is a static gate over
+    literal source, not a proof that pickle can never be requested.
+
+    Being AST rather than substring, it is not fooled by ``allow_pickle = True``
+    with spaces, which the token scan below misses.
     """
     found = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         for keyword in node.keywords:
-            if keyword.arg != "allow_pickle":
-                continue
-            if not (isinstance(keyword.value, ast.Constant)
-                    and keyword.value.value is False):
-                found.append(node)
+            if keyword.arg == "allow_pickle":
+                if not (isinstance(keyword.value, ast.Constant)
+                        and keyword.value.value is False):
+                    found.append(node)
+                    break
+            elif keyword.arg is None and isinstance(keyword.value, ast.Dict):
+                # `**{...}`. Only a literal mapping can be read; anything else
+                # is out of scope and deliberately not guessed at.
+                enabling = any(
+                    isinstance(key, ast.Constant) and key.value == "allow_pickle"
+                    and not (isinstance(value, ast.Constant) and value.value is False)
+                    for key, value in zip(keyword.value.keys, keyword.value.values)
+                )
+                if enabling:
+                    found.append(node)
+                    break
     return found
 
 
@@ -266,17 +290,21 @@ _PLANTED_MODULE = (
     "_rebound = np.load\n"
     "_rebound('e.npz', allow_pickle=True)\n"          # local rebinding
     "np.lib.npyio.NpzFile(fh, allow_pickle = True)\n"  # not `load` at all
+    "np.lib.format.read_array(fh, allow_pickle=True)\n"  # nor is this
+    "np.load('g.npz', **{'allow_pickle': True})\n"    # literal dict expansion
     "import json\n"
     "json.load(open('f.json'))\n"                     # must be ignored
 )
 
-#: Five of the six NumPy loads reach `_np_load_calls`; the `NpzFile`
-#: constructor is not a `load` call and is caught only by the argument-based
+#: Reaching `_np_load_calls`: the five `load`-named spellings plus the literal
+#: dict expansion, which is a `load` call whose keyword is not readable as
+#: `False` and so counts as unguarded. The `NpzFile` and `read_array`
+#: constructors are not `load` calls and are caught only by the argument-based
 #: matcher. `json.load` is caught by neither.
-_PLANTED_UNGUARDED = 5
-#: Every call that names `allow_pickle` with a non-False value, including the
-#: whitespaced `NpzFile` constructor a substring scan would miss.
-_PLANTED_ENABLING = 5
+_PLANTED_UNGUARDED = 6
+#: Every call whose `allow_pickle` is statically readable and not `False`,
+#: including the whitespaced `NpzFile`, `read_array`, and the `**{...}` form.
+_PLANTED_ENABLING = 7
 
 
 def test_no_unguarded_np_load_survives_under_scripts_or_vis():
@@ -300,7 +328,12 @@ def test_no_call_under_scripts_or_vis_asks_for_pickle():
     one: ``NpzFile(fh, allow_pickle=True)`` and ``read_array(...,
     allow_pickle=True)`` reach it directly and are invisible to a matcher keyed
     on the callee's name. This asks the other question -- did anything, under
-    any name, request pickle at all.
+    any name, request pickle through a statically readable argument.
+
+    Static gate, stated exactly: it reads explicit ``allow_pickle=`` keywords
+    and literal ``**{...}`` mappings. It does not resolve forwarded
+    ``**kwargs``, runtime-built mappings or computed values, and does not claim
+    to.
     """
     _, enabling = _sweep()
     assert enabling == {}, (

--- a/tests/test_snapshot_pickle_policy.py
+++ b/tests/test_snapshot_pickle_policy.py
@@ -2,7 +2,8 @@
 
 An NPZ member of object dtype is stored as a pickle, so loading one with
 pickle enabled is arbitrary code execution by construction. This module is the
-repository-wide gate: every covered loader must pass the literal
+gate over ``scripts/`` and ``vis/`` -- see ``SWEPT_DIRS``, which is the honest
+extent of it, not "the repository". Every covered loader must pass the literal
 ``allow_pickle=False``, explicitly.
 
 Explicit rather than relying on NumPy's default -- which is already ``False`` --
@@ -45,10 +46,53 @@ TARGETS = (
 #:
 #: The sweep below therefore requires ZERO unguarded NumPy loads.
 
-#: Directories the repo-wide sweep must cover. Asserted to exist, because
-#: `Path.rglob` on a missing directory yields nothing silently -- renaming one
-#: would otherwise narrow the sweep without any test noticing.
+#: Directories the sweep covers. Asserted to exist, because `Path.rglob` on a
+#: missing directory yields nothing silently -- renaming one would otherwise
+#: narrow the sweep without any test noticing.
+#:
+#: Deliberately NOT the repository root. Widening it that far would sweep
+#: `tests/`, where the pickle-enabling calls are legitimate positive controls,
+#: and carving `tests/` back out would reintroduce exactly the exemption
+#: mechanism removed above. Directories outside this tuple are unswept, and
+#: saying so is the honest description of the gate.
 SWEPT_DIRS = ("scripts", "vis")
+
+
+def _numpy_load_names(tree):
+    """Resolve, from ``tree``'s own imports, every name that means NumPy ``load``.
+
+    Returns ``(module_names, direct_names)``.
+
+    ``asname`` is honoured in BOTH import forms. An earlier revision set a flag
+    from ``from numpy import load as npload`` but still matched only the literal
+    name ``load``, so the aliased call slipped through the sweep entirely.
+
+    A local rebinding is the same call under another name, so ``_l = np.load``
+    is resolved too.
+    """
+    module_names = {"np", "numpy"}
+    direct_names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "numpy":
+                    module_names.add(alias.asname or "numpy")
+        elif isinstance(node, ast.ImportFrom) and node.module == "numpy":
+            for alias in node.names:
+                if alias.name == "load":
+                    direct_names.add(alias.asname or "load")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        value = node.value
+        if (isinstance(value, ast.Attribute) and value.attr == "load"
+                and isinstance(value.value, ast.Name)
+                and value.value.id in module_names):
+            direct_names.update(
+                target.id for target in node.targets if isinstance(target, ast.Name)
+            )
+    return module_names, direct_names
 
 
 def _np_load_calls(tree):
@@ -60,22 +104,17 @@ def _np_load_calls(tree):
     policy fail spuriously. Working from the AST also means the docstrings
     that mention ``np.load(...)`` in prose are correctly ignored.
 
-    Both spellings are matched -- ``np.load`` / ``numpy.load`` via an
-    attribute, and a bare ``load`` bound by ``from numpy import load``. The
-    repo-wide sweep has no per-file "is `np` numpy?" backstop, so a new module
-    written in either of the other two styles would otherwise slip past it.
+    Four spellings are matched: ``np.load`` / ``numpy.load`` / any aliased
+    module, a direct name bound by ``from numpy import load [as ...]``, a name
+    rebound from ``np.load``, and ``getattr(np, "load")(...)``. The sweep has
+    no per-file "is `np` numpy?" backstop, so a module written in any of the
+    other styles would otherwise slip past it.
+
+    This matcher is necessarily name-based and therefore never complete on its
+    own. ``_pickle_enabling_calls`` is the argument-based backstop that does
+    not depend on guessing the callee's name.
     """
-    aliases = {"np", "numpy"}
-    bare_load_imported = any(
-        isinstance(node, ast.ImportFrom) and node.module == "numpy"
-        and any(a.name == "load" for a in node.names)
-        for node in ast.walk(tree)
-    )
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name == "numpy":
-                    aliases.add(alias.asname or "numpy")
+    module_names, direct_names = _numpy_load_names(tree)
 
     found = []
     for node in ast.walk(tree):
@@ -83,11 +122,43 @@ def _np_load_calls(tree):
             continue
         func = node.func
         if (isinstance(func, ast.Attribute) and func.attr == "load"
-                and isinstance(func.value, ast.Name) and func.value.id in aliases):
+                and isinstance(func.value, ast.Name)
+                and func.value.id in module_names):
             found.append(node)
-        elif (bare_load_imported and isinstance(func, ast.Name)
-                and func.id == "load"):
+        elif isinstance(func, ast.Name) and func.id in direct_names:
             found.append(node)
+        elif (isinstance(func, ast.Call) and isinstance(func.func, ast.Name)
+                and func.func.id == "getattr" and len(func.args) == 2
+                and isinstance(func.args[0], ast.Name)
+                and func.args[0].id in module_names
+                and isinstance(func.args[1], ast.Constant)
+                and func.args[1].value == "load"):
+            found.append(node)
+    return found
+
+
+def _pickle_enabling_calls(tree):
+    """Every call that ASKS for pickle, whatever the callee is called.
+
+    ``np.load`` is not the only door. ``np.lib.npyio.NpzFile(fh,
+    allow_pickle=True)`` and ``np.lib.format.read_array(fh,
+    allow_pickle=True)`` reach the same unpickling code and are structurally
+    invisible to any matcher keyed on the callee's NAME. Keying on the ARGUMENT
+    instead catches every spelling, including ones that do not exist yet.
+
+    Being AST rather than substring, it is also not fooled by
+    ``allow_pickle = True`` with spaces, which the token scan below misses.
+    """
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "allow_pickle":
+                continue
+            if not (isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is False):
+                found.append(node)
     return found
 
 
@@ -133,28 +204,79 @@ def test_no_pickle_enabling_escape_hatch_exists(rel):
     `MEDUSA_EVENT_BUS_DISABLED` legitimately, and `gpu_accelerator` manipulates
     the environment for unrelated reasons. Only pickle-specific constructions
     are forbidden.
+
+    This is a raw substring scan and is therefore whitespace-sensitive --
+    `allow_pickle = True` with spaces would pass it. That gap is closed
+    structurally by `test_no_call_under_scripts_or_vis_asks_for_pickle`, which
+    reads the AST and does not care how the argument is spaced. The scan is
+    kept anyway because it also catches the token in prose, where a claim that
+    pickle is enabled would be a lie about what the code now does.
     """
     source = (_REPO_ROOT / rel).read_text(encoding="utf-8")
     for banned in ("allow_pickle=True", "ALLOW_PICKLE", "allow-pickle"):
         assert banned not in source, f"{rel} references {banned}"
 
 
-def _unguarded_load_counts():
-    """Map each swept file to how many NumPy loads lack literal False."""
-    counts = {}
-    for name in SWEPT_DIRS:
-        directory = _REPO_ROOT / name
+def _sweep(root=None, dirs=None):
+    """Walk ``dirs`` under ``root``; return ``(unguarded, enabling)`` per file.
+
+    ``unguarded`` counts NumPy loads that do not pass literal ``False``;
+    ``enabling`` counts calls of any name that ask for pickle.
+
+    Parameterised on purpose. Hard-coding the repository root left the walk
+    itself -- the glob, the classification, the relative-path key -- with no
+    test of its own, so an inverted comparison or a wrong suffix would return
+    an empty mapping and every assertion built on it would still pass.
+    ``test_the_sweep_itself_can_see_a_planted_loader`` points this at a tree it
+    controls for exactly that reason.
+    """
+    root = _REPO_ROOT if root is None else root
+    dirs = SWEPT_DIRS if dirs is None else dirs
+    unguarded, enabling = {}, {}
+    for name in dirs:
+        directory = root / name
         assert directory.is_dir(), (
             f"{name}/ is missing -- the sweep would silently cover nothing"
         )
         for path in sorted(directory.rglob("*.py")):
-            rel = path.relative_to(_REPO_ROOT).as_posix()
-            for call in _np_load_calls(ast.parse(path.read_text(encoding="utf-8"))):
+            rel = path.relative_to(root).as_posix()
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for call in _np_load_calls(tree):
                 keywords = {kw.arg: kw.value for kw in call.keywords}
                 value = keywords.get("allow_pickle")
                 if not (isinstance(value, ast.Constant) and value.value is False):
-                    counts[rel] = counts.get(rel, 0) + 1
-    return counts
+                    unguarded[rel] = unguarded.get(rel, 0) + 1
+            asking = len(_pickle_enabling_calls(tree))
+            if asking:
+                enabling[rel] = asking
+    return unguarded, enabling
+
+
+#: A module exercising every spelling the two matchers are meant to catch, plus
+#: one they must ignore. Shared by both non-vacuity guards so the guards and
+#: the matchers cannot drift apart.
+_PLANTED_MODULE = (
+    "import numpy as np\n"
+    "import numpy as _alias\n"
+    "from numpy import load as _aliased_load\n"
+    "np.load('a.npz', allow_pickle=True)\n"          # plain, enabled
+    "_alias.load('b.npz')\n"                          # aliased module, no kwarg
+    "_aliased_load('c.npz', allow_pickle=True)\n"     # aliased direct import
+    "getattr(np, 'load')('d.npz', allow_pickle=True)\n"   # getattr indirection
+    "_rebound = np.load\n"
+    "_rebound('e.npz', allow_pickle=True)\n"          # local rebinding
+    "np.lib.npyio.NpzFile(fh, allow_pickle = True)\n"  # not `load` at all
+    "import json\n"
+    "json.load(open('f.json'))\n"                     # must be ignored
+)
+
+#: Five of the six NumPy loads reach `_np_load_calls`; the `NpzFile`
+#: constructor is not a `load` call and is caught only by the argument-based
+#: matcher. `json.load` is caught by neither.
+_PLANTED_UNGUARDED = 5
+#: Every call that names `allow_pickle` with a non-False value, including the
+#: whitespaced `NpzFile` constructor a substring scan would miss.
+_PLANTED_ENABLING = 5
 
 
 def test_no_unguarded_np_load_survives_under_scripts_or_vis():
@@ -164,32 +286,62 @@ def test_no_unguarded_np_load_survives_under_scripts_or_vis():
     list to consult and no count to keep in step: the requirement is simply
     zero.
     """
-    counts = _unguarded_load_counts()
-    assert counts == {}, (
+    unguarded, _ = _sweep()
+    assert unguarded == {}, (
         "NumPy load without literal allow_pickle=False (path -> count): "
-        f"{counts}"
+        f"{unguarded}"
     )
 
 
-def test_the_sweep_can_actually_see_a_pickle_enabled_load(tmp_path):
-    """Non-vacuity guard for the sweep above.
+def test_no_call_under_scripts_or_vis_asks_for_pickle():
+    """The doors that are not called ``load``.
 
-    `test_no_unguarded_np_load_survives_under_scripts_or_vis` now asserts an
-    empty dict, and an empty dict is exactly what a broken matcher returns.
-    Feeding `_np_load_calls` a module that really does enable pickle proves the
-    detector still detects, so a green sweep means "nothing found" rather than
-    "nothing looked for".
+    ``np.load`` is one entry point to NumPy's unpickling code, not the only
+    one: ``NpzFile(fh, allow_pickle=True)`` and ``read_array(...,
+    allow_pickle=True)`` reach it directly and are invisible to a matcher keyed
+    on the callee's name. This asks the other question -- did anything, under
+    any name, request pickle at all.
     """
-    hostile = ast.parse(
-        "import numpy as np\n"
-        "import numpy as _alias\n"
-        "from numpy import load\n"
-        "np.load('a.npz', allow_pickle=True)\n"
-        "_alias.load('b.npz')\n"
-        "load('c.npz', allow_pickle=True)\n"
-        "import json\n"
-        "json.load(open('d.json'))\n"
+    _, enabling = _sweep()
+    assert enabling == {}, (
+        "call requesting allow_pickle other than literal False (path -> count): "
+        f"{enabling}"
     )
-    calls = _np_load_calls(hostile)
-    # Three NumPy loads caught across all three spellings; `json.load` ignored.
-    assert len(calls) == 3
+
+
+def test_the_matchers_can_actually_see_a_pickle_enabled_load():
+    """Non-vacuity guard for the two matchers.
+
+    Both sweeps assert an empty mapping, and an empty mapping is exactly what a
+    broken matcher returns. Feeding them a module that really does enable
+    pickle proves the detectors still detect, so a green sweep means "nothing
+    found" rather than "nothing looked for".
+    """
+    tree = ast.parse(_PLANTED_MODULE)
+    assert len(_np_load_calls(tree)) == _PLANTED_UNGUARDED
+    assert len(_pickle_enabling_calls(tree)) == _PLANTED_ENABLING
+
+
+def test_the_sweep_itself_can_see_a_planted_loader(tmp_path):
+    """Non-vacuity guard for the sweep, not merely the matchers it calls.
+
+    The guard above would still pass if `_sweep` globbed the wrong suffix,
+    inverted its `allow_pickle` comparison, or walked a directory that yields
+    nothing -- because it never calls `_sweep`. Pointing the real function at a
+    tree this test controls exercises the walk, the classification and the
+    relative-path key end to end.
+    """
+    planted = tmp_path / "scripts"
+    planted.mkdir()
+    (planted / "hostile.py").write_text(_PLANTED_MODULE, encoding="utf-8")
+    (planted / "safe.py").write_text(
+        "import numpy as np\n"
+        "with np.load('a.npz', allow_pickle=False) as snap:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    unguarded, enabling = _sweep(root=tmp_path, dirs=("scripts",))
+
+    assert unguarded == {"scripts/hostile.py": _PLANTED_UNGUARDED}
+    assert enabling == {"scripts/hostile.py": _PLANTED_ENABLING}


### PR DESCRIPTION
Security-hardening follow-up to the snapshot work in PR #457, which made the Observatory NPZ path pickle-free and named six remaining repository consumers that were outside its boundary. **All six are now converted.**

Original audited base: `feba238c579d7f7efec4204069d4ece48a1a50c1`.

**Synchronized with `main`.** Branch protection sets `strict: true` on the required checks, so an up-to-date branch is required before a merge audit. Live `main` at `d15b1943f289d753ede2b7042190b97a274af6d7` (PR #459, five tech-ledger V4 entries plus their test file) was brought in with **one ordinary merge commit** â€” `a9bd8983fcd4a1d97cc2a752c190329bee525a9e`, parents `924f285` and `d15b194`. No rebase, no squash, no force-push, no amended commit. The advance touches only `experiments/tech_ledger/`, is entirely disjoint from this PR's boundary, merged without conflict, and contributes **no files** to this PR's diff: the delta against `d15b194` is byte-identical to the pre-sync delta against `feba238c`.

---

## The property

An NPZ member of object dtype **is** a pickle. Loading one with pickle enabled is arbitrary code execution by construction â€” not a hypothetical parser weakness, but the documented behaviour of the format. Every converted loader now passes the literal `allow_pickle=False`, so NumPy refuses such a member with a `ValueError` before any reconstruction callback runs.

`allow_pickle=False` is already NumPy's default. It is passed **explicitly anyway**, because a default makes the property invisible at the call site and silently reversible by an upstream change. There is deliberately:

- no fallback retry,
- no flag, environment variable, config key or hidden compatibility mode,
- no whole-archive validation claim.

## Scope, stated plainly

This is an **object-member refusal**. It is not archive validation. Nothing here resists decompression amplification, absurd declared shapes, hostile member names, or defects in NumPy's own header parsing. That limit is written into each docstring rather than left for a reader to infer.

## Reachability â€” all six, ordered by exposure

| Consumer | How an archive reaches the loader | Attendance |
|---|---|---|
| `scripts/medusa_api.py` | 4 unauthenticated GET routes, bound `0.0.0.0` | unattended |
| `scripts/lucid_server.py` | every client connect **and** every change the 2 s watcher detects | unattended |
| `scripts/geometry_daemon.py` | directory watcher | unattended |
| `scripts/gpu_benchmark.py` | `--snapshot` from raw argv | operator present |
| `scripts/acoustic_map.py` | snapshot path from raw argv | operator present |
| `scripts/portable_genome.py` | `export --snapshot` from raw argv | operator present |

Before this branch, the top three could attempt to unpickle an object-bearing archive arriving through a watched or served directory with nobody present. That is the reason this package exists. `portable_genome` is the least exposed of the six, which is why it was the last converted â€” not because its loader was any safer.

## Producer verdict: nothing legitimate needed pickle

Checked before changing any loader, because a refusal that breaks real snapshots is not hardening:

- `scripts/run_v070_engine.py:223` â€” the canonical producer â€” writes ndarrays and plain Python scalars.
- `ca/replicate.py:601` writes ndarrays.
- `meta_json` is `<U` dtype, not object.
- Six other snapshot loaders in the repository were already pickle-free.

No producer in the repository emits an object-dtype member. Numeric arrays and scalar metadata keep working, and a compatibility test in each suite proves it rather than asserting it.

## The export CLI â€” the sixth consumer

`scripts/portable_genome.py` was held back in the first round of this branch because `test_export_cli_snapshot_path_unchanged` **pinned** it to `allow_pickle=True` by AST assertion, and that test file was outside the authorized boundary at the time:

```python
assert keywords["allow_pickle"].value is True
```

That test asserted the insecure behaviour, so it has been **replaced with an assertion of the intended secure contract**, not merely deleted.

The security change itself was one keyword plus archive ownership. The final corrective head then added `contextlib` and **conditional ownership**, because owning the loaded object unconditionally cost the legacy `.npy` failure for no benefit. This is the shipped state (wrapped here for readability):

```python
loaded = np.load(args.snapshot, allow_pickle=False)
owner = (
    contextlib.nullcontext(loaded)
    if isinstance(loaded, np.ndarray)
    else loaded
)
with owner as snap:
    lattice, memory_grid = snap["lattice"], snap["memory_grid"]
    gen, ca_step_count = (
        int(snap.get("generation", 0)),
        int(snap.get("ca_step", 0)),
    )
    best_fit = float(snap.get("best_fitness", 0.0))
```

`np.load` returns an `NpzFile` for a zip archive but a plain ndarray for a `.npy`, and only the archive owns an operating-system handle. What each input does now:

- **NPZ** â€” deterministically closed, on success *and* on a refusal raised mid-extraction, before `export_genome` begins.
- **Numeric `.npy`** â€” reaches its legacy `snap["lattice"]` subscript failure: same exception class, same point as before this branch.
- **Object-dtype `.npy`** â€” refused earlier, by `np.load` itself, before anything is returned. That one is an intended change, not preserved behaviour.

### All five members it touches â€” including the three behind `.get`

The CLI dereferences `lattice` and `memory_grid` by subscript, and `generation`, `ca_step` and `best_fitness` through `.get(name, default)`. **A `.get` default does not make a member safe.** `NpzFile` is a `Mapping`, and `Mapping.get` is:

```python
def get(self, key, default=None):
    try:
        return self[key]
    except KeyError:
        return default
```

Only `KeyError` is caught. A key that is *present* still decodes, and an object-dtype member's `ValueError` propagates straight past the default. All five members are covered by a parametrised refusal test.

The member list is **derived from the live source by AST** â€” it reads the `with` block that owns the snapshot, then the constant-string subscripts and `.get` calls on the name that block binds, in source order. An earlier revision of this branch *described* it as derived while it was in fact a hand-written tuple that merely happened to be right; that is now true rather than aspirational. A sixth member would be refusal-tested the moment it appeared, and `_EXPECTED_CLI_MEMBERS` remains as an explicit review alarm that fires when the contract moves.

Scope is narrow and stated: only constant-string members on the bound name. A computed key would not be seen â€” the CLI has none, and widening the match to cover a case that does not exist would trade a true narrow claim for a false wide one. The derivation captures its own failure rather than raising at import, because a module-scope assertion here would be a collection error for ~70 unrelated configuration-shape tests; coverage falls back to the reviewed list and a dedicated test reports the failure.

## Archive lifetime â€” conditional ownership

`lucid_server.extract_render_data` and the `portable_genome` export CLI each had **no context manager at all**; both handles were left to garbage collection. Both now use conditional ownership:

```python
loaded = np.load(<path>, allow_pickle=False)
owner = contextlib.nullcontext(loaded) if isinstance(loaded, np.ndarray) else loaded
with owner as snap:
    # existing extraction, unchanged
```

**Why conditional.** `np.load` returns an `NpzFile` for a zip archive but a plain ndarray for a `.npy`. Only the archive owns an operating-system handle and needs deterministic closure; the array owns nothing and has no context-manager protocol. Wrapping both identically would have cost the legacy `.npy` failure for no benefit â€” an earlier revision of this branch did exactly that and recorded it as an unavoidable trade-off. It was not unavoidable, and this is the correction.

- **NPZ** closes deterministically, on success *and* on a refusal raised mid-extraction, because the members are read inside the block. `lucid_server` now closes before `state.shape[0]`, before the non-void search, and before the per-cell loop that previously ran up to `MAX_CELLS` = 15 000 iterations with the handle open. `portable_genome` closes before `export_genome` begins.
- **`.npy`** reaches the same constant-string subscript that has always been where a non-archive input fails â€” same exception class, same point, no output, no downstream work.

Because `NpzFile.__getitem__` materialises a real in-memory ndarray, closing first is safe: the test decodes the exported base64 payload back to its exact bytes to prove it.

The other four loaders preserve their established closure ordering exactly.

### The legacy `.npy` class is derived, not remembered

At the base commit both loaders did `snap = np.load(...)` then immediately a constant-string subscript, so the legacy failure is whatever that subscript raises on a plain ndarray. The tests **derive** the class by performing that identical operation on a probe rather than hard-coding a name, and a parity test pins the derived class against `_LEGACY_NPY_ERROR = IndexError` so the documented contract cannot quietly become fiction. A companion assertion requires that class **not** to be `TypeError` â€” `TypeError` is what the regression raised, so if the two coincided the suite could not tell the broken state from the correct one.

## Compatibility â€” what did **not** change

Casts, defaults, required-key semantics, `str(path)` coercion, extraction order and returned tuple order are all preserved verbatim. For the export CLI specifically: the supplied path object (no `str()` coercion introduced), the key-access order, the `.get` defaults of `0`/`0`/`0.0`, the `int()`/`int()`/`float()` casts, the printed output line, and the exception behaviour â€” a refusal propagates uncaught exactly as a malformed archive already did. No CLI or API error handling was redesigned, no helper was extracted, and no public surface was added.

Two compatibility hazards were found by review and handled in-boundary:

- `tests/test_lucid_server.py` deliberately runs **without** NumPy â€” it stubs a missing numpy so the malformed-frame contract executes in ordinary CI instead of being skipped away behind an optional dependency. An unconditional `import numpy as np` would have failed collection of that whole file in a bare environment, taking 330 pre-existing lines with it. NumPy is now imported defensively and only the seven pickle tests carry `@requires_numpy`. Verified on a genuinely NumPy-free interpreter: the module still imports and all 11 pre-existing malformed-frame tests still collect.
- `run_acoustic_diagnostic` performs a *function-local* engine import at `scripts/acoustic_map.py:355`, **before** the `np.load` at `:358`. The new acoustic tests therefore install that module's scoped engine stand-in at all five call sites, so no real engine is imported.

No server, WebSocket listener, daemon loop, API service, GPU benchmark or long simulation is started by any test. Payload markers and archives are written only into pytest's own `tmp_path`.

## Failing-first proof, twice

Tests were pushed **before** each production change and CI was allowed to go red on purpose.

**Round 1 â€” the five unattended and argv-driven consumers** (`push`-event build history):

| Commit | Run | verify-python | Result |
|---|---|---|---|
| `d0a3a3e` tests only | `31099089713` | `92608037982` | **47 failed**, 4038 passed, 13 skipped |
| `fad893b` production change | `31099379674` | `92608975768` | 4085 passed, 13 skipped |
| `f32909c` policy hole tightened | `31100107436` | `92611337960` | 4085 passed, 13 skipped |
| `9bf83ff` compatibility corrections | `31100792765` | `92613587636` | 4085 passed, 13 skipped |

**Round 2 â€” the export CLI** (`push`-event):

| Commit | Run | verify-python | Result |
|---|---|---|---|
| `19074d5` tests + policy only | `31133963686` | `92729097678` | **13 failed**, 4088 passed, 13 skipped |
| `42c4c8a` production change | `31134215189` | `92729891717` | 4101 passed, 13 skipped |
| `918877a` review corrections | `31135757327` | `92734570408` | 4104 passed, 13 skipped |

Every one of those 13 failures was predicted in advance and failed for the intended reason â€” no unrelated breakage was manufactured:

- 6 Ã— `Failed: DID NOT RAISE ValueError` â€” the five member refusals plus the no-retry test
- `assert True is False` â€” the `allow_pickle` literal
- `the export CLI's np.load is not owned by a `with`` â€” the ownership contract
- `export_genome ran with the archive open` â€” the closure ordering
- `scripts/portable_genome.py:733 allow_pickle must be the literal False` â€” policy target
- `scripts/portable_genome.py references allow_pickle=True` â€” escape-hatch ban
- `NumPy load without literal allow_pickle=False (path -> count): {'scripts/portable_genome.py': 1}` â€” repo sweep
- `assert 'allow_pickle=False' in 'Traceback ... runpy ...'` â€” the public subprocess entry point

**Round 3 â€” the `.npy` compatibility correction** (`push`-event):

| Commit | Run | verify-python | Result |
|---|---|---|---|
| `4756d6f` tests only | `31173855341` | `92851403206` | **3 failed**, 4102 passed, 13 skipped |
| `74c29fc` conditional ownership | â€” | â€” | 4108 passed, 13 skipped |
| `64bca1e` derivation + claims | â€” | â€” | 4110 passed, 13 skipped |
| `924f285` review corrections | `31176473783` | `92859462456` | 4113 passed, 13 skipped |

All 3 of round 3's failures were the intended ones. Both `.npy` tests failed with `TypeError: 'numpy.ndarray' object does not support the context manager protocol` â€” the regression caught in the act â€” and the structural test failed because `nullcontext` was not yet present.

**The authoritative receipt for this PR is the `pull_request`-event run at the synchronized head `a9bd898`**, not any push run above:

| Check | Run | Job | Result |
|---|---|---|---|
| `verify-python` | `31195840177` | `92923710103` | **`4113 passed, 13 skipped in 80.89s (0:01:20)`** |
| `frontend-quality` | `31195840177` | `92923709843` | pass |
| `Analyze Python` (CodeQL baseline) | `31195840163` | `92923709206` | pass |
| `agent-safety` | `31195840368` | `92923710348` | pass |

Rollup at head `a9bd898` is **SUCCESS**, and `mergeStateStatus` is `CLEAN` (it was `BEHIND` before the sync). The pre-sync head `924f285` was also fully green â€” run `31176476974`, job `92859473153`, `4113 passed, 13 skipped in 59.19s` â€” and the count is unchanged across the sync, as expected. (`Theory Tripwire` triggers on `opened`/`reopened`/`labeled` only, so it ran when this PR was opened and correctly does not re-run on push; it is not a required check.)

Baseline `main` is **still 4033 passed, 13 skipped** after the sync â€” verified at `d15b194` on run `31184478279`, the same figure as at `feba238c` on run `31078685407`. PR #459 does not move it: `verify-python` runs `python -m pytest tests/ -q` and `pytest.ini` scopes collection to `tests/`, while #459's new tests live under `experiments/tech_ledger/tests/`, outside that scope. **This branch adds 80 test items.**

## What the tests actually assert

Per converted module: a fires-control, a per-member refusal parametrisation, a no-retry recorder proving `np.load` is never re-invoked with pickle enabled after a refusal, an archive-closure proof, and a numeric round-trip. `geometry_daemon` adds compressed-archive coverage; `lucid_server` adds object-bearing **structured** dtype coverage â€” a structured member can hide an object field where `dtype.kind == 'O'` reads `'V'`.

The export CLI is exercised on **two surfaces**, matching the split already used in `tests/test_portable_genome_config_shapes.py`:

- **IN-PROCESS** â€” the module's real `if __name__ == "__main__":` body is *lifted from the live source by AST* and executed against a copy of the module's own globals. It therefore cannot drift from what `python -m scripts.portable_genome` runs, and load counting, archive lifetime and call ordering are observed on the real objects. A single-block assertion keeps the lift honest.
- **PUBLIC** â€” a real subprocess run of the shipped entry point, proving it refuses and writes no genome.

Marker absence is deliberately *not* asserted on the subprocess surface: the payload's reduction names a callable in the test module, which a fresh interpreter cannot import, so an absent marker there would prove nothing either way. The in-process tests own that evidence.

Closure is proven by real-object introspection, never by a `getattr(..., default)` â€” a default is precisely what makes a closure assertion pass on an object that was never observed. The export-CLI closure test is non-vacuous from both ends: the archive is recorded as genuinely **open** at load time and `export_genome` as genuinely **reached**, and both are asserted before the closure claim.

`tests/test_snapshot_pickle_policy.py` is the cross-module gate. Its matcher is NumPy-qualified and alias-aware: a bare `attr == "load"` filter would have matched `json.load` in `medusa_api.py` and `tomli.load` in `portable_genome.py`, and a plain `np.load` string sweep would have missed `numpy.load`, an aliased import, and `from numpy import load`. The sweep asserts its directories exist, because `Path.rglob` on a renamed directory yields nothing silently.

The `KNOWN_PENDING` exemption that previously held `portable_genome` back has been **removed outright**, not emptied â€” an exemption mechanism that no longer exempts anything is an invitation to reuse it. The sweep now requires **zero** unguarded NumPy loads.

A name-based matcher is never complete, so the policy module asks a second, independent question: **did any call, under any name, request pickle through a statically readable argument?** `np.load` is one entry point to NumPy's unpickling code, not the only one â€” `NpzFile(fh, allow_pickle=True)` and `read_array(..., allow_pickle=True)` reach it directly and are invisible to any matcher keyed on the callee.

Stated exactly, because an earlier revision of this branch overclaimed here and then overcorrected in the other direction. **Enforced:** an explicit `allow_pickle=` keyword whose value is not literal `False`, on a call to anything â€” including attribute-reached calls, `functools.partial`, and a computed value (a non-literal is treated as enabling precisely because it cannot be read); a literal `**{"allow_pickle": ...}` mapping; and a **positional** `allow_pickle` on the three callees that accept it by position. That last one was a real hole â€” `read_array(fh, True)` names no keyword and is not called `load`, so it passed every gate until this pass. **Not enforced, and not claimed:** `**kwargs` forwarded from another function, or a mapping built at runtime. For a `load`-named callee those are still caught by the *unguarded* sweep, which requires a readable literal `False`; for any other callee they are a genuine blind spot. Being AST rather than substring, none of it is fooled by `allow_pickle = True` with spaces.

Because "zero" is also what a broken detector returns, non-vacuity is enforced at **both levels**: one guard feeds the matchers a planted module exercising every spelling â€” aliased module, aliased `from`-import, `getattr` indirection, local rebinding, `NpzFile` and `read_array` constructors, literal dict expansion, both positional forms, a **guarded negative control**, and a `json.load` that must be ignored â€” and a second points the *real sweep function* at a planted directory tree, so the walk, the classification and the path key are exercised end to end. The earlier guard tested only the matcher it called; inverting the sweep's own comparison would have left everything green. The planted counts are deliberately three different numbers (7 loads, 6 unguarded, 9 enabling), so no single constant can satisfy them and a classification that stopped discriminating cannot pass.

## Files touched â€” 14, the full authorized boundary

```
 scripts/acoustic_map.py                     |  17 +-
 scripts/geometry_daemon.py                  |  21 +-
 scripts/gpu_benchmark.py                    |  17 +-
 scripts/lucid_server.py                     |  58 +-
 scripts/medusa_api.py                       |  22 +-
 scripts/nextness_observer.py                |  61 +-
 scripts/portable_genome.py                  |  43 +-
 tests/test_acoustic_map_snapshot_loader.py  | 171 +++++-
 tests/test_geometry_daemon.py               | 169 +++++-
 tests/test_gpu_benchmark_snapshot_loader.py | 130 ++++-
 tests/test_lucid_server.py                  | 302 +++++++++-
 tests/test_medusa_api_snapshot_loader.py    | 148 ++++-
 tests/test_portable_genome_config_shapes.py | 706 +++++++++++++++++++++++-
 tests/test_snapshot_pickle_policy.py        | 432 +++++++++++++++
 14 files changed, 2237 insertions(+), 60 deletions(-)
```

`scripts/nextness_observer.py` is **documentation only** â€” its AST is byte-identical to the base commit once docstrings are stripped, checked before each commit that touched it.

No fifteenth file. No workflow, dependency, packaging, Observatory, policy, Tech Ledger, Rust or unrelated-documentation change. No package installed. `main` was synchronized once, by the ordinary merge commit `a9bd898` recorded above; there has been no rebase, no squash, no force-push and no amended commit.

## Known limitations

1. Object-member refusal only â€” see *Scope* above.
2. A malformed or truncated NPZ still raises whatever NumPy raises; error contracts were left alone by instruction.
3. **An object-dtype `.npy` now fails earlier**, at `np.load` itself, rather than at the subscript â€” pickle is refused before anything is returned. That is the intended change, not preserved behaviour; the preservation claim is scoped to *numeric* `.npy` input, which is what the tests cover.
4. **`np.memmap` would not be closed by the ndarray branch.** It is an ndarray subclass and does own a mapping. It is unreachable here only because neither call site passes `mmap_mode` â€” so the argument list at those two calls is load-bearing, and both comments now say so rather than claiming an ndarray "owns no handle".
5. The policy sweep covers `scripts/` and `vis/`, and its argument matcher is a **static** gate â€” see the exact enforced / not-enforced split above. It is deliberately not repository-wide: `tests/` is full of legitimate pickle-enabling positive controls, and carving `tests/` back out would reintroduce the exemption mechanism this branch removed. A sweep of every non-test `.py` confirms no `np.load` exists outside those two directories today â€” true in effect, but not by construction.
6. **`nextness_observer` accepts an archive carrying a pickled OPTIONAL member.** `_is_valid_snapshot_npz` lists keys only, and `load_snapshot` catches the `ValueError` for non-required keys and skips them silently, so the load succeeds minus one key and nothing propagates. Only a pickled *required* key raises. The pickle is never executed either way, which is the property that matters â€” but "the archive is refused" would be too strong, and the docstrings now say so.
7. `tests/test_dandelion_snapshot_loading.py:310` still uses a `getattr(fid, "closed", True)` closure assertion that passes vacuously. Outside this boundary, deliberately left untouched â€” disclosed rather than repaired, so it is not lost.
8. `scripts/workstream_b_profile_predicates.py:68` loads pickle-free but never closes its handle. Outside this boundary; a separate resource-lifetime concern, routed rather than repaired here.

## Reviews

Two independent read-only lanes ran against each green head â€” a security lane (hostile representation, member coverage, retry paths, sweep completeness, archive lifetime, harness integrity) and a compatibility lane (export semantics, lazy-read hazard, harness side effects, optional-dependency collection, docstring truth, cross-file staleness). Every finding was reproduced on this seat before being acted on; nothing was taken on assertion, and two agent claims that turned out to be wrong on the detail were corrected rather than applied. No lane raised a HIGH finding against loader *behaviour*; round 3's two HIGH findings were both false claims in prose, corrected in `924f285`.

Round 2 caught, and `918877a` corrected: the policy matcher missed `from numpy import load as X`, `getattr(np, "load")`, local rebinding, and the two constructor-level pickle entry points; the sweep function itself had no test; four suites used a closure witness that could pass on an unobserved handle; and five documentation claims had been made false by this branch's own commits.

Round 3 caught, and `924f285` corrected: **positional** `allow_pickle` slipped every gate â€” `read_array(fh, True)` names no keyword and is not called `load`; the planted non-vacuity constant was doing double duty as both the total and the unguarded count; closure on the *refusal* path was unwitnessed in exactly the two files whose ownership shape is new; the narrowed policy claim was wrong in the other direction (three constructs listed as unenforced are in fact caught, while the real gap went unlisted); `nextness_observer`'s new docstring overstated refusal for optional members, which `load_snapshot` silently skips; the member derivation could take out ~70 unrelated tests as a collection error; and the memmap, watch-poll and "only place that enables pickle" claims were each false as written.

Items that are genuine limits rather than defects are recorded under *Known limitations* rather than silently narrowed.

## Status

**MERGED** on 2026-08-07T16:34:15Z by `Goldislops`, as an ordinary merge commit. No squash, no rebase, no administrator bypass, no auto-merge, no force-push.

| | |
|---|---|
| Merge commit | `f35bff8aae93b49b5afabd7b2eb8aca3786c737d` |
| First parent (base at merge time) | `d15b1943f289d753ede2b7042190b97a274af6d7` |
| Second parent (merged head) | `a9bd8983fcd4a1d97cc2a752c190329bee525a9e` |
| Live `main` after merge | `f35bff8aae93b49b5afabd7b2eb8aca3786c737d` — identical to the merge commit |
| Merged delta | exactly the 14 authorized files, `+2237/−60` |
| PR commits reachable from the merge commit | all 12 |

The remote branch `security/snapshot-consumers-pickle-free` was removed automatically by the repository's existing `delete_branch_on_merge` setting. It was not removed by hand and has not been recreated.

Untouched throughout this package: issue #67 remains OPEN with unchanged metadata, and PRs #441, #442 and #443 remain OPEN and unchanged. No label, comment, review, workflow rerun or repository-setting change was made.

---

Prepared on the Ian seat. Reviewed against the file boundary, the closing-keyword rule and the no-service-startup constraint before publishing.




