### PR TITLE
fix(benchmark): protect temporary backend state

### DIFF
--- a/scripts/gpu_benchmark.py
+++ b/scripts/gpu_benchmark.py
@@ -230,9 +230,8 @@ def run_benchmarks(snapshot_path: str, num_steps: int = 10):
         )
         print(f"  max_neighbor_value (CPU):     {median_maxn_cpu:8.1f} ms")
     finally:
-        # Restore GPU state -- on every exit, not just the successful one. The
-        # original exception is untouched: this clause neither swallows nor
-        # replaces it.
+        # Restore the captured backend state whenever cleanup runs to completion.
+        # The two restoration assignments are not interrupt-atomic.
         ca_module.GPU_AVAILABLE = old_gpu
         ca_module._xp = old_xp
 

--- a/scripts/gpu_benchmark.py
+++ b/scripts/gpu_benchmark.py
@@ -186,16 +186,25 @@ def run_benchmarks(snapshot_path: str, num_steps: int = 10):
     # `AttributeError`.
     old_gpu = getattr(ca_module, 'GPU_AVAILABLE', False)
     old_xp = ca_module._xp
-    ca_module.GPU_AVAILABLE = False
-    ca_module._xp = np
 
-    # Everything that runs under the forced-CPU backend lives inside this
-    # `try`. The restore used to sit after the third benchmark on the success
-    # path only, so any failure in a component, or in the CPU preparation
-    # between them, left `scripts.continuous_evolution_ca` pinned to CPU for
-    # the rest of the process -- module globals, so every later user of the
-    # engine inherited it, including the GPU section immediately below.
+    # The FORCING assignments are inside the `try`, not above it. Capturing is
+    # safe outside because it mutates nothing, but the moment the first global
+    # is written the protected interval must already be entered: an
+    # asynchronous interrupt -- a KeyboardInterrupt, or a tracing callback --
+    # delivered between `GPU_AVAILABLE = False` and `_xp = np` would otherwise
+    # unwind past a `finally` that had not yet been established, leaving the
+    # engine pinned to CPU with nothing to put it back.
+    #
+    # Everything that runs under the forced-CPU backend lives in here too. The
+    # restore originally sat after the third benchmark on the success path
+    # only, so any failure in a component, or in the CPU preparation between
+    # them, left `scripts.continuous_evolution_ca` pinned to CPU for the rest
+    # of the process -- module globals, so every later user of the engine
+    # inherited it, including the GPU section immediately below.
     try:
