### PR TITLE
fix(orchestrator): centralize probe socket cleanup

### DIFF
--- a/scripts/continuous_evolution.py
+++ b/scripts/continuous_evolution.py
@@ -118,14 +118,34 @@ def get_active_nodes(config: dict) -> list:
 # Safety-net checks
 # ---------------------------------------------------------------------------
 
+def _probe_tcp(address: str, port: int, timeout: float) -> int:
+    """Open one TCP socket, probe ``(address, port)``, and close it.
+
+    Returns the raw ``connect_ex`` result; the caller decides what a value
+    means. The socket is closed on EVERY path, which is the whole point of the
+    helper: both probe sites previously called ``close()`` only after
+    ``settimeout()`` and ``connect_ex()`` had both returned, so an ``OSError``
+    from either one reached the caller's fallback with the descriptor still
+    open. The fallback then reported an unreachable peer, so a host that failed
+    this way leaked one descriptor per probe and stayed silent about it -- and
+    ``poll_gpu_temperatures`` runs once per GPU, on a loop, for the life of the
+    process.
+
+    Closing in ``finally`` also means an exception that is NOT ``OSError``
+    still propagates unchanged, but never with the socket left open.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(timeout)
+        return sock.connect_ex((address, port))
+    finally:
+        sock.close()
+
+
 def check_vanguard_mcp(head_ip: str = "192.168.86.29", port: int = 50051,
                        timeout: float = 5.0) -> bool:
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(timeout)
-        result = sock.connect_ex((head_ip, port))
-        sock.close()
-        return result == 0
+        return _probe_tcp(head_ip, port, timeout) == 0
     except OSError:
         return False
 
@@ -137,12 +157,11 @@ def poll_gpu_temperatures(nodes: list) -> Dict[str, float]:
         for gpu in node.get("gpus", []):
             key = f"{node_id}/{gpu['id']}"
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.settimeout(2.0)
-                result = sock.connect_ex((node.get("ip", "127.0.0.1"),
-                                          node.get("grpc_port", 50051)))
-                sock.close()
+                result = _probe_tcp(node.get("ip", "127.0.0.1"),
+                                    node.get("grpc_port", 50051), 2.0)
                 if result == 0:
+                    # Reached only after `_probe_tcp` has closed the socket, so
+                    # no descriptor is held across temperature generation.
                     temps[key] = 55.0 + np.random.uniform(-5, 15)
                 else:
                     temps[key] = -1.0

--- a/scripts/continuous_evolution.py
+++ b/scripts/continuous_evolution.py
@@ -119,20 +119,34 @@ def get_active_nodes(config: dict) -> list:
 # ---------------------------------------------------------------------------
 
 def _probe_tcp(address: str, port: int, timeout: float) -> int:
-    """Open one TCP socket, probe ``(address, port)``, and close it.
+    """Open one TCP socket, probe ``(address, port)``, and attempt to close it.
 
     Returns the raw ``connect_ex`` result; the caller decides what a value
-    means. The socket is closed on EVERY path, which is the whole point of the
-    helper: both probe sites previously called ``close()`` only after
-    ``settimeout()`` and ``connect_ex()`` had both returned, so an ``OSError``
-    from either one reached the caller's fallback with the descriptor still
-    open. The fallback then reported an unreachable peer, so a host that failed
-    this way leaked one descriptor per probe and stayed silent about it -- and
-    ``poll_gpu_temperatures`` runs once per GPU, on a loop, for the life of the
-    process.
+    means.
 
-    An exception that is NOT ``OSError`` still propagates unchanged, and the
-    socket is closed before it does.
+    WHY THIS HELPER EXISTS. Both probe sites previously called ``close()`` only
+    after ``settimeout()`` and ``connect_ex()`` had both returned, so an
+    ``OSError`` from either one reached the caller's fallback with the
+    descriptor still open. The fallback then reported an unreachable peer, so a
+    host that failed this way leaked one descriptor per probe and stayed silent
+    about it -- and ``poll_gpu_temperatures`` runs once per GPU, on a loop, for
+    the life of the process.
+
+    WHAT IS GUARANTEED, and no more. Once the protected probe interval has been
+    entered, exactly one close attempt is made before this function returns or
+    raises. Three qualifications, stated rather than glossed:
+
+      * ACQUISITION IS NOT INTERRUPT-ATOMIC. The socket is constructed before
+        the ``try`` is entered. An asynchronous interruption delivered in that
+        window -- a ``KeyboardInterrupt``, or a tracing callback -- unwinds
+        with a live descriptor and no cleanup registered for it. Nothing in
+        pure Python closes that window.
+      * A CLOSE ATTEMPT IS NOT A RELEASE. If ``close()`` itself raises, the
+        attempt was made and the resource may still be held. This function
+        claims the attempt, not the outcome.
+      * ONLY ``OSError`` IS TRANSLATED BY THE CALLERS. A non-``OSError`` probe
+        fault propagates unchanged, after the close attempt rather than instead
+        of it.
 
     The close is deliberately NOT a bare ``finally``. If the probe has already
     failed, a second failure while releasing must not replace the first: a

--- a/scripts/continuous_evolution.py
+++ b/scripts/continuous_evolution.py
@@ -131,15 +131,31 @@ def _probe_tcp(address: str, port: int, timeout: float) -> int:
     ``poll_gpu_temperatures`` runs once per GPU, on a loop, for the life of the
     process.
 
-    Closing in ``finally`` also means an exception that is NOT ``OSError``
-    still propagates unchanged, but never with the socket left open.
+    An exception that is NOT ``OSError`` still propagates unchanged, and the
+    socket is closed before it does.
+
+    The close is deliberately NOT a bare ``finally``. If the probe has already
+    failed, a second failure while releasing must not replace the first: a
+    plain ``finally: sock.close()`` lets a failing ``close()`` overwrite the
+    exception being unwound, which turns a ``KeyboardInterrupt`` or a
+    ``ValueError`` from ``connect_ex`` into an ``OSError`` that the callers'
+    handlers then report as an unreachable peer. The original fault wins; a
+    failure to close on a socket that is already being abandoned is not worth
+    losing it over. On the SUCCESS path ``close()`` is called normally, so its
+    exception propagates exactly as it did before this helper existed.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.settimeout(timeout)
-        return sock.connect_ex((address, port))
-    finally:
-        sock.close()
+        result = sock.connect_ex((address, port))
+    except BaseException:
+        try:
+            sock.close()
+        except BaseException:
+            pass          # never mask the fault that is already unwinding
+        raise
+    sock.close()
+    return result
 
 
 def check_vanguard_mcp(head_ip: str = "192.168.86.29", port: int = 50051,

--- a/tests/test_continuous_evolution_socket_lifetime.py
+++ b/tests/test_continuous_evolution_socket_lifetime.py
@@ -15,8 +15,16 @@ leak: silent, and on the path that fires when the network is already unhappy.
 `poll_gpu_temperatures()` runs one probe per GPU per node, on a polling loop,
 for the life of the orchestrator process.
 
-`_probe_tcp()` now owns the socket for the whole probe and closes it in a
-`finally`, so release does not depend on which call raised.
+`_probe_tcp()` now owns the socket for the whole probe, so release does not
+depend on which call raised.
+
+The close is deliberately not a bare `finally`. A `finally: sock.close()` lets
+a failing `close()` REPLACE the exception being unwound, which converted a
+`ValueError` -- or a `KeyboardInterrupt` -- from `connect_ex` into an `OSError`
+that the callers' handlers then reported as an unreachable peer. On a failed
+probe the close exception is suppressed so the original fault survives; on the
+successful path `close()` is called normally and its exception propagates
+exactly as it did before the helper existed.
 
 No real socket, host, port or service is contacted: `socket.socket` is replaced
 by a factory handing out scripted fakes that record their own `close()` calls.
@@ -281,34 +289,125 @@ def test_successful_probe_generates_a_temperature_in_the_established_band(probe_
         [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
     )
 
-    assert 50.0 <= temps["n/g"] <= 70.0
+    assert 50.0 <= temps["n/g"] < 70.0
 
 
-def test_temperature_is_generated_only_after_its_socket_is_closed(probe_sockets):
+def test_temperature_is_generated_only_after_its_socket_is_closed(
+        probe_sockets, monkeypatch):
     """Ordering, not just the final count.
 
