### PR TITLE
ci(uft-ca): compile benches and python-feature tests

### DIFF
--- a/.github/workflows/native-test.yml
+++ b/.github/workflows/native-test.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Run native test suite
         run: cargo test
+
+      - name: Compile benchmarks (no run)
+        run: cargo bench --no-run
+
+      - name: Type-check python-feature tests (no link)
+        run: cargo check --tests --features python


### PR DESCRIPTION
Extends the existing non-required `native-test` lane with two compile-only coverage steps, closing the two coverage FAILs proven by the feature/target CI readiness audit (sealed packets of 2026-08-12, accepted remedy V2):

- `cargo bench --no-run` — compiles the two Criterion benches, which the default `cargo test` target selection provably excludes (bench-only breakage previously merged green).
- `cargo check --tests --features python` — type-checks the python-feature test configuration with no link stage, catching `cfg(all(test, feature = "python"))` defects while avoiding the PyO3 `extension-module` Linux link break that disqualified the earlier `--no-run` variant.

## Provenance

- Base: branched directly from `main` at `4f98e65ca01f943fdbe10b3652fffd15328577bc` (verified live immediately before branch creation and again before push).
- The single changed file `.github/workflows/native-test.yml` is byte-exact with the sealed, Jack-accepted remedy candidate V2: 1,514 LF bytes, SHA-256 `16f74830b12d68b4ba9dc5982616640a2d1bd7fc3f76d28152d2a4c77d8a6560`; its one-file diff regenerates byte-identical to the sealed 353-byte diff, SHA-256 `e6e3a66b86ddf164995f882a3108755a987f34c7c3dfa89ff1f123eb3d1c71a6`.
- Predecessor identity confirmed: the prior workflow blob at base is 1,329 bytes, SHA-256 `c34305cd…`, and is a strict byte prefix of the new file — nothing but the two steps was added (+6/−0). Workflow name, triggers, all 12 path filters, permissions, concurrency, runner, and the existing steps are unchanged; the lane remains non-required.

## Local validation (receipted, exit 0 each)

- `cargo test` — 86 lib + 15 integration + 0 doctests, all passing.
- `cargo bench --no-run` — benches compile.
- `cargo check --tests --features python` — python-feature test configuration type-checks.

Draft for Jack's audit; merge remains gated on Kev's word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
