### PR TITLE
ci(uft-ca): align wasm-check path filters with cargo lookup ancestry

### DIFF
--- a/.github/workflows/wasm-check.yml
+++ b/.github/workflows/wasm-check.yml
@@ -3,13 +3,33 @@ name: wasm-check
 on:
   pull_request:
     paths:
-      - "crates/uft_ca/**"
+      - ".cargo/**"
       - ".github/workflows/wasm-check.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/.cargo/**"
+      - "crates/Cargo.lock"
+      - "crates/Cargo.toml"
+      - "crates/rust-toolchain"
+      - "crates/rust-toolchain.toml"
+      - "crates/uft_ca/**"
+      - "rust-toolchain"
+      - "rust-toolchain.toml"
   push:
     branches: [main]
     paths:
-      - "crates/uft_ca/**"
+      - ".cargo/**"
       - ".github/workflows/wasm-check.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/.cargo/**"
+      - "crates/Cargo.lock"
+      - "crates/Cargo.toml"
+      - "crates/rust-toolchain"
+      - "crates/rust-toolchain.toml"
+      - "crates/uft_ca/**"
+      - "rust-toolchain"
+      - "rust-toolchain.toml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Aligns the non-required `wasm-check` lane's path filters with the repository paths through which Cargo or rustup can actually affect the command it runs from `crates/uft_ca`, closing the forward-guarding scheduling gap recorded by the sealed wasm-check filter-alignment audit (2026-08-13 lineage).

## What changes

Only the two `paths:` lists (one per event). Each grows from 2 entries to the same 12-entry set, covering every Cargo/rustup lookup level between the working directory and the repository root:

- the crate itself (`crates/uft_ca/**`) and this workflow file (self-trigger);
- at `crates/`: `Cargo.toml`, `Cargo.lock`, `.cargo/**`, `rust-toolchain`, `rust-toolchain.toml`;
- at the repository root: the same five.

Nothing else changes: workflow name, permissions, concurrency, runner, timeout, working directory, job name, action pins, toolchain + `wasm32-unknown-unknown` target, and the `cargo build --target wasm32-unknown-unknown` command are byte-preserved. The lane remains **non-required**.

## Why these paths

Derived from Cargo/rustup lookup semantics and confirmed against official documentation and executed probes in the sealed audit: Cargo searches parent directories for a `Cargo.toml` with a `[workspace]` definition; workspace members share the workspace-root `Cargo.lock`; Cargo's configuration hierarchy reads `.cargo/config(.toml)` in parent directories; rustup discovers a toolchain file by walking up the directory tree, honouring both `rust-toolchain.toml` and `rust-toolchain`. None of those ancestor files exists today, so this is forward-guarding: no present file is uncovered, and no scheduling behaviour changes for the current tree.

## Provenance

- Base: branched directly from `main` at `fe348a71cee227a305c2dfc326cfc6cdf574937b`, verified live immediately before branching and again before push.
- The prior workflow blob is `bc9890e8ea5ad590aa04c2cc066e5993c757e82f` (900 bytes); the new file is byte-exact with the sealed audit candidate — 1,438 LF bytes, SHA-256 `50db25c545c1bceb113a1dae0808008b1e6d172737c42958158406c62555f0a1` — and the one-file diff regenerates byte-identical to the sealed 997-byte diff, SHA-256 `fcbe4b33f31501f6156b198bb0eba50d31ca662cc0b5641f4bc33267b2de21ce`.
- Mechanically proven before commit: with every `paths:` entry stripped, the old and new files are byte-identical remainders — nothing outside the two lists moved.

## Local validation

`cargo build --target wasm32-unknown-unknown` from `crates/uft_ca` — exit 0. Workflow YAML re-parsed and asserted (12 unique filters per event, `push` still limited to `main`, default pull_request activity types).

Draft for Jack's audit; ready and merge remain Kev's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