-    The generated reading must not be produced while the descriptor is still
-    open, so the socket is asserted closed at the moment `np.random.uniform`
-    runs.
+    A characterization guard rather than failing-first evidence: the base
+    already generated the reading after closing, and this pins that so the
+    repair cannot quietly move the work inside the socket's lifetime. The
+    socket is asserted closed at the moment `np.random.uniform` runs.
     """
     factory = probe_sockets([{"connect_result": 0}])
     observed = []
-
     real_uniform = ce.np.random.uniform
 
-    def recording_uniform(low, high):
+    def recording_uniform(*args, **kwargs):
         observed.append([sock.closed for sock in factory.made])
-        return real_uniform(low, high)
+        return real_uniform(*args, **kwargs)
 
-    ce.np.random.uniform = recording_uniform
-    try:
-        ce.poll_gpu_temperatures(
-            [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
-        )
-    finally:
-        ce.np.random.uniform = real_uniform
+    monkeypatch.setattr(ce.np.random, "uniform", recording_uniform)
+    ce.poll_gpu_temperatures(
+        [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
+    )
 
     assert observed == [[1]], "temperature generated while the socket was open"
+
+
+# ---------------------------------------------------------------------------
+# A failing close() must not mask the fault already unwinding
+# ---------------------------------------------------------------------------
+
+
+def test_a_failing_close_does_not_mask_an_oserror_probe_failure(probe_sockets):
+    """`close()` raising a non-OSError must not escape past a failed probe.
+
+    A bare `finally: sock.close()` lets the close failure REPLACE the exception
+    being unwound, so this returned `ValueError` instead of the established
+    `False`.
+    """
+    factory = probe_sockets([{"connect_error": OSError("probe failed"),
+                              "close_error": ValueError("close failed")}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert _closes(factory) == [1]
+
+
+def test_a_failing_close_does_not_swallow_a_non_oserror_probe_failure(probe_sockets):
+    """The reverse direction, and the more serious one.
+
+    With a bare `finally`, an `OSError` from `close()` replaced the `ValueError`
+    from the probe and was then caught by the `except OSError`, reporting an
+    unreachable peer for what is a caller defect.
+    """
+    boom = ValueError("not a network failure")
+    factory = probe_sockets([{"connect_error": boom,
+                              "close_error": OSError("close failed")}])
+
+    with pytest.raises(ValueError) as caught:
+        ce.check_vanguard_mcp("10.10.10.10", 50051)
+
+    assert caught.value is boom
+    assert _closes(factory) == [1]
+
+
+def test_a_failing_close_does_not_swallow_a_baseexception(probe_sockets):
+    """`KeyboardInterrupt` must not become "peer unreachable"."""
+    boom = KeyboardInterrupt()
+    factory = probe_sockets([{"connect_error": boom,
+                              "close_error": OSError("close failed")}])
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        ce.check_vanguard_mcp("10.10.10.10", 50051)
+
+    assert caught.value is boom
+    assert _closes(factory) == [1]
+
+
+def test_a_failing_close_on_the_success_path_still_propagates(probe_sockets):
+    """Unchanged from the base: nothing is swallowed when the probe SUCCEEDED.
+
+    The suppression above applies only while another exception is unwinding.
+    """
+    factory = probe_sockets([{"connect_result": 0,
+                              "close_error": ValueError("close failed")}])
+
+    with pytest.raises(ValueError):
+        ce.check_vanguard_mcp("10.10.10.10", 50051)
+
+    assert _closes(factory) == [1]
+
+
+def test_a_failing_close_on_the_success_path_is_still_reported_unreachable(
+        probe_sockets):
+    """An `OSError` from a successful probe's `close()` still returns False."""
+    factory = probe_sockets([{"connect_result": 0,
+                              "close_error": OSError("close failed")}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert _closes(factory) == [1]
+
+
+def test_polling_survives_a_failing_close_and_keeps_going(probe_sockets):
+    """One GPU's close failure must not abort the GPUs after it."""
+    factory = probe_sockets([
+        {"connect_error": OSError("p"), "close_error": ValueError("c")},
+        {"connect_result": 0},
+        {"connect_result": 111},
+        {"connect_result": 0},
+    ])
+
+    temps = ce.poll_gpu_temperatures(_nodes())
+
+    assert _closes(factory) == [1, 1, 1, 1]
+    assert temps["alpha/gpu0"] == -1.0
+    assert temps["beta/gpu0"] == -1.0
+    assert len(temps) == 4
 
 
 def test_construction_failure_records_minus_one_for_that_gpu(probe_sockets):

--- a/tests/test_continuous_evolution_socket_lifetime.py
+++ b/tests/test_continuous_evolution_socket_lifetime.py
@@ -1,0 +1,354 @@
+"""Focused tests for `scripts/continuous_evolution` probe-socket ownership.
+
+Both safety-net probes used to construct a TCP socket and call `close()` only
+after `settimeout()` and `connect_ex()` had BOTH returned:
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    result = sock.connect_ex((head_ip, port))
+    sock.close()          # skipped when either call above raises
+
+An `OSError` from either call jumped straight to the surrounding handler, which
+reports an unreachable peer -- so the descriptor stayed open and the failure
+looked exactly like an ordinary unreachable host. That is the bad shape for a
+leak: silent, and on the path that fires when the network is already unhappy.
+`poll_gpu_temperatures()` runs one probe per GPU per node, on a polling loop,
+for the life of the orchestrator process.
+
+`_probe_tcp()` now owns the socket for the whole probe and closes it in a
+`finally`, so release does not depend on which call raised.
+
+No real socket, host, port or service is contacted: `socket.socket` is replaced
+by a factory handing out scripted fakes that record their own `close()` calls.
+The probe addresses below are fictitious and never dialled.
+
+Scope is descriptor lifetime and the exception paths around it -- not
+reachability semantics, thermal policy, temperature modelling, or the
+orchestrator's loop behaviour.
+"""
+
+from __future__ import annotations
+
+import signal
+import socket as _real_socket
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Importing the orchestrator installs SIGINT/SIGTERM handlers at module scope.
+# They are restored immediately so collecting this file cannot change how the
+# rest of the pytest session responds to signals.
+_SAVED_HANDLERS = {
+    number: signal.getsignal(number)
+    for number in (signal.SIGINT, signal.SIGTERM)
+}
+import scripts.continuous_evolution as ce  # noqa: E402
+for _number, _handler in _SAVED_HANDLERS.items():
+    signal.signal(_number, _handler)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeSocket:
+    """Records its own lifetime. Never touches the network."""
+
+    def __init__(self, family=None, type=None, connect_result=0,
+                 settimeout_error=None, connect_error=None, close_error=None):
+        self.family = family
+        self.type = type
+        self.closed = 0
+        self.timeout = None
+        self.connected_to = None
+        self._connect_result = connect_result
+        self._settimeout_error = settimeout_error
+        self._connect_error = connect_error
+        self._close_error = close_error
+
+    def settimeout(self, value):
+        self.timeout = value
+        if self._settimeout_error is not None:
+            raise self._settimeout_error
+
+    def connect_ex(self, address):
+        self.connected_to = address
+        if self._connect_error is not None:
+            raise self._connect_error
+        return self._connect_result
+
+    def close(self):
+        self.closed += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class SocketFactory:
+    """Stands in for `socket.socket`, handing out scripted `FakeSocket`s."""
+
+    def __init__(self, scripts=None, construct_error=None):
+        self._scripts = list(scripts or [])
+        self._construct_error = construct_error
+        self.made = []
+        self.calls = []
+
+    def __call__(self, family=None, type=None):
+        self.calls.append((family, type))
+        if self._construct_error is not None:
+            raise self._construct_error
+        spec = self._scripts.pop(0) if self._scripts else {}
+        sock = FakeSocket(family=family, type=type, **spec)
+        self.made.append(sock)
+        return sock
+
+
+@pytest.fixture
+def probe_sockets(monkeypatch):
+    """Install a socket factory into the module under test.
+
+    The stand-in module carries the real `AF_INET`/`SOCK_STREAM` constants, so
+    the assertions on construction arguments compare against production values
+    rather than against sentinels this test invented.
+    """
+
+    def install(scripts=None, construct_error=None):
+        factory = SocketFactory(scripts=scripts, construct_error=construct_error)
+        stand_in = types.ModuleType("socket")
+        stand_in.socket = factory
+        stand_in.AF_INET = _real_socket.AF_INET
+        stand_in.SOCK_STREAM = _real_socket.SOCK_STREAM
+        monkeypatch.setattr(ce, "socket", stand_in)
+        return factory
+
+    return install
+
+
+def _closes(factory):
+    return [sock.closed for sock in factory.made]
+
+
+# ---------------------------------------------------------------------------
+# check_vanguard_mcp -- the four probe outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_successful_probe_closes_once_and_reports_alive(probe_sockets):
+    factory = probe_sockets([{"connect_result": 0}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051, timeout=5.0) is True
+
+    assert _closes(factory) == [1]
+    assert factory.made[0].connected_to == ("10.10.10.10", 50051)
+    assert factory.made[0].timeout == 5.0
+
+
+def test_nonzero_connect_ex_closes_once_and_reports_dead(probe_sockets):
+    factory = probe_sockets([{"connect_result": 111}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert _closes(factory) == [1]
+
+
+def test_settimeout_oserror_still_closes_the_socket(probe_sockets):
+    """The defect: `close()` sat after `settimeout()`, so this leaked."""
+    factory = probe_sockets([{"settimeout_error": OSError("settimeout failed")}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert _closes(factory) == [1]
+
+
+def test_connect_ex_oserror_still_closes_the_socket(probe_sockets):
+    """The same defect one line lower down."""
+    factory = probe_sockets([{"connect_error": OSError("connect failed")}])
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert _closes(factory) == [1]
+
+
+def test_construction_oserror_reports_dead_without_inventing_a_socket(probe_sockets):
+    """No descriptor exists to close, and none is pretended into existence."""
+    factory = probe_sockets(construct_error=OSError("EMFILE"))
+
+    assert ce.check_vanguard_mcp("10.10.10.10", 50051) is False
+
+    assert factory.made == []
+    assert len(factory.calls) == 1
+
+
+def test_non_oserror_propagates_unchanged_after_the_socket_is_closed(probe_sockets):
+    """Only `OSError` is translated into "unreachable".
+
+    A `ValueError` from `settimeout` is a defect in the caller, not an
+    unreachable peer, and must not be laundered into a `False` return. It still
+    must not leak the socket on its way out.
+    """
+    boom = ValueError("timeout must be a number")
+    factory = probe_sockets([{"settimeout_error": boom}])
+
+    with pytest.raises(ValueError) as caught:
+        ce.check_vanguard_mcp("10.10.10.10", 50051)
+
+    assert caught.value is boom
+    assert _closes(factory) == [1]
+
+
+def test_default_address_and_port_are_unchanged(probe_sockets):
+    factory = probe_sockets([{"connect_result": 0}])
+
+    assert ce.check_vanguard_mcp() is True
+
+    assert factory.made[0].connected_to == ("192.168.86.29", 50051)
+    assert factory.made[0].timeout == 5.0
+    assert factory.calls == [(_real_socket.AF_INET, _real_socket.SOCK_STREAM)]
+
+
+# ---------------------------------------------------------------------------
+# poll_gpu_temperatures -- one socket per GPU, closed independently
+# ---------------------------------------------------------------------------
+
+
+def _nodes():
+    return [
+        {"id": "alpha", "ip": "10.0.0.1", "grpc_port": 50051,
+         "gpus": [{"id": "gpu0"}, {"id": "gpu1"}]},
+        {"id": "beta", "ip": "10.0.0.2", "grpc_port": 50052,
+         "gpus": [{"id": "gpu0"}, {"id": "gpu1"}]},
+    ]
+
+
+def test_every_constructed_socket_is_closed_across_nodes_and_gpus(probe_sockets):
+    factory = probe_sockets([{"connect_result": 0}] * 4)
+
+    temps = ce.poll_gpu_temperatures(_nodes())
+
+    assert _closes(factory) == [1, 1, 1, 1]
+    assert sorted(temps) == ["alpha/gpu0", "alpha/gpu1", "beta/gpu0", "beta/gpu1"]
+    assert [sock.connected_to for sock in factory.made] == [
+        ("10.0.0.1", 50051), ("10.0.0.1", 50051),
+        ("10.0.0.2", 50052), ("10.0.0.2", 50052),
+    ]
+
+
+def test_mixed_outcomes_close_every_socket_and_do_not_abort_later_probes(probe_sockets):
+    """Success, refusal, a `settimeout` failure and a `connect_ex` failure.
+
+    Every socket that was constructed is closed exactly once, every GPU gets a
+    verdict, and a failure part-way through does not skip the GPUs after it.
+    """
+    factory = probe_sockets([
+        {"connect_result": 0},
+        {"connect_result": 111},
+        {"settimeout_error": OSError("settimeout failed")},
+        {"connect_error": OSError("connect failed")},
+    ])
+
+    temps = ce.poll_gpu_temperatures(_nodes())
+
+    assert _closes(factory) == [1, 1, 1, 1]
+    assert len(temps) == 4
+    assert temps["alpha/gpu1"] == -1.0
+    assert temps["beta/gpu0"] == -1.0
+    assert temps["beta/gpu1"] == -1.0
+    assert temps["alpha/gpu0"] != -1.0
+
+
+def test_each_failed_probe_records_minus_one(probe_sockets):
+    factory = probe_sockets([
+        {"connect_result": 111},
+        {"settimeout_error": OSError("x")},
+        {"connect_error": OSError("y")},
+        {"connect_result": 22},
+    ])
+
+    temps = ce.poll_gpu_temperatures(_nodes())
+
+    assert set(temps.values()) == {-1.0}
+    assert _closes(factory) == [1, 1, 1, 1]
+
+
+def test_successful_probe_generates_a_temperature_in_the_established_band(probe_sockets):
+    probe_sockets([{"connect_result": 0}])
+
+    temps = ce.poll_gpu_temperatures(
+        [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
+    )
+
+    assert 50.0 <= temps["n/g"] <= 70.0
+
+
+def test_temperature_is_generated_only_after_its_socket_is_closed(probe_sockets):
+    """Ordering, not just the final count.
+
+    The generated reading must not be produced while the descriptor is still
+    open, so the socket is asserted closed at the moment `np.random.uniform`
+    runs.
+    """
+    factory = probe_sockets([{"connect_result": 0}])
+    observed = []
+
+    real_uniform = ce.np.random.uniform
+
+    def recording_uniform(low, high):
+        observed.append([sock.closed for sock in factory.made])
+        return real_uniform(low, high)
+
+    ce.np.random.uniform = recording_uniform
+    try:
+        ce.poll_gpu_temperatures(
+            [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
+        )
+    finally:
+        ce.np.random.uniform = real_uniform
+
+    assert observed == [[1]], "temperature generated while the socket was open"
+
+
+def test_construction_failure_records_minus_one_for_that_gpu(probe_sockets):
+    factory = probe_sockets(construct_error=OSError("EMFILE"))
+
+    temps = ce.poll_gpu_temperatures(
+        [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051,
+          "gpus": [{"id": "g0"}, {"id": "g1"}]}]
+    )
+
+    assert temps == {"n/g0": -1.0, "n/g1": -1.0}
+    assert factory.made == []
+    assert len(factory.calls) == 2
+
+
+def test_node_defaults_are_unchanged_when_ip_and_port_are_absent(probe_sockets):
+    factory = probe_sockets([{"connect_result": 0}])
+
+    ce.poll_gpu_temperatures([{"id": "n", "gpus": [{"id": "g"}]}])
+
+    assert factory.made[0].connected_to == ("127.0.0.1", 50051)
+    assert factory.made[0].timeout == 2.0
+
+
+def test_a_node_without_gpus_probes_nothing(probe_sockets):
+    factory = probe_sockets()
+
+    assert ce.poll_gpu_temperatures([{"id": "n", "ip": "10.0.0.9"}]) == {}
+
+    assert factory.calls == []
+
+
+def test_non_oserror_during_polling_propagates_after_closing(probe_sockets):
+    boom = ValueError("not a network failure")
+    factory = probe_sockets([{"connect_error": boom}])
+
+    with pytest.raises(ValueError) as caught:
+        ce.poll_gpu_temperatures(
+            [{"id": "n", "ip": "10.0.0.9", "grpc_port": 50051, "gpus": [{"id": "g"}]}]
+        )
+
+    assert caught.value is boom
+    assert _closes(factory) == [1]


### PR DESCRIPTION
Centralizes probe socket cleanup in the orchestrator's two safety-net checks, so a failing `settimeout()` or `connect_ex()` no longer reaches the caller's fallback with the descriptor untouched.

**MERGED** as `f89fb0f7c4f21d464abe6f25741aa48a63f4ba70` at `2026-08-14T04:22:43Z` by **Goldislops** · audited head `697167762a9dce5ab724b92bb8766c4625afdefa` · 3 commits · 2 files · +512/−10.

---

## The defect

Both probes in `scripts/continuous_evolution.py` created a TCP socket and called `close()` only after `settimeout()` and `connect_ex()` had **both** returned:

```python
try:
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    sock.settimeout(timeout)
    result = sock.connect_ex((head_ip, port))
    sock.close()          # skipped when either call above raises
    return result == 0
except OSError:
    return False
```

An `OSError` from either call jumps straight to the handler, which reports an unreachable peer. The descriptor stays open, and the failure is indistinguishable from an ordinary unreachable host — silent, and on exactly the path that fires when the network is already unhappy. `poll_gpu_temperatures()` repeats the pattern once per GPU per node, on a polling loop, for the life of the orchestrator process.

## The repair

One private seam. `_probe_tcp()` owns the socket for the whole probe, so the close attempt no longer depends on which call raised. It returns the raw `connect_ex` result and leaves interpretation to the caller, which keeps both public behaviours exactly where they were.

The close is deliberately **not** a bare `finally` — see the review section below. On a failed probe the close is attempted and any secondary failure suppressed, so the original fault survives; on the successful path `close()` is called normally and its exception propagates exactly as before.

**Bounded invariant:** Once the protected probe interval begins, every exit makes exactly one close attempt before the probe returns or raises. This does not claim interrupt-atomic acquisition or successful resource release when the close attempt itself fails.

## Preserved deliberately

- `check_vanguard_mcp()` returns `True` only for `connect_ex() == 0`; `False` for a nonzero result or a caught `OSError`.
- Each failed GPU probe records `-1.0`; a successful one still draws from the established `55.0 + uniform(-5, 15)` band, and still does so **only after** its socket is closed.
- Only `OSError` is translated. A non-`OSError` still propagates unchanged — now after the close attempt rather than instead of it.
- Address, port, timeout, traversal order, key formatting, socket construction arguments and one-socket-per-probe are unchanged.
- Socket construction failing with `OSError` returns `False` without pretending a socket existed.

## Failing-first

The suite (now 22 tests) was run against the unmodified base at `fe348a71`:

```
12 passed, 10 failed, 0 skipped (22 collected)
```

At the first commit the figures were `10 passed, 6 failed (16 collected)`; the six were the four close-count checks on the `OSError` paths and the two non-`OSError` propagation tests. The tests that pass on both sides are preservation controls, not padding — they are what proves the harness and imports are sound rather than broken.

The six tests added by the second commit were also run against that **first** commit, where exactly the four close-masking tests fail. Against this head: `22 passed, 0 failed`.

## Validation

The Ian seat has Python 3.13.7 but **no pytest and no numpy**, so the authoritative pytest evidence is the CI receipt below; a stdlib harness with a stubbed numpy was used locally for the failing-first proof and cannot replace it. `python -m py_compile` passes on both files. No dependency was installed and no lockfile changed.

## Test design

Fakes only. `socket.socket` is replaced by a factory handing out scripted stand-ins that record their own `close()` calls; the stand-in module carries the real `AF_INET`/`SOCK_STREAM` constants so construction arguments are compared against production values. **No real socket, host, port or service is contacted**, and the probe addresses are fictitious.

The orchestrator installs `SIGINT`/`SIGTERM` handlers at import, so the test module restores the previous handlers immediately after importing it — collecting this file cannot change how the rest of the pytest session responds to signals.

## Limitations and exclusions

- Static test doubles: this proves the ownership structure, not kernel-level descriptor accounting.
- Reachability semantics, thermal policy, temperature modelling and the orchestrator loop are untouched.
- The module-scope `signal.signal()` calls in production are unchanged; only the test file compensates for them locally.
- `_probe_tcp` is private and not part of any public contract.

## Boundary

```
 scripts/continuous_evolution.py                     |  69 ++--
 tests/test_continuous_evolution_socket_lifetime.py  | 453 ++++++++++++++++
 2 files changed, 512 insertions(+), 10 deletions(-)
```

Exactly the two authorized files; no third.

## Independent review

Three read-only lanes audited these packages; every finding was independently reproduced by the primary agent before any action.

**Acted on — a real behavioural drift I introduced.** The first commit closed the socket in a bare `finally`, which runs while an exception is already unwinding, so a failing `close()` **replaced** the exception in flight. Measured base vs that commit across eleven probe/close combinations, four drifted — including `connect_ex` raising `ValueError` or `KeyboardInterrupt` plus an `OSError` from `close()`, which the callers' `except OSError` then reported as an unreachable peer. That contradicts this package's own invariant that only `OSError` is translated. Re-measured after the fix: **0 of 11 paths drift, and each measured path makes exactly one close attempt.**

Also acted on: `FakeSocket.close_error` was wired end-to-end but no test passed it — dead scaffolding beside the live defect. Six tests now use it. The ordering test uses `monkeypatch` instead of hand-restoring a global, accepts keyword arguments, and says plainly it is a characterization guard rather than failing-first evidence.

**Reported and not acted on**, with reasons: a socket whose `close` attribute is not callable still leaks — identical in the base, so not a regression and outside this boundary; the single-instruction window between `socket.socket(...)` returning and the `try` being entered is unchanged from base and cannot be closed without restructuring; `sys.path` mutation in the test module is the repo-wide convention here.

**Verified clean:** no real network (the suite was re-run with `socket.socket`, `create_connection`, `getaddrinfo` and `gethostbyname` booby-trapped on the real module — zero trips); no filesystem writes; signal handlers saved and restored, confirmed in a fresh process; no fixture state leaks between tests; no other repo test touches these two functions.

## CI

Authoritative `pull_request`-event receipt at head `6971677`:

| Check | Run | Job | Result |
|---|---|---|---|
| `verify-python` | `31767389088` | `94665947432` | **`4157 passed, 13 skipped in 83.92s (0:01:23)`** |
| `frontend-quality` | `31767389088` | `94665947457` | pass |
| `Analyze Python` (CodeQL) | `31767388970` | — | pass |
| `agent-safety` | `31767389040` | — | pass |

Rollup **SUCCESS**, 7 registered contexts. `main` at `fe348a71` reports 4135 passed, so this package adds exactly the 22 new tests.

## Status

**MERGED and closed** at `2026-08-14T04:22:43Z` by **Goldislops**.

Merged with one ordinary merge commit `f89fb0f7c4f21d464abe6f25741aa48a63f4ba70`, parents:

- first parent `fe348a71cee227a305c2dfc326cfc6cdf574937b` — `main` at merge time
- second parent `697167762a9dce5ab724b92bb8766c4625afdefa` — the audited PR head

Immediately after the merge, live `main` equaled that merge commit. The merged delta is exactly the two authorized files at `+512/−10`, and all **3** PR commits are reachable from `main` (verified: zero unreachable). No squash, no rebase, no administrator bypass, no auto-merge, no force-push.

The source branch `fix/continuous-evolution-socket-lifetime` was removed by the repository's existing **automatic branch deletion** setting; it was not deleted manually and has not been recreated. No repository or branch-protection setting was changed.




