### PR TITLE
ci(uft-ca): add non-required wasm build lane

### DIFF
--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -1,0 +1,38 @@
+name: wasm-check
+
+on:
+  pull_request:
+    paths:
+      - "crates/uft_ca/**"
+      - ".github/workflows/wasm-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/uft_ca/**"
+      - ".github/workflows/wasm-check.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wasm-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: crates/uft_ca
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Rust toolchain with wasm32 target
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Compile uft_ca for wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown


### PR DESCRIPTION
Implements the `wasm-check` CI lane exactly as specified in the sealed audit contract (`UFT_UFT_CA_WASM_CI_READINESS_AUDIT_2026-08-10/PROPOSED_CI_CONTRACT.md`). The workflow bytes are byte-exact with the sealed YAML block (sha256 `5e92b8d18fbf46568d49c51086012ab658112e2d513fffcf011682fccd1375e5`, mechanically extracted, not retyped).

**What this PR is**
- **One new workflow file only**: `.github/workflows/wasm-check.yml` (+38 lines). No existing file is modified.
- **Path-filtered and deliberately non-required**: triggers on `crates/uft_ca/**` and on the workflow file itself; it is not added to branch protection.
- **`cargo build`, not `cargo check`**: code generation and rust-lld linking are exercised, not only type-checking.
- **Coverage**: pull requests on all base branches, and pushes to `main`.
- **What it detects**: WASM-only compilation failures in `crates/uft_ca` — the `cfg(target_arch = "wasm32")` module surface and the getrandom `wasm_js` backend selection that no current CI job compiles.

**What this PR is not**
- No WASM runtime, browser, wasm-bindgen-cli, or packaging test — compilation and linking only.
- No change to native Rust-test coverage (the native `cargo test` suite remains CI-absent; separately tracked gap).
- `crates/uft_ca` has no committed Cargo.lock, so this lane resolves dependencies fresh each run — dependency-resolution drift continues and can redden the lane without any repo change.
- No branch-protection or required-check change: the required set remains `agent-safety`, `verify-python`, `frontend-quality`.
- No readiness or merge authorization: opened as a draft for Jack's independent audit; any ready/merge transition requires Kev's word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
