### PR TITLE
fix(uft-ca): complete getrandom 0.4 native and WASM migration

### DIFF
--- a/crates/uft_ca/Cargo.toml
+++ b/crates/uft_ca/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0"
 toml = "1.1"
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 rand_xoshiro = "0.6"
-getrandom = "0.2"
+getrandom = "0.4"
 
 # Platform-specific: Rayon for native parallelism (not available on wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -25,7 +25,7 @@ rayon = "1.8"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dependencies.pyo3]
 version = "0.29"

--- a/crates/uft_ca/src/rng_util.rs
+++ b/crates/uft_ca/src/rng_util.rs
@@ -1,7 +1,7 @@
 //\! WASM-safe seedable PRNG using Xoshiro256**.
 //\!
 //\! On native: seeded from getrandom.
-//\! On WASM: seeded from getrandom (crypto.getRandomValues via js feature).
+//\! On WASM: seeded from getrandom (crypto.getRandomValues via wasm_js feature).
 
 use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256StarStar;
@@ -17,7 +17,7 @@ pub fn create_rng(seed: u64) -> CaRng {
 /// Uses getrandom which maps to crypto.getRandomValues on WASM.
 pub fn create_rng_from_entropy() -> CaRng {
     let mut seed = [0u8; 32];
-    getrandom::getrandom(&mut seed).unwrap_or_else(|_| {
+    getrandom::fill(&mut seed).unwrap_or_else(|_| {
         // Fallback: use a fixed seed if getrandom fails
         seed = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,


### PR DESCRIPTION
## What this is

Completes the `getrandom` 0.2 → 0.4 migration for `crates/uft_ca`. Dependabot's PR #442 bumped only the general dependency line, which leaves the crate **uncompilable on both the native and the wasm32 target**. This is a complete native-and-WASM migration, not a version bump.

Supersedes #442 in substance. #442 is deliberately left open and untouched; closing it is a separate decision.

## The two defects

**1. API rename — this is what CI sees.** getrandom 0.3.0 renamed the free function `getrandom` to `fill` (upstream CHANGELOG, Breaking Changes: *"Rename `getrandom` and `getrandom_uninit` functions to `fill` and `fill_uninit` respectively"*). The call site was untouched, so `verify-python` failed on both of #442's CI runs with exactly one error:

```
error[E0425]: cannot find function `getrandom` in crate `getrandom`
  --> src/rng_util.rs:20:16
```

**2. WASM feature rename — invisible to CI.** The `[target.'cfg(target_arch = "wasm32")'.dependencies]` entry still requested getrandom `0.2` with the `js` feature. That feature **does not exist in 0.4** — 0.4.3's features are exactly `std`, `wasm_js`, `sys_rng`. A wasm32 build therefore fails *inside getrandom itself*, before `uft_ca` is reached:

```
error: The wasm32/64-unknown-unknown are not supported by default; you may need to
       enable the "wasm_js" crate feature.
error: could not compile `getrandom` (lib) due to 4 previous errors
```

**No workflow builds wasm32** (mechanical count: 0 occurrences of `wasm` across all 7 tracked workflow files), so this half cannot fail a required check. A rename-only patch was tested and goes **green on all checks while leaving WASM broken** — which is why both lines move here.

## The change — 2 files, +4/−4

`crates/uft_ca/Cargo.toml`
- L18 `getrandom = "0.2"` → `"0.4"`
- L28 `getrandom = { version = "0.2", features = ["js"] }` → `{ version = "0.4", features = ["wasm_js"] }`

`crates/uft_ca/src/rng_util.rs`
- L20 `getrandom::getrandom(&mut seed)` → `getrandom::fill(&mut seed)`
- L4 doc comment: `via js feature` → `via wasm_js feature` (the old text names a feature that no longer exists)

Nothing else: no new file, no `.cargo/config.toml`, no RUSTFLAGS, no lockfile, no toolchain pin, no workflow edit.

## Semantics are preserved, not just compilable

`fill(dest: &mut [u8]) -> Result<(), Error>` is signature- and contract-identical to 0.2's `getrandom`, including the same sentence *"This function returns an error on any failure, including partial reads. We make no guarantees regarding the contents of `dest` on error."* The existing `.unwrap_or_else(|_| { seed = [fixed 32 bytes] })` fallback therefore behaves exactly as before, and `create_rng(seed)` — the deterministic path — never touches getrandom and is untouched here. None of the `Error` APIs removed in 0.3.x is used anywhere in the crate (mechanical count: 0 files for each of `Error::code`, `From<NonZeroU32>`, `INTERNAL_START`, `CUSTOM_START`, `register_custom_getrandom!`).

**No backend cfg is required.** 0.3.0–0.3.3 needed the feature *plus* `--cfg getrandom_backend="wasm_js"`; **0.3.4** made the feature select the backend by default; 0.4.x continues feature-only selection, and `wasm_js` is not even a recognised `getrandom_backend` value there. Leaving `RUSTFLAGS` unset is deliberate: under 0.4 a stale `wasm_js` cfg is a silent no-op (rustc does not validate `--cfg` *values*), while a *recognised* value would silently displace the JS backend.

## Verified receipts

Against this exact tree, on `cargo 1.93.1` / `rustc 1.93.1`, targets `x86_64-pc-windows-msvc` + `wasm32-unknown-unknown`:

| Lane | Result |
|---|---|
| `cargo check` (native) | exit 0, one pre-existing warning |
| `cargo test` (native) | **86 + 15 passed, 0 failed** |
| the exact failing CI invocation `cargo rustc --profile release --features python --lib --crate-type cdylib` | **exit 0**, with the same 6 pre-existing warnings — previously those 6 **plus** `error[E0425]` |
| maturin wheel via `pip install ./crates/uft_ca` | builds and installs |
| the five `uft_ca`-dependent Python suites | **114 passed** |
| `cargo check` / `build --release` for `wasm32-unknown-unknown` | exit 0 |
| documented route `--no-default-features --features wasm` | exit 0 |
| emitted wasm artifact | imports exactly one entropy function, `__wbg_getRandomValues_*`; glue calls `globalThis.crypto.getRandomValues` |
| real execution under Node | **10/10 fail-closed assertions** (`node:assert/strict`) |
| resolved lockfile | exactly **one** getrandom, `0.4.3` (#442's state resolves two) |
| feature isolation | `wasm_js` appears 0× on native, 1× on wasm32 — no leak |

The Node run includes an **injected `crypto.getRandomValues` failure**: construction still succeeds, the `Err` reaches Rust, the fixed fallback seed is used, and no panic escapes to JS. The harness was also verified to *fail* — `INJECT_FAULT=w2` exits 2 with no success verdict — so the green result is meaningful.

## Residuals

- **MSRV rises.** getrandom 0.4.3 declares `rust-version = "1.85"` and `edition = "2024"` (0.2.x declared no `rust-version`). CI's `dtolnay/rust-toolchain` with `toolchain: stable` satisfies this, and no `rust-toolchain` file is tracked. Upstream has shipped MSRV bumps in patch releases, so a floating `"0.4"` can raise the floor without a semver signal.
- **No tracked lockfile changes** — `crates/uft_ca/.gitignore` ignores `Cargo.lock`. `crates/vanguard-mcp/Cargo.lock` belongs to a different crate and is untouched.
- **No WASM CI coverage** exists. Worth its own change; deliberately out of scope here.
- **Pre-existing and deliberately not fixed:** `src/rng_util.rs` lines 1–4 use `//\!` rather than `//!`, so the module docs are silently lost. Present in `main`'s blob; folding it in would widen a 4-line correction.

## Provenance

Single ordinary commit whose sole parent is `c1d5601857831ef2c1bbb92cfa46af9971a86898` (`main` at time of writing). The diff against that parent is byte-pinned: **1,772 bytes**, SHA-256 `34ea4824eb055b17d0821aad5025679077f22178cc625491727b4c1e152c24e8`, resulting blobs `62f85b9f623ecbfa326341040b3778bdb6e8fb66` and `155784366bd215240adc40cbbbe553e6e2a77228`.

Opened as a **draft** pending review.