+        ca_module.GPU_AVAILABLE = False
+        ca_module._xp = np
+
         median_cpu_neighbors = benchmark_component(
             "count_neighbors_3d (CPU)",
             lambda: count_neighbors_3d(lattice),

--- a/scripts/gpu_benchmark.py
+++ b/scripts/gpu_benchmark.py
@@ -125,6 +125,16 @@ def _load_snapshot(snapshot_path):
 
 def run_benchmarks(snapshot_path: str, num_steps: int = 10):
     """Run the full benchmark suite."""
+    # Refuse a nonpositive step count HERE, before anything observable happens.
+    # Previously the run proceeded through the banner, snapshot loading, rule
+    # loading, RNG construction, the temporary backend switch and every
+    # component benchmark, and only then failed in the timing aggregation --
+    # `np.min([])` on an empty list, or an unbound `first_metrics` because the
+    # step loop never ran. That is a long way to travel, and a lot of state to
+    # touch, to report an argument that was wrong before the function started.
+    if num_steps <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+
     print("=" * 72)
     print("  Phase 14a GPU Benchmark — Medusa Stepping Pipeline")
     print("=" * 72)
@@ -170,39 +180,52 @@ def run_benchmarks(snapshot_path: str, num_steps: int = 10):
     # 1. count_neighbors_3d (CPU)
     # Force CPU mode temporarily
     import scripts.continuous_evolution_ca as ca_module
+    # BOTH originals are read before EITHER is written. Reading `_xp` after
+    # forcing `GPU_AVAILABLE = False` meant an engine without an `_xp`
+    # attribute left the backend pinned to CPU on the way out of the
+    # `AttributeError`.
     old_gpu = getattr(ca_module, 'GPU_AVAILABLE', False)
-    ca_module.GPU_AVAILABLE = False
     old_xp = ca_module._xp
+    ca_module.GPU_AVAILABLE = False
     ca_module._xp = np
 
-    median_cpu_neighbors = benchmark_component(
-        "count_neighbors_3d (CPU)",
-        lambda: count_neighbors_3d(lattice),
-        warmup=1, iterations=5
-    )
-    print(f"  count_neighbors_3d (CPU):     {median_cpu_neighbors:8.1f} ms")
+    # Everything that runs under the forced-CPU backend lives inside this
+    # `try`. The restore used to sit after the third benchmark on the success
+    # path only, so any failure in a component, or in the CPU preparation
+    # between them, left `scripts.continuous_evolution_ca` pinned to CPU for
+    # the rest of the process -- module globals, so every later user of the
+    # engine inherited it, including the GPU section immediately below.
+    try:
+        median_cpu_neighbors = benchmark_component(
+            "count_neighbors_3d (CPU)",
+            lambda: count_neighbors_3d(lattice),
+            warmup=1, iterations=5
+        )
+        print(f"  count_neighbors_3d (CPU):     {median_cpu_neighbors:8.1f} ms")
 
-    # 2. _separable_box_filter_3d
-    test_field = np.random.rand(*shape).astype(np.float32)
-    median_box_cpu = benchmark_component(
-        "box_filter_3d R=12 (CPU)",
-        lambda: _separable_box_filter_3d(test_field, radius=12),
-        warmup=1, iterations=5
-    )
-    print(f"  box_filter_3d R=12 (CPU):     {median_box_cpu:8.1f} ms")
+        # 2. _separable_box_filter_3d
+        test_field = np.random.rand(*shape).astype(np.float32)
+        median_box_cpu = benchmark_component(
+            "box_filter_3d R=12 (CPU)",
+            lambda: _separable_box_filter_3d(test_field, radius=12),
+            warmup=1, iterations=5
+        )
+        print(f"  box_filter_3d R=12 (CPU):     {median_box_cpu:8.1f} ms")
 
-    # 3. _max_neighbor_value
-    test_ages = memory_grid[0].copy()
-    median_maxn_cpu = benchmark_component(
-        "max_neighbor_value (CPU)",
-        lambda: _max_neighbor_value(test_ages),
-        warmup=1, iterations=5
-    )
-    print(f"  max_neighbor_value (CPU):     {median_maxn_cpu:8.1f} ms")
-
-    # Restore GPU state
-    ca_module.GPU_AVAILABLE = old_gpu
-    ca_module._xp = old_xp
+        # 3. _max_neighbor_value
+        test_ages = memory_grid[0].copy()
+        median_maxn_cpu = benchmark_component(
+            "max_neighbor_value (CPU)",
+            lambda: _max_neighbor_value(test_ages),
+            warmup=1, iterations=5
+        )
+        print(f"  max_neighbor_value (CPU):     {median_maxn_cpu:8.1f} ms")
+    finally:
+        # Restore GPU state -- on every exit, not just the successful one. The
+        # original exception is untouched: this clause neither swallows nor
+        # replaces it.
+        ca_module.GPU_AVAILABLE = old_gpu
+        ca_module._xp = old_xp
 
     # 4. GPU versions of same components (if available)
     if GPU_AVAILABLE:

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -21,9 +21,21 @@ deterministic recorder rather than a timing loop, arrays are 2x2x2, and
 appended at the end DO write real NPZ archives, but only inside pytest's
 own `tmp_path`.
 
-Scope is archive resource lifetime relative to extraction — not snapshot
-validation, benchmark mathematics, timing methodology, or the separate question
-of exception-safe restoration of the temporary engine globals.
+Two further sections were added later, and are named here because this
+docstring previously listed the first of them as explicitly OUT of scope:
+
+  * TEMPORARY-BACKEND FAILURE ATOMICITY. `run_benchmarks()` forces the engine
+    module's `GPU_AVAILABLE`/`_xp` globals to CPU for the three CPU component
+    benchmarks. The restore used to run on the success path only, so any
+    failure in between left process-global backend state pinned to CPU.
+  * NONPOSITIVE STEP COUNTS, which used to travel through snapshot loading,
+    the backend switch and every component benchmark before failing in the
+    timing aggregation.
+
+Scope is archive resource lifetime relative to extraction, the exception
+atomicity of that temporary backend switch, and the step-count guard — not
+snapshot validation, benchmark mathematics, timing methodology, or
+`benchmark_component()`'s own contract.
 """
 
 from __future__ import annotations
@@ -271,14 +283,24 @@ class _Recorder:
         self.components = []
         self.steps = []
         self.measured = []  # what the measured callables actually received
+        self.random_rand = []  # CPU preparation between two components
 
 
-def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
+def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None,
+                    component_errors=None, random_rand_error=None,
+                    capture=None):
     """Drive the genuine `run_benchmarks()` with every seam controlled.
 
     Returns (archive, recorder). Nothing real is benchmarked: the engine is a
     scoped stand-in, `benchmark_component` is a deterministic recorder rather
     than a timing loop, and the arrays are 2x2x2.
+
+    `component_errors` maps a component name to an exception raised instead of
+    running it; `random_rand_error` does the same for the `np.random.rand` call
+    that prepares the box-filter input between two of them. `capture`, if
+    given, is populated with the engine stand-in and its sentinel BEFORE the
+    run starts, so a test can inspect the engine's globals even when the run
+    raises and never reaches the return.
     """
     archive = archive if archive is not None else _FakeArchive(
         _contents() if contents is None else contents, raise_on=raise_on
@@ -289,6 +311,12 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
     sentinel_xp = object()
     engine.GPU_AVAILABLE = True      # a distinctive prior value...
     engine._xp = sentinel_xp         # ...so restoration is observable
+    component_errors = dict(component_errors or {})
+    if capture is not None:
+        capture["engine"] = engine
+        capture["sentinel_xp"] = sentinel_xp
+        capture["archive"] = archive
+        capture["rec"] = rec
 
     def _load_rule_spec(rule_path):
         rec.load_rule_spec.append({"closed": archive.closed, "path": rule_path,
@@ -305,8 +333,18 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
             "iterations": iterations, "gpu": engine.GPU_AVAILABLE,
             "xp_is_numpy": engine._xp is np,
         })
+        if name in component_errors:
+            raise component_errors[name]
         fn()  # exactly once — deterministic, no warmup/iteration timing loop
         return 1.0
+
+    def _random_rand(*shape):
+        rec.random_rand.append({"shape": tuple(shape),
+                                "gpu": engine.GPU_AVAILABLE,
+                                "xp_is_numpy": engine._xp is np})
+        if random_rand_error is not None:
+            raise random_rand_error
+        return np.random.random_sample(shape)
 
     def _measured(label):
         def _record(arg, *rest, **kwargs):
@@ -345,6 +383,7 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None):
                            _measured("box_filter")), \
          mock.patch.object(gpu_benchmark, "_max_neighbor_value",
                            _measured("max_neighbor")), \
+         mock.patch.object(gpu_benchmark.np.random, "rand", _random_rand), \
          mock.patch.object(gpu_benchmark, "GPU_AVAILABLE", False):
         gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", num_steps)
 
@@ -618,3 +657,164 @@ def test_a_numeric_snapshot_still_loads_and_converts(tmp_path):
     lattice, grid, generation = gpu_benchmark._load_snapshot(archive)
     assert lattice.dtype == np.uint8 and grid.dtype == np.float32
     assert generation == 9 and type(generation) is int
+
+
+# -- temporary-backend failure atomicity --------------------------------------
+#
+# `run_benchmarks()` forces `scripts.continuous_evolution_ca` onto the CPU
+# backend for the three CPU component benchmarks, then restores it. The restore
+# used to sit after the third benchmark on the SUCCESS path only, so any failure
+# in between -- a component, or the `np.random.rand` preparation between two of
+# them -- left the engine's module globals pinned to CPU for the rest of the
+# process. Module globals, so every later user inherited it, starting with the
+# optional GPU section a few lines below.
+#
+# These drive the genuine function; the engine is the same scoped stand-in used
+# above, carrying a distinctive `GPU_AVAILABLE = True` and an identity-sensitive
+# `_xp` sentinel so restoration is observable rather than merely plausible.
+
+_CPU_COMPONENTS = [
+    "count_neighbors_3d (CPU)",
+    "box_filter_3d R=12 (CPU)",
+    "max_neighbor_value (CPU)",
+]
+
+
+class BenchBoom(Exception):
+    """Distinct benchmark failure, so propagation can be asserted by identity."""
+
+
+@pytest.mark.parametrize("failing", _CPU_COMPONENTS)
+def test_backend_is_restored_when_a_cpu_component_fails(failing):
+    boom = BenchBoom(f"{failing} exploded")
+    capture = {}
+
+    with pytest.raises(BenchBoom) as caught:
+        _run_benchmarks(num_steps=1, component_errors={failing: boom},
+                        capture=capture)
+
+    assert caught.value is boom, "the original exception must propagate unwrapped"
+    engine = capture["engine"]
+    assert engine.GPU_AVAILABLE is True
+    assert engine._xp is capture["sentinel_xp"]
+
+
+def test_backend_is_restored_when_cpu_preparation_fails():
+    """`np.random.rand` sits between the first and second components."""
+    boom = BenchBoom("rand exploded")
+    capture = {}
+
+    with pytest.raises(BenchBoom) as caught:
+        _run_benchmarks(num_steps=1, random_rand_error=boom, capture=capture)
+
+    assert caught.value is boom
+    engine = capture["engine"]
+    assert engine.GPU_AVAILABLE is True
+    assert engine._xp is capture["sentinel_xp"]
+    # It really did fail where we think: one component ran, the second did not.
+    assert [c["name"] for c in capture["rec"].components] == _CPU_COMPONENTS[:1]
+    assert len(capture["rec"].random_rand) == 1
+
+
+def test_a_failure_in_the_first_component_still_restores_both_values():
+    """Both globals are restored, not just the flag.
+
+    `_xp` is compared by identity against a sentinel that is not numpy, so a
+    restore that wrote `np` back instead of the previous object would fail here
+    even though the flag looked right.
+    """
+    capture = {}
+    with pytest.raises(BenchBoom):
+        _run_benchmarks(num_steps=1,
+                        component_errors={_CPU_COMPONENTS[0]: BenchBoom("x")},
+                        capture=capture)
+
+    engine = capture["engine"]
+    assert engine._xp is capture["sentinel_xp"]
+    assert engine._xp is not np
+    assert engine.GPU_AVAILABLE is True
+
+
+def test_the_successful_path_still_sees_cpu_mode_for_all_three_components():
+    """The repair must not weaken what the forced-CPU interval is for."""
+    _archive, rec = _run_benchmarks(num_steps=1)
+
+    cpu = [c for c in rec.components if c["name"] in _CPU_COMPONENTS]
+    assert [c["name"] for c in cpu] == _CPU_COMPONENTS
+    assert all(c["gpu"] is False for c in cpu)
+    assert all(c["xp_is_numpy"] for c in cpu)
+    # ...and the CPU preparation between them ran under the same forced backend.
+    assert rec.random_rand and all(r["gpu"] is False for r in rec.random_rand)
+    # Restored before anything after the interval.
+    assert rec.engine_after == {"gpu": True, "xp_is_sentinel": True}
+
+
+# -- nonpositive step counts --------------------------------------------------
+#
+# A nonpositive `num_steps` used to travel through the banner, snapshot
+# loading, rule loading, RNG construction, the backend switch and every
+# component benchmark before failing in the timing aggregation -- `np.min([])`
+# on an empty list, or an unbound `first_metrics` because the loop never ran.
+
+
+@pytest.mark.parametrize("steps", [0, -1, -10])
+def test_nonpositive_steps_are_refused_before_anything_is_touched(steps):
+    archive = _FakeArchive(_contents())
+    engine = _engine_stand_in()
+    sentinel_xp = object()
+    engine.GPU_AVAILABLE = True
+    engine._xp = sentinel_xp
+    load_mock = mock.Mock(return_value=archive)
+    touched = []
+
+    def _tripwire(label, result=None):
+        def _fn(*a, **k):
+            touched.append(label)
+            return result
+        return _fn
+
+    with mock.patch.dict(sys.modules, {_ENGINE: engine}), \
+         mock.patch.object(_scripts_package, _ENGINE_ATTR, engine, create=True), \
+         mock.patch.object(gpu_benchmark.np, "load", load_mock), \
+         mock.patch.object(gpu_benchmark, "load_rule_spec",
+                           _tripwire("load_rule_spec", {"rule": "stub"})), \
+         mock.patch.object(gpu_benchmark, "init_memory_grid",
+                           _tripwire("init_memory_grid", _grid())), \
+         mock.patch.object(gpu_benchmark, "benchmark_component",
+                           _tripwire("benchmark_component", 1.0)), \
+         mock.patch.object(gpu_benchmark, "step_ca_lattice",
+                           _tripwire("step_ca_lattice")), \
+         mock.patch.object(gpu_benchmark.np.random, "default_rng",
+                           _tripwire("default_rng")), \
+         mock.patch.object(gpu_benchmark.np.random, "rand",
+                           _tripwire("rand")), \
+         mock.patch.object(gpu_benchmark, "GPU_AVAILABLE", False):
+        with pytest.raises(ValueError) as caught:
+            gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", steps)
+
+    assert str(steps) in str(caught.value)
+    # Nothing downstream was reached: no snapshot, rule, RNG, benchmark or step.
+    assert touched == []
+    assert load_mock.call_count == 0
+    assert archive.entered == 0 and archive.closed == 0
+    # ...and the engine globals were never mutated.
+    assert engine.GPU_AVAILABLE is True
+    assert engine._xp is sentinel_xp
+
+
+def test_nonpositive_steps_print_nothing(capsys):
+    with pytest.raises(ValueError):
+        gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", 0)
+    assert capsys.readouterr().out == ""
+
+
+def test_a_single_step_run_is_unaffected(capsys):
+    """The established positive-path contract still holds."""
+    archive, rec = _run_benchmarks(num_steps=1)
+
+    assert len(rec.steps) == 1
+    assert archive.closed == 1
+    assert rec.engine_after == {"gpu": True, "xp_is_sentinel": True}
+    out = capsys.readouterr().out
+    assert "FULL STEP BENCHMARK (1 steps)" in out
+    assert "SUMMARY" in out

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -766,6 +766,91 @@ def test_an_engine_without_xp_is_left_completely_untouched():
     assert not hasattr(engine, "_xp"), "an `_xp` was invented that never existed"
 
 
+class _BetweenWrites(KeyboardInterrupt):
+    """Distinctive interrupt, so propagation can be asserted by identity."""
+
+
+def test_an_interrupt_between_the_two_forcing_writes_still_restores():
+    """The forcing assignments must be INSIDE the protected interval.
+
+    Capturing the originals outside the `try` is safe -- it mutates nothing --
+    but the moment the first global is written the `finally` must already be
+    established. With
+
+        ca_module.GPU_AVAILABLE = False
+        ca_module._xp = np
+        try:
+            ...
+        finally:
+            ...
+
+    an asynchronous interrupt delivered between those two writes unwinds past a
+    `finally` that does not yet exist, and the engine is left pinned to CPU
+    with nothing to put it back.
+
+    The interrupt is injected by a `sys.settrace` line hook that fires on a
+    STATE predicate rather than a hard-coded line number: the genuine
+    `run_benchmarks` frame, `GPU_AVAILABLE` already forced to False, and `_xp`
+    still holding the caller's sentinel. That is precisely the window, and it
+    keeps working if the surrounding code moves.
+
+    LIMITATION, stated rather than implied: this shows the window between the
+    two forcing writes is covered. It does not and cannot promise atomicity
+    against an asynchronous interruption delivered inside the cleanup itself --
+    an interrupt landing between the two restore assignments would still leave
+    the second one undone. No pure-Python construct closes that.
+    """
+    engine = _engine_stand_in()
+    sentinel_xp = object()
+    engine.GPU_AVAILABLE = True
+    engine._xp = sentinel_xp
+    archive = _FakeArchive(_contents())
+    boom = _BetweenWrites("between the forcing assignments")
+    components = []
+    fired = []
+
+    def _tripwire_component(name, fn, warmup=2, iterations=10):
+        components.append(name)
+        return 1.0
+
+    def _tracer(frame, event, arg):
+        if frame.f_code is not gpu_benchmark.run_benchmarks.__code__:
+            return None
+        if event == "line" and not fired:
+            ca = frame.f_locals.get("ca_module")
+            if (ca is not None
+                    and getattr(ca, "GPU_AVAILABLE", None) is False
+                    and getattr(ca, "_xp", None) is sentinel_xp):
+                fired.append(frame.f_lineno)
+                raise boom
+        return _tracer
+
+    previous_trace = sys.gettrace()
+    try:
+        with mock.patch.dict(sys.modules, {_ENGINE: engine}), \
+             mock.patch.object(_scripts_package, _ENGINE_ATTR, engine, create=True), \
+             mock.patch.object(gpu_benchmark.np, "load",
+                               mock.Mock(return_value=archive)), \
+             mock.patch.object(gpu_benchmark, "load_rule_spec",
+                               lambda path: {"rule": "stub"}), \
+             mock.patch.object(gpu_benchmark, "init_memory_grid",
+                               lambda shape: _grid(channels=8, size=shape[0])), \
+             mock.patch.object(gpu_benchmark, "benchmark_component",
+                               _tripwire_component), \
+             mock.patch.object(gpu_benchmark, "GPU_AVAILABLE", False):
+            sys.settrace(_tracer)
+            with pytest.raises(_BetweenWrites) as caught:
+                gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", 1)
+    finally:
+        sys.settrace(previous_trace)
+
+    assert fired, "the between-writes window was never reached"
+    assert caught.value is boom
+    assert engine.GPU_AVAILABLE is True, "flag left forced after the interrupt"
+    assert engine._xp is sentinel_xp
+    assert components == [], "a component ran despite the interrupt"
+
+
 def test_the_successful_path_still_sees_cpu_mode_for_all_three_components():
     """The repair must not weaken what the forced-CPU interval is for."""
     _archive, rec = _run_benchmarks(num_steps=1)

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -288,7 +288,7 @@ class _Recorder:
 
 def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None,
                     component_errors=None, random_rand_error=None,
-                    capture=None):
+                    capture=None, drop_xp=False):
     """Drive the genuine `run_benchmarks()` with every seam controlled.
 
     Returns (archive, recorder). Nothing real is benchmarked: the engine is a
@@ -312,6 +312,10 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None,
     engine.GPU_AVAILABLE = True      # a distinctive prior value...
     engine._xp = sentinel_xp         # ...so restoration is observable
     component_errors = dict(component_errors or {})
+    if drop_xp:
+        # An engine with no `_xp` at all: capturing it must not have been
+        # preceded by a write to `GPU_AVAILABLE`.
+        del engine._xp
     if capture is not None:
         capture["engine"] = engine
         capture["sentinel_xp"] = sentinel_xp
@@ -733,6 +737,28 @@ def test_a_failure_in_the_first_component_still_restores_both_values():
     assert engine._xp is capture["sentinel_xp"]
     assert engine._xp is not np
     assert engine.GPU_AVAILABLE is True
+
+
+def test_an_engine_without_xp_is_left_completely_untouched():
+    """The capture-order half of the repair, which nothing else exercises.
+
+    The base read `old_xp = ca_module._xp` AFTER writing
+    `ca_module.GPU_AVAILABLE = False`, so an engine with no `_xp` attribute
+    raised `AttributeError` with the flag already forced -- and no `try` had
+    been entered yet, so nothing put it back. Both originals are now read
+    before either is written, so the failure happens before any mutation.
+
+    Without this test, reverting just that half of the repair leaves the whole
+    suite green.
+    """
+    capture = {}
+
+    with pytest.raises(AttributeError):
+        _run_benchmarks(num_steps=1, drop_xp=True, capture=capture)
+
+    engine = capture["engine"]
+    assert engine.GPU_AVAILABLE is True, "flag was mutated before the capture failed"
+    assert not hasattr(engine, "_xp"), "an `_xp` was invented that never existed"
 
 
 def test_the_successful_path_still_sees_cpu_mode_for_all_three_components():

--- a/tests/test_gpu_benchmark_snapshot_loader.py
+++ b/tests/test_gpu_benchmark_snapshot_loader.py
@@ -348,7 +348,12 @@ def _run_benchmarks(contents=None, archive=None, num_steps=1, raise_on=None,
                                 "xp_is_numpy": engine._xp is np})
         if random_rand_error is not None:
             raise random_rand_error
