### PR TITLE
fix(uft-ca): complete rand 0.10 migration

### DIFF
--- a/crates/uft_ca/Cargo.toml
+++ b/crates/uft_ca/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
-rand_xoshiro = "0.6"
+rand = { version = "0.10", default-features = false }
+rand_xoshiro = "0.8"
 getrandom = "0.4"
 
 # Platform-specific: Rayon for native parallelism (not available on wasm32)

--- a/crates/uft_ca/benches/counter_rng.rs
+++ b/crates/uft_ca/benches/counter_rng.rs
@@ -35,7 +35,7 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use rand_xoshiro::Xoshiro256StarStar;
 
 #[path = "support/counter_rng.rs"]
@@ -76,7 +76,7 @@ fn bench_xoshiro_persistent_dense(c: &mut Criterion) {
             // iterations (throughput is sequence-position independent).
             let mut rng = Xoshiro256StarStar::seed_from_u64(SEED);
             b.iter(|| {
-                let v: Vec<f32> = (0..n).map(|_| rng.gen::<f32>()).collect();
+                let v: Vec<f32> = (0..n).map(|_| rng.random::<f32>()).collect();
                 black_box(checksum(v))
             })
         });
@@ -94,7 +94,7 @@ fn bench_xoshiro_reseed_dense(c: &mut Criterion) {
         group.bench_function(label, |b| {
             b.iter(|| {
                 let mut rng = Xoshiro256StarStar::seed_from_u64(black_box(SEED));
-                let v: Vec<f32> = (0..n).map(|_| rng.gen::<f32>()).collect();
+                let v: Vec<f32> = (0..n).map(|_| rng.random::<f32>()).collect();
                 black_box(checksum(v))
             })
         });

--- a/crates/uft_ca/src/stepper.rs
+++ b/crates/uft_ca/src/stepper.rs
@@ -3,7 +3,7 @@
 //! This is the heart of the CA engine - one call to step() advances the lattice
 //! by exactly one generation, applying all Phase 3-6c mechanics.
 
-use rand::Rng;
+use rand::RngExt;
 
 use crate::memory::{
     VoxelMemoryParams, VOID, STRUCTURAL, COMPUTE, ENERGY, SENSOR, NUM_STATES,
@@ -29,7 +29,7 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
     let params = &config.memory_params;
 
     // Pre-generate random values for this step
-    let rng_vals: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+    let rng_vals: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
 
     // ---- Phase 1: Count neighbors (26 Moore, all 5 states) ----
     let neighbor_counts = filters::count_neighbors_3d(&lattice.states, n);
@@ -107,7 +107,7 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
         .fold(0.0f32, f32::max);
 
     if signal_interval > 0 && gen % signal_interval == 0 {
-        let rng_vals2: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals2: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         let (sa, ca) = phase6c::nervous_system_step(
             &out, &mut lattice.memory, n, params, compute_max_age, &rng_vals2,
         );
@@ -120,19 +120,19 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
 
     // ---- Phase 6: Stochastic transitions ----
     if config.stochastic.enabled {
-        let rng_vals3: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals3: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_stochastic(&mut out, &neighbor_counts, &config, &rng_vals3);
     }
 
     // ---- Phase 7: Forward contagion ----
     if config.contagion.enabled {
-        let rng_vals4: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals4: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_forward_contagion(&mut out, &neighbor_counts, &config, params, &rng_vals4);
     }
 
     // ---- Phase 8: Reverse contagion (COMPUTE reclaims STRUCTURAL) ----
     {
-        let rng_vals5: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals5: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_reverse_contagion(&mut out, &neighbor_counts, params, &rng_vals5);
     }
 
@@ -146,7 +146,7 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
 
     // ---- Phase 11: Energy->Compute conversion (biofilm, super-pod) ----
     {
-        let rng_vals6: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals6: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_energy_conversion(&mut out, &neighbor_counts, &config, &rng_vals6);
     }
 
@@ -158,7 +158,7 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
 
     // ---- Phase 13: Decay resistance ----
     {
-        let rng_vals7: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals7: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_decay_resistance(
             &mut out, &lattice.memory, &nonvoid_counts, &neighbor_counts,
             params, &config.stochastic, &rng_vals7,
@@ -171,7 +171,7 @@ pub fn step(lattice: &mut VoxelLattice, config: &FullConfig, rng: &mut CaRng) ->
     // ---- Phase 15: Analogue mutation (3%, pre_mut snapshot critical) ----
     {
         let pre_mut = out.clone();
-        let rng_vals8: Vec<f32> = (0..n3).map(|_| rng.gen::<f32>()).collect();
+        let rng_vals8: Vec<f32> = (0..n3).map(|_| rng.random::<f32>()).collect();
         apply_analogue_mutation(&mut out, &pre_mut, &config.cosmic, &rng_vals8);
     }
 


### PR DESCRIPTION
## What this is

Completes the `rand` 0.8 → 0.10 migration for `crates/uft_ca`. Dependabot's #441 bumps only the version
requirement, which **cannot even resolve** — so `verify-python` fails twice there, before `rustc` ever
runs:

```
error: failed to select a version for `rand`.
versions that meet the requirements `^0.10` are: 0.10.2, 0.10.1, 0.10.0
package `uft_ca` depends on `rand` with feature `small_rng` but `rand` does not have that feature.
error: metadata-generation-failed
```

This supersedes #441 in substance. #441 is deliberately left open and untouched; what happens to it is a
separate decision.

## Four independent breaking changes

1. **`small_rng` feature removed.** rand 0.10.2's features are `std, std_rng, sys_rng, thread_rng, alloc,
   chacha, log, serde, simd_support, unbiased`. `SmallRng` still exists but is now **unconditional**
   (`rngs/mod.rs:106`, no `cfg`), which is why the feature went away — and this crate never used
   `SmallRng` at all, so the feature request was already gratuitous. Dropped.
2. **`Rng::gen()` removed.** `fn gen` appears **0** times in rand 0.10.2 (`gen` became a reserved keyword
   in edition 2024). The replacement is `random<T>()`. **10 call sites** updated: 8 in `src/stepper.rs`,
   2 in `benches/counter_rng.rs`.
3. **`rand::Rng` now names the low-level trait.** rand 0.10 re-exports
   `rand_core::{CryptoRng, Rng, SeedableRng, …}`; the convenience methods moved to a new extension trait,
   `pub trait RngExt: Rng` with `impl<R: Rng + ?Sized> RngExt for R {}`. So `use rand::Rng;` alone does
   **not** provide `.random()` — the imports become `RngExt`. This is the non-obvious one.
4. **`rand_xoshiro 0.6` is trait-incompatible.** rand 0.10.2 depends on `rand_core 0.10.0`;
   rand_xoshiro 0.6 implements `rand_core 0.6`. `Xoshiro256StarStar` has **0** occurrences in rand 0.10.2
   (it vendors only `Xoshiro256PlusPlus`/`Xoshiro128PlusPlus`), so rand_xoshiro is still required and moves
   to **0.8.1**, which depends on `rand_core 0.10.0` and exports `Xoshiro256StarStar`.

## The change — 3 files, +14/−14

`crates/uft_ca/Cargo.toml` (+2/−2)
- `rand = { version = "0.8", default-features = false, features = ["small_rng"] }`
  → `rand = { version = "0.10", default-features = false }`
- `rand_xoshiro = "0.6"` → `"0.8"`

`crates/uft_ca/src/stepper.rs` (+9/−9)
- `use rand::Rng;` → `use rand::RngExt;`
- 8 × `.gen::<f32>()` → `.random::<f32>()`

`crates/uft_ca/benches/counter_rng.rs` (+3/−3)
- `use rand::{Rng, SeedableRng};` → `{RngExt, SeedableRng}`
- 2 × `.gen::<f32>()` → `.random::<f32>()`

`default-features = false` is deliberately retained: enabling defaults would pull
`std`/`std_rng`/`sys_rng`/`thread_rng`, dragging in chacha20 and a rand-side getrandom — wrong for the
wasm32 target.

## Seeded determinism is preserved — proved, not assumed

Two probes under **exactly pinned** resolutions (`rand =0.8.7` + `rand_xoshiro =0.6.0` versus
`rand =0.10.2` + `rand_xoshiro =0.8.1`, both lockfiles retained as receipts) produced **byte-identical**
output for all three sequences:

| Sequence | Value (identical in both lanes) |
|---|---|
| `next_u64` ×4 from `seed_from_u64(12345)` | `13720838825685603483, 2398916695208396998, 17770384849984869256, 891717726879801395` |
| `f32` ×6 from `seed_from_u64(12345)` | `0.74380815, 0.13004553, 0.96333444, 0.048340082, 0.5551828, 0.010678053` |
| `f32` ×3 from `from_seed([7u8; 32])` | `0.11764705, 0.11764705, 0.2352941` |

Both outputs hash to `0aed64bf81186883abe362b81d7c0e0c2e041021117eb624e5e27267b4ba01ec`. Seed expansion,
the xoshiro256** core and the f32 conversion are all unchanged, so seeded simulation streams are
preserved.

## Verification

Re-run in a **clean checkout at this commit's parent**, with every lane's exit code recorded:

| Lane | Result |
|---|---|
| `cargo check` (native) | exit 0 |
| `cargo test` (native) | **86 + 15 + 0 = 101 passed, 0 failed** |
| `cargo rustc --profile release --features python --lib --crate-type cdylib` (the exact failing CI invocation) | **exit 0** |
| **`pip install ./crates/uft_ca`** (the exact failing CI step) | **exit 0** |
| five `uft_ca`-dependent Python suites | **114 passed** |
| `cargo check --benches` | exit 0 |
| `cargo check --target wasm32-unknown-unknown` | exit 0 |
| resolved lock | exactly one `rand` — 0.10.2, with `rand_core` 0.10.1, `rand_xoshiro` 0.8.1, `getrandom` 0.4.3 |

A fail-closed residual scan over the 21 tracked files in `crates/uft_ca` reports **0** matches for
`.gen::`, `.gen_range`, `.gen_bool`, `use rand::Rng;`, `small_rng`, `SmallRng` and `thread_rng`. (Note
`from_entropy` still matches two files — those are the crate's own `create_rng_from_entropy`, not rand's
removed `SeedableRng::from_entropy`.)

The change was preserved and audited as a sealed evidence chain of five packets before delivery, each
with a write-once checksum seal that independently verifies (22, 20, 21, 21 and 8 rows). The candidate
itself is byte-pinned: the diff against this commit's parent is **5,934 bytes**, SHA-256
`f28a03fc0be7b960fbff18439d7148eddd80fff4814a05ed5efded1a25a619c9`.

## Residuals

- **MSRV rises to 1.85** with edition 2024 (rand 0.10.2 and rand_xoshiro 0.8.1). `main` already requires
  1.85 via getrandom 0.4.3, so there is **no new floor**; CI's rolling `stable` satisfies it and no
  `rust-toolchain` file is tracked.
- **`zerocopy 0.8.56` is newly introduced** into the graph (97 packages in the resolved lock).
- **No tracked lockfile changes** — `crates/uft_ca/.gitignore` ignores `Cargo.lock`.
- Forward-looking: `src/stepper.rs:28` has `let gen = lattice.generation;`. `gen` is a reserved keyword in
  edition 2024 — harmless at edition 2021, but it must be renamed before any edition bump. Untouched here.
- There is no WASM CI lane in this repository, so the wasm32 half of this change is ungated on CI. Worth
  its own change; out of scope here.

## Provenance

One ordinary commit whose sole parent is `ce0b6dcecf24259858dd218824f4f490589a38c7`. Tree
`85121cba53cf2b107738373aa61496475b845bad`. Resulting blobs
`0b43413cd06ff9d57d4c8d14c97708f2d918a645`, `8cfbb49c73ec6f89b6fe7291c10f59e37852a1cf`,
`ca2bafcd3406d5f97a2ae80f71244b34401c9883`.

Opened as a **draft** pending review.
