### PR TITLE
ci(uft-ca): add non-required native test lane

### DIFF
--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -1,0 +1,57 @@
+name: native-test
+
+on:
+  pull_request:
+    paths:
+      - "crates/uft_ca/**"
+      - ".github/workflows/native-test.yml"
+      - "crates/Cargo.toml"
+      - "crates/Cargo.lock"
+      - "crates/.cargo/**"
+      - "crates/rust-toolchain"
+      - "crates/rust-toolchain.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/**"
+      - "rust-toolchain"
+      - "rust-toolchain.toml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/uft_ca/**"
+      - ".github/workflows/native-test.yml"
+      - "crates/Cargo.toml"
+      - "crates/Cargo.lock"
+      - "crates/.cargo/**"
+      - "crates/rust-toolchain"
+      - "crates/rust-toolchain.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/**"
+      - "rust-toolchain"
+      - "rust-toolchain.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: crates/uft_ca
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      - name: Run native test suite
+        run: cargo test


### PR DESCRIPTION
Implements the `native-test` CI lane exactly as specified by the accepted V3 contract (`UFT_UFT_CA_NATIVE_CI_READINESS_AUDIT_2026-08-11_CORRECTION_02/PROPOSED_NATIVE_CI_CONTRACT_V3.md`). The workflow bytes are byte-exact with the sealed V3 fence (1,329 bytes, SHA-256 `c34305cdd724f46c2d3cda8ffc0de6fe793dda12fd1a6df9b650db9a012c4b7d`, mechanically extracted, verified in working tree, staged file, and staged git blob).

- **One new workflow file only**: `.github/workflows/native-test.yml` (+57 lines). No existing file is modified.
- **Local test result**: `cargo test` in `crates/uft_ca` at this exact tree — exit 0; 86 lib + 15 integration + 0 doctests, all passed.
- **Deliberately non-required**: the lane is path-filtered (crate + both ancestor lookup levels + its own file) and is not added to branch protection; the required set remains `agent-safety`, `verify-python`, `frontend-quality`. A path-filtered required check would wedge unrelated PRs, so promotion is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