-        return np.random.random_sample(shape)
+        # `gpu_benchmark.np` IS the real numpy module, so this patch rebinds
+        # `numpy.random.rand` process-wide for the duration of the `with`.
+        # Match `rand`'s contract exactly rather than approximately:
+        # `rand()` with no arguments returns a float, while
+        # `random_sample(())` returns a 0-d array.
+        return np.random.random_sample(shape) if shape else np.random.random_sample()
 
     def _measured(label):
         def _record(arg, *rest, **kwargs):
@@ -829,8 +834,24 @@ def test_nonpositive_steps_are_refused_before_anything_is_touched(steps):
 
 
 def test_nonpositive_steps_print_nothing(capsys):
-    with pytest.raises(ValueError):
-        gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", 0)
+    """The refusal precedes even the banner.
+
+    The seams are patched even though the guard should stop execution before
+    any of them: if the guard ever regresses, this test must fail on its
+    assertions rather than reach `cp.cuda.runtime.memGetInfo()` on a
+    CuPy-equipped runner and then a real `np.load` of a path that does not
+    exist. A test that only passes because the code under test is correct is
+    not a safe test.
+    """
+    def _tripwire(*a, **k):
+        raise AssertionError("guard regressed: execution passed the refusal")
+
+    with mock.patch.object(gpu_benchmark, "GPU_AVAILABLE", False), \
+         mock.patch.object(gpu_benchmark.np, "load", _tripwire), \
+         mock.patch.object(gpu_benchmark, "load_rule_spec", _tripwire):
+        with pytest.raises(ValueError):
+            gpu_benchmark.run_benchmarks("/fake/v070_gen1000.npz", 0)
+
     assert capsys.readouterr().out == ""
 
 


### PR DESCRIPTION
Protects the benchmark's temporary backend state across failures inside the protected interval when cleanup runs to completion, and refuses a nonpositive step count before touching anything. Cleanup itself is not interrupt-atomic.

**MERGED** as `a7a5dbc79b613eeb13d239f76180be01c2331c99` at `2026-08-14T04:28:20Z` by **Goldislops** · audited head `13c646a6f14cd9d18e1bc28538ea3d9b2aeed71d`, synchronized to `c60530c14d6131712f26523626d973ad13cd2801` · 6 commits · 2 files · +398/−35.

Created directly from the same base as its sibling package, not stacked on it: this branch contains none of that branch's changes.

---

## Defect 1 — restoration was not atomic

`run_benchmarks()` forces the engine module's backend globals to CPU for the three CPU component benchmarks:

```python
old_gpu = getattr(ca_module, 'GPU_AVAILABLE', False)
ca_module.GPU_AVAILABLE = False
old_xp = ca_module._xp
ca_module._xp = np
... three benchmarks, and the np.random.rand preparation between them ...
ca_module.GPU_AVAILABLE = old_gpu     # success path only
ca_module._xp = old_xp
```

The restore ran only if everything in between succeeded. Any failure left `scripts.continuous_evolution_ca` pinned to CPU — **module globals**, so every later user in the process inherited it, starting with the optional GPU section a few lines below.

The capture order was wrong too: `_xp` was read *after* `GPU_AVAILABLE` had already been written, so an engine without an `_xp` attribute left the flag forced on the way out of the `AttributeError`.

**Repair.** Both originals are read before either is written, and **both forcing assignments happen inside the `try`**, so the protected interval is entered before the first global is touched:

```python
old_gpu = getattr(ca_module, 'GPU_AVAILABLE', False)
old_xp = ca_module._xp
try:
    ca_module.GPU_AVAILABLE = False
    ca_module._xp = np
    ... three benchmarks, and the np.random.rand preparation between them ...
finally:
    ca_module.GPU_AVAILABLE = old_gpu
    ca_module._xp = old_xp
```

Capturing stays above the `try` because it mutates nothing. The `finally` restores and does nothing else, so a failed benchmark propagates its own exception object unwrapped and untranslated — provided cleanup runs to completion. An asynchronous interruption *of the cleanup* could still interpose, which is why the invariant below is scoped rather than absolute.

**The bounded claim, precisely.** Once temporary mutation begins, returns and exceptions delivered within the protected interval restore the captured backend values when cleanup runs to completion. The trace regression specifically covers an interruption between the two forcing writes. The two cleanup assignments themselves are not interrupt-atomic, so an asynchronous interruption during cleanup remains outside the guarantee. This is stated in the source comment and in the test rather than implied.

## Defect 2 — nonpositive `num_steps` failed late

A zero or negative step count travelled through the banner, snapshot loading, rule loading, RNG construction, the backend switch and every component benchmark, then failed in the timing aggregation. Under real numpy `np.median([])` and `np.mean([])` return `nan` with a `RuntimeWarning`, so the first call that actually raises is `np.min([])` — `ValueError: zero-size array to reduction operation minimum which has no identity`. (`first_metrics` is also left unbound, but `np.min` raises first, so that variant is unreachable.)

**Repair.** Refused with a `ValueError` as the first statement of the function, before any output, snapshot, rule, RNG, benchmark or global mutation.

**Bounded invariant:** when cleanup runs to completion, the engine's backend globals hold their exact prior values on exit from the protected interval — including an interrupt between the two forcing writes — and a nonpositive step count produces one deterministic refusal with nothing else touched. The two cleanup assignments are not themselves interrupt-atomic.

## Failing-first

Measured against the unmodified base at `fe348a71` by driving the real `run_benchmarks()` with every seam controlled:

| Case | Base `fe348a71` | Repaired |
|---|---|---|
| failure in `count_neighbors_3d (CPU)` | `GPU_AVAILABLE=False`, `_xp` unrestored | restored, `Boom` propagates |
| failure in `box_filter_3d R=12 (CPU)` | `GPU_AVAILABLE=False`, `_xp` unrestored | restored, `Boom` propagates |
| failure in `max_neighbor_value (CPU)` | `GPU_AVAILABLE=False`, `_xp` unrestored | restored, `Boom` propagates |
| failure in `np.random.rand` preparation | `GPU_AVAILABLE=False`, `_xp` unrestored | restored, `Boom` propagates |
| `num_steps=0` / `-1` / `-10` | `ValueError` from the empty-array reduction, after touching `np.load`, `load_rule_spec`, `default_rng` and all three benchmarks | `ValueError: num_steps must be positive, got 0`, **zero seams touched** |
| interrupt between the two forcing writes | (vs `c7fcb255`) propagates with `GPU_AVAILABLE=False` left forced | restored, interrupt propagates by identity, no component ran |
| successful 1-step run | restores | restores |

The successful path restores on both sides, so the harness is sound and the failures are the defects.

## Preserved

Every calculation, print, warmup, iteration count and ordering for positive step counts. The successful path still observes CPU mode across all three CPU components *and* the preparation between them, and restores before the optional GPU section. `benchmark_component()`'s public contract is untouched.

## Validation

The Ian seat has Python 3.13.7 but **no pytest and no numpy**, so the authoritative pytest evidence is the CI receipt below; a stdlib probe with a small array stand-in was used locally for the failing-first proof and cannot replace it. `python -m py_compile` passes on both files. No dependency was installed and no lockfile changed.

## Test design

Tests extend the existing file rather than adding one, because its controlled `run_benchmarks()` driver already plants a distinctive `GPU_AVAILABLE = True` and an identity-sensitive `_xp` sentinel, so restoration is observable rather than merely plausible. The driver gained optional failure injection and a `capture` dict, so the engine's globals can be inspected even when the run raises; existing call sites are unaffected.

That file's docstring previously listed exception-safe restoration of these globals as explicitly **out of scope**. That claim is now false, so it is corrected in the same commit.

**No real benchmark, GPU, CuPy operation, snapshot, server or long-running process is used.**

## Limitations and exclusions

- The engine is a scoped stand-in; this proves the restoration structure, not real backend behaviour.
- Not general benchmark validation: only `num_steps <= 0` is rejected, and nothing else about the arguments is checked.
- Timing methodology, benchmark mathematics and snapshot validation are untouched.
- `ValueError` is the refusal type; no new exception class is introduced.
- The guard fires on `num_steps <= 0`, which for a non-int nonpositive argument (`0.0`, `-0.5`) now raises `ValueError` where the base raised `TypeError` further downstream. Every such input already failed on the base, so nothing previously working changes; and `argparse` types `--steps` as `int`, so only ints reach it from the CLI.
- `getattr(ca_module, 'GPU_AVAILABLE', False)` still turns a genuinely absent flag into `False` rather than restoring absence. Identical in the base, so not introduced here.
- The `finally` restores `GPU_AVAILABLE` before `_xp`; if the first assignment itself raised, the second would not run. Unreachable for a plain module, whose `__dict__` assignment cannot fail.

## Boundary

```
 scripts/gpu_benchmark.py                    |  93 ++++++----
 tests/test_gpu_benchmark_snapshot_loader.py | 340 ++++++++++++++++++++++++----
 2 files changed, 398 insertions(+), 35 deletions(-)
```

Exactly the two authorized files; no third. Most of the production churn is re-indentation into the `try` block.

## Independent review

Three read-only lanes audited these packages; every finding was independently reproduced by the primary agent before any action.

**Acted on — a claimed defect with no test.** Two lanes independently found that the capture-order half of Defect 1 was asserted but never demonstrated: `_engine_stand_in()` always sets `_xp`, so no test could reach the path where capturing it raises. Reverting **only** that half of the repair left the entire suite green. Reproduced directly — with an engine carrying `GPU_AVAILABLE = True` and no `_xp`, the base exits with the flag forced to `False` while this head leaves it `True` — and a test now pins it.

**Acted on — two test seams that could mislead or reach a real resource.** `test_nonpositive_steps_print_nothing` drove production with *no* seam patched; safe only while the guard is correct, and on a CuPy-equipped runner a regressed guard would have reached `cp.cuda.runtime.memGetInfo()` and then a real `np.load`. It now patches tripwires. Separately, `gpu_benchmark.np` **is** the real numpy module, so patching `np.random.rand` rebinds it process-wide for the duration of the block; scoping and restoration were already correct, but the substitute now matches `rand`'s contract exactly instead of approximately.

**Corrected in this description:** the failing-first table previously quoted `ValueError('empty')` for the nonpositive-step case. That was the message from the author's local numpy stand-in, not what real numpy produces on CI. The exception type and the seam list were right; the message was not reproducible, and is now stated correctly above.

**Acted on — the forcing writes were outside the protected interval.** An earlier revision of this description claimed the pre-`try` mutation window was "unreachable for a plain module". That was **wrong**: it holds only for synchronous failure. An asynchronous interrupt — a `KeyboardInterrupt`, or a tracing callback — delivered between `GPU_AVAILABLE = False` and `_xp = np` unwinds past a `finally` that has not been established yet. Reproduced against `c7fcb255` by injecting at exactly that moment: the interrupt propagated with the engine left pinned to CPU. Both forcing assignments are now inside the `try`; capturing stays above it because it mutates nothing. The claim that the previous head restored state on *literally every* exit is likewise retired — it did not.

**Reported and not acted on**, with reasons: `getattr(..., False)` materialising an absent flag is identical in the base; two new tests partly restate pre-existing coverage, which is redundancy rather than a defect.

**Verified clean by the lanes:** for positive step counts, stdout is 46 lines on both sides and identical once timing digits are normalised, with an identical seam trace and ordering; the re-indentation orphans no binding (all three medians, `test_field` and `test_ages` are still readable after the `try`, and the SUMMARY renders); restoration holds for `KeyboardInterrupt`, `SystemExit`, `GeneratorExit` and `MemoryError`, for a failing engine import, for failures after the `finally`, and under re-entrancy; `benchmark_component()` is untouched; nothing reaches a real GPU, CuPy, benchmark, snapshot, network or long-running process.

## CI

Authoritative `pull_request`-event receipt at the synchronized head `c60530c`:

| Check | Run | Job | Result |
|---|---|---|---|
| `verify-python` | `31769789508` | `94673157533` | **`4170 passed, 13 skipped in 70.04s (0:01:10)`** |
| `frontend-quality` | `31769789508` | `94673157524` | pass |
| `Analyze Python` (CodeQL) | `31769789525` | — | pass |
| `agent-safety` | `31769789564` | — | pass |

Rollup **SUCCESS**, 7 registered contexts, all `completed/success`. The synchronized tree combines this package's 13 new tests with the 22 from the sibling orchestrator package on top of the 4135-test base, which is exactly the 4170 above.

## Status

**MERGED and closed** at `2026-08-14T04:28:20Z` by **Goldislops**.

Synchronized before merging with one ordinary merge commit `c60530c14d6131712f26523626d973ad13cd2801`, parents:

- first parent `13c646a6f14cd9d18e1bc28538ea3d9b2aeed71d` — the audited PR head
- second parent `f89fb0f7c4f21d464abe6f25741aa48a63f4ba70` — `main` after the sibling orchestrator package merged

The synchronization was clean and automatic, with no conflict and no manual resolution; both of this package's file blobs were byte-identical before and after it.

Merged with one ordinary merge commit `a7a5dbc79b613eeb13d239f76180be01c2331c99`, parents:

- first parent `f89fb0f7c4f21d464abe6f25741aa48a63f4ba70` — `main` at merge time
- second parent `c60530c14d6131712f26523626d973ad13cd2801` — the synchronized head

Immediately after the merge, live `main` equaled that merge commit. The delta from the pre-merge `main` is exactly the two authorized files at `+398/−35`, and all six commits — the five original plus the synchronization commit — are reachable from `main` (verified: zero unreachable). Ordinary merge commits only: no squash, no rebase, no administrator bypass, no auto-merge, no force-push.

The source branch `fix/gpu-benchmark-backend-restoration` was removed by the repository's existing **automatic branch deletion** setting; it was not deleted manually and has not been recreated. No repository or branch-protection setting was changed.





