### PR TITLE
security(snapshot): preflight unattended service archives

### DIFF
--- a/scripts/geometry_daemon.py
+++ b/scripts/geometry_daemon.py
@@ -322,7 +322,17 @@ def run_daemon():
             # silence: no repeated reason-code log, no repeated preflight, no
             # export attempt. A file that CHANGES at the same path has a
             # different fingerprint and gets a fresh attempt.
-            fingerprint = _snapshot_fingerprint(latest)
+            try:
+                fingerprint = _snapshot_fingerprint(latest)
+            except OSError:
+                # The file was rotated or deleted between the glob above and
+                # this stat. Letting that escape would reach the broad handler
+                # at the bottom of the loop, which prints the exception — and
+                # OSError's message carries the full path, which is a name the
+                # attacker chose. Nothing to do but look again next poll.
+                time.sleep(WATCH_INTERVAL)
+                continue
+
             if fingerprint == last_rejected:
                 time.sleep(WATCH_INTERVAL)
                 continue

--- a/scripts/geometry_daemon.py
+++ b/scripts/geometry_daemon.py
@@ -25,6 +25,25 @@ from datetime import datetime
 import numpy as np
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# This module is documented as `python scripts/geometry_daemon.py`, which
+# leaves the repository root off sys.path. The shared snapshot guard lives in
+# the `scripts` package, so the root is put on the path before importing it --
+# one canonical module name either way, which matters because the guard's
+# exception type is caught by identity below.
+if str(PROJECT_ROOT) not in sys.path:
+    # Appended, not prepended: this must not be able to shadow a standard
+    # library module with a repository file of the same name.
+    sys.path.append(str(PROJECT_ROOT))
+
+from scripts.snapshot_archive_guard import (  # noqa: E402
+    PRODUCTION_POLICY as SNAPSHOT_POLICY,
+)
+from scripts.snapshot_archive_guard import (  # noqa: E402
+    SnapshotArchiveRejected,
+    admit_snapshot,
+)
+
 DATA_DIR = PROJECT_ROOT / "data"
 GEO_DIR = DATA_DIR / "geometry"
 GEO_DIR.mkdir(parents=True, exist_ok=True)
@@ -75,15 +94,49 @@ def _load_snapshot(path):
     no fallback retry and no override.
 
     The claim here is an OBJECT-MEMBER REFUSAL plus archive resource lifetime
-    — not snapshot validation, whole-archive security, deterministic export or
-    atomic output. Nothing here resists decompression amplification, absurd
-    declared shapes, hostile member names or NumPy header defects.
+    — not deterministic export or atomic output.
+
+    Structural admission
+    --------------------
+    `admit_snapshot` now runs first and raises `SnapshotArchiveRejected`
+    before `np.load`, its decompressor or its allocator is reached, for an
+    archive that is out of the data directory, not a ZIP, wrong in its
+    membership, hostile in its member names, oversized in its declared or
+    physical size, or wrong in any member's NPY header. Both call sites — the
+    daemon loop and `--once` — catch that type and stop before any exporter
+    runs.
+
+    The guard opens the file once and hands this helper the very descriptor it
+    preflighted, so the bytes inspected are the bytes NumPy reads. `str(path)`
+    is therefore gone: there is no second open to convert a path for. The
+    inner `with` closes the archive, the guard closes the descriptor, on
+    success and on every exceptional exit.
+
+    Extraction failures are still NOT caught, translated or suppressed: a
+    missing key or a failing `int()` conversion propagates exactly as before.
+
+    `allow_pickle=False` stays at this call site even though an object-dtype
+    member can no longer survive admission. It is the second line of defence
+    and the property the repository-wide static gate reads.
     """
-    with np.load(str(path), allow_pickle=False) as snap:
-        state = snap["lattice"]
-        memory_grid = snap["memory_grid"]
-        generation = int(snap["generation"])
+    with admit_snapshot(path, data_dir=DATA_DIR, policy=SNAPSHOT_POLICY) as descriptor:
+        with np.load(descriptor, allow_pickle=False) as snap:
+            state = snap["lattice"]
+            memory_grid = snap["memory_grid"]
+            generation = int(snap["generation"])
     return state, memory_grid, generation
+
+
+def _snapshot_fingerprint(path):
+    """Identify a snapshot by the attributes that change when it changes.
+
+    A rejected archive is remembered by this triple so the daemon neither logs
+    nor retries it on every poll, while a genuinely new file at the same path
+    — a replaced or rotated snapshot — differs in size or modification time
+    and is admitted for a fresh attempt.
+    """
+    info = path.stat()
+    return (str(path), info.st_size, info.st_mtime_ns)
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +296,7 @@ def run_daemon():
 
     last_export_time = 0
     last_snapshot = None
+    last_rejected = None
 
     while True:
         try:
@@ -264,20 +318,42 @@ def run_daemon():
                 time.sleep(WATCH_INTERVAL)
                 continue
 
+            # An unchanged archive that was already refused is skipped in
+            # silence: no repeated reason-code log, no repeated preflight, no
+            # export attempt. A file that CHANGES at the same path has a
+            # different fingerprint and gets a fresh attempt.
+            fingerprint = _snapshot_fingerprint(latest)
+            if fingerprint == last_rejected:
+                time.sleep(WATCH_INTERVAL)
+                continue
+
             if time.time() - last_export_time < EXPORT_INTERVAL:
                 time.sleep(WATCH_INTERVAL)
                 continue
 
-            # Skip tiny/corrupt files
-            if latest.stat().st_size < 1_000_000:
-                time.sleep(WATCH_INTERVAL)
-                continue
-
-            print(f"\n  [GEO] New snapshot: {latest.name}")
+            # The former one-megabyte minimum is gone. It was a guess at
+            # "tiny/corrupt" and it was wrong in both directions: a sparse but
+            # structurally valid snapshot compresses to far less and was
+            # skipped, while a hostile archive only had to be padded past the
+            # threshold to be processed. Admission decides usability instead.
 
             # Load snapshot. The archive is closed inside the helper, so it is
             # already released before any exporter below runs.
-            state, mg, gen = _load_snapshot(latest)
+            try:
+                state, mg, gen = _load_snapshot(latest)
+            except SnapshotArchiveRejected as refusal:
+                # One bounded reason code. Nothing about the archive's path,
+                # name, members or headers is logged, because this daemon runs
+                # unattended over a directory anyone able to write there can
+                # fill.
+                print(f"  [GEO] Snapshot rejected: {refusal.reason}")
+                last_rejected = fingerprint
+                time.sleep(WATCH_INTERVAL)
+                continue
+
+            # Logged only once the archive has been admitted, so a refused
+            # file's chosen name never reaches the log at all.
+            print(f"\n  [GEO] New snapshot: {latest.name}")
 
             # Export geometry
             t0 = time.time()
@@ -313,6 +389,50 @@ def run_daemon():
         time.sleep(WATCH_INTERVAL)
 
 
+def run_once():
+    """Single export from the latest snapshot — the `--once` production path.
+
+    Split out of the `__main__` block, which pytest never executes, so the
+    refusal contract is reachable by a test rather than restated by one: a
+    rejected archive prints exactly one bounded reason on stderr and exits
+    nonzero, with no exporter having run. The body is otherwise the block that
+    was here before, unchanged.
+    """
+    snapshots = sorted(
+        DATA_DIR.glob("v070_gen*.npz"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not snapshots:
+        print("No snapshots found!")
+        return
+
+    try:
+        state, mg, gen = _load_snapshot(snapshots[0])
+    except SnapshotArchiveRejected as refusal:
+        # Exactly one bounded reason on stderr, then a nonzero exit. Only the
+        # typed refusal is caught here: a MemoryError, a KeyboardInterrupt or
+        # a programmer error must not be turned into "the snapshot was bad".
+        print(f"Snapshot rejected: {refusal.reason}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Exporting geometry for gen {gen:,}...")
+
+    csv = export_sage_pointcloud(state, mg, gen, GEO_DIR)
+    if csv:
+        print(f"  Sage CSV: {csv}")
+
+    js = export_voxel_summary(state, mg, gen, GEO_DIR)
+    if js:
+        print(f"  Summary: {js}")
+
+    stl = export_stl(state, gen, GEO_DIR)
+    if stl:
+        print(f"  STL: {stl} ({stl.stat().st_size / 1024 / 1024:.1f} MB)")
+
+    print("Done!")
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Geometry Export Daemon (Phase 16b)")
@@ -325,31 +445,6 @@ if __name__ == "__main__":
     EXPORT_INTERVAL = args.export_interval
 
     if args.once:
-        # Single export from latest snapshot
-        snapshots = sorted(
-            DATA_DIR.glob("v070_gen*.npz"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )
-        if snapshots:
-            state, mg, gen = _load_snapshot(snapshots[0])
-
-            print(f"Exporting geometry for gen {gen:,}...")
-
-            csv = export_sage_pointcloud(state, mg, gen, GEO_DIR)
-            if csv:
-                print(f"  Sage CSV: {csv}")
-
-            js = export_voxel_summary(state, mg, gen, GEO_DIR)
-            if js:
-                print(f"  Summary: {js}")
-
-            stl = export_stl(state, gen, GEO_DIR)
-            if stl:
-                print(f"  STL: {stl} ({stl.stat().st_size / 1024 / 1024:.1f} MB)")
-
-            print("Done!")
-        else:
-            print("No snapshots found!")
+        run_once()
     else:
         run_daemon()

--- a/scripts/geometry_daemon.py
+++ b/scripts/geometry_daemon.py
@@ -42,6 +42,8 @@ from scripts.snapshot_archive_guard import (  # noqa: E402
 from scripts.snapshot_archive_guard import (  # noqa: E402
     SnapshotArchiveRejected,
     admit_snapshot,
+    entry_fingerprint,
+    newest_first,
 )
 
 DATA_DIR = PROJECT_ROOT / "data"
@@ -82,7 +84,8 @@ def _load_snapshot(path):
     or a failing `int()` conversion propagates exactly as before, and the `with`
     block still closes the archive on the way out.
 
-    The `str(path)` conversion is preserved verbatim.
+    The `str(path)` conversion is NOT preserved: it was deliberately replaced
+    by same-descriptor loading, described below.
 
     `allow_pickle=False` — an object-dtype member is stored as a pickle, so
     loading one with pickle enabled is arbitrary code execution. This daemon
@@ -134,9 +137,13 @@ def _snapshot_fingerprint(path):
     nor retries it on every poll, while a genuinely new file at the same path
     — a replaced or rotated snapshot — differs in size or modification time
     and is admitted for a fresh attempt.
+
+    Non-following: `stat` described a symlink's TARGET, so a rejected link kept
+    changing fingerprint whenever anything touched the target, and the daemon
+    re-preflighted and re-logged the same unchanged poison on every poll — the
+    exact churn the memory exists to stop.
     """
-    info = path.stat()
-    return (str(path), info.st_size, info.st_mtime_ns)
+    return entry_fingerprint(path)
 
 
 # ---------------------------------------------------------------------------
@@ -300,12 +307,12 @@ def run_daemon():
 
     while True:
         try:
-            # Find latest snapshot
-            snapshots = sorted(
-                DATA_DIR.glob("v070_gen*.npz"),
-                key=lambda p: p.stat().st_mtime,
-                reverse=True,
-            )
+            # Find latest snapshot. Non-following ordering that also drops
+            # entries vanishing mid-enumeration: `p.stat()` followed symlinks,
+            # so a link could borrow its target's mtime to become "newest"
+            # before admission had any say, and it raised OSError into the
+            # broad handler below, whose message carries the path.
+            snapshots = newest_first(DATA_DIR.glob("v070_gen*.npz"))
 
             if not snapshots:
                 time.sleep(WATCH_INTERVAL)
@@ -408,11 +415,7 @@ def run_once():
     nonzero, with no exporter having run. The body is otherwise the block that
     was here before, unchanged.
     """
-    snapshots = sorted(
-        DATA_DIR.glob("v070_gen*.npz"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
+    snapshots = newest_first(DATA_DIR.glob("v070_gen*.npz"))
     if not snapshots:
         print("No snapshots found!")
         return

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -14,13 +14,33 @@ The server:
 """
 
 import asyncio
-import contextlib
 import json
 import glob
 import time
 import os
 import sys
+from pathlib import Path
+
 import numpy as np
+
+# This module is documented as `python scripts/lucid_server.py`, which leaves
+# the repository root off sys.path. The shared snapshot guard lives in the
+# `scripts` package, so the root is put on the path before importing it -- one
+# canonical module name either way, which matters because the guard's
+# exception type is caught by identity below.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    # Appended, not prepended: this must not be able to shadow a standard
+    # library module with a repository file of the same name.
+    sys.path.append(str(PROJECT_ROOT))
+
+from scripts.snapshot_archive_guard import (  # noqa: E402
+    PRODUCTION_POLICY as SNAPSHOT_POLICY,
+)
+from scripts.snapshot_archive_guard import (  # noqa: E402
+    SnapshotArchiveRejected,
+    admit_snapshot,
+)
 
 try:
     import websockets
@@ -74,32 +94,42 @@ def extract_render_data(snap_path):
     still open. Closure is explicit, not left to garbage collection, and it
     holds on refusal too because the members are read inside the block.
 
-    Ownership is CONDITIONAL because ``np.load`` returns two different kinds of
-    thing. A zip archive yields an ``NpzFile``, which owns an operating-system
-    handle and needs that deterministic close. A ``.npy`` yields a plain
-    ndarray, which owns no handle and has no context-manager protocol; wrapping
-    it in ``nullcontext`` lets it reach the same ``snap['lattice']`` subscript
-    that has always been where a NUMERIC non-archive input fails. The archive
-    gains closure without the array losing its established exception.
+    Structural admission
+    --------------------
+    ``admit_snapshot`` now runs first and raises ``SnapshotArchiveRejected``
+    before ``np.load``, its decompressor or its allocator is reached, for an
+    archive that is out of the data directory, not a ZIP, wrong in its
+    membership, hostile in its member names, oversized in its declared or
+    physical size, or wrong in any member's NPY header. The watcher and the
+    initial-client send below each catch that type, log one bounded reason
+    code and send no frame; the server, the watcher and every client stay
+    alive.
 
-    Two limits on that, stated rather than implied. An OBJECT-dtype ``.npy``
-    now fails earlier, at ``np.load`` itself, because pickle is refused before
-    anything is returned -- that is the intended change, not a preserved one.
-    And ``np.load`` returns a ``memmap`` only when passed ``mmap_mode``, which
-    this call site never does; a memmap WOULD own a mapping and would not be
-    closed by this branch, so the argument list here is load-bearing.
+    Ownership is no longer conditional. It used to be, because ``np.load``
+    returns an ``NpzFile`` for a zip and a plain ndarray for a ``.npy``, and
+    only the first owns a handle. Admission refuses non-ZIP input outright, so
+    this call site now only ever sees an ``NpzFile``.
 
-    The claim is an OBJECT-MEMBER REFUSAL and archive resource lifetime -- not
-    whole-archive validation. Nothing here resists decompression
-    amplification, absurd declared shapes, hostile member names or defects in
-    NumPy's own header parsing.
+    That is a DELIBERATE behaviour change, recorded rather than glossed: a
+    numeric ``.npy`` renamed to ``.npz`` used to fail with the incidental
+    ``IndexError`` of a string subscript on an ndarray, and now receives a
+    typed admission refusal instead.
+
+    The guard opens the file once and hands this function the very descriptor
+    it preflighted, so the bytes inspected are the bytes NumPy reads. The
+    inner ``with`` closes the archive; the guard closes the descriptor; both
+    hold on success and on every exceptional exit.
+
+    ``allow_pickle=False`` stays at this call site even though an object-dtype
+    member can no longer survive admission. It is the second line of defence
+    and the property the repository-wide static gate reads.
     """
-    loaded = np.load(snap_path, allow_pickle=False)
-    owner = contextlib.nullcontext(loaded) if isinstance(loaded, np.ndarray) else loaded
-    with owner as snap:
-        state = snap['lattice']
-        mg = snap['memory_grid']
-        gen = int(snap['generation'])
+    with admit_snapshot(snap_path, data_dir=DATA_DIR,
+                        policy=SNAPSHOT_POLICY) as descriptor:
+        with np.load(descriptor, allow_pickle=False) as snap:
+            state = snap['lattice']
+            mg = snap['memory_grid']
+            gen = int(snap['generation'])
 
     n = state.shape[0]
 
@@ -170,15 +200,23 @@ async def snapshot_watcher():
                     last_snapshot_path = latest
                     last_snapshot_mtime = mtime
 
-                    # Extract and broadcast
-                    data = extract_render_data(latest)
-                    msg = json.dumps({'type': 'frame', 'data': data})
-                    await broadcast(msg)
+                    # Extract and broadcast. A refused archive logs one bounded
+                    # reason code and sends nothing; `last_snapshot_path` and
+                    # `last_snapshot_mtime` were already advanced above, so the
+                    # same rejected file is not reprocessed on every poll, and
+                    # a later valid snapshot is picked up normally.
+                    try:
+                        data = extract_render_data(latest)
+                    except SnapshotArchiveRejected as refusal:
+                        print(f"  Snapshot rejected: {refusal.reason}")
+                    else:
+                        msg = json.dumps({'type': 'frame', 'data': data})
+                        await broadcast(msg)
 
-                    gen = data['metrics']['generation']
-                    n_clients = len(connected_clients)
-                    if n_clients > 0:
-                        print(f"  Broadcast gen {gen:,} to {n_clients} client(s) ({len(data['cells'])} cells)")
+                        gen = data['metrics']['generation']
+                        n_clients = len(connected_clients)
+                        if n_clients > 0:
+                            print(f"  Broadcast gen {gen:,} to {n_clients} client(s) ({len(data['cells'])} cells)")
         except Exception as e:
             print(f"  Snapshot error: {e}")
 
@@ -191,12 +229,16 @@ async def handle_client(websocket):
     remote = websocket.remote_address
     print(f"Client connected: {remote}")
 
-    # Send initial snapshot immediately
+    # Send initial snapshot immediately. A refused archive costs this client
+    # its opening frame and nothing else: one bounded reason code is logged,
+    # the connection stays open and its messages are handled as usual.
     try:
         latest = find_latest_snapshot(DATA_DIR)
         if latest:
             data = extract_render_data(latest)
             await websocket.send(json.dumps({'type': 'frame', 'data': data}))
+    except SnapshotArchiveRejected as refusal:
+        print(f"  Snapshot rejected: {refusal.reason}")
     except Exception as e:
         print(f"  Initial send error: {e}")
 

--- a/scripts/lucid_server.py
+++ b/scripts/lucid_server.py
@@ -40,6 +40,8 @@ from scripts.snapshot_archive_guard import (  # noqa: E402
 from scripts.snapshot_archive_guard import (  # noqa: E402
     SnapshotArchiveRejected,
     admit_snapshot,
+    entry_fingerprint,
+    newest_first,
 )
 
 try:
@@ -61,10 +63,22 @@ connected_clients = set()
 
 
 def find_latest_snapshot(data_dir):
-    """Find the most recent .npz snapshot."""
+    """Find the most recent .npz snapshot.
+
+    Ordering uses non-following metadata and skips entries that vanish during
+    enumeration. `os.path.getmtime` follows symlinks, so a link could borrow
+    its target's modification time to become "newest" before admission had any
+    say, and it raises `OSError` for an entry rotated mid-sort -- which, from
+    inside the watcher's loop, reached a handler that prints the exception, and
+    `OSError`'s message carries the full attacker-chosen path.
+
+    A dangling link or a symlink loop still `lstat`s, so it remains a candidate
+    and is refused by `admit_snapshot` with a typed reason rather than
+    disappearing from selection unrecorded.
+    """
     pattern = os.path.join(data_dir, "v070_gen*.npz")
-    files = sorted(glob.glob(pattern), key=os.path.getmtime)
-    return files[-1] if files else None
+    ordered = newest_first(glob.glob(pattern))
+    return ordered[0] if ordered else None
 
 
 def extract_render_data(snap_path):
@@ -195,8 +209,19 @@ async def snapshot_watcher():
         try:
             latest = find_latest_snapshot(DATA_DIR)
             if latest:
-                mtime = os.path.getmtime(latest)
-                if latest != last_snapshot_path or mtime != last_snapshot_mtime:
+                # The SECOND metadata read, and it needs the same protection as
+                # the first: selection and this line are separate syscalls, so
+                # the chosen snapshot can be rotated away in between. Non-
+                # following, and a vanished entry ends this poll quietly rather
+                # than printing an OSError whose message carries the path.
+                try:
+                    mtime = entry_fingerprint(latest)[2]
+                except OSError:
+                    mtime = None
+
+                if mtime is not None and (
+                    latest != last_snapshot_path or mtime != last_snapshot_mtime
+                ):
                     last_snapshot_path = latest
                     last_snapshot_mtime = mtime
 

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -43,6 +43,7 @@ from scripts.snapshot_archive_guard import PRODUCTION_POLICY as SNAPSHOT_POLICY
 from scripts.snapshot_archive_guard import (
     SnapshotArchiveRejected,
     admit_snapshot,
+    entry_fingerprint,
     newest_first,
 )
 
@@ -249,8 +250,19 @@ def status():
     if not snap_path:
         return jsonify({"error": "No snapshots found"}), 404
 
-    snap_age = time.time() - snap_path.stat().st_mtime
-    snap_size = snap_path.stat().st_size
+    # Non-following, and typed. Selection deliberately KEEPS a dangling link
+    # or a symlink loop as a candidate so it reaches the guard and is refused
+    # with a reason — and when nothing in the window is admissible the newest
+    # is still returned. A following, unguarded `.stat()` here would then raise
+    # `FileNotFoundError`/`ELOOP` into a 500 whose message carries the
+    # attacker-chosen path: the exact disclosure the rest of this change
+    # closes. If the entry cannot be described it is not a snapshot to report.
+    try:
+        _, snap_size, snap_mtime_ns = entry_fingerprint(snap_path)
+    except OSError:
+        return jsonify({"error": "No snapshots found"}), 404
+
+    snap_age = time.time() - snap_mtime_ns / 1_000_000_000
 
     # Count total snapshots
     all_snaps = list(DATA_DIR.glob("v070_gen*.npz"))

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -40,7 +40,11 @@ import numpy as np
 from flask import Flask, jsonify, send_file, Response
 
 from scripts.snapshot_archive_guard import PRODUCTION_POLICY as SNAPSHOT_POLICY
-from scripts.snapshot_archive_guard import SnapshotArchiveRejected, admit_snapshot
+from scripts.snapshot_archive_guard import (
+    SnapshotArchiveRejected,
+    admit_snapshot,
+    newest_first,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -100,12 +104,15 @@ def _find_latest_snapshot():
     ``/api/status`` and ``/api/snapshot/latest`` keep reporting and serving the
     file that is actually there, exactly as before, while the four loading
     routes go on to answer 503.
+
+    Ordering comes from ``newest_first``, which reads non-following metadata
+    and silently drops entries that vanish mid-enumeration. Sorting on
+    ``stat`` let a symlink borrow its target's modification time to promote
+    itself to "newest" — followed during ORDERING, before admission had any
+    say — and let a snapshot rotated during the scan turn a request into a 500
+    whose message carried the attacker-chosen path.
     """
-    snapshots = sorted(
-        DATA_DIR.glob("v070_gen*.npz"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
+    snapshots = newest_first(DATA_DIR.glob("v070_gen*.npz"))
     for candidate in snapshots[:SNAPSHOT_SELECTION_DEPTH]:
         try:
             with admit_snapshot(candidate, data_dir=DATA_DIR,
@@ -148,9 +155,10 @@ def _load_snapshot(path):
 
     Extraction is not guarded: a missing key or a failing ``int()`` / ``float()``
     conversion propagates exactly as before, and the ``with`` block still closes
-    the archive on the way out. ``str(path)``, the required-key semantics, the
-    extraction order, both conversions and the tuple order are preserved
-    verbatim.
+    the archive on the way out. The required-key semantics, the extraction
+    order, both conversions and the tuple order are preserved verbatim. The
+    ``str(path)`` conversion is NOT: it was deliberately replaced by
+    same-descriptor loading, described below.
 
     ``allow_pickle=False`` -- an object-dtype member is stored as a pickle, so
     loading one with pickle enabled is arbitrary code execution. This helper

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -62,21 +62,57 @@ app.config["API_PORT"] = API_PORT
 # Helpers
 # ---------------------------------------------------------------------------
 
+#: How many of the newest snapshots may be preflighted while looking for a
+#: usable one. The previous code scanned the whole directory, which now holds
+#: five figures' worth of archives; preflighting all of them on every request
+#: would itself be the denial of service. Bounded, so one poisoned batch costs
+#: a fixed amount of work and anything older is simply not considered.
+SNAPSHOT_SELECTION_DEPTH = 8
+
+
 def _find_latest_snapshot():
-    """Find the most recent .npz snapshot.
+    """Find the most recent USABLE .npz snapshot.
 
     The former one-megabyte minimum is gone. It was a guess at "tiny/corrupt",
     and it was wrong in both directions: a structurally valid snapshot of a
     sparse lattice compresses to far less than a megabyte and was skipped,
     while a hostile archive only had to be padded past the threshold to be
-    selected. Selection is now purely "most recent", and whether the file is
-    usable is decided by ``admit_snapshot`` from the archive's own structure.
+    selected.
+
+    What that guess was DOING, though, was not merely filtering — it was a
+    newest-first search that skipped an unusable file and fell back to the
+    previous good one. Dropping it and returning ``snapshots[0]`` would have
+    meant that a single truncated or hostile archive with the newest mtime
+    wedged all four snapshot routes at 503 until a fresh snapshot landed. That
+    is a real regression: ``run_v070_engine._save_snapshot`` writes straight to
+    its final path with no temporary-and-rename, so a partially written archive
+    IS the newest file for as long as the write takes.
+
+    So the search is kept and the predicate is replaced: admission, not size.
+    ``admit_snapshot`` is the same preflight ``_load_snapshot`` will run, and it
+    is bounded, so this costs a bounded number of bounded reads.
+
+    Two things this deliberately does NOT do. It does not hold the descriptor
+    open between selection and loading — ``_load_snapshot`` opens and
+    preflights its own, so a file swapped in between is caught there rather
+    than trusted here; this probe decides only WHICH path to try. And when
+    nothing in the window is admissible it still returns the newest, so
+    ``/api/status`` and ``/api/snapshot/latest`` keep reporting and serving the
+    file that is actually there, exactly as before, while the four loading
+    routes go on to answer 503.
     """
     snapshots = sorted(
         DATA_DIR.glob("v070_gen*.npz"),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
+    for candidate in snapshots[:SNAPSHOT_SELECTION_DEPTH]:
+        try:
+            with admit_snapshot(candidate, data_dir=DATA_DIR,
+                                policy=SNAPSHOT_POLICY):
+                return candidate
+        except SnapshotArchiveRejected:
+            continue
     return snapshots[0] if snapshots else None
 
 

--- a/scripts/medusa_api.py
+++ b/scripts/medusa_api.py
@@ -39,6 +39,9 @@ from threading import Thread
 import numpy as np
 from flask import Flask, jsonify, send_file, Response
 
+from scripts.snapshot_archive_guard import PRODUCTION_POLICY as SNAPSHOT_POLICY
+from scripts.snapshot_archive_guard import SnapshotArchiveRejected, admit_snapshot
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -60,17 +63,34 @@ app.config["API_PORT"] = API_PORT
 # ---------------------------------------------------------------------------
 
 def _find_latest_snapshot():
-    """Find the most recent .npz snapshot."""
+    """Find the most recent .npz snapshot.
+
+    The former one-megabyte minimum is gone. It was a guess at "tiny/corrupt",
+    and it was wrong in both directions: a structurally valid snapshot of a
+    sparse lattice compresses to far less than a megabyte and was skipped,
+    while a hostile archive only had to be padded past the threshold to be
+    selected. Selection is now purely "most recent", and whether the file is
+    usable is decided by ``admit_snapshot`` from the archive's own structure.
+    """
     snapshots = sorted(
         DATA_DIR.glob("v070_gen*.npz"),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
-    # Skip tiny/corrupt files (< 10 MB for 256³)
-    for s in snapshots:
-        if s.stat().st_size > 1_000_000:
-            return s
     return snapshots[0] if snapshots else None
+
+
+def _snapshot_rejected():
+    """The one response every admission refusal produces.
+
+    503 rather than 500: the snapshot is unusable, so the service cannot
+    answer right now, and a later valid snapshot will fix it without any code
+    change. The body carries no reason code, no member name and no traceback --
+    these routes are unauthenticated GETs on a process that binds 0.0.0.0, and
+    the caller who supplied the archive must learn nothing about which check
+    caught it.
+    """
+    return jsonify({"error": "snapshot_rejected"}), 503
 
 
 def _load_snapshot(path):
@@ -113,12 +133,34 @@ def _load_snapshot(path):
     The claim is archive resource lifetime relative to extraction — not an
     indefinitely accumulating descriptor leak, not snapshot validation, endpoint
     totality, API authentication or atomic file access.
+
+    Structural admission
+    --------------------
+    ``admit_snapshot`` now runs first and raises ``SnapshotArchiveRejected``
+    before ``np.load``, its decompressor or its allocator is reached, for an
+    archive that is out of the data directory, not a ZIP, wrong in its
+    membership, hostile in its member names, oversized in its declared or
+    physical size, or wrong in any member's NPY header. The four routes below
+    translate that refusal into a sanitized 503; nothing else about the
+    refusal is exposed.
+
+    The guard opens the file once and hands this helper the very descriptor it
+    preflighted, so the bytes that were inspected are the bytes NumPy reads.
+    ``str(path)`` is therefore gone: there is no second open to convert a path
+    for. Ownership is split and both halves are explicit — the inner ``with``
+    closes the archive, the guard closes the descriptor, on success and on
+    every exceptional exit.
+
+    ``allow_pickle=False`` stays at this call site even though an object-dtype
+    member can no longer survive admission. It is the second line of defence
+    and the property the repository-wide static gate reads.
     """
-    with np.load(str(path), allow_pickle=False) as snap:
-        lattice = snap["lattice"]
-        memory_grid = snap["memory_grid"]
-        generation = int(snap["generation"])
-        best_fitness = float(snap["best_fitness"])
+    with admit_snapshot(path, data_dir=DATA_DIR, policy=SNAPSHOT_POLICY) as descriptor:
+        with np.load(descriptor, allow_pickle=False) as snap:
+            lattice = snap["lattice"]
+            memory_grid = snap["memory_grid"]
+            generation = int(snap["generation"])
+            best_fitness = float(snap["best_fitness"])
     return (lattice, memory_grid, generation, best_fitness)
 
 
@@ -207,7 +249,11 @@ def census():
     if not snap_path:
         return jsonify({"error": "No snapshots found"}), 404
 
-    state, mg, gen, fitness = _load_snapshot(snap_path)
+    try:
+        state, mg, gen, fitness = _load_snapshot(snap_path)
+    except SnapshotArchiveRejected:
+        return _snapshot_rejected()
+
     N = state.shape[0]
     total = state.size
 
@@ -245,7 +291,10 @@ def equanimity():
     if not snap_path:
         return jsonify({"error": "No snapshots found"}), 404
 
-    state, mg, gen, fitness = _load_snapshot(snap_path)
+    try:
+        state, mg, gen, fitness = _load_snapshot(snap_path)
+    except SnapshotArchiveRejected:
+        return _snapshot_rejected()
 
     compute_mask = state == 2
     ages = mg[0][compute_mask]
@@ -306,7 +355,11 @@ def acoustic():
     if not snap_path:
         return jsonify({"error": "No data available"}), 404
 
-    state, mg, gen, _ = _load_snapshot(snap_path)
+    try:
+        state, mg, gen, _ = _load_snapshot(snap_path)
+    except SnapshotArchiveRejected:
+        return _snapshot_rejected()
+
     N = state.shape[0]
     S = 16
     K = N // S
@@ -352,7 +405,10 @@ def geometry_stl():
     if not snap_path:
         return jsonify({"error": "No snapshots found"}), 404
 
-    state, mg, gen, _ = _load_snapshot(snap_path)
+    try:
+        state, mg, gen, _ = _load_snapshot(snap_path)
+    except SnapshotArchiveRejected:
+        return _snapshot_rejected()
 
     # Sample non-void cells (limit to 50K for reasonable STL size)
     non_void_coords = np.argwhere(state > 0)

--- a/scripts/snapshot_archive_guard.py
+++ b/scripts/snapshot_archive_guard.py
@@ -186,7 +186,11 @@ class MemberSpec:
     kinds: Tuple[str, ...]
     max_payload_bytes: int
     role: str
-    itemsizes: Tuple[int, ...] = (1, 2, 4, 8, 16)
+    #: Default excludes 16 for the same portability reason as
+    #: :data:`_FLOAT_WIDTHS`. Every production spec passes an explicit tuple,
+    #: so this only governs a spec built without one — but leaving 16 here
+    #: would have quietly readmitted `<f16` through any such spec.
+    itemsizes: Tuple[int, ...] = (1, 2, 4, 8)
 
     @property
     def archive_name(self) -> str:
@@ -249,8 +253,7 @@ class SnapshotArchivePolicy:
         return {spec.archive_name: spec for spec in self.members}
 
 
-#: Widths NumPy can construct for each family. Integers: 1, 2, 4, 8 bytes.
-#: Floats: 2 (float16), 4, 8, and 16 (longdouble, where the platform has it).
+#: Widths NumPy can construct portably, per family.
 _INTEGER_WIDTHS = (1, 2, 4, 8)
 #: 16-byte floats are deliberately absent. ``float128``/``longdouble`` is not
 #: portable -- NumPy 2.3.5 on Windows refuses ``<f16`` outright -- and no
@@ -444,11 +447,15 @@ class _LiteralParser:
 
     #: ASCII decimal digits, spelled out. ``str.isdigit()`` is TRUE for the
     #: whole Unicode digit property -- superscripts, circled numerals and so
-    #: on -- while ``int()`` accepts only these ten. Using ``isdigit`` here let
-    #: a header declaring a shape of ``(\xb2,)`` reach ``int()``, which raised a
-    #: bare ``ValueError`` carrying the attacker's character out of the guard
-    #: entirely, past every ``except SnapshotArchiveRejected`` in the
-    #: consumers and into a 500 with a traceback.
+    #: on -- while ``int()`` accepts only these ten, so a shape of ``(\xb2,)``
+    #: reached ``int()`` and raised a bare ``ValueError``.
+    #:
+    #: Stated precisely, because the obvious reading overclaims: the ``except``
+    #: clause in :func:`_read_member_header` now also covers ``ValueError``, so
+    #: that escape is closed twice over and no test can separate the two.
+    #: What this line buys on its own is that the parser refuses the input
+    #: rather than relying on the conversion to fail -- defence in depth, not
+    #: the sole barrier.
     DECIMAL_DIGITS = "0123456789"
 
     def _parse_int(self) -> int:
@@ -553,6 +560,12 @@ def _read_member_header(stream, policy: SnapshotArchivePolicy) -> _MemberHeader:
         raise _reject("member_dtype_structured")
     size_text = match.group("size")
     if not size_text:
+        raise _reject("member_dtype_unsupported")
+    if len(size_text) > 1 and size_text[0] == "0":
+        # `<i000004` normalises to a width of 4 and would pass the allowlist,
+        # but NumPy is handed the DESCRIPTOR STRING, not the normalised width.
+        # Refusing padded forms keeps the thing checked and the thing used the
+        # same thing; NumPy never writes one.
         raise _reject("member_dtype_unsupported")
     if len(size_text) > _MAX_ITEMSIZE_DIGITS:
         # ``int()`` refuses very long decimal strings outright (CPython's
@@ -716,6 +729,10 @@ def _check_member_names(names: Tuple[str, ...], policy: SnapshotArchivePolicy) -
     for name in names:
         if not name or _UNSAFE_NAME_RE.search(name):
             raise _reject("member_name_unsafe")
+        if not name.isascii():
+            # The schema's five names are ASCII. Anything else is either a
+            # different name or an encoding trick, and both are refusals.
+            raise _reject("member_name_unsafe")
 
     seen = set()
     for name in names:
@@ -806,7 +823,15 @@ def newest_first(paths):
         except OSError:
             continue
         described.append((info.st_mtime_ns, os.fspath(candidate), candidate))
-    described.sort(key=lambda row: (row[0], row[1]), reverse=True)
+    # Newest first, and on a tie the LOWEST path first -- not `reverse=True`
+    # over the whole key, which would order tied paths descending. The
+    # producer's filenames are `v070_gen{n:06d}_step{m:06d}_{ts}.npz`, and
+    # `:06d` is a minimum width that production has already outgrown, so
+    # lexicographic order inverts across a digit-count boundary: descending
+    # ties would prefer `v070_gen999999...` over `v070_gen1000000...`, i.e.
+    # the OLDER snapshot. Ties are only reachable on coarse-granularity
+    # storage, but the direction should not be an accident either way.
+    described.sort(key=lambda row: (-row[0], row[1]))
     return [row[2] for row in described]
 
 
@@ -963,7 +988,18 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
         # "not_zip_archive". Nothing raises one today; this keeps that true
         # if anything is ever moved inside the try.
         raise
-    except (zipfile.BadZipFile, OSError, ValueError):
+    except (zipfile.BadZipFile, OSError, ValueError, NotImplementedError,
+            zlib.error):
+        # `NotImplementedError` is the one that had to be added rather than
+        # assumed. `ZipFile()`'s constructor reads the central directory, and
+        # `_RealGetContents` refuses an entry whose "version needed to
+        # extract" exceeds MAX_EXTRACT_VERSION (63) by raising it. Because it
+        # subclasses `RuntimeError`, none of the other three clauses caught it,
+        # so a single byte set to 255 in each central header made a
+        # schema-perfect archive escape the guard untyped -- turning every
+        # Medusa snapshot route into a 500 instead of the promised sanitized
+        # 503, and wedging the geometry daemon in a retry loop because the
+        # broad handler there never records a non-refusal as rejected.
         raise _reject("not_zip_archive") from None
 
     with archive:
@@ -972,7 +1008,18 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
             if entry.is_dir():
                 raise _reject("member_is_directory")
 
+        # BOTH the sanitised name and the raw one. `ZipInfo.filename` has
+        # already been through `_sanitize_filename` (NUL truncation, backslash
+        # folding) and may additionally have been overridden by a 0x7075
+        # Unicode-Path extra field, so an entry can present a schema name here
+        # while `orig_filename` holds something else entirely -- which CPython
+        # then quotes verbatim in its "Overlapped entries" warning, putting
+        # attacker-chosen text on an unattended daemon's stderr from an
+        # ADMITTED archive.
         _check_member_names(tuple(entry.filename for entry in infos), policy)
+        for entry in infos:
+            if entry.orig_filename != entry.filename:
+                raise _reject("member_name_unsafe")
 
         specs = policy.by_archive_name
         headers: Dict[str, _MemberHeader] = {}
@@ -997,12 +1044,17 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
             except SnapshotArchiveRejected:
                 raise  # never re-coded by the broad clause below
             except NotImplementedError:
-                # The same two flags, declared in the LOCAL header only, where
-                # the central-directory check above cannot see them.
-                # `NotImplementedError` subclasses `RuntimeError`, so it would
-                # otherwise be swallowed by the clause below and reported as an
-                # unreadable header. Its message names the flag and is
-                # discarded with `from None`.
+                # Defensive, and stated as such. `ZipFile.open` raises this for
+                # flag bits 5 and 6 -- but it tests `zinfo.flag_bits`, which for
+                # `open(ZipInfo)` is the CENTRAL value, so the check above
+                # always wins and no crafted archive reaches here. Local-header
+                # flag bits are used by CPython only to pick the filename
+                # codec, and are ignored by both zipfile and this guard.
+                #
+                # The clause is kept because `NotImplementedError` subclasses
+                # `RuntimeError`: without it, any future CPython that raises it
+                # from this call would be reported as an unreadable header, and
+                # its message names the flag. Discarded with `from None`.
                 raise _reject("member_flags_unsupported") from None
             except (zipfile.BadZipFile, OSError, ValueError, RuntimeError,
                     zlib.error):

--- a/scripts/snapshot_archive_guard.py
+++ b/scripts/snapshot_archive_guard.py
@@ -100,6 +100,7 @@ REASON_CODES: Tuple[str, ...] = (
     "archive_too_large",
     "archive_truncated",
     "not_zip_archive",
+    "zip64_unsupported",
     "central_directory_too_large",
     "archive_payload_total_too_large",
     # membership
@@ -162,8 +163,17 @@ class MemberSpec:
 
     ``kinds`` are NumPy dtype *family* characters, not exact dtypes: the
     producer writes ``uint8``/``float32``/platform ``int``, and documented
-    legacy snapshots differ in width, so pinning exact widths would refuse
-    valid history. Width is bounded instead by ``max_payload_bytes``.
+    legacy snapshots differ in width, so pinning one exact dtype would refuse
+    valid history.
+
+    ``itemsizes`` bounds that freedom to widths NumPy can actually construct.
+    The descriptor grammar accepts any letter followed by any digits, so
+    ``|u3``, ``<f5`` and ``<i1000`` all parse and all satisfy a family rule --
+    and each of them makes ``np.dtype()`` raise a ``TypeError`` whose message
+    quotes the attacker's descriptor verbatim, from a call site downstream of
+    every ``except SnapshotArchiveRejected``. Admitting a width that cannot
+    exist is the same defect as admitting a wrong family, so it is refused
+    here rather than by NumPy.
     """
 
     name: str
@@ -171,6 +181,7 @@ class MemberSpec:
     kinds: Tuple[str, ...]
     max_payload_bytes: int
     role: str
+    itemsizes: Tuple[int, ...] = (1, 2, 4, 8, 16)
 
     @property
     def archive_name(self) -> str:
@@ -193,11 +204,14 @@ class SnapshotArchivePolicy:
     A 512³ archive is outside this tranche by construction and is refused.
 
     Stated rather than implied: under these production numbers the aggregate
-    ceiling cannot be the binding constraint, because the per-member ceilings
-    already sum to 528 MiB plus three kilobyte-scale scalars. It is kept
-    because it is the envelope that would otherwise widen silently if a future
-    policy raised one member's ceiling, and it is exercised by tests through an
-    injected policy rather than by pretending a production archive reaches it.
+    ceiling cannot be the binding constraint. The accumulator sums
+    ``ZipInfo.file_size``, which covers each member's NPY header as well as its
+    payload, so the true worst case is 528 MiB of payload + 3 KiB of scalars +
+    5 x 4 KiB of headers = 553,695,104 bytes, against a ceiling of
+    554,696,704 — about 978 KiB of margin. It is kept because it is the
+    envelope that would otherwise widen silently if a future policy raised one
+    member's ceiling, and it is exercised by tests through an injected policy
+    rather than by pretending a production archive reaches it.
 
     ``central_directory_max_bytes`` is a bounded-parsing safeguard rather than
     a production capacity: a five-member snapshot's central directory is a few
@@ -227,12 +241,18 @@ class SnapshotArchivePolicy:
         return {spec.archive_name: spec for spec in self.members}
 
 
+#: Widths NumPy can construct for each family. Integers: 1, 2, 4, 8 bytes.
+#: Floats: 2 (float16), 4, 8, and 16 (longdouble, where the platform has it).
+_INTEGER_WIDTHS = (1, 2, 4, 8)
+_FLOAT_WIDTHS = (2, 4, 8, 16)
+
 PRODUCTION_MEMBERS: Tuple[MemberSpec, ...] = (
-    MemberSpec("lattice", 3, ("u",), 16 * _MIB, ROLE_LATTICE),
-    MemberSpec("memory_grid", 4, ("f",), 512 * _MIB, ROLE_MEMORY_GRID),
-    MemberSpec("generation", 0, ("i",), 1 * _KIB, ROLE_SCALAR),
-    MemberSpec("ca_step", 0, ("i",), 1 * _KIB, ROLE_SCALAR),
-    MemberSpec("best_fitness", 0, ("f",), 1 * _KIB, ROLE_SCALAR),
+    MemberSpec("lattice", 3, ("u",), 16 * _MIB, ROLE_LATTICE, _INTEGER_WIDTHS),
+    MemberSpec("memory_grid", 4, ("f",), 512 * _MIB, ROLE_MEMORY_GRID,
+               _FLOAT_WIDTHS),
+    MemberSpec("generation", 0, ("i",), 1 * _KIB, ROLE_SCALAR, _INTEGER_WIDTHS),
+    MemberSpec("ca_step", 0, ("i",), 1 * _KIB, ROLE_SCALAR, _INTEGER_WIDTHS),
+    MemberSpec("best_fitness", 0, ("f",), 1 * _KIB, ROLE_SCALAR, _FLOAT_WIDTHS),
 )
 
 #: The named policy the three services use.
@@ -245,6 +265,10 @@ PRODUCTION_POLICY = SnapshotArchivePolicy(members=PRODUCTION_MEMBERS)
 
 _NPY_MAGIC = b"\x93NUMPY"
 _SUPPORTED_NPY_VERSIONS = frozenset({(1, 0), (2, 0), (3, 0)})
+
+#: Enough digits for any width in :attr:`MemberSpec.itemsizes`, far short of
+#: CPython's integer-string conversion limit.
+_MAX_ITEMSIZE_DIGITS = 6
 
 #: ``<f4``, ``|u1``, ``>i8`` ... byte order optional, size digits required.
 #: A descriptor NumPy would write for a plain numeric array always matches.
@@ -310,6 +334,12 @@ class _LiteralParser:
         self._count()
         self.skip_space()
         char = self._peek()
+        if not char:
+            # `_peek` returns "" at end of input, and "" is a substring of
+            # every string -- so without this the dispatch below would treat
+            # end-of-input as an opening bracket and recurse until the depth
+            # cap fired.
+            raise _HeaderSyntaxError("end of input")
         if char == "{":
             return self._parse_dict()
         if char in "([":
@@ -394,12 +424,21 @@ class _LiteralParser:
         self.pos += 1
         return value
 
+    #: ASCII decimal digits, spelled out. ``str.isdigit()`` is TRUE for the
+    #: whole Unicode digit property -- superscripts, circled numerals and so
+    #: on -- while ``int()`` accepts only these ten. Using ``isdigit`` here let
+    #: a header declaring a shape of ``(\xb2,)`` reach ``int()``, which raised a
+    #: bare ``ValueError`` carrying the attacker's character out of the guard
+    #: entirely, past every ``except SnapshotArchiveRejected`` in the
+    #: consumers and into a 500 with a traceback.
+    DECIMAL_DIGITS = "0123456789"
+
     def _parse_int(self) -> int:
         start = self.pos
         if self._peek() == "-":
             self.pos += 1
         digits = 0
-        while self._peek().isdigit():
+        while self._peek() in self.DECIMAL_DIGITS and self._peek():
             self.pos += 1
             digits += 1
             if digits > self.MAX_INT_DIGITS:
@@ -458,7 +497,12 @@ def _read_member_header(stream, policy: SnapshotArchivePolicy) -> _MemberHeader:
     try:
         text = raw.decode("utf-8" if version == (3, 0) else "latin1")
         parsed = _parse_literal(text.strip())
-    except (UnicodeDecodeError, _HeaderSyntaxError):
+    except (UnicodeDecodeError, _HeaderSyntaxError, ValueError, RecursionError):
+        # ``ValueError`` and ``RecursionError`` are belt-and-braces: the parser
+        # is written not to raise either, but a header is attacker-controlled
+        # and an escape from here would carry its bytes past every
+        # ``except SnapshotArchiveRejected`` in the consumers. Nothing derived
+        # from the archive may leave this function untyped.
         raise _reject("member_header_malformed") from None
 
     if not isinstance(parsed, dict) or set(parsed) != {
@@ -491,6 +535,12 @@ def _read_member_header(stream, policy: SnapshotArchivePolicy) -> _MemberHeader:
         raise _reject("member_dtype_structured")
     size_text = match.group("size")
     if not size_text:
+        raise _reject("member_dtype_unsupported")
+    if len(size_text) > _MAX_ITEMSIZE_DIGITS:
+        # ``int()`` refuses very long decimal strings outright (CPython's
+        # integer-string limit), and the header ceiling alone does not bound
+        # this below that limit. Refused here so the conversion below cannot
+        # raise.
         raise _reject("member_dtype_unsupported")
     itemsize = int(size_text)
     if kind == "U":
@@ -545,6 +595,8 @@ _EOCD_SIGNATURE = b"PK\x05\x06"
 _EOCD_SIZE = 22
 _MAX_EOCD_COMMENT = 0xFFFF
 _LOCAL_FILE_SIGNATURE = b"PK\x03\x04"
+_ZIP64_LOCATOR_SIGNATURE = b"PK\x06\x07"
+_ZIP64_LOCATOR_SIZE = 20
 
 _UNSAFE_NAME_RE = re.compile(r"(^/)|(^[A-Za-z]:)|(\\)|(^\.\.$)|(^\.\./)|(/\.\./)|(/\.\.$)|(/)")
 
@@ -576,6 +628,29 @@ def _preflight_eocd(fh, size: int, policy: SnapshotArchivePolicy) -> None:
     index = tail.rfind(_EOCD_SIGNATURE)
     if index < 0 or len(tail) - index < _EOCD_SIZE:
         raise _reject("not_zip_archive")
+
+    # A ZIP64 end-of-central-directory locator sitting immediately before the
+    # 32-bit record makes every field below ADVISORY. CPython's
+    # ``zipfile._EndRecData`` looks for that locator and, when it is present,
+    # takes the entry count, directory size and directory offset from the
+    # ZIP64 record instead -- without requiring the 0xFFFF/0xFFFFFFFF
+    # sentinels this function refuses further down. A crafted archive can
+    # therefore declare "five entries, a 300-byte directory" here while
+    # ``ZipFile`` goes on to build one ``ZipInfo`` per entry from a directory
+    # that is orders of magnitude larger; measured at 60,000 entries from a
+    # 2.7 MB file, and the physical ceiling permits far more.
+    #
+    # The condition below is exactly the one ``_EndRecData`` uses, read from
+    # the file rather than from the tail window so it cannot be pushed out of
+    # range by a comment. A five-member snapshot inside a 544 MiB ceiling
+    # never needs ZIP64 -- NumPy's ``force_zip64`` affects only LOCAL headers,
+    # and the central directory it writes stays 32-bit -- so the whole
+    # extension is refused rather than parsed.
+    eocd_offset = size - window + index
+    if eocd_offset >= _ZIP64_LOCATOR_SIZE:
+        fh.seek(eocd_offset - _ZIP64_LOCATOR_SIZE)
+        if fh.read(len(_ZIP64_LOCATOR_SIGNATURE)) == _ZIP64_LOCATOR_SIGNATURE:
+            raise _reject("zip64_unsupported")
 
     record = tail[index:index + _EOCD_SIZE]
     entries_here, entries_total, directory_size = struct.unpack("<HHI", record[8:16])
@@ -645,8 +720,17 @@ def _check_geometry(
         raise _reject("spatial_disagreement")
     if grid.shape[0] < 1:
         # The channel count is bounded by the memory-grid payload ceiling
-        # rather than pinned: documented legacy snapshots carry 3 or 5
-        # channels where the current producer writes 8.
+        # rather than pinned. Stated precisely, because the obvious reading is
+        # wrong: this is NOT a claim that a legacy grid is usable. The current
+        # producer writes 8 channels; migration for the documented 3- and
+        # 5-channel forms lives in `continuous_evolution_ca._migrate_memory_grid`
+        # and NONE of the three consumers calls it. Lucid indexes channel 6 and
+        # all three index channel 3, so a grid with fewer channels is admitted
+        # here and then raises IndexError downstream — exactly as it did before
+        # this guard existed. Admission neither introduces that failure nor
+        # repairs it; pinning the count would be a new restriction, and
+        # refusing every legacy form would be a new policy. Both are out of
+        # scope, and the gap is recorded rather than papered over.
         raise _reject("member_shape_invalid")
 
 
@@ -685,9 +769,31 @@ def admit_snapshot(
         # directory pointing anywhere else is refused here.
         raise _reject("path_not_confined")
 
+    # Opened through os.open with O_NONBLOCK and O_NOFOLLOW where the platform
+    # has them (POSIX; both are absent on Windows and default to 0).
+    #
+    # The regular-file test below cannot protect the OPEN itself, and a plain
+    # open() of a FIFO blocks until a writer appears. An attacker who can
+    # write to the watched directory could therefore `mkfifo` a
+    # `v070_gen*.npz` and hang the caller indefinitely -- which for Lucid means
+    # the whole asyncio server, since extraction is synchronous inside the
+    # event loop, and for Medusa means one request thread per attempt.
+    # O_NONBLOCK makes that open return immediately so S_ISREG can refuse it.
+    #
+    # O_NOFOLLOW closes the window between resolving the path and opening it:
+    # confinement is decided on the resolved path, and without this a symlink
+    # swapped in afterwards would still be followed.
+    _flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    _flags |= getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
-        fh = open(candidate, "rb")
+        fd = os.open(candidate, _flags)
     except OSError:
+        raise _reject("path_not_regular_file") from None
+
+    try:
+        fh = os.fdopen(fd, "rb")
+    except OSError:
+        os.close(fd)
         raise _reject("path_not_regular_file") from None
 
     try:
@@ -726,6 +832,12 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
     fh.seek(0)
     try:
         archive = zipfile.ZipFile(fh)
+    except SnapshotArchiveRejected:
+        # Re-raised ahead of the bare ValueError below, which would otherwise
+        # silently re-code a refusal raised from within this call as
+        # "not_zip_archive". Nothing raises one today; this keeps that true
+        # if anything is ever moved inside the try.
+        raise
     except (zipfile.BadZipFile, OSError, ValueError):
         raise _reject("not_zip_archive") from None
 
@@ -750,11 +862,15 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
 
             try:
                 member = archive.open(entry)
+            except SnapshotArchiveRejected:
+                raise  # never re-coded by the broad clause below
             except (zipfile.BadZipFile, OSError, ValueError, RuntimeError):
                 raise _reject("member_header_unreadable") from None
             with member:
                 try:
                     header = _read_member_header(member, policy)
+                except SnapshotArchiveRejected:
+                    raise  # the refusal _read_member_header already decided
                 except (zipfile.BadZipFile, OSError, EOFError):
                     raise _reject("member_header_unreadable") from None
 
@@ -766,6 +882,8 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
                 raise _reject("member_rank")
             if header.kind not in spec.kinds:
                 raise _reject("member_dtype_family")
+            if header.itemsize not in spec.itemsizes:
+                raise _reject("member_dtype_unsupported")
 
             headers[entry.filename] = header
 

--- a/scripts/snapshot_archive_guard.py
+++ b/scripts/snapshot_archive_guard.py
@@ -1,0 +1,796 @@
+"""Structural and resource admission for unattended snapshot archives.
+
+Three services load ``v070_gen*.npz`` snapshots with nobody watching: the
+Medusa REST API (four routes, on a process that binds ``0.0.0.0``), the Lucid
+WebSocket server (a directory watcher plus every client connect) and the
+geometry export daemon (a directory watcher plus ``--once``). Each already
+refuses pickled members, and each already closes its archive deterministically.
+Neither property says anything about the archive's *structure* or its *cost*:
+a file dropped into ``data/`` could still declare absurd shapes, name members
+outside the schema, carry traversal-bearing entries, or expand into hundreds of
+gigabytes of allocation before a single value was read.
+
+This module adds the missing admission step. It inspects the ZIP central
+directory and each member's NPY header — bounded reads only, no extraction —
+and either refuses the archive with a typed, sanitized error or yields the
+already-open descriptor for the consumer's own load.
+
+What it does NOT claim
+----------------------
+Not authentication, not authorization, not atomic writing, not semantic state
+validation, not numeric-value validation, not arbitrary NPZ compatibility, and
+not protection for any consumer that does not call it. It admits archives that
+match one schema — the ``v070_gen`` snapshot contract — and refuses everything
+else. An archive that passes admission can still fail downstream on a missing
+key or a conversion; those failures are deliberately untouched.
+
+Design notes that matter
+------------------------
+*One descriptor.* The file is opened exactly once, preflighted on that
+descriptor, rewound, and handed to the consumer. A pathname is never validated
+and then reopened for loading, so there is no window between the check and the
+use.
+
+*Sanitized refusals.* Every refusal carries a fixed reason code from
+:data:`REASON_CODES` and nothing else. No path, filename, member name, header
+text or underlying exception string ever reaches the message, because these
+messages are logged by unattended services and returned (in translated form) to
+unauthenticated HTTP callers. The cost is diagnostic granularity: a refusal
+says *what kind* of defect was found, never *which member* carried it.
+
+*No compression-ratio threshold.* A legitimate snapshot is mostly void cells
+and compresses extremely well; a ratio rule would refuse real inputs. The
+controlling resource envelope is absolute and header-derived: declared payload
+per member, declared payload in aggregate, and physical archive size.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import os
+import re
+import stat
+import struct
+import zipfile
+from pathlib import Path
+from typing import Dict, Iterator, Tuple
+
+__all__ = [
+    "SnapshotArchiveRejected",
+    "SnapshotArchivePolicy",
+    "MemberSpec",
+    "PRODUCTION_POLICY",
+    "REASON_CODES",
+    "admit_snapshot",
+]
+
+
+# ---------------------------------------------------------------------------
+# Refusal type
+# ---------------------------------------------------------------------------
+
+class SnapshotArchiveRejected(ValueError):
+    """A snapshot archive was refused before any array was loaded.
+
+    Derives from ``ValueError`` deliberately: the consumers' established
+    failure mode for an unloadable archive is already a ``ValueError`` (that is
+    what NumPy raises for a pickled member), so callers that only distinguish
+    "the snapshot was unusable" keep working unchanged, while the three
+    services in this package catch the exact type.
+
+    ``str(exc)`` is exactly ``exc.reason`` — a fixed code, never derived from
+    the archive's contents.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+#: Every code :func:`admit_snapshot` can raise. Enumerated so a test can assert
+#: that no refusal message outside this set is ever produced, and so a log
+#: consumer has a closed vocabulary.
+REASON_CODES: Tuple[str, ...] = (
+    # selection / containment
+    "path_not_confined",
+    "path_not_regular_file",
+    "path_suffix_not_npz",
+    # whole-archive resource envelope
+    "archive_too_large",
+    "archive_truncated",
+    "not_zip_archive",
+    "central_directory_too_large",
+    "archive_payload_total_too_large",
+    # membership
+    "member_count",
+    "member_name_unsafe",
+    "member_is_directory",
+    "member_duplicate",
+    "member_unexpected",
+    "member_missing",
+    "member_encrypted",
+    "member_compression_unsupported",
+    "member_payload_too_large",
+    # NPY header
+    "member_header_unreadable",
+    "member_npy_magic_invalid",
+    "member_npy_version_unsupported",
+    "member_header_too_large",
+    "member_header_malformed",
+    "member_dtype_object",
+    "member_dtype_structured",
+    "member_dtype_subarray",
+    "member_dtype_zero_itemsize",
+    "member_dtype_unsupported",
+    "member_dtype_family",
+    "member_fortran_order",
+    "member_rank",
+    "member_shape_invalid",
+    "member_size_inconsistent",
+    # snapshot geometry
+    "lattice_not_cubic",
+    "edge_out_of_range",
+    "edge_not_multiple",
+    "spatial_disagreement",
+)
+
+
+def _reject(reason: str) -> "SnapshotArchiveRejected":
+    """Build a refusal, refusing in turn to invent a code outside the roster."""
+    if reason not in REASON_CODES:  # pragma: no cover - programmer error only
+        raise AssertionError("undeclared snapshot refusal reason")
+    return SnapshotArchiveRejected(reason)
+
+
+# ---------------------------------------------------------------------------
+# Policy
+# ---------------------------------------------------------------------------
+
+_KIB = 1024
+_MIB = 1024 * 1024
+
+#: Roles, used to attach the cross-member geometry rules to the right members.
+ROLE_LATTICE = "lattice"
+ROLE_MEMORY_GRID = "memory_grid"
+ROLE_SCALAR = "scalar"
+
+
+@dataclasses.dataclass(frozen=True)
+class MemberSpec:
+    """The admissible form of one archive member.
+
+    ``kinds`` are NumPy dtype *family* characters, not exact dtypes: the
+    producer writes ``uint8``/``float32``/platform ``int``, and documented
+    legacy snapshots differ in width, so pinning exact widths would refuse
+    valid history. Width is bounded instead by ``max_payload_bytes``.
+    """
+
+    name: str
+    rank: int
+    kinds: Tuple[str, ...]
+    max_payload_bytes: int
+    role: str
+
+    @property
+    def archive_name(self) -> str:
+        return self.name + ".npy"
+
+
+@dataclasses.dataclass(frozen=True)
+class SnapshotArchivePolicy:
+    """Immutable admission limits.
+
+    Calibration, so the numbers are auditable rather than arbitrary. The
+    compatibility ceiling for this tranche is an edge of 256 cells:
+
+    * lattice at 256³ × 1 byte (``uint8``)            = 16 MiB
+    * memory grid at 8 × 256³ × 4 bytes (``float32``) = 512 MiB
+    * three scalars, generously                       = 1 MiB
+    * aggregate declared uncompressed                 = 529 MiB
+    * physical archive, with ZIP framing headroom     = 544 MiB
+
+    A 512³ archive is outside this tranche by construction and is refused.
+
+    Stated rather than implied: under these production numbers the aggregate
+    ceiling cannot be the binding constraint, because the per-member ceilings
+    already sum to 528 MiB plus three kilobyte-scale scalars. It is kept
+    because it is the envelope that would otherwise widen silently if a future
+    policy raised one member's ceiling, and it is exercised by tests through an
+    injected policy rather than by pretending a production archive reaches it.
+
+    ``central_directory_max_bytes`` is a bounded-parsing safeguard rather than
+    a production capacity: a five-member snapshot's central directory is a few
+    hundred bytes, so 64 KiB is enormous headroom, while it stops a 544 MiB
+    file made entirely of central-directory entries from being materialised as
+    millions of ``ZipInfo`` objects before any other check could run.
+
+    Tests build tiny variants with :func:`dataclasses.replace`, which is why
+    hostile-size behaviour never requires allocating a hostile-sized file.
+    """
+
+    members: Tuple[MemberSpec, ...]
+    max_members: int = 5
+    max_header_bytes: int = 4 * _KIB
+    max_total_declared_bytes: int = 529 * _MIB
+    max_physical_bytes: int = 544 * _MIB
+    central_directory_max_bytes: int = 64 * _KIB
+    min_edge: int = 16
+    max_edge: int = 256
+    edge_multiple: int = 16
+    #: Per-dimension sanity bound applied before any multiplication, so a
+    #: header declaring 10**300 cells is refused rather than multiplied out.
+    max_dimension: int = 2 ** 32
+
+    @property
+    def by_archive_name(self) -> Dict[str, MemberSpec]:
+        return {spec.archive_name: spec for spec in self.members}
+
+
+PRODUCTION_MEMBERS: Tuple[MemberSpec, ...] = (
+    MemberSpec("lattice", 3, ("u",), 16 * _MIB, ROLE_LATTICE),
+    MemberSpec("memory_grid", 4, ("f",), 512 * _MIB, ROLE_MEMORY_GRID),
+    MemberSpec("generation", 0, ("i",), 1 * _KIB, ROLE_SCALAR),
+    MemberSpec("ca_step", 0, ("i",), 1 * _KIB, ROLE_SCALAR),
+    MemberSpec("best_fitness", 0, ("f",), 1 * _KIB, ROLE_SCALAR),
+)
+
+#: The named policy the three services use.
+PRODUCTION_POLICY = SnapshotArchivePolicy(members=PRODUCTION_MEMBERS)
+
+
+# ---------------------------------------------------------------------------
+# Bounded NPY header parsing
+# ---------------------------------------------------------------------------
+
+_NPY_MAGIC = b"\x93NUMPY"
+_SUPPORTED_NPY_VERSIONS = frozenset({(1, 0), (2, 0), (3, 0)})
+
+#: ``<f4``, ``|u1``, ``>i8`` ... byte order optional, size digits required.
+#: A descriptor NumPy would write for a plain numeric array always matches.
+_DESCR_RE = re.compile(r"^(?P<order>[<>|=])?(?P<kind>[a-zA-Z])(?P<size>\d*)$")
+
+
+class _HeaderSyntaxError(Exception):
+    """Internal: the header text is not the restricted literal we accept."""
+
+
+def _parse_literal(text: str) -> object:
+    """Parse the restricted Python-literal subset an NPY header may contain.
+
+    Deliberately *not* :func:`ast.literal_eval` and emphatically not ``eval``.
+    The accepted grammar is exactly: dict, tuple, list, single-quoted or
+    double-quoted string, decimal integer, ``True``/``False``/``None``. Depth
+    and token count are both capped, so a header made of ten thousand nested
+    brackets is refused by this parser rather than by the interpreter's
+    recursion limit.
+
+    Raises :class:`_HeaderSyntaxError` for anything else, including trailing
+    content after the value.
+    """
+    parser = _LiteralParser(text)
+    value = parser.parse_value()
+    parser.skip_space()
+    if parser.pos != len(parser.text):
+        raise _HeaderSyntaxError("trailing content")
+    return value
+
+
+class _LiteralParser:
+    MAX_DEPTH = 4
+    MAX_TOKENS = 512
+    MAX_INT_DIGITS = 20
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 0
+        self.depth = 0
+        self.tokens = 0
+
+    # -- helpers -----------------------------------------------------------
+    def skip_space(self) -> None:
+        while self.pos < len(self.text) and self.text[self.pos] in " \t\r\n":
+            self.pos += 1
+
+    def _peek(self) -> str:
+        return self.text[self.pos] if self.pos < len(self.text) else ""
+
+    def _expect(self, char: str) -> None:
+        if self._peek() != char:
+            raise _HeaderSyntaxError("expected " + char)
+        self.pos += 1
+
+    def _count(self) -> None:
+        self.tokens += 1
+        if self.tokens > self.MAX_TOKENS:
+            raise _HeaderSyntaxError("too many tokens")
+
+    # -- grammar -----------------------------------------------------------
+    def parse_value(self) -> object:
+        self._count()
+        self.skip_space()
+        char = self._peek()
+        if char == "{":
+            return self._parse_dict()
+        if char in "([":
+            return self._parse_sequence(char)
+        if char in "'\"":
+            return self._parse_string()
+        if self.text.startswith("True", self.pos):
+            self.pos += 4
+            return True
+        if self.text.startswith("False", self.pos):
+            self.pos += 5
+            return False
+        if self.text.startswith("None", self.pos):
+            self.pos += 4
+            return None
+        return self._parse_int()
+
+    def _enter(self) -> None:
+        self.depth += 1
+        if self.depth > self.MAX_DEPTH:
+            raise _HeaderSyntaxError("too deep")
+
+    def _parse_dict(self) -> dict:
+        self._enter()
+        self._expect("{")
+        result: dict = {}
+        while True:
+            self.skip_space()
+            if self._peek() == "}":
+                self.pos += 1
+                break
+            key = self.parse_value()
+            if not isinstance(key, str):
+                raise _HeaderSyntaxError("non-string key")
+            self.skip_space()
+            self._expect(":")
+            result[key] = self.parse_value()
+            self.skip_space()
+            if self._peek() == ",":
+                self.pos += 1
+                continue
+            self.skip_space()
+            self._expect("}")
+            break
+        self.depth -= 1
+        return result
+
+    def _parse_sequence(self, opener: str) -> object:
+        closer = ")" if opener == "(" else "]"
+        self._enter()
+        self._expect(opener)
+        items: list = []
+        while True:
+            self.skip_space()
+            if self._peek() == closer:
+                self.pos += 1
+                break
+            items.append(self.parse_value())
+            self.skip_space()
+            if self._peek() == ",":
+                self.pos += 1
+                continue
+            self.skip_space()
+            self._expect(closer)
+            break
+        self.depth -= 1
+        return tuple(items) if opener == "(" else items
+
+    def _parse_string(self) -> str:
+        quote = self._peek()
+        self.pos += 1
+        start = self.pos
+        while self.pos < len(self.text) and self.text[self.pos] != quote:
+            # No escape handling: a descriptor NumPy writes never needs one,
+            # and accepting escapes would widen this parser for nothing.
+            if self.text[self.pos] == "\\":
+                raise _HeaderSyntaxError("escape in string")
+            self.pos += 1
+        if self.pos >= len(self.text):
+            raise _HeaderSyntaxError("unterminated string")
+        value = self.text[start:self.pos]
+        self.pos += 1
+        return value
+
+    def _parse_int(self) -> int:
+        start = self.pos
+        if self._peek() == "-":
+            self.pos += 1
+        digits = 0
+        while self._peek().isdigit():
+            self.pos += 1
+            digits += 1
+            if digits > self.MAX_INT_DIGITS:
+                raise _HeaderSyntaxError("integer too long")
+        if digits == 0:
+            raise _HeaderSyntaxError("not a value")
+        return int(self.text[start:self.pos])
+
+
+@dataclasses.dataclass(frozen=True)
+class _MemberHeader:
+    """What a member's NPY header declares, once validated as well-formed."""
+
+    kind: str
+    itemsize: int
+    shape: Tuple[int, ...]
+    fortran_order: bool
+    header_bytes: int
+
+
+def _read_member_header(stream, policy: SnapshotArchivePolicy) -> _MemberHeader:
+    """Read and validate one member's NPY header from an open member stream.
+
+    Bounded on every axis: at most ``12 + max_header_bytes`` bytes are read,
+    the descriptor is matched against a fixed pattern, and the shape is parsed
+    by the capped literal parser above. Nothing is decompressed beyond the
+    header, and no array is materialised.
+    """
+    prefix = stream.read(10)
+    if len(prefix) < 10:
+        raise _reject("member_header_unreadable")
+    if prefix[:6] != _NPY_MAGIC:
+        raise _reject("member_npy_magic_invalid")
+
+    version = (prefix[6], prefix[7])
+    if version not in _SUPPORTED_NPY_VERSIONS:
+        raise _reject("member_npy_version_unsupported")
+
+    if version == (1, 0):
+        header_len = struct.unpack("<H", prefix[8:10])[0]
+        prelude = 10
+    else:
+        extra = stream.read(2)
+        if len(extra) < 2:
+            raise _reject("member_header_unreadable")
+        header_len = struct.unpack("<I", prefix[8:10] + extra)[0]
+        prelude = 12
+
+    if prelude + header_len > policy.max_header_bytes:
+        raise _reject("member_header_too_large")
+
+    raw = stream.read(header_len)
+    if len(raw) < header_len:
+        raise _reject("member_header_unreadable")
+
+    try:
+        text = raw.decode("utf-8" if version == (3, 0) else "latin1")
+        parsed = _parse_literal(text.strip())
+    except (UnicodeDecodeError, _HeaderSyntaxError):
+        raise _reject("member_header_malformed") from None
+
+    if not isinstance(parsed, dict) or set(parsed) != {
+        "descr", "fortran_order", "shape"
+    }:
+        raise _reject("member_header_malformed")
+
+    descr = parsed["descr"]
+    if isinstance(descr, (list, dict)):
+        # A list of field tuples is a structured dtype; a dict is the mapping
+        # spelling of one. Either way the member is a record array, which no
+        # snapshot member ever is, and which can carry object fields.
+        raise _reject("member_dtype_structured")
+    if isinstance(descr, tuple):
+        # ('<f4', (2, 2)) — a subarray dtype: the declared shape then understates
+        # the real element count, so payload arithmetic would be wrong.
+        raise _reject("member_dtype_subarray")
+    if not isinstance(descr, str):
+        raise _reject("member_header_malformed")
+
+    match = _DESCR_RE.match(descr)
+    if match is None:
+        raise _reject("member_dtype_unsupported")
+    kind = match.group("kind")
+    if kind == "O":
+        raise _reject("member_dtype_object")
+    if kind == "V":
+        # Void: opaque bytes or an unnamed structured slot. Refused outright
+        # rather than sized, because it carries no numeric meaning here.
+        raise _reject("member_dtype_structured")
+    size_text = match.group("size")
+    if not size_text:
+        raise _reject("member_dtype_unsupported")
+    itemsize = int(size_text)
+    if kind == "U":
+        itemsize *= 4  # UCS-4 code points, per the NPY descriptor convention
+    if itemsize == 0:
+        raise _reject("member_dtype_zero_itemsize")
+
+    fortran_order = parsed["fortran_order"]
+    if not isinstance(fortran_order, bool):
+        raise _reject("member_header_malformed")
+
+    shape = parsed["shape"]
+    if not isinstance(shape, tuple):
+        raise _reject("member_header_malformed")
+    for dim in shape:
+        if not isinstance(dim, int) or isinstance(dim, bool):
+            raise _reject("member_header_malformed")
+        if dim < 0 or dim > policy.max_dimension:
+            raise _reject("member_shape_invalid")
+
+    return _MemberHeader(
+        kind=kind,
+        itemsize=itemsize,
+        shape=shape,
+        fortran_order=fortran_order,
+        header_bytes=prelude + header_len,
+    )
+
+
+def _declared_payload(header: _MemberHeader, limit: int) -> int:
+    """Element count × itemsize, accumulated with an early ceiling.
+
+    Python integers do not overflow, so the hazard is not wraparound but
+    unbounded work and unbounded magnitude. Each dimension is already capped by
+    :attr:`SnapshotArchivePolicy.max_dimension`; the running product is capped
+    here, so the arithmetic stops the moment it exceeds what could ever be
+    admitted rather than computing a 300-digit number first.
+    """
+    total = header.itemsize
+    for dim in header.shape:
+        total *= dim
+        if total > limit:
+            return limit + 1
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Central-directory inspection
+# ---------------------------------------------------------------------------
+
+_EOCD_SIGNATURE = b"PK\x05\x06"
+_EOCD_SIZE = 22
+_MAX_EOCD_COMMENT = 0xFFFF
+_LOCAL_FILE_SIGNATURE = b"PK\x03\x04"
+
+_UNSAFE_NAME_RE = re.compile(r"(^/)|(^[A-Za-z]:)|(\\)|(^\.\.$)|(^\.\./)|(/\.\./)|(/\.\.$)|(/)")
+
+
+#: Slack above the schema's member count that the pre-parse bound tolerates.
+#: Its only job is to keep ``ZipFile`` construction bounded; the exact "five
+#: members, these five names, each once" rule is enforced afterwards by
+#: :func:`_check_member_names`, which is total over the name multiset.
+_COUNT_PARSE_SLACK = 8
+
+
+def _preflight_eocd(fh, size: int, policy: SnapshotArchivePolicy) -> None:
+    """Bound the central directory before ``zipfile`` is allowed near it.
+
+    ``ZipFile`` builds one ``ZipInfo`` per central-directory entry as soon as
+    it is constructed. On a hostile 544 MiB file made entirely of entries that
+    is millions of objects, allocated before any later check could refuse the
+    archive. Reading the end-of-central-directory record first — 22 bytes, in a
+    window of at most 64 KiB + 22 — gives the declared entry count and
+    directory size, both of which are bounded here.
+
+    This is deliberately a *bound*, not the schema check: an archive with four
+    members must reach :func:`_check_member_names` and be refused as missing a
+    member, not swallowed here as a bad count.
+    """
+    window = min(size, _EOCD_SIZE + _MAX_EOCD_COMMENT)
+    fh.seek(size - window)
+    tail = fh.read(window)
+    index = tail.rfind(_EOCD_SIGNATURE)
+    if index < 0 or len(tail) - index < _EOCD_SIZE:
+        raise _reject("not_zip_archive")
+
+    record = tail[index:index + _EOCD_SIZE]
+    entries_here, entries_total, directory_size = struct.unpack("<HHI", record[8:16])
+    if entries_here == 0xFFFF or entries_total == 0xFFFF or directory_size == 0xFFFFFFFF:
+        # ZIP64 sentinels. A five-member snapshot inside a 544 MiB ceiling
+        # never needs ZIP64, so this is refused rather than parsed.
+        raise _reject("member_count")
+    if entries_here != entries_total:
+        raise _reject("member_count")
+    if entries_total > policy.max_members + _COUNT_PARSE_SLACK:
+        raise _reject("member_count")
+    if directory_size > policy.central_directory_max_bytes:
+        raise _reject("central_directory_too_large")
+
+
+def _check_member_names(names: Tuple[str, ...], policy: SnapshotArchivePolicy) -> None:
+    """Name safety first, then exact schema membership.
+
+    Name safety runs before the schema comparison on purpose. A traversal- or
+    backslash-bearing name would also fail the schema test, but it deserves its
+    own code: the schema test alone would report the archive as merely having
+    the wrong members, which understates what was found.
+
+    The three membership rules together are exactly "five members, these five
+    names, each once": no duplicates, nothing outside the schema, nothing from
+    the schema absent. A separate count equality would be unreachable, so none
+    is written.
+    """
+    for name in names:
+        if not name or _UNSAFE_NAME_RE.search(name):
+            raise _reject("member_name_unsafe")
+
+    seen = set()
+    for name in names:
+        if name in seen:
+            raise _reject("member_duplicate")
+        seen.add(name)
+
+    expected = set(policy.by_archive_name)
+    if seen - expected:
+        raise _reject("member_unexpected")
+    if expected - seen:
+        raise _reject("member_missing")
+
+
+def _check_geometry(
+    headers: Dict[str, _MemberHeader], policy: SnapshotArchivePolicy
+) -> None:
+    """Cross-member rules: cubic lattice, admissible edge, agreeing spatial shape."""
+    lattice_spec = next(s for s in policy.members if s.role == ROLE_LATTICE)
+    grid_spec = next(s for s in policy.members if s.role == ROLE_MEMORY_GRID)
+    lattice = headers[lattice_spec.archive_name]
+    grid = headers[grid_spec.archive_name]
+
+    edges = lattice.shape
+    if len(set(edges)) != 1:
+        raise _reject("lattice_not_cubic")
+    edge = edges[0]
+    if edge < policy.min_edge or edge > policy.max_edge:
+        raise _reject("edge_out_of_range")
+    if edge % policy.edge_multiple:
+        # /api/acoustic reshapes the lattice into 16³ sectors, so an edge that
+        # is not a multiple of the sector size cannot be served at all.
+        raise _reject("edge_not_multiple")
+
+    if grid.shape[1:] != edges:
+        raise _reject("spatial_disagreement")
+    if grid.shape[0] < 1:
+        # The channel count is bounded by the memory-grid payload ceiling
+        # rather than pinned: documented legacy snapshots carry 3 or 5
+        # channels where the current producer writes 8.
+        raise _reject("member_shape_invalid")
+
+
+# ---------------------------------------------------------------------------
+# The admission context manager
+# ---------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def admit_snapshot(
+    path,
+    *,
+    data_dir,
+    policy: SnapshotArchivePolicy = PRODUCTION_POLICY,
+) -> Iterator:
+    """Admit ``path`` as a snapshot archive and yield its open descriptor.
+
+    On success the yielded object is a binary file positioned at 0, already
+    preflighted. The caller performs its own load from that same descriptor —
+    ``np.load(descriptor, allow_pickle=False)`` — so the bytes that were
+    inspected are exactly the bytes that are read. The descriptor is closed
+    when the block exits, on success and on every exceptional path; the
+    caller's own ``with`` around the returned archive closes the NumPy side,
+    which is the arrangement each consumer uses and each consumer's tests pin
+    structurally.
+
+    Raises :class:`SnapshotArchiveRejected` — never anything else derived from
+    the archive's contents — for every refusal.
+    """
+    root = Path(os.fspath(data_dir)).resolve()
+    candidate = Path(os.fspath(path)).resolve()
+
+    if candidate.suffix.lower() != ".npz":
+        raise _reject("path_suffix_not_npz")
+    if not candidate.is_relative_to(root):
+        # Resolution has already followed symlinks, so a link inside the data
+        # directory pointing anywhere else is refused here.
+        raise _reject("path_not_confined")
+
+    try:
+        fh = open(candidate, "rb")
+    except OSError:
+        raise _reject("path_not_regular_file") from None
+
+    try:
+        info = os.fstat(fh.fileno())
+        if not stat.S_ISREG(info.st_mode):
+            raise _reject("path_not_regular_file")
+        size = info.st_size
+        if size > policy.max_physical_bytes:
+            raise _reject("archive_too_large")
+        if size < _EOCD_SIZE + len(_LOCAL_FILE_SIGNATURE):
+            raise _reject("archive_truncated")
+        if fh.read(len(_LOCAL_FILE_SIGNATURE)) != _LOCAL_FILE_SIGNATURE:
+            raise _reject("not_zip_archive")
+
+        _preflight_eocd(fh, size, policy)
+        _preflight_members(fh, policy)
+
+        fh.seek(0)
+        yield fh
+    finally:
+        fh.close()
+
+
+def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
+    """Validate every member's directory entry and NPY header, then geometry.
+
+    Three passes, in this order for a reason. Pass one does only work whose
+    cost is independent of what the archive *declares*: directory flags and a
+    bounded header read per member. Pass two applies the cross-member geometry
+    rules, so a 512³ archive is reported as an out-of-range edge rather than as
+    a large payload — both are true, and the edge is the useful one. Pass three
+    applies the size arithmetic. Deferring the size verdicts costs nothing,
+    because nothing before pass three allocates or reads in proportion to a
+    declared size.
+    """
+    fh.seek(0)
+    try:
+        archive = zipfile.ZipFile(fh)
+    except (zipfile.BadZipFile, OSError, ValueError):
+        raise _reject("not_zip_archive") from None
+
+    with archive:
+        infos = archive.infolist()
+        for entry in infos:
+            if entry.is_dir():
+                raise _reject("member_is_directory")
+
+        _check_member_names(tuple(entry.filename for entry in infos), policy)
+
+        specs = policy.by_archive_name
+        headers: Dict[str, _MemberHeader] = {}
+
+        # -- pass one: directory entry and bounded header, per member --------
+        for entry in infos:
+            spec = specs[entry.filename]
+            if entry.flag_bits & 0x1:
+                raise _reject("member_encrypted")
+            if entry.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED):
+                raise _reject("member_compression_unsupported")
+
+            try:
+                member = archive.open(entry)
+            except (zipfile.BadZipFile, OSError, ValueError, RuntimeError):
+                raise _reject("member_header_unreadable") from None
+            with member:
+                try:
+                    header = _read_member_header(member, policy)
+                except (zipfile.BadZipFile, OSError, EOFError):
+                    raise _reject("member_header_unreadable") from None
+
+            if header.fortran_order:
+                # Fortran order changes the element traversal every consumer
+                # assumes, and the producer never writes it.
+                raise _reject("member_fortran_order")
+            if len(header.shape) != spec.rank:
+                raise _reject("member_rank")
+            if header.kind not in spec.kinds:
+                raise _reject("member_dtype_family")
+
+            headers[entry.filename] = header
+
+        # -- pass two: cross-member geometry ---------------------------------
+        _check_geometry(headers, policy)
+
+        # -- pass three: size arithmetic -------------------------------------
+        declared_total = 0
+        for entry in infos:
+            spec = specs[entry.filename]
+            header = headers[entry.filename]
+
+            payload = _declared_payload(header, spec.max_payload_bytes)
+            if payload > spec.max_payload_bytes:
+                raise _reject("member_payload_too_large")
+            # ``file_size`` is the member's declared UNCOMPRESSED size, which
+            # covers the NPY header as well as the payload — comparing it
+            # against a payload ceiling would refuse a snapshot sitting exactly
+            # on the limit.
+            if header.header_bytes + payload != entry.file_size:
+                # The directory's declared uncompressed size and the header's
+                # own arithmetic must agree exactly. A mismatch means one of
+                # them is lying, and the loader would trust the other.
+                raise _reject("member_size_inconsistent")
+
+            declared_total += entry.file_size
+            if declared_total > policy.max_total_declared_bytes:
+                raise _reject("archive_payload_total_too_large")

--- a/scripts/snapshot_archive_guard.py
+++ b/scripts/snapshot_archive_guard.py
@@ -53,6 +53,7 @@ import re
 import stat
 import struct
 import zipfile
+import zlib
 from pathlib import Path
 from typing import Dict, Iterator, Tuple
 
@@ -63,6 +64,8 @@ __all__ = [
     "PRODUCTION_POLICY",
     "REASON_CODES",
     "admit_snapshot",
+    "newest_first",
+    "entry_fingerprint",
 ]
 
 
@@ -111,8 +114,10 @@ REASON_CODES: Tuple[str, ...] = (
     "member_unexpected",
     "member_missing",
     "member_encrypted",
+    "member_flags_unsupported",
     "member_compression_unsupported",
     "member_payload_too_large",
+    "member_payload_unreadable",
     # NPY header
     "member_header_unreadable",
     "member_npy_magic_invalid",
@@ -206,9 +211,12 @@ class SnapshotArchivePolicy:
     Stated rather than implied: under these production numbers the aggregate
     ceiling cannot be the binding constraint. The accumulator sums
     ``ZipInfo.file_size``, which covers each member's NPY header as well as its
-    payload, so the true worst case is 528 MiB of payload + 3 KiB of scalars +
-    5 x 4 KiB of headers = 553,695,104 bytes, against a ceiling of
-    554,696,704 — about 978 KiB of margin. It is kept because it is the
+    payload, so the true worst case is
+
+        528 MiB + 3 KiB + 5 x 4 KiB = 553,671,680 bytes
+
+    against a ceiling of 554,696,704 — leaving 1,025,024 bytes, exactly
+    1001 KiB. It is kept because it is the
     envelope that would otherwise widen silently if a future policy raised one
     member's ceiling, and it is exercised by tests through an injected policy
     rather than by pretending a production archive reaches it.
@@ -244,7 +252,12 @@ class SnapshotArchivePolicy:
 #: Widths NumPy can construct for each family. Integers: 1, 2, 4, 8 bytes.
 #: Floats: 2 (float16), 4, 8, and 16 (longdouble, where the platform has it).
 _INTEGER_WIDTHS = (1, 2, 4, 8)
-_FLOAT_WIDTHS = (2, 4, 8, 16)
+#: 16-byte floats are deliberately absent. ``float128``/``longdouble`` is not
+#: portable -- NumPy 2.3.5 on Windows refuses ``<f16`` outright -- and no
+#: snapshot member has ever used one. Admitting a width that a consumer's own
+#: NumPy cannot construct would push the failure past the guard, which is the
+#: defect the width allowlist exists to prevent.
+_FLOAT_WIDTHS = (2, 4, 8)
 
 PRODUCTION_MEMBERS: Tuple[MemberSpec, ...] = (
     MemberSpec("lattice", 3, ("u",), 16 * _MIB, ROLE_LATTICE, _INTEGER_WIDTHS),
@@ -272,7 +285,12 @@ _MAX_ITEMSIZE_DIGITS = 6
 
 #: ``<f4``, ``|u1``, ``>i8`` ... byte order optional, size digits required.
 #: A descriptor NumPy would write for a plain numeric array always matches.
-_DESCR_RE = re.compile(r"^(?P<order>[<>|=])?(?P<kind>[a-zA-Z])(?P<size>\d*)$")
+#: ``[0-9]`` rather than ``\d``: a v3.0 NPY header is decoded as UTF-8, and
+#: ``\d`` matches the whole Unicode decimal-digit category. A descriptor of
+#: ``<i١`` (Arabic-Indic digit one) therefore matched, and ``int()`` -- which
+#: also accepts that category -- turned it into a width of 1, admitting a
+#: descriptor string no NumPy can construct.
+_DESCR_RE = re.compile(r"^(?P<order>[<>|=])?(?P<kind>[a-zA-Z])(?P<size>[0-9]*)$")
 
 
 class _HeaderSyntaxError(Exception):
@@ -598,6 +616,11 @@ _LOCAL_FILE_SIGNATURE = b"PK\x03\x04"
 _ZIP64_LOCATOR_SIGNATURE = b"PK\x06\x07"
 _ZIP64_LOCATOR_SIZE = 20
 
+#: ZIP general-purpose flag bits this guard understands.
+_FLAG_ENCRYPTED = 0x0001          # bit 0
+_FLAG_COMPRESSED_PATCH = 0x0020   # bit 5, Zip 2.7 compressed patched data
+_FLAG_STRONG_ENCRYPTION = 0x0040  # bit 6
+
 _UNSAFE_NAME_RE = re.compile(r"(^/)|(^[A-Za-z]:)|(\\)|(^\.\.$)|(^\.\./)|(/\.\./)|(/\.\.$)|(/)")
 
 
@@ -653,11 +676,22 @@ def _preflight_eocd(fh, size: int, policy: SnapshotArchivePolicy) -> None:
             raise _reject("zip64_unsupported")
 
     record = tail[index:index + _EOCD_SIZE]
-    entries_here, entries_total, directory_size = struct.unpack("<HHI", record[8:16])
-    if entries_here == 0xFFFF or entries_total == 0xFFFF or directory_size == 0xFFFFFFFF:
-        # ZIP64 sentinels. A five-member snapshot inside a 544 MiB ceiling
-        # never needs ZIP64, so this is refused rather than parsed.
-        raise _reject("member_count")
+    entries_here, entries_total, directory_size, directory_offset = struct.unpack(
+        "<HHII", record[8:20])
+    if (entries_here == 0xFFFF or entries_total == 0xFFFF
+            or directory_size == 0xFFFFFFFF or directory_offset == 0xFFFFFFFF):
+        # Every CENTRAL ZIP64 sentinel, the directory offset included. The
+        # offset one matters as much as the counts: it is the field that says
+        # "the real value is in the ZIP64 record", so an archive can carry
+        # honest-looking counts and still redirect `zipfile` through ZIP64.
+        #
+        # This refuses CENTRAL-DIRECTORY ZIP64 structures only. The
+        # LOCAL-header ZIP64 length form stays supported and must: NumPy's
+        # `savez` opens each member with `force_zip64=True`, which reserves
+        # ZIP64 sizes in the local header while the central directory it
+        # writes remains 32-bit. Refusing that would refuse every real
+        # snapshot. Nothing here inspects local headers.
+        raise _reject("zip64_unsupported")
     if entries_here != entries_total:
         raise _reject("member_count")
     if entries_total > policy.max_members + _COUNT_PARSE_SLACK:
@@ -735,6 +769,61 @@ def _check_geometry(
 
 
 # ---------------------------------------------------------------------------
+# Safe candidate discovery
+# ---------------------------------------------------------------------------
+
+def newest_first(paths):
+    """Order snapshot candidates newest-first, safely.
+
+    Discovery runs before admission, over a directory an attacker may be able
+    to write to, so it has to survive that directory changing underneath it and
+    must not itself become a way in. Three properties, each deliberate:
+
+    *Non-following metadata.* ``os.lstat`` describes the directory entry, not
+    whatever it points at. Sorting on ``stat`` meant a symlink could borrow its
+    target's modification time to promote itself to "newest", and it meant a
+    link out of the data directory was followed during ORDERING -- before
+    ``admit_snapshot`` had any say.
+
+    *Entries that vanish are skipped silently.* A snapshot rotated or deleted
+    between the glob and this call raises ``OSError`` here. Every caller was
+    reading that metadata inside a loop whose only handler printed the
+    exception, and ``OSError``'s message carries the full path -- a name the
+    attacker chose. There is nothing to report: the entry is simply gone.
+
+    *A broken link is still a candidate.* ``lstat`` succeeds on a dangling
+    symlink and on a symlink loop, so those are ORDERED rather than filtered.
+    That is the point: they reach :func:`admit_snapshot` and are refused with a
+    typed reason, instead of disappearing from selection and letting an older
+    archive be served with no record of why.
+
+    Ties break on the path so the order is total and reproducible.
+    """
+    described = []
+    for candidate in paths:
+        try:
+            info = os.lstat(candidate)
+        except OSError:
+            continue
+        described.append((info.st_mtime_ns, os.fspath(candidate), candidate))
+    described.sort(key=lambda row: (row[0], row[1]), reverse=True)
+    return [row[2] for row in described]
+
+
+def entry_fingerprint(path):
+    """Identify a directory entry by what changes when it changes.
+
+    ``(path, size, mtime_ns)`` from ``os.lstat``, so a symlink is fingerprinted
+    as itself rather than as its target -- otherwise a rejected link could be
+    made to look "changed" by touching something else entirely, and be retried
+    on every poll. Raises ``OSError`` if the entry is gone; callers treat that
+    as "look again next time".
+    """
+    info = os.lstat(path)
+    return (os.fspath(path), info.st_size, info.st_mtime_ns)
+
+
+# ---------------------------------------------------------------------------
 # The admission context manager
 # ---------------------------------------------------------------------------
 
@@ -757,10 +846,23 @@ def admit_snapshot(
     structurally.
 
     Raises :class:`SnapshotArchiveRejected` — never anything else derived from
-    the archive's contents — for every refusal.
+    the archive's contents — for every refusal. That includes failures raised
+    by the caller's own load out of the yielded descriptor, where they are
+    narrowly identifiable as archive transport: see the translation around the
+    ``yield`` below.
     """
-    root = Path(os.fspath(data_dir)).resolve()
-    candidate = Path(os.fspath(path)).resolve()
+    try:
+        root = Path(os.fspath(data_dir)).resolve()
+        candidate = Path(os.fspath(path)).resolve()
+    except (OSError, RuntimeError):
+        # `resolve()` is not total. A symlink loop raises OSError(ELOOP) on
+        # POSIX and RuntimeError on some paths; a path too long or a
+        # disappearing component raises OSError too. Uncaught, that left the
+        # guard by a route with no reason code and, worse, with the path in the
+        # exception message. If the real path cannot be determined then
+        # confinement cannot be proved, so the fail-closed answer is the
+        # confinement refusal.
+        raise _reject("path_not_confined") from None
 
     if candidate.suffix.lower() != ".npz":
         raise _reject("path_suffix_not_npz")
@@ -812,7 +914,30 @@ def admit_snapshot(
         _preflight_members(fh, policy)
 
         fh.seek(0)
-        yield fh
+        try:
+            yield fh
+        except SnapshotArchiveRejected:
+            # Already typed. Re-raised unchanged so a refusal decided anywhere
+            # inside the caller's block keeps its own reason code.
+            raise
+        except (zipfile.BadZipFile, zlib.error, EOFError):
+            # Archive TRANSPORT failures, and only those.
+            #
+            # Preflight reads each member's header but cannot read its payload
+            # without decompressing it, so a valid header over a corrupt body
+            # or a wrong CRC is undetectable until NumPy extracts. Left
+            # untranslated it surfaced as a raw `zipfile.BadZipFile` -- which
+            # is not a `ValueError`, so it sailed past every consumer's typed
+            # handler into a 500 with a traceback naming the member.
+            #
+            # The list is deliberately short. `zipfile.BadZipFile` covers a bad
+            # CRC and a malformed local header; `zlib.error` covers corrupt
+            # DEFLATE data; `EOFError` covers a stream that ends early. A
+            # `MemoryError`, a `KeyboardInterrupt`, an arbitrary `ValueError`
+            # -- including NumPy's own "EOF: reading array data" -- and every
+            # programmer error stay outside this lane and propagate unchanged.
+            # Nothing from the exception's message reaches the reason.
+            raise _reject("member_payload_unreadable") from None
     finally:
         fh.close()
 
@@ -855,8 +980,15 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
         # -- pass one: directory entry and bounded header, per member --------
         for entry in infos:
             spec = specs[entry.filename]
-            if entry.flag_bits & 0x1:
+            if entry.flag_bits & _FLAG_ENCRYPTED:
                 raise _reject("member_encrypted")
+            if entry.flag_bits & (_FLAG_COMPRESSED_PATCH | _FLAG_STRONG_ENCRYPTION):
+                # Bit 5 is Zip 2.7 "compressed patched data"; bit 6 is strong
+                # encryption. Neither can be read, and both are refused HERE,
+                # from the central directory, before the member is opened --
+                # `zipfile` checks them too, but only once it is already
+                # materialising the entry.
+                raise _reject("member_flags_unsupported")
             if entry.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED):
                 raise _reject("member_compression_unsupported")
 
@@ -864,14 +996,29 @@ def _preflight_members(fh, policy: SnapshotArchivePolicy) -> None:
                 member = archive.open(entry)
             except SnapshotArchiveRejected:
                 raise  # never re-coded by the broad clause below
-            except (zipfile.BadZipFile, OSError, ValueError, RuntimeError):
+            except NotImplementedError:
+                # The same two flags, declared in the LOCAL header only, where
+                # the central-directory check above cannot see them.
+                # `NotImplementedError` subclasses `RuntimeError`, so it would
+                # otherwise be swallowed by the clause below and reported as an
+                # unreadable header. Its message names the flag and is
+                # discarded with `from None`.
+                raise _reject("member_flags_unsupported") from None
+            except (zipfile.BadZipFile, OSError, ValueError, RuntimeError,
+                    zlib.error):
                 raise _reject("member_header_unreadable") from None
             with member:
                 try:
                     header = _read_member_header(member, policy)
                 except SnapshotArchiveRejected:
                     raise  # the refusal _read_member_header already decided
-                except (zipfile.BadZipFile, OSError, EOFError):
+                except (zipfile.BadZipFile, OSError, EOFError, zlib.error):
+                    # `zlib.error` is the one that is easy to miss: the header
+                    # read is bounded, but for a DEFLATED member those bounded
+                    # bytes still go through the decompressor, and malformed
+                    # compressed data raises `zlib.error` -- which inherits
+                    # from `Exception`, not `OSError`, so no other clause here
+                    # catches it. Untranslated it escaped the guard entirely.
                     raise _reject("member_header_unreadable") from None
 
             if header.fortran_order:

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -102,12 +102,45 @@ def _good_contents(generation=7):
     }
 
 
+_DESCRIPTOR = object()
+
+
+class _FakeAdmission:
+    """Stand-in for the shared guard.
+
+    Records how it was called, hands back a sentinel descriptor, and records
+    that its block was exited. Using a sentinel rather than a real file is what
+    lets the lifetime tests below stay free of any archive on disk, while the
+    real guard is exercised end to end by the hostile-archive tests.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.exited = 0
+
+    def __call__(self, path, *, data_dir, policy=None):
+        self.calls.append({"path": path, "data_dir": data_dir, "policy": policy})
+        return self
+
+    def __enter__(self):
+        return _DESCRIPTOR
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        return False  # never suppress anything
+
+
 def _load_with(archive, path="/fake/v070_gen0001000.npz"):
-    """Run the real `_load_snapshot` against `archive`; return the load mock."""
+    """Run the real `_load_snapshot` against `archive`.
+
+    Returns (result, load mock, admission recorder).
+    """
     loader = mock.Mock(return_value=archive)
-    with mock.patch.object(geometry_daemon.np, "load", loader):
+    admission = _FakeAdmission()
+    with mock.patch.object(geometry_daemon, "admit_snapshot", admission), \
+         mock.patch.object(geometry_daemon.np, "load", loader):
         result = geometry_daemon._load_snapshot(path)
-    return result, loader
+    return result, loader, admission
 
 
 # -- helper contract ----------------------------------------------------------
@@ -116,7 +149,7 @@ def _load_with(archive, path="/fake/v070_gen0001000.npz"):
 def test_helper_returns_the_exact_extracted_objects():
     contents = _good_contents(generation=7)
     archive = _FakeArchive(contents)
-    (state, memory_grid, generation), _ = _load_with(archive)
+    (state, memory_grid, generation), *_ = _load_with(archive)
     assert state is contents["lattice"]
     assert memory_grid is contents["memory_grid"]
     assert generation == 7
@@ -125,19 +158,53 @@ def test_helper_returns_the_exact_extracted_objects():
 
 def test_helper_preserves_the_int_generation_conversion():
     archive = _FakeArchive(_good_contents(generation=_IntLike()))
-    (_, _, generation), _ = _load_with(archive)
+    (_, _, generation), *_ = _load_with(archive)
     assert generation == 42
     assert type(generation) is int
 
 
-def test_helper_calls_np_load_with_the_same_path_conversion_and_allow_pickle():
+def test_helper_loads_from_the_admitted_descriptor_with_allow_pickle_false():
+    """The path is handed to the guard; NumPy is handed the descriptor the
+    guard opened. There is no second open and no `str(path)` conversion left
+    to make, because a pathname is never re-resolved for loading."""
     archive = _FakeArchive(_good_contents())
-    _, loader = _load_with(archive, path=Path("/fake/dir/v070_gen42.npz"))
+    path = Path("/fake/dir/v070_gen42.npz")
+    _, loader, admission = _load_with(archive, path=path)
     assert loader.call_count == 1
     args, kwargs = loader.call_args
-    assert args == (str(Path("/fake/dir/v070_gen42.npz")),)
-    assert type(args[0]) is str
+    assert args == (_DESCRIPTOR,)
     assert kwargs == {"allow_pickle": False}
+    assert [call["path"] for call in admission.calls] == [path]
+
+
+def test_helper_admits_against_the_module_data_dir_and_named_policy():
+    archive = _FakeArchive(_good_contents())
+    _, _, admission = _load_with(archive)
+    assert len(admission.calls) == 1
+    assert admission.calls[0]["data_dir"] is geometry_daemon.DATA_DIR
+    assert admission.calls[0]["policy"] is geometry_daemon.SNAPSHOT_POLICY
+    assert admission.exited == 1
+
+
+def test_admission_precedes_the_load():
+    """Ordering, not merely presence: the guard must have decided before
+    NumPy was asked for anything."""
+    order = []
+    archive = _FakeArchive(_good_contents())
+
+    class _OrderedAdmission(_FakeAdmission):
+        def __call__(self, path, *, data_dir, policy=None):
+            order.append("admit")
+            return super().__call__(path, data_dir=data_dir, policy=policy)
+
+    def _ordered_load(*args, **kwargs):
+        order.append("load")
+        return archive
+
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _OrderedAdmission()), \
+         mock.patch.object(geometry_daemon.np, "load", _ordered_load):
+        geometry_daemon._load_snapshot("/fake/v070_gen1.npz")
+    assert order == ["admit", "load"]
 
 
 def test_helper_enters_the_archive_context_exactly_once():
@@ -157,7 +224,7 @@ def test_archive_is_already_closed_when_the_helper_returns():
     """The assertion runs immediately after the return, while this frame still
     holds a live reference to the archive — so closure was explicit."""
     archive = _FakeArchive(_good_contents())
-    (state, memory_grid, generation), _ = _load_with(archive)
+    (state, memory_grid, generation), *_ = _load_with(archive)
     assert archive.closed == 1
     assert state is not None and generation == 7
 
@@ -224,6 +291,7 @@ class _FakeStat:
     def __init__(self, size, mtime):
         self.st_size = size
         self.st_mtime = mtime
+        self.st_mtime_ns = int(mtime * 1_000_000_000)
 
 
 class _FakeSnapshotPath:
@@ -233,6 +301,14 @@ class _FakeSnapshotPath:
 
     def stat(self):
         return self._stat
+
+    def change(self, size=None, mtime=None):
+        """Replace the file at this path, as a rotating producer would."""
+        self._stat = _FakeStat(
+            self._stat.st_size if size is None else size,
+            self._stat.st_mtime if mtime is None else mtime,
+        )
+        return self
 
     def __str__(self):
         return f"/fake/{self.name}"
@@ -285,7 +361,8 @@ def _run_one_daemon_cycle(archive, tmp_path):
     clock = _FakeClock(stop_after_sleeps=1)
     loader = mock.Mock(return_value=archive)
 
-    with mock.patch.object(geometry_daemon.np, "load", loader), \
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _FakeAdmission()), \
+         mock.patch.object(geometry_daemon.np, "load", loader), \
          mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
          mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
          mock.patch.object(geometry_daemon, "time", clock), \
@@ -340,12 +417,12 @@ def test_daemon_cycle_passes_the_same_objects_to_every_exporter(tmp_path):
     assert by_name["stl"][2] == tmp_path
 
 
-def test_daemon_cycle_loads_with_the_preserved_call_shape(tmp_path):
+def test_daemon_cycle_loads_from_the_admitted_descriptor(tmp_path):
     archive = _FakeArchive(_good_contents(generation=1000))
-    _, loader, snapshot = _run_one_daemon_cycle(archive, tmp_path)
+    _, loader, _snapshot = _run_one_daemon_cycle(archive, tmp_path)
     assert loader.call_count == 1
     args, kwargs = loader.call_args
-    assert args == (str(snapshot),)
+    assert args == (_DESCRIPTOR,)
     assert kwargs == {"allow_pickle": False}
 
 
@@ -354,7 +431,8 @@ def test_daemon_cycle_keeps_the_snapshot_glob_pattern(tmp_path):
     snapshot = _FakeSnapshotPath()
     data_dir = _FakeDataDir([snapshot])
     clock = _FakeClock(stop_after_sleeps=1)
-    with mock.patch.object(geometry_daemon.np, "load",
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _FakeAdmission()), \
+         mock.patch.object(geometry_daemon.np, "load",
                            mock.Mock(return_value=archive)), \
          mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
          mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
@@ -371,21 +449,164 @@ def test_daemon_cycle_keeps_the_snapshot_glob_pattern(tmp_path):
     assert data_dir.globs == ["v070_gen*.npz"]
 
 
-def test_daemon_skips_tiny_snapshot_without_loading(tmp_path):
-    """The established tiny-file threshold still short-circuits before any load."""
-    archive = _FakeArchive(_good_contents())
+def test_a_small_but_valid_snapshot_is_no_longer_skipped(tmp_path):
+    """The one-megabyte minimum is gone.
+
+    It was a guess at "tiny/corrupt" and it was wrong in both directions: a
+    sparse but structurally valid snapshot compresses far below a megabyte and
+    was skipped for ever, while a hostile archive only had to be padded past
+    the threshold to be processed. Admission decides usability now, so a
+    valid 40 kB snapshot must be loaded.
+    """
+    archive = _FakeArchive(_good_contents(generation=7))
     loader = mock.Mock(return_value=archive)
-    data_dir = _FakeDataDir([_FakeSnapshotPath(size=999_999)])
-    with mock.patch.object(geometry_daemon.np, "load", loader), \
+    data_dir = _FakeDataDir([_FakeSnapshotPath(size=40_000)])
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _FakeAdmission()), \
+         mock.patch.object(geometry_daemon.np, "load", loader), \
          mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
          mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "export_sage_pointcloud",
+                           lambda *a: None), \
+         mock.patch.object(geometry_daemon, "export_voxel_summary",
+                           lambda *a: None), \
+         mock.patch.object(geometry_daemon, "export_stl", lambda *a: None), \
          mock.patch.object(geometry_daemon, "time", _FakeClock(stop_after_sleeps=1)):
         try:
             geometry_daemon.run_daemon()
         except KeyboardInterrupt:
             pass
-    assert loader.call_count == 0
-    assert archive.entered == 0
+    assert loader.call_count == 1
+    assert archive.entered == 1
+
+
+def _run_rejecting_daemon(tmp_path, snapshot, refusals, sleeps=1):
+    """Drive `run_daemon()` with an admission that refuses `refusals` times.
+
+    Returns (exporter calls, printed output lines, admission attempt count).
+    """
+    attempts = []
+
+    class _RefusingAdmission:
+        def __call__(self, path, *, data_dir, policy=None):
+            attempts.append(str(path))
+            if len(attempts) <= refusals:
+                raise geometry_daemon.SnapshotArchiveRejected("member_missing")
+            return self
+
+        def __enter__(self):
+            return _DESCRIPTOR
+
+        def __exit__(self, *exc):
+            return False
+
+    calls = []
+    data_dir = _FakeDataDir([snapshot])
+    clock = _FakeClock(stop_after_sleeps=sleeps)
+    archive = _FakeArchive(_good_contents())
+
+    def _recorder(name):
+        def _record(*args):
+            calls.append(name)
+            return None
+        return _record
+
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _RefusingAdmission()), \
+         mock.patch.object(geometry_daemon.np, "load",
+                           mock.Mock(return_value=archive)), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time", clock), \
+         mock.patch.object(geometry_daemon, "export_sage_pointcloud",
+                           _recorder("csv")), \
+         mock.patch.object(geometry_daemon, "export_voxel_summary",
+                           _recorder("json")), \
+         mock.patch.object(geometry_daemon, "export_stl", _recorder("stl")):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass
+    return calls, attempts
+
+
+def test_a_rejected_snapshot_runs_no_exporter_and_leaves_the_daemon_alive(
+    tmp_path, capsys
+):
+    snapshot = _FakeSnapshotPath()
+    calls, attempts = _run_rejecting_daemon(tmp_path, snapshot, refusals=1)
+    output = capsys.readouterr().out
+    assert calls == [], "an exporter ran on a rejected snapshot"
+    assert attempts == [str(snapshot)]
+    assert "Snapshot rejected: member_missing" in output
+    # The daemon reached its sleep, which is how this loop is stopped at all.
+    assert output.count("Snapshot rejected") == 1
+
+
+def test_a_rejection_never_logs_the_archive_name(tmp_path, capsys):
+    snapshot = _FakeSnapshotPath(name="v070_gen_LEAKNAME_0001.npz")
+    _run_rejecting_daemon(tmp_path, snapshot, refusals=1)
+    output = capsys.readouterr().out
+    assert "LEAKNAME" not in output, (
+        "the daemon logged a rejected archive's chosen name")
+
+
+def test_an_unchanged_rejected_snapshot_is_not_reprocessed(tmp_path, capsys):
+    """Fingerprint memory: repeated polls over a poisoned directory must not
+    repeat the preflight or repeat the log."""
+    snapshot = _FakeSnapshotPath()
+    calls, attempts = _run_rejecting_daemon(tmp_path, snapshot, refusals=5,
+                                            sleeps=4)
+    output = capsys.readouterr().out
+    assert calls == []
+    assert attempts == [str(snapshot)], "the rejected archive was re-preflighted"
+    assert output.count("Snapshot rejected") == 1
+
+
+def test_a_changed_snapshot_at_the_same_path_is_retried(tmp_path):
+    """A rotated or replaced file differs in size or mtime, so the memory must
+    not lock the daemon out of a subsequently valid snapshot."""
+    snapshot = _FakeSnapshotPath()
+    attempts = []
+    calls = []
+
+    class _RefuseThenAccept:
+        def __call__(self, path, *, data_dir, policy=None):
+            attempts.append(snapshot.stat().st_mtime_ns)
+            if len(attempts) == 1:
+                raise geometry_daemon.SnapshotArchiveRejected("member_missing")
+            return self
+
+        def __enter__(self):
+            return _DESCRIPTOR
+
+        def __exit__(self, *exc):
+            return False
+
+    class _ChangingClock(_FakeClock):
+        def sleep(self, seconds):
+            snapshot.change(mtime=self.now + len(self.sleeps) + 1)
+            super().sleep(seconds)
+
+    data_dir = _FakeDataDir([snapshot])
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _RefuseThenAccept()), \
+         mock.patch.object(geometry_daemon.np, "load",
+                           mock.Mock(return_value=_FakeArchive(_good_contents()))), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time",
+                           _ChangingClock(stop_after_sleeps=2)), \
+         mock.patch.object(geometry_daemon, "export_sage_pointcloud",
+                           lambda *a: calls.append("csv")), \
+         mock.patch.object(geometry_daemon, "export_voxel_summary",
+                           lambda *a: calls.append("json")), \
+         mock.patch.object(geometry_daemon, "export_stl",
+                           lambda *a: calls.append("stl")):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass
+
+    assert len(attempts) == 2, "the changed snapshot was never retried"
+    assert calls == ["csv", "json", "stl"], "the retry did not export"
 
 
 # -- both load sites use the helper -------------------------------------------
@@ -440,6 +661,18 @@ def test_daemon_path_uses_the_helper():
 def test_once_path_uses_the_helper():
     """The `--once` production path calls the closing helper, not a second load."""
     tree = _module_tree()
+    once = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "run_once"
+    )
+    assert len(_helper_calls(once)) == 1
+    assert _np_load_calls(once) == []
+
+
+def test_the_main_block_delegates_to_the_two_named_entry_points():
+    """`run_once` is the real `--once` path, not a paraphrase of it: the
+    `__main__` block calls it and does no snapshot work of its own."""
+    tree = _module_tree()
     main_blocks = [
         node for node in tree.body
         if isinstance(node, ast.If) and any(
@@ -449,7 +682,12 @@ def test_once_path_uses_the_helper():
     ]
     assert len(main_blocks) == 1
     main_block = main_blocks[0]
-    assert len(_helper_calls(main_block)) == 1
+    called = {
+        node.func.id for node in ast.walk(main_block)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert {"run_once", "run_daemon"} <= called
+    assert _helper_calls(main_block) == []
     assert _np_load_calls(main_block) == []
 
 
@@ -498,16 +736,36 @@ def _marker_gd(tmp_path):
 
 
 def _write_snapshot_gd(path, compressed=False, **members):
-    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    """A real NPZ. Object members pickle on the way in, which is harmless.
+
+    The edge is 16 and all five schema members are present, because the
+    archive now has to be ADMISSIBLE before its member dtypes matter: a 2-cube
+    with three members would be refused for its shape and its membership, and
+    the pickle property below would never be reached.
+    """
     payload = {
-        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
-        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "lattice": np.zeros((16, 16, 16), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 16, 16, 16), dtype=np.float32),
         "generation": 7,
+        "ca_step": 11,
+        "best_fitness": 0.5,
     }
     payload.update(members)
     writer = np.savez_compressed if compressed else np.savez
     writer(path, **payload)
     return str(path)
+
+
+@pytest.fixture
+def confined(tmp_path, monkeypatch):
+    """Point the daemon's data directory at pytest's own tmp_path.
+
+    Admission confines the archive to the configured data directory, so a
+    fixture written anywhere else is refused for CONTAINMENT before the
+    property under test is reached.
+    """
+    monkeypatch.setattr(geometry_daemon, "DATA_DIR", tmp_path)
+    return tmp_path
 
 
 def test_gd_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
@@ -526,27 +784,51 @@ def test_gd_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
 
 
 @pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
-def test_object_payload_is_refused_by_the_helper(tmp_path, field):
+def test_object_payload_is_refused_by_the_helper(confined, field):
+    """The refusal moved EARLIER, and the code says so.
+
+    An object member used to be caught by NumPy at `np.load`. It is now caught
+    by admission from the member's NPY header, before NumPy is involved at
+    all -- so the assertion is the typed reason code, not NumPy's message. The
+    property that matters is unchanged and stronger: the payload never runs.
+    """
     archive = _write_snapshot_gd(
-        tmp_path / f"{field}.npz", **{field: _payload_array_gd(tmp_path)}
+        confined / f"v070_{field}.npz", **{field: _payload_array_gd(confined)}
+    )
+    with pytest.raises(geometry_daemon.SnapshotArchiveRejected) as excinfo:
+        geometry_daemon._load_snapshot(archive)
+    assert excinfo.value.reason == "member_dtype_object"
+    assert not _marker_gd(confined).exists(), "the pickle payload executed"
+
+
+def test_numpys_own_pickle_refusal_is_still_in_place_behind_admission(confined):
+    """Second line of defence, kept non-vacuous.
+
+    Admission now stops an object member first, so the load-site refusal would
+    otherwise never be observed again. Calling NumPy directly on the same
+    archive shows it is still exactly as it was.
+    """
+    archive = _write_snapshot_gd(
+        confined / "v070_direct.npz", lattice=_payload_array_gd(confined)
     )
     with pytest.raises(ValueError) as excinfo:
-        geometry_daemon._load_snapshot(archive)
+        with np.load(archive, allow_pickle=False) as snap:
+            snap["lattice"]
     assert "allow_pickle=False" in str(excinfo.value)
-    assert not _marker_gd(tmp_path).exists(), "the pickle payload executed"
+    assert not _marker_gd(confined).exists()
 
 
-def test_a_compressed_hostile_archive_is_refused_the_same_way(tmp_path):
+def test_a_compressed_hostile_archive_is_refused_the_same_way(confined):
     """Real producers use `np.savez_compressed`, so the hostile fixture
     exercises that shape too rather than only the uncompressed one."""
     archive = _write_snapshot_gd(
-        tmp_path / "compressed.npz", compressed=True,
-        lattice=_payload_array_gd(tmp_path),
+        confined / "v070_compressed.npz", compressed=True,
+        lattice=_payload_array_gd(confined),
     )
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(geometry_daemon.SnapshotArchiveRejected) as excinfo:
         geometry_daemon._load_snapshot(archive)
-    assert "allow_pickle=False" in str(excinfo.value)
-    assert not _marker_gd(tmp_path).exists()
+    assert excinfo.value.reason == "member_dtype_object"
+    assert not _marker_gd(confined).exists()
 
 
 def test_the_compressed_payload_also_fires_when_pickle_is_enabled(tmp_path):
@@ -559,9 +841,11 @@ def test_the_compressed_payload_also_fires_when_pickle_is_enabled(tmp_path):
     assert _marker_gd(tmp_path).exists(), "the compressed payload is inert"
 
 
-def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+def test_a_refused_archive_never_reaches_np_load_at_all(confined, monkeypatch):
+    """Stronger than "it was not retried with pickle enabled": NumPy is not
+    asked to open the archive even once."""
     archive = _write_snapshot_gd(
-        tmp_path / "retry.npz", lattice=_payload_array_gd(tmp_path)
+        confined / "v070_retry.npz", lattice=_payload_array_gd(confined)
     )
     real_load = np.load
     calls = []
@@ -571,41 +855,106 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
         return real_load(*args, **kwargs)
 
     monkeypatch.setattr(geometry_daemon.np, "load", _recording_load)
-    with pytest.raises(ValueError):
+    with pytest.raises(geometry_daemon.SnapshotArchiveRejected):
         geometry_daemon._load_snapshot(archive)
+    assert calls == []
+
+
+def test_a_valid_archive_is_loaded_with_pickle_explicitly_disabled(confined,
+                                                                   monkeypatch):
+    """The counterpart control: on the admitted path the explicit literal is
+    still what NumPy receives, so the assertion above is about ordering rather
+    than about the flag having quietly disappeared."""
+    archive = _write_snapshot_gd(confined / "v070_ok.npz", compressed=True)
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(geometry_daemon.np, "load", _recording_load)
+    geometry_daemon._load_snapshot(archive)
     assert calls == [False]
 
 
-def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
+    """Closure on the exceptional path, witnessed on the real file object the
+    guard opened rather than on a NumPy handle that is never created."""
     archive = _write_snapshot_gd(
-        tmp_path / "closed.npz", lattice=_payload_array_gd(tmp_path)
+        confined / "v070_closed.npz", lattice=_payload_array_gd(confined)
     )
-    real_load = np.load
+    import builtins
     opened = []
+    real_open = builtins.open
 
-    def _tracking_load(*args, **kwargs):
-        handle = real_load(*args, **kwargs)
-        opened.append(handle)
+    def _tracking_open(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        if str(args[0]).endswith(".npz"):
+            opened.append(handle)
         return handle
 
-    monkeypatch.setattr(geometry_daemon.np, "load", _tracking_load)
-    with pytest.raises(ValueError):
+    monkeypatch.setattr(builtins, "open", _tracking_open)
+    with pytest.raises(geometry_daemon.SnapshotArchiveRejected):
         geometry_daemon._load_snapshot(archive)
-    assert len(opened) == 1
-    # `zip` is the primary witness: `close()` drops it unconditionally,
-    # whereas `fid` is a CLASS attribute defaulting to None, so asserting
-    # on it alone would pass on a handle that was never closed at all.
-    assert opened[0].zip is None and (
-        opened[0].fid is None or opened[0].fid.closed
-    )
+    assert len(opened) == 1, "the archive was opened more than once, or not at all"
+    assert opened[0].closed
 
 
-def test_a_numeric_snapshot_still_loads_unchanged(tmp_path):
-    archive = _write_snapshot_gd(tmp_path / "clean.npz", generation=np.int64(12))
+def test_a_numeric_snapshot_still_loads_unchanged(confined):
+    archive = _write_snapshot_gd(confined / "v070_clean.npz",
+                                 generation=np.int64(12))
     state, grid, generation = geometry_daemon._load_snapshot(archive)
-    assert state.shape == (2, 2, 2)
-    assert grid.shape == (8, 2, 2, 2)
+    assert state.shape == (16, 16, 16)
+    assert grid.shape == (8, 16, 16, 16)
     assert generation == 12 and type(generation) is int
+
+
+def test_the_once_path_exits_nonzero_with_one_bounded_reason(confined, capsys,
+                                                             monkeypatch):
+    """`--once` has no loop to stay alive in: it reports and fails.
+
+    The REAL `run_once` runs here, with only admission replaced.
+    """
+    _write_snapshot_gd(confined / "v070_gen000once.npz")
+    exporters = []
+    monkeypatch.setattr(geometry_daemon, "GEO_DIR", confined)
+    for name in ("export_sage_pointcloud", "export_voxel_summary", "export_stl"):
+        monkeypatch.setattr(geometry_daemon, name,
+                            lambda *a, _n=name: exporters.append(_n))
+
+    def _refuse(path, *, data_dir, policy=None):
+        raise geometry_daemon.SnapshotArchiveRejected("member_missing")
+
+    monkeypatch.setattr(geometry_daemon, "admit_snapshot", _refuse)
+
+    with pytest.raises(SystemExit) as excinfo:
+        geometry_daemon.run_once()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.err.strip() == "Snapshot rejected: member_missing"
+    assert "v070_gen000once" not in captured.err
+    assert "v070_gen000once" not in captured.out
+    assert exporters == [], "an exporter ran on a rejected snapshot"
+
+
+def test_the_once_path_still_exports_a_valid_snapshot(confined, capsys,
+                                                      monkeypatch):
+    """The counterpart control, so the test above is about the REFUSAL and not
+    about `run_once` being broken."""
+    _write_snapshot_gd(confined / "v070_gen000ok.npz", compressed=True)
+    exporters = []
+    monkeypatch.setattr(geometry_daemon, "GEO_DIR", confined)
+    for name in ("export_sage_pointcloud", "export_voxel_summary", "export_stl"):
+        monkeypatch.setattr(geometry_daemon, name,
+                            lambda *a, _n=name: exporters.append(_n) or None)
+
+    geometry_daemon.run_once()
+
+    assert exporters == ["export_sage_pointcloud", "export_voxel_summary",
+                         "export_stl"]
+    assert "Done!" in capsys.readouterr().out
 
 
 # ===========================================================================

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -971,7 +971,7 @@ def test_the_once_path_still_exports_a_valid_snapshot(confined, capsys,
 #
 # The fixtures below are built with the standard library rather than NumPy,
 # because NumPy cannot write a duplicate member, a corrupt NPY magic or a
-# lying shape. None of them is hostile in SIZE: each is a few kilobytes, and
+# lying shape. None of them is hostile in SIZE: each is a few hundred kilobytes at most, and
 # the oversized cases lie in their headers instead of on disk.
 # ===========================================================================
 
@@ -1034,6 +1034,26 @@ def _zip_gd(path, members, *, compressed=True, duplicate=None):
     return str(path)
 
 
+def _declared_gd(edge, channels=8):
+    """The same five members, DECLARING an `edge` it does not carry.
+
+    The guard checks geometry before size arithmetic, so an archive that lies
+    about its shape is refused on the geometry rule without the bytes ever
+    needing to exist. That is what keeps a 512-edge case at a few kilobytes
+    instead of the 4.1 GiB a real 512-cube payload would require.
+    """
+    members = _schema_gd(16, channels)
+    members["lattice.npy"] = _npy_gd(
+        "|u1", (edge, edge, edge), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d), }" % (edge, edge, edge))
+    members["memory_grid.npy"] = _npy_gd(
+        "<f4", (channels, edge, edge, edge), payload=b"",
+        header="{'descr': '<f4', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d, %d), }" % (channels, edge, edge, edge))
+    return members
+
+
 def _hostile_gd(kind, path):
     """Build one hostile archive of the named kind at `path`."""
     members = _schema_gd()
@@ -1062,7 +1082,7 @@ def _hostile_gd(kind, path):
                    "'shape': (8, 256, 256, 256), }")
         return _zip_gd(path, members)
     if kind == "oversized_edge":
-        return _zip_gd(path, _schema_gd(edge=512))
+        return _zip_gd(path, _declared_gd(512))
     if kind == "header_payload_mismatch":
         members["lattice.npy"] = _npy_gd("|u1", (16, 16, 16)) + b"\x00" * 64
         return _zip_gd(path, members)
@@ -1091,7 +1111,10 @@ def _hostile_gd(kind, path):
         members["lattice.npy"] = _npy_gd("|u1", (16, 16))
         return _zip_gd(path, members)
     if kind == "spatial_mismatch":
-        members["memory_grid.npy"] = _npy_gd("<f4", (8, 32, 32, 32))
+        members["memory_grid.npy"] = _npy_gd(
+            "<f4", (8, 32, 32, 32), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 32, 32, 32), }")
         return _zip_gd(path, members)
     if kind == "fortran_order":
         members["lattice.npy"] = _npy_gd("|u1", (16, 16, 16), fortran=True)
@@ -1109,6 +1132,30 @@ _HOSTILE_KINDS = [
     "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
     "spatial_mismatch", "fortran_order", "not_an_npz",
 ]
+
+#: The reason code each hostile kind must produce. Asserting only that a
+#: ValueError was raised would be weak: SnapshotArchiveRejected IS a
+#: ValueError, so an unrelated failure would satisfy it. Pinning the code ties
+#: each fixture to the defect its name claims.
+_EXPECTED_REASON = {
+    "duplicate_member": "member_duplicate",
+    "traversal_name": "member_name_unsafe",
+    "backslash_name": "member_name_unsafe",
+    "missing_member": "member_missing",
+    "extra_member": "member_unexpected",
+    "oversized_declared_payload": "member_payload_too_large",
+    "oversized_edge": "edge_out_of_range",
+    "header_payload_mismatch": "member_size_inconsistent",
+    "invalid_magic": "member_npy_magic_invalid",
+    "invalid_version": "member_npy_version_unsupported",
+    "invalid_header": "member_header_malformed",
+    "object_dtype": "member_dtype_object",
+    "structured_dtype": "member_dtype_structured",
+    "wrong_rank": "member_rank",
+    "spatial_mismatch": "spatial_disagreement",
+    "fortran_order": "member_fortran_order",
+    "not_an_npz": "not_zip_archive",
+}
 
 
 @pytest.mark.parametrize("kind", _HOSTILE_KINDS)
@@ -1131,8 +1178,10 @@ def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
 
     monkeypatch.setattr(geometry_daemon.np, "load", _recording_load)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(geometry_daemon.SnapshotArchiveRejected) as excinfo:
         geometry_daemon._load_snapshot(archive)
+    assert excinfo.value.reason == _EXPECTED_REASON[kind], (
+        "the fixture was refused for a different defect than its name claims")
     assert reached == [], "np.load was reached on a hostile archive"
 
 

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -884,17 +884,19 @@ def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
     archive = _write_snapshot_gd(
         confined / "v070_closed.npz", lattice=_payload_array_gd(confined)
     )
-    import builtins
+    # Hooked on `os.fdopen`, not `builtins.open`: the guard opens through
+    # `os.open` so it can pass O_NONBLOCK and O_NOFOLLOW, and `os.fdopen` is
+    # what turns that descriptor into the file object it yields.
+    import os as _os
     opened = []
-    real_open = builtins.open
+    real_fdopen = _os.fdopen
 
-    def _tracking_open(*args, **kwargs):
-        handle = real_open(*args, **kwargs)
-        if str(args[0]).endswith(".npz"):
-            opened.append(handle)
+    def _tracking_fdopen(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        opened.append(handle)
         return handle
 
-    monkeypatch.setattr(builtins, "open", _tracking_open)
+    monkeypatch.setattr(_os, "fdopen", _tracking_fdopen)
     with pytest.raises(geometry_daemon.SnapshotArchiveRejected):
         geometry_daemon._load_snapshot(archive)
     assert len(opened) == 1, "the archive was opened more than once, or not at all"

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -903,6 +903,53 @@ def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
     assert opened[0].closed
 
 
+def test_discovery_skips_a_candidate_that_disappears_mid_scan(confined,
+                                                              monkeypatch,
+                                                              capsys):
+    """The glob and the metadata read are separate syscalls. A vanished entry
+    must be skipped silently — the old `p.stat()` raised into the loop's broad
+    handler, which prints the exception, and OSError's message carries the
+    attacker-chosen path."""
+    _write_snapshot_gd(confined / "v070_gen000030.npz", compressed=True)
+    ghost = confined / "v070_gen_GHOSTNAME_0031.npz"
+    real_glob = Path.glob
+
+    def _glob_with_a_ghost(self, pattern):
+        return list(real_glob(self, pattern)) + [ghost]
+
+    monkeypatch.setattr(Path, "glob", _glob_with_a_ghost)
+    monkeypatch.setattr(geometry_daemon, "GEO_DIR", confined)
+    exporters = []
+    for name in ("export_sage_pointcloud", "export_voxel_summary", "export_stl"):
+        monkeypatch.setattr(geometry_daemon, name,
+                            lambda *a, _n=name: exporters.append(_n))
+
+    geometry_daemon.run_once()
+
+    output = capsys.readouterr()
+    assert exporters == ["export_sage_pointcloud", "export_voxel_summary",
+                         "export_stl"], "the ghost blocked a valid snapshot"
+    assert "GHOSTNAME" not in output.out and "GHOSTNAME" not in output.err
+
+
+def test_the_fingerprint_does_not_follow_a_symlink(confined, tmp_path):
+    """A rejected link fingerprinted by its TARGET kept changing whenever
+    anything touched the target, so the daemon re-preflighted and re-logged the
+    same unchanged poison on every poll."""
+    target = tmp_path / "fingerprint_target.npz"
+    target.write_bytes(b"x" * 64)
+    link = confined / "v070_fplink.npz"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+
+    before = geometry_daemon._snapshot_fingerprint(link)
+    target.write_bytes(b"y" * 4096)  # the target changes; the link does not
+    after = geometry_daemon._snapshot_fingerprint(link)
+    assert before == after, "the fingerprint tracked the target, not the entry"
+
+
 def test_a_numeric_snapshot_still_loads_unchanged(confined):
     archive = _write_snapshot_gd(confined / "v070_clean.npz",
                                  generation=np.int64(12))
@@ -939,6 +986,76 @@ def test_the_once_path_exits_nonzero_with_one_bounded_reason(confined, capsys,
     assert "v070_gen000once" not in captured.err
     assert "v070_gen000once" not in captured.out
     assert exporters == [], "an exporter ran on a rejected snapshot"
+
+
+@pytest.mark.parametrize("raised", [
+    MemoryError("oom"),
+    KeyboardInterrupt(),
+    RuntimeError("programmer error"),
+    TypeError("wrong argument"),
+], ids=["memory", "keyboard_interrupt", "runtime", "type"])
+def test_the_once_path_lets_everything_but_a_refusal_propagate(confined,
+                                                               monkeypatch,
+                                                               raised):
+    """Only `SnapshotArchiveRejected` becomes the bounded exit-1 refusal.
+
+    A `MemoryError` means the machine is out of memory, a `KeyboardInterrupt`
+    means the operator asked to stop, and a programmer error means the code is
+    wrong. Reporting any of them as "the snapshot was bad" would hide a real
+    fault behind a sanitized message and exit 1 as though the input were at
+    fault. Each must leave `run_once` exactly as it was raised, and no exporter
+    may run.
+    """
+    _write_snapshot_gd(confined / "v070_gen000prop.npz")
+    exporters = []
+    monkeypatch.setattr(geometry_daemon, "GEO_DIR", confined)
+    for name in ("export_sage_pointcloud", "export_voxel_summary", "export_stl"):
+        monkeypatch.setattr(geometry_daemon, name,
+                            lambda *a, _n=name: exporters.append(_n))
+
+    def _raise(path, *, data_dir, policy=None):
+        raise raised
+
+    monkeypatch.setattr(geometry_daemon, "admit_snapshot", _raise)
+
+    with pytest.raises(type(raised)) as excinfo:
+        geometry_daemon.run_once()
+
+    assert type(excinfo.value) is type(raised)
+    assert str(excinfo.value) == str(raised)
+    assert not isinstance(excinfo.value, SystemExit), (
+        "a non-refusal was converted into the bounded exit-1 lane")
+    assert exporters == []
+
+
+def test_the_daemon_loop_does_not_treat_a_programmer_error_as_a_refusal(
+    tmp_path, capsys
+):
+    """The watcher's broad handler still catches non-refusals so the daemon
+    survives — but it must not record them as rejected snapshots, or the
+    fingerprint memory would suppress a real, recurring fault."""
+    snapshot = _FakeSnapshotPath()
+    data_dir = _FakeDataDir([snapshot])
+
+    class _Boom(RuntimeError):
+        pass
+
+    def _raise(path, *, data_dir, policy=None):
+        raise _Boom("programmer error")
+
+    with mock.patch.object(geometry_daemon, "admit_snapshot", _raise), \
+         mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
+         mock.patch.object(geometry_daemon, "GEO_DIR", tmp_path), \
+         mock.patch.object(geometry_daemon, "time",
+                           _FakeClock(stop_after_sleeps=1)):
+        try:
+            geometry_daemon.run_daemon()
+        except KeyboardInterrupt:
+            pass
+
+    output = capsys.readouterr().out
+    assert "Snapshot rejected" not in output, (
+        "a programmer error was reported as a snapshot refusal")
 
 
 def test_the_once_path_still_exports_a_valid_snapshot(confined, capsys,

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -606,3 +606,195 @@ def test_a_numeric_snapshot_still_loads_unchanged(tmp_path):
     assert state.shape == (2, 2, 2)
     assert grid.shape == (8, 2, 2, 2)
     assert generation == 12 and type(generation) is int
+
+
+# ===========================================================================
+# Structural admission -- a hostile archive must be refused BEFORE np.load
+#
+# Pickle refusal and archive lifetime say nothing about an archive's shape or
+# its cost. This daemon loads whatever appears in the watched directory, so an
+# archive can still name members outside the schema, carry traversal-bearing
+# entries, declare a payload of hundreds of gigabytes, or lie about its own
+# sizes -- and every one of those reached `np.load` and the allocation behind
+# it.
+#
+# The fixtures below are built with the standard library rather than NumPy,
+# because NumPy cannot write a duplicate member, a corrupt NPY magic or a
+# lying shape. None of them is hostile in SIZE: each is a few kilobytes, and
+# the oversized cases lie in their headers instead of on disk.
+# ===========================================================================
+
+import struct  # noqa: E402
+import warnings  # noqa: E402
+import zipfile  # noqa: E402
+
+_NPY_MAGIC = b"\x93NUMPY"
+
+
+def _npy_gd(descr, shape, *, fortran=False, payload=None, header=None,
+            version=(1, 0)):
+    """One `.npy` member as raw bytes, with every field independently forgeable."""
+    if header is None:
+        if not shape:
+            shape_text = "()"
+        elif len(shape) == 1:
+            shape_text = "(%d,)" % shape[0]
+        else:
+            shape_text = "(" + ", ".join(str(d) for d in shape) + ")"
+        header = "{'descr': '%s', 'fortran_order': %s, 'shape': %s, }" % (
+            descr, fortran, shape_text)
+    body = header.encode("latin1")
+    prelude = 10 if version == (1, 0) else 12
+    body += b" " * ((-(prelude + len(body) + 1)) % 64) + b"\n"
+    out = bytearray(_NPY_MAGIC) + bytes(version)
+    out += (struct.pack("<H", len(body)) if version == (1, 0)
+            else struct.pack("<I", len(body)))
+    out += body
+    if payload is None:
+        digits = descr[2:] if descr[0] in "<>|=" else descr[1:]
+        itemsize = int(digits) if digits else 0
+        count = 1
+        for dim in shape:
+            count *= dim
+        payload = b"\x00" * (count * itemsize)
+    return bytes(out) + payload
+
+
+def _schema_gd(edge=16, channels=8):
+    """The five members a `v070_gen` snapshot carries, at a valid edge."""
+    return {
+        "lattice.npy": _npy_gd("|u1", (edge, edge, edge)),
+        "memory_grid.npy": _npy_gd("<f4", (channels, edge, edge, edge)),
+        "generation.npy": _npy_gd("<i8", ()),
+        "ca_step.npy": _npy_gd("<i8", ()),
+        "best_fitness.npy": _npy_gd("<f8", ()),
+    }
+
+
+def _zip_gd(path, members, *, compressed=True, duplicate=None):
+    mode = zipfile.ZIP_DEFLATED if compressed else zipfile.ZIP_STORED
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # a duplicate name is the point here
+        with zipfile.ZipFile(path, "w", compression=mode) as archive:
+            for name, blob in members.items():
+                archive.writestr(name, blob)
+            if duplicate is not None:
+                archive.writestr(duplicate, members[duplicate])
+    return str(path)
+
+
+def _hostile_gd(kind, path):
+    """Build one hostile archive of the named kind at `path`."""
+    members = _schema_gd()
+    if kind == "duplicate_member":
+        return _zip_gd(path, members, duplicate="lattice.npy")
+    if kind == "traversal_name":
+        members["../../escape.npy"] = _npy_gd("|u1", (1,))
+        return _zip_gd(path, members)
+    if kind == "backslash_name":
+        members["sub\\escape.npy"] = _npy_gd("|u1", (1,))
+        return _zip_gd(path, members)
+    if kind == "missing_member":
+        members.pop("ca_step.npy")
+        return _zip_gd(path, members)
+    if kind == "extra_member":
+        members["surprise.npy"] = _npy_gd("|u1", (1,))
+        return _zip_gd(path, members)
+    if kind == "oversized_declared_payload":
+        members["lattice.npy"] = _npy_gd(
+            "|u8", (256, 256, 256), payload=b"",
+            header="{'descr': '|u8', 'fortran_order': False, "
+                   "'shape': (256, 256, 256), }")
+        members["memory_grid.npy"] = _npy_gd(
+            "<f4", (8, 256, 256, 256), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 256, 256, 256), }")
+        return _zip_gd(path, members)
+    if kind == "oversized_edge":
+        return _zip_gd(path, _schema_gd(edge=512))
+    if kind == "header_payload_mismatch":
+        members["lattice.npy"] = _npy_gd("|u1", (16, 16, 16)) + b"\x00" * 64
+        return _zip_gd(path, members)
+    if kind == "invalid_magic":
+        members["lattice.npy"] = b"XXXXXX" + members["lattice.npy"][6:]
+        return _zip_gd(path, members)
+    if kind == "invalid_version":
+        blob = bytearray(members["lattice.npy"])
+        blob[6] = 9
+        members["lattice.npy"] = bytes(blob)
+        return _zip_gd(path, members)
+    if kind == "invalid_header":
+        members["lattice.npy"] = _npy_gd(
+            "|u1", (16, 16, 16), header="{'descr': '|u1', 'shape': (1,), }")
+        return _zip_gd(path, members)
+    if kind == "object_dtype":
+        members["generation.npy"] = _npy_gd("|O", (), payload=b"")
+        return _zip_gd(path, members)
+    if kind == "structured_dtype":
+        members["generation.npy"] = _npy_gd(
+            "<i8", (), payload=b"",
+            header="{'descr': [('payload', '|O'), ('n', '<i4')], "
+                   "'fortran_order': False, 'shape': (1,), }")
+        return _zip_gd(path, members)
+    if kind == "wrong_rank":
+        members["lattice.npy"] = _npy_gd("|u1", (16, 16))
+        return _zip_gd(path, members)
+    if kind == "spatial_mismatch":
+        members["memory_grid.npy"] = _npy_gd("<f4", (8, 32, 32, 32))
+        return _zip_gd(path, members)
+    if kind == "fortran_order":
+        members["lattice.npy"] = _npy_gd("|u1", (16, 16, 16), fortran=True)
+        return _zip_gd(path, members)
+    if kind == "not_an_npz":
+        Path(path).write_bytes(_npy_gd("|u1", (16, 16, 16)))
+        return str(path)
+    raise AssertionError("unknown hostile archive kind: " + kind)
+
+
+_HOSTILE_KINDS = [
+    "duplicate_member", "traversal_name", "backslash_name", "missing_member",
+    "extra_member", "oversized_declared_payload", "oversized_edge",
+    "header_payload_mismatch", "invalid_magic", "invalid_version",
+    "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
+    "spatial_mismatch", "fortran_order", "not_an_npz",
+]
+
+
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
+    """The load-reached recorder is the whole point.
+
+    Asserting only that something was raised would pass on code that let
+    `np.load` open, decompress and allocate first and then failed downstream --
+    which is exactly the behaviour this replaces.
+    """
+    archive = _hostile_gd(kind, tmp_path / "v070_gen000001.npz")
+    monkeypatch.setattr(geometry_daemon, "DATA_DIR", tmp_path)
+
+    reached = []
+    real_load = np.load
+
+    def _recording_load(*args, **kwargs):
+        reached.append(args[:1])
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(geometry_daemon.np, "load", _recording_load)
+
+    with pytest.raises(ValueError):
+        geometry_daemon._load_snapshot(archive)
+    assert reached == [], "np.load was reached on a hostile archive"
+
+
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_refusal_names_no_path_member_or_header(kind, tmp_path, monkeypatch):
+    """The refusal reaches unattended logs, so it must carry no archive content."""
+    archive = _hostile_gd(kind, tmp_path / "v070_gen000002.npz")
+    monkeypatch.setattr(geometry_daemon, "DATA_DIR", tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        geometry_daemon._load_snapshot(archive)
+    message = str(excinfo.value)
+    assert str(tmp_path) not in message
+    assert "v070_gen000002" not in message
+    assert ".npy" not in message
+    assert "descr" not in message and "escape" not in message
+    assert message == message.strip() and "\n" not in message

--- a/tests/test_geometry_daemon.py
+++ b/tests/test_geometry_daemon.py
@@ -27,6 +27,7 @@ output or whole-daemon correctness.
 from __future__ import annotations
 
 import ast
+import os
 from pathlib import Path
 from unittest import mock
 
@@ -287,31 +288,54 @@ def test_original_extraction_exception_propagates_unchanged():
 # -- one controlled daemon cycle ----------------------------------------------
 
 
-class _FakeStat:
-    def __init__(self, size, mtime):
-        self.st_size = size
-        self.st_mtime = mtime
-        self.st_mtime_ns = int(mtime * 1_000_000_000)
-
-
 class _FakeSnapshotPath:
-    def __init__(self, name="v070_gen0001000.npz", size=2_000_000, mtime=100.0):
+    """A stand-in for one snapshot path that is also a REAL directory entry.
+
+    It used to be a pure duck type: `.stat()`, `.name`, `__str__` and nothing
+    else. That worked while discovery sorted on `p.stat().st_mtime`, which
+    accepts any object with a `.stat()`. Discovery now describes candidates
+    with `os.lstat`, which takes only `str | bytes | os.PathLike` -- deliberately,
+    because reading the ENTRY rather than whatever it points at is the whole
+    point of the non-following ordering.
+
+    So the fake owns a real, tiny file and forwards `__fspath__` to it. That
+    keeps the double honest in both directions: `os.lstat` returns real
+    metadata, and `change()` rewrites the real file rather than a fabricated
+    stat result, so the daemon's fingerprint sees a genuine change.
+
+    Backing this with a fabricated `.stat()` instead would have been worse than
+    useless: `os.lstat` on a path that does not exist raises `OSError`,
+    `newest_first` skips it, and every daemon-cycle test would pass while
+    exercising nothing.
+    """
+
+    def __init__(self, directory, name="v070_gen0001000.npz", size=64,
+                 mtime=100.0):
         self.name = name
-        self._stat = _FakeStat(size, mtime)
+        self._real = Path(directory) / name
+        self._real.write_bytes(b"\x00" * size)
+        self._set_mtime(mtime)
+
+    def _set_mtime(self, mtime):
+        stamp = int(mtime * 1_000_000_000)
+        os.utime(self._real, ns=(stamp, stamp))
 
     def stat(self):
-        return self._stat
+        return self._real.stat()
 
     def change(self, size=None, mtime=None):
         """Replace the file at this path, as a rotating producer would."""
-        self._stat = _FakeStat(
-            self._stat.st_size if size is None else size,
-            self._stat.st_mtime if mtime is None else mtime,
-        )
+        if size is not None:
+            self._real.write_bytes(b"\x00" * size)
+        if mtime is not None:
+            self._set_mtime(mtime)
         return self
 
+    def __fspath__(self):
+        return os.fspath(self._real)
+
     def __str__(self):
-        return f"/fake/{self.name}"
+        return os.fspath(self._real)
 
 
 class _FakeDataDir:
@@ -356,7 +380,7 @@ def _run_one_daemon_cycle(archive, tmp_path):
             return None
         return _record
 
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     data_dir = _FakeDataDir([snapshot])
     clock = _FakeClock(stop_after_sleeps=1)
     loader = mock.Mock(return_value=archive)
@@ -428,7 +452,7 @@ def test_daemon_cycle_loads_from_the_admitted_descriptor(tmp_path):
 
 def test_daemon_cycle_keeps_the_snapshot_glob_pattern(tmp_path):
     archive = _FakeArchive(_good_contents(generation=1000))
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     data_dir = _FakeDataDir([snapshot])
     clock = _FakeClock(stop_after_sleeps=1)
     with mock.patch.object(geometry_daemon, "admit_snapshot", _FakeAdmission()), \
@@ -460,7 +484,7 @@ def test_a_small_but_valid_snapshot_is_no_longer_skipped(tmp_path):
     """
     archive = _FakeArchive(_good_contents(generation=7))
     loader = mock.Mock(return_value=archive)
-    data_dir = _FakeDataDir([_FakeSnapshotPath(size=40_000)])
+    data_dir = _FakeDataDir([_FakeSnapshotPath(tmp_path, size=40_000)])
     with mock.patch.object(geometry_daemon, "admit_snapshot", _FakeAdmission()), \
          mock.patch.object(geometry_daemon.np, "load", loader), \
          mock.patch.object(geometry_daemon, "DATA_DIR", data_dir), \
@@ -531,7 +555,7 @@ def _run_rejecting_daemon(tmp_path, snapshot, refusals, sleeps=1):
 def test_a_rejected_snapshot_runs_no_exporter_and_leaves_the_daemon_alive(
     tmp_path, capsys
 ):
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     calls, attempts = _run_rejecting_daemon(tmp_path, snapshot, refusals=1)
     output = capsys.readouterr().out
     assert calls == [], "an exporter ran on a rejected snapshot"
@@ -542,7 +566,7 @@ def test_a_rejected_snapshot_runs_no_exporter_and_leaves_the_daemon_alive(
 
 
 def test_a_rejection_never_logs_the_archive_name(tmp_path, capsys):
-    snapshot = _FakeSnapshotPath(name="v070_gen_LEAKNAME_0001.npz")
+    snapshot = _FakeSnapshotPath(tmp_path, name="v070_gen_LEAKNAME_0001.npz")
     _run_rejecting_daemon(tmp_path, snapshot, refusals=1)
     output = capsys.readouterr().out
     assert "LEAKNAME" not in output, (
@@ -552,7 +576,7 @@ def test_a_rejection_never_logs_the_archive_name(tmp_path, capsys):
 def test_an_unchanged_rejected_snapshot_is_not_reprocessed(tmp_path, capsys):
     """Fingerprint memory: repeated polls over a poisoned directory must not
     repeat the preflight or repeat the log."""
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     calls, attempts = _run_rejecting_daemon(tmp_path, snapshot, refusals=5,
                                             sleeps=4)
     output = capsys.readouterr().out
@@ -564,7 +588,7 @@ def test_an_unchanged_rejected_snapshot_is_not_reprocessed(tmp_path, capsys):
 def test_a_changed_snapshot_at_the_same_path_is_retried(tmp_path):
     """A rotated or replaced file differs in size or mtime, so the memory must
     not lock the daemon out of a subsequently valid snapshot."""
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     attempts = []
     calls = []
 
@@ -1034,7 +1058,7 @@ def test_the_daemon_loop_does_not_treat_a_programmer_error_as_a_refusal(
     """The watcher's broad handler still catches non-refusals so the daemon
     survives — but it must not record them as rejected snapshots, or the
     fingerprint memory would suppress a real, recurring fault."""
-    snapshot = _FakeSnapshotPath()
+    snapshot = _FakeSnapshotPath(tmp_path)
     data_dir = _FakeDataDir([snapshot])
 
     class _Boom(RuntimeError):

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import types
 from unittest import mock
@@ -700,34 +701,114 @@ def test_a_numeric_snapshot_still_produces_cells_and_metrics(confined):
     assert data["metrics"]["grid_size"] == 16
 
 
-@requires_numpy
-def test_the_watcher_survives_a_rejected_snapshot_and_recovers(confined,
-                                                               monkeypatch):
-    """One poll over a poisoned directory, then one over a repaired one.
+class _WatcherStopped(Exception):
+    """Ends the watcher's infinite loop from its own sleep."""
 
-    The watcher must log one bounded reason and broadcast nothing, then pick
-    up the next valid snapshot without a restart.
+
+def _run_watcher(monkeypatch, polls):
+    """Drive the REAL `snapshot_watcher` coroutine for `polls` iterations.
+
+    The loop's trailing `await asyncio.sleep(POLL_INTERVAL)` sits outside its
+    try/except, so raising from a patched sleep ends the coroutine without
+    being swallowed by the broad handler. Returns everything broadcast.
     """
-    poison = confined / "v070_gen000001.npz"
-    _zip_ls(poison, _schema_ls(edge=24))  # admissible-looking, wrong edge
-
     broadcasts = []
+    seen = {"polls": 0}
 
     async def _record(message):
         broadcasts.append(message)
 
+    async def _sleep(_seconds):
+        seen["polls"] += 1
+        if seen["polls"] >= polls:
+            raise _WatcherStopped
+
     monkeypatch.setattr(lucid_server, "broadcast", _record)
+    monkeypatch.setattr(lucid_server.asyncio, "sleep", _sleep)
+
+    async def _drive():
+        try:
+            await lucid_server.snapshot_watcher()
+        except _WatcherStopped:
+            pass
+
+    asyncio.run(_drive())
+    return broadcasts, seen["polls"]
+
+
+@pytest.fixture
+def _fresh_watcher_state(monkeypatch):
+    """`snapshot_watcher` keeps its cursor in module globals."""
     monkeypatch.setattr(lucid_server, "last_snapshot_path", None)
     monkeypatch.setattr(lucid_server, "last_snapshot_mtime", 0)
 
-    with pytest.raises(lucid_server.SnapshotArchiveRejected):
-        lucid_server.extract_render_data(str(poison))
-    assert broadcasts == []
 
-    valid = _write_snapshot_ls(confined / "v070_gen000002.npz", compressed=True)
-    data = lucid_server.extract_render_data(valid)
-    assert data["metrics"]["generation"] == 7, (
-        "a later valid snapshot must still be accepted")
+@requires_numpy
+def test_the_watcher_logs_once_and_broadcasts_nothing_for_a_rejected_snapshot(
+    confined, monkeypatch, capsys, _fresh_watcher_state
+):
+    """The REAL watcher loop runs here.
+
+    Previously this called `extract_render_data` directly and asserted on a
+    patched `broadcast` that the function never calls -- so the assertion could
+    not fail and `snapshot_watcher` was executed by no test at all.
+    """
+    _zip_ls(confined / "v070_gen000001.npz", _declared_ls(512))
+
+    broadcasts, polls = _run_watcher(monkeypatch, polls=4)
+    output = capsys.readouterr().out
+
+    assert broadcasts == [], "a rejected snapshot must not be broadcast"
+    assert polls == 4, "the watcher must keep polling after a refusal"
+    assert output.count("Snapshot rejected: edge_out_of_range") == 1, (
+        "exactly one bounded reason code, and it is the typed handler's -- "
+        "the broad handler would have printed 'Snapshot error'")
+    assert "Snapshot error" not in output
+    assert "v070_gen000001" not in output
+
+
+@requires_numpy
+def test_the_watcher_does_not_reprocess_an_unchanged_rejected_snapshot(
+    confined, monkeypatch, capsys, _fresh_watcher_state
+):
+    """The cursor is advanced before extraction, so repeated polls over an
+    unchanged poisoned directory neither re-extract nor re-log."""
+    _zip_ls(confined / "v070_gen000001.npz", _declared_ls(512))
+
+    extractions = []
+    real_extract = lucid_server.extract_render_data
+
+    def _counting_extract(path):
+        extractions.append(path)
+        return real_extract(path)
+
+    monkeypatch.setattr(lucid_server, "extract_render_data", _counting_extract)
+    _run_watcher(monkeypatch, polls=5)
+
+    assert len(extractions) == 1, "the rejected snapshot was reprocessed"
+    assert capsys.readouterr().out.count("Snapshot rejected") == 1
+
+
+@requires_numpy
+def test_the_watcher_accepts_a_later_valid_snapshot(confined, monkeypatch,
+                                                    capsys, _fresh_watcher_state):
+    """Recovery, through the real loop: after a refusal, a newer valid
+    snapshot is broadcast without a restart."""
+    poison = confined / "v070_gen000001.npz"
+    _zip_ls(poison, _declared_ls(512))
+    os.utime(poison, (1_000_000, 1_000_000))
+
+    _run_watcher(monkeypatch, polls=1)
+
+    valid = Path(_write_snapshot_ls(confined / "v070_gen000002.npz",
+                                    compressed=True))
+    os.utime(valid, (2_000_000, 2_000_000))
+
+    broadcasts, _ = _run_watcher(monkeypatch, polls=1)
+    assert len(broadcasts) == 1, "the later valid snapshot was not broadcast"
+    frame = json.loads(broadcasts[0])
+    assert frame["type"] == "frame"
+    assert frame["data"]["metrics"]["generation"] == 7
 
 
 # ===========================================================================
@@ -742,7 +823,7 @@ def test_the_watcher_survives_a_rejected_snapshot_and_recovers(confined,
 #
 # The fixtures are built with the standard library, because NumPy cannot write
 # a duplicate member, a corrupt NPY magic or a lying shape. None is hostile in
-# SIZE: each is a few kilobytes, and the oversized cases lie in their headers
+# SIZE: each is a few hundred kilobytes at most, and the oversized cases lie in their headers
 # rather than on disk.
 # ===========================================================================
 
@@ -805,6 +886,26 @@ def _zip_ls(path, members, *, compressed=True, duplicate=None):
     return str(path)
 
 
+def _declared_ls(edge, channels=8):
+    """The same five members, DECLARING an `edge` it does not carry.
+
+    The guard checks geometry before size arithmetic, so an archive that lies
+    about its shape is refused on the geometry rule without the bytes ever
+    needing to exist. That is what keeps a 512-edge case at a few kilobytes
+    instead of the 4.1 GiB a real 512-cube payload would require.
+    """
+    members = _schema_ls(16, channels)
+    members["lattice.npy"] = _npy_ls(
+        "|u1", (edge, edge, edge), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d), }" % (edge, edge, edge))
+    members["memory_grid.npy"] = _npy_ls(
+        "<f4", (channels, edge, edge, edge), payload=b"",
+        header="{'descr': '<f4', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d, %d), }" % (channels, edge, edge, edge))
+    return members
+
+
 def _hostile_ls(kind, path):
     """Build one hostile archive of the named kind at `path`."""
     members = _schema_ls()
@@ -833,7 +934,7 @@ def _hostile_ls(kind, path):
                    "'shape': (8, 256, 256, 256), }")
         return _zip_ls(path, members)
     if kind == "oversized_edge":
-        return _zip_ls(path, _schema_ls(edge=512))
+        return _zip_ls(path, _declared_ls(512))
     if kind == "header_payload_mismatch":
         members["lattice.npy"] = _npy_ls("|u1", (16, 16, 16)) + b"\x00" * 64
         return _zip_ls(path, members)
@@ -862,7 +963,10 @@ def _hostile_ls(kind, path):
         members["lattice.npy"] = _npy_ls("|u1", (16, 16))
         return _zip_ls(path, members)
     if kind == "spatial_mismatch":
-        members["memory_grid.npy"] = _npy_ls("<f4", (8, 32, 32, 32))
+        members["memory_grid.npy"] = _npy_ls(
+            "<f4", (8, 32, 32, 32), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 32, 32, 32), }")
         return _zip_ls(path, members)
     if kind == "fortran_order":
         members["lattice.npy"] = _npy_ls("|u1", (16, 16, 16), fortran=True)
@@ -880,6 +984,30 @@ _HOSTILE_KINDS = [
     "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
     "spatial_mismatch", "fortran_order", "not_an_npz",
 ]
+
+#: The reason code each hostile kind must produce. Asserting only that a
+#: ValueError was raised would be weak: SnapshotArchiveRejected IS a
+#: ValueError, so an unrelated failure would satisfy it. Pinning the code ties
+#: each fixture to the defect its name claims.
+_EXPECTED_REASON = {
+    "duplicate_member": "member_duplicate",
+    "traversal_name": "member_name_unsafe",
+    "backslash_name": "member_name_unsafe",
+    "missing_member": "member_missing",
+    "extra_member": "member_unexpected",
+    "oversized_declared_payload": "member_payload_too_large",
+    "oversized_edge": "edge_out_of_range",
+    "header_payload_mismatch": "member_size_inconsistent",
+    "invalid_magic": "member_npy_magic_invalid",
+    "invalid_version": "member_npy_version_unsupported",
+    "invalid_header": "member_header_malformed",
+    "object_dtype": "member_dtype_object",
+    "structured_dtype": "member_dtype_structured",
+    "wrong_rank": "member_rank",
+    "spatial_mismatch": "spatial_disagreement",
+    "fortran_order": "member_fortran_order",
+    "not_an_npz": "not_zip_archive",
+}
 
 
 @requires_numpy
@@ -903,8 +1031,10 @@ def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
 
     monkeypatch.setattr(lucid_server.np, "load", _recording_load)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(lucid_server.SnapshotArchiveRejected) as excinfo:
         lucid_server.extract_render_data(archive)
+    assert excinfo.value.reason == _EXPECTED_REASON[kind], (
+        "the fixture was refused for a different defect than its name claims")
     assert reached == [], "np.load was reached on a hostile archive"
 
 
@@ -926,29 +1056,32 @@ def test_hostile_refusal_names_no_path_member_or_header(kind, tmp_path, monkeypa
 
 @requires_numpy
 @pytest.mark.parametrize("kind", _HOSTILE_KINDS)
-def test_a_rejected_snapshot_sends_no_frame_and_keeps_the_server_alive(
-    kind, tmp_path, monkeypatch
+def test_a_rejected_initial_snapshot_sends_no_frame_and_serves_the_client(
+    kind, tmp_path, monkeypatch, capsys
 ):
-    """The watcher must survive a poisoned directory: no frame, no broadcast,
-    no crash, and the poll loop keeps running."""
+    """The initial-client send, not the watcher.
+
+    `handle_client` sends through `websocket.send`, never through `broadcast`,
+    so an assertion on a patched `broadcast` here would be permanently true and
+    prove nothing. The log line is what distinguishes the typed handler from
+    the pre-existing broad one directly below it, which would print
+    "Initial send error" instead.
+    """
     archive = _hostile_ls(kind, tmp_path / "v070_gen000003.npz")
     monkeypatch.setattr(lucid_server, "DATA_DIR", str(tmp_path))
     monkeypatch.setattr(lucid_server, "find_latest_snapshot",
                         lambda data_dir: archive)
 
-    sent = []
-
-    async def _record_broadcast(message):
-        sent.append(message)
-
-    monkeypatch.setattr(lucid_server, "broadcast", _record_broadcast)
-
     websocket = FakeWebSocket([PING])
     asyncio.run(lucid_server.handle_client(websocket))
+    output = capsys.readouterr().out
 
-    assert sent == []
     assert [json.loads(s)["type"] for s in websocket.sent] == ["pong"], (
         "a rejected initial snapshot must send no frame, and must not stop the "
         "client from being served"
     )
+    assert "Snapshot rejected:" in output
+    assert "Initial send error" not in output, (
+        "the refusal fell through to the broad handler")
+    assert "v070_gen000003" not in output
     assert websocket not in lucid_server.connected_clients

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -25,6 +25,7 @@ totality.
 from __future__ import annotations
 
 import asyncio
+import glob
 import json
 import os
 import sys
@@ -787,6 +788,59 @@ def test_the_watcher_does_not_reprocess_an_unchanged_rejected_snapshot(
 
     assert len(extractions) == 1, "the rejected snapshot was reprocessed"
     assert capsys.readouterr().out.count("Snapshot rejected") == 1
+
+
+@requires_numpy
+def test_the_watcher_survives_candidates_that_disappear_mid_scan(
+    confined, monkeypatch, capsys, _fresh_watcher_state
+):
+    """Discovery and the watcher's own second metadata read are separate
+    syscalls from the glob, and the producer rotates snapshots. Neither may
+    raise into the loop's broad handler, whose message carries the path."""
+    valid = Path(_write_snapshot_ls(confined / "v070_gen000001.npz",
+                                    compressed=True))
+    ghost = str(confined / "v070_gen_GHOSTNAME_0002.npz")
+    real_glob = glob.glob
+
+    def _glob_with_a_ghost(pattern):
+        return list(real_glob(pattern)) + [ghost]
+
+    monkeypatch.setattr(lucid_server.glob, "glob", _glob_with_a_ghost)
+
+    broadcasts, polls = _run_watcher(monkeypatch, polls=2)
+    output = capsys.readouterr().out
+
+    assert len(broadcasts) == 1, "the ghost blocked a valid snapshot"
+    assert "GHOSTNAME" not in output
+    assert "Snapshot error" not in output
+    assert valid.exists()
+
+
+@requires_numpy
+def test_the_watcher_survives_the_chosen_snapshot_vanishing_after_selection(
+    confined, monkeypatch, capsys, _fresh_watcher_state
+):
+    """The second metadata read specifically: selection succeeded, then the
+    file went away before the watcher fingerprinted it."""
+    chosen = confined / "v070_gen000003.npz"
+    _write_snapshot_ls(chosen, compressed=True)
+    monkeypatch.setattr(lucid_server, "find_latest_snapshot",
+                        lambda data_dir: str(chosen))
+
+    real_fingerprint = lucid_server.entry_fingerprint
+
+    def _vanishing(path):
+        raise FileNotFoundError(2, "No such file or directory", str(path))
+
+    monkeypatch.setattr(lucid_server, "entry_fingerprint", _vanishing)
+    broadcasts, polls = _run_watcher(monkeypatch, polls=2)
+    output = capsys.readouterr().out
+
+    assert broadcasts == []
+    assert polls == 2, "the watcher stopped polling"
+    assert "v070_gen000003" not in output
+    assert "No such file" not in output
+    assert real_fingerprint is not None
 
 
 @requires_numpy

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -559,17 +559,19 @@ def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
     archive = _write_snapshot_ls(
         confined / "v070_refused.npz", lattice=_payload_array_ls(confined)
     )
-    import builtins
+    # Hooked on `os.fdopen`, not `builtins.open`: the guard opens through
+    # `os.open` so it can pass O_NONBLOCK and O_NOFOLLOW, and `os.fdopen` is
+    # what turns that descriptor into the file object it yields.
+    import os as _os
     opened = []
-    real_open = builtins.open
+    real_fdopen = _os.fdopen
 
-    def _tracking_open(*args, **kwargs):
-        handle = real_open(*args, **kwargs)
-        if str(args[0]).endswith(".npz"):
-            opened.append(handle)
+    def _tracking_fdopen(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        opened.append(handle)
         return handle
 
-    monkeypatch.setattr(builtins, "open", _tracking_open)
+    monkeypatch.setattr(_os, "fdopen", _tracking_fdopen)
     with pytest.raises(lucid_server.SnapshotArchiveRejected):
         lucid_server.extract_render_data(str(archive))
 

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -624,3 +624,227 @@ def test_a_numeric_snapshot_still_produces_cells_and_metrics(tmp_path):
     assert data["metrics"]["generation"] == 5
     assert type(data["metrics"]["generation"]) is int
     assert data["cells"], "a fully non-void lattice must yield cells"
+
+
+# ===========================================================================
+# Structural admission -- a hostile archive must be refused BEFORE np.load
+#
+# `extract_render_data` is reached from the watched directory on every change
+# and from every client connect, with nobody present. Pickle refusal and
+# archive lifetime say nothing about an archive's shape or its cost: an
+# archive could still name members outside the schema, carry traversal-bearing
+# entries, declare a payload of hundreds of gigabytes, or lie about its own
+# sizes, and every one of those reached `np.load` and the allocation behind it.
+#
+# The fixtures are built with the standard library, because NumPy cannot write
+# a duplicate member, a corrupt NPY magic or a lying shape. None is hostile in
+# SIZE: each is a few kilobytes, and the oversized cases lie in their headers
+# rather than on disk.
+# ===========================================================================
+
+import struct  # noqa: E402
+import warnings  # noqa: E402
+import zipfile  # noqa: E402
+
+_NPY_MAGIC = b"\x93NUMPY"
+
+
+def _npy_ls(descr, shape, *, fortran=False, payload=None, header=None,
+            version=(1, 0)):
+    """One `.npy` member as raw bytes, with every field independently forgeable."""
+    if header is None:
+        if not shape:
+            shape_text = "()"
+        elif len(shape) == 1:
+            shape_text = "(%d,)" % shape[0]
+        else:
+            shape_text = "(" + ", ".join(str(d) for d in shape) + ")"
+        header = "{'descr': '%s', 'fortran_order': %s, 'shape': %s, }" % (
+            descr, fortran, shape_text)
+    body = header.encode("latin1")
+    prelude = 10 if version == (1, 0) else 12
+    body += b" " * ((-(prelude + len(body) + 1)) % 64) + b"\n"
+    out = bytearray(_NPY_MAGIC) + bytes(version)
+    out += (struct.pack("<H", len(body)) if version == (1, 0)
+            else struct.pack("<I", len(body)))
+    out += body
+    if payload is None:
+        digits = descr[2:] if descr[0] in "<>|=" else descr[1:]
+        itemsize = int(digits) if digits else 0
+        count = 1
+        for dim in shape:
+            count *= dim
+        payload = b"\x00" * (count * itemsize)
+    return bytes(out) + payload
+
+
+def _schema_ls(edge=16, channels=8):
+    """The five members a `v070_gen` snapshot carries, at a valid edge."""
+    return {
+        "lattice.npy": _npy_ls("|u1", (edge, edge, edge)),
+        "memory_grid.npy": _npy_ls("<f4", (channels, edge, edge, edge)),
+        "generation.npy": _npy_ls("<i8", ()),
+        "ca_step.npy": _npy_ls("<i8", ()),
+        "best_fitness.npy": _npy_ls("<f8", ()),
+    }
+
+
+def _zip_ls(path, members, *, compressed=True, duplicate=None):
+    mode = zipfile.ZIP_DEFLATED if compressed else zipfile.ZIP_STORED
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # a duplicate name is the point here
+        with zipfile.ZipFile(path, "w", compression=mode) as archive:
+            for name, blob in members.items():
+                archive.writestr(name, blob)
+            if duplicate is not None:
+                archive.writestr(duplicate, members[duplicate])
+    return str(path)
+
+
+def _hostile_ls(kind, path):
+    """Build one hostile archive of the named kind at `path`."""
+    members = _schema_ls()
+    if kind == "duplicate_member":
+        return _zip_ls(path, members, duplicate="lattice.npy")
+    if kind == "traversal_name":
+        members["../../escape.npy"] = _npy_ls("|u1", (1,))
+        return _zip_ls(path, members)
+    if kind == "backslash_name":
+        members["sub\\escape.npy"] = _npy_ls("|u1", (1,))
+        return _zip_ls(path, members)
+    if kind == "missing_member":
+        members.pop("ca_step.npy")
+        return _zip_ls(path, members)
+    if kind == "extra_member":
+        members["surprise.npy"] = _npy_ls("|u1", (1,))
+        return _zip_ls(path, members)
+    if kind == "oversized_declared_payload":
+        members["lattice.npy"] = _npy_ls(
+            "|u8", (256, 256, 256), payload=b"",
+            header="{'descr': '|u8', 'fortran_order': False, "
+                   "'shape': (256, 256, 256), }")
+        members["memory_grid.npy"] = _npy_ls(
+            "<f4", (8, 256, 256, 256), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 256, 256, 256), }")
+        return _zip_ls(path, members)
+    if kind == "oversized_edge":
+        return _zip_ls(path, _schema_ls(edge=512))
+    if kind == "header_payload_mismatch":
+        members["lattice.npy"] = _npy_ls("|u1", (16, 16, 16)) + b"\x00" * 64
+        return _zip_ls(path, members)
+    if kind == "invalid_magic":
+        members["lattice.npy"] = b"XXXXXX" + members["lattice.npy"][6:]
+        return _zip_ls(path, members)
+    if kind == "invalid_version":
+        blob = bytearray(members["lattice.npy"])
+        blob[6] = 9
+        members["lattice.npy"] = bytes(blob)
+        return _zip_ls(path, members)
+    if kind == "invalid_header":
+        members["lattice.npy"] = _npy_ls(
+            "|u1", (16, 16, 16), header="{'descr': '|u1', 'shape': (1,), }")
+        return _zip_ls(path, members)
+    if kind == "object_dtype":
+        members["generation.npy"] = _npy_ls("|O", (), payload=b"")
+        return _zip_ls(path, members)
+    if kind == "structured_dtype":
+        members["generation.npy"] = _npy_ls(
+            "<i8", (), payload=b"",
+            header="{'descr': [('payload', '|O'), ('n', '<i4')], "
+                   "'fortran_order': False, 'shape': (1,), }")
+        return _zip_ls(path, members)
+    if kind == "wrong_rank":
+        members["lattice.npy"] = _npy_ls("|u1", (16, 16))
+        return _zip_ls(path, members)
+    if kind == "spatial_mismatch":
+        members["memory_grid.npy"] = _npy_ls("<f4", (8, 32, 32, 32))
+        return _zip_ls(path, members)
+    if kind == "fortran_order":
+        members["lattice.npy"] = _npy_ls("|u1", (16, 16, 16), fortran=True)
+        return _zip_ls(path, members)
+    if kind == "not_an_npz":
+        Path(path).write_bytes(_npy_ls("|u1", (16, 16, 16)))
+        return str(path)
+    raise AssertionError("unknown hostile archive kind: " + kind)
+
+
+_HOSTILE_KINDS = [
+    "duplicate_member", "traversal_name", "backslash_name", "missing_member",
+    "extra_member", "oversized_declared_payload", "oversized_edge",
+    "header_payload_mismatch", "invalid_magic", "invalid_version",
+    "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
+    "spatial_mismatch", "fortran_order", "not_an_npz",
+]
+
+
+@requires_numpy
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
+    """The load-reached recorder is the whole point.
+
+    Asserting only that something was raised would pass on code that let
+    `np.load` open, decompress and allocate first and then failed downstream --
+    which is exactly the behaviour this replaces.
+    """
+    archive = _hostile_ls(kind, tmp_path / "v070_gen000001.npz")
+    monkeypatch.setattr(lucid_server, "DATA_DIR", str(tmp_path))
+
+    reached = []
+    real_load = np.load
+
+    def _recording_load(*args, **kwargs):
+        reached.append(args[:1])
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(lucid_server.np, "load", _recording_load)
+
+    with pytest.raises(ValueError):
+        lucid_server.extract_render_data(archive)
+    assert reached == [], "np.load was reached on a hostile archive"
+
+
+@requires_numpy
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_refusal_names_no_path_member_or_header(kind, tmp_path, monkeypatch):
+    """The refusal reaches unattended logs, so it must carry no archive content."""
+    archive = _hostile_ls(kind, tmp_path / "v070_gen000002.npz")
+    monkeypatch.setattr(lucid_server, "DATA_DIR", str(tmp_path))
+    with pytest.raises(ValueError) as excinfo:
+        lucid_server.extract_render_data(archive)
+    message = str(excinfo.value)
+    assert str(tmp_path) not in message
+    assert "v070_gen000002" not in message
+    assert ".npy" not in message
+    assert "descr" not in message and "escape" not in message
+    assert message == message.strip() and "\n" not in message
+
+
+@requires_numpy
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_a_rejected_snapshot_sends_no_frame_and_keeps_the_server_alive(
+    kind, tmp_path, monkeypatch
+):
+    """The watcher must survive a poisoned directory: no frame, no broadcast,
+    no crash, and the poll loop keeps running."""
+    archive = _hostile_ls(kind, tmp_path / "v070_gen000003.npz")
+    monkeypatch.setattr(lucid_server, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(lucid_server, "find_latest_snapshot",
+                        lambda data_dir: archive)
+
+    sent = []
+
+    async def _record_broadcast(message):
+        sent.append(message)
+
+    monkeypatch.setattr(lucid_server, "broadcast", _record_broadcast)
+
+    websocket = FakeWebSocket([PING])
+    asyncio.run(lucid_server.handle_client(websocket))
+
+    assert sent == []
+    assert [json.loads(s)["type"] for s in websocket.sent] == ["pong"], (
+        "a rejected initial snapshot must send no frame, and must not stop the "
+        "client from being served"
+    )
+    assert websocket not in lucid_server.connected_clients

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -402,16 +402,36 @@ def _marker_ls(tmp_path):
 
 
 def _write_snapshot_ls(path, compressed=False, **members):
-    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    """A real NPZ. Object members pickle on the way in, which is harmless.
+
+    The edge is 16 and all five schema members are present, because the
+    archive now has to be ADMISSIBLE before its member dtypes matter: a 4-cube
+    with three members would be refused for its shape and its membership, and
+    the pickle property below would never be reached.
+    """
     payload = {
-        "lattice": np.ones((4, 4, 4), dtype=np.uint8),
-        "memory_grid": np.zeros((8, 4, 4, 4), dtype=np.float32),
+        "lattice": np.ones((16, 16, 16), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 16, 16, 16), dtype=np.float32),
         "generation": 7,
+        "ca_step": 11,
+        "best_fitness": 0.5,
     }
     payload.update(members)
     writer = np.savez_compressed if compressed else np.savez
     writer(path, **payload)
     return str(path)
+
+
+@pytest.fixture
+def confined(tmp_path, monkeypatch):
+    """Point the server's data directory at pytest's own tmp_path.
+
+    Admission confines the archive to the configured data directory, so a
+    fixture written anywhere else is refused for CONTAINMENT before the
+    property under test is reached.
+    """
+    monkeypatch.setattr(lucid_server, "DATA_DIR", str(tmp_path))
+    return tmp_path
 
 
 @requires_numpy
@@ -432,14 +452,39 @@ def test_ls_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
 
 @requires_numpy
 @pytest.mark.parametrize("field", ["lattice", "memory_grid", "generation"])
-def test_object_payload_is_refused_by_extract_render_data(tmp_path, field):
+def test_object_payload_is_refused_by_extract_render_data(confined, field):
+    """The refusal moved EARLIER, and the code says so.
+
+    An object member used to be caught by NumPy at `np.load`. It is now caught
+    by admission from the member's NPY header, before NumPy is involved at
+    all -- so the assertion is the typed reason code, not NumPy's message. The
+    property that matters is unchanged and stronger: the payload never runs.
+    """
     archive = _write_snapshot_ls(
-        tmp_path / f"{field}.npz", **{field: _payload_array_ls(tmp_path)}
+        confined / f"v070_{field}.npz", **{field: _payload_array_ls(confined)}
+    )
+    with pytest.raises(lucid_server.SnapshotArchiveRejected) as excinfo:
+        lucid_server.extract_render_data(archive)
+    assert excinfo.value.reason == "member_dtype_object"
+    assert not _marker_ls(confined).exists(), "the pickle payload executed"
+
+
+@requires_numpy
+def test_numpys_own_pickle_refusal_is_still_in_place_behind_admission(confined):
+    """Second line of defence, kept non-vacuous.
+
+    Admission now stops an object member first, so the load-site refusal would
+    otherwise never be observed again. Calling NumPy directly on the same
+    archive shows it is still exactly as it was.
+    """
+    archive = _write_snapshot_ls(
+        confined / "v070_direct.npz", lattice=_payload_array_ls(confined)
     )
     with pytest.raises(ValueError) as excinfo:
-        lucid_server.extract_render_data(archive)
+        with np.load(archive, allow_pickle=False) as snap:
+            snap["lattice"]
     assert "allow_pickle=False" in str(excinfo.value)
-    assert not _marker_ls(tmp_path).exists(), "the pickle payload executed"
+    assert not _marker_ls(confined).exists()
 
 
 def _structured_payload_ls(directory):
@@ -462,24 +507,25 @@ def test_the_structured_payload_also_fires_when_pickle_is_enabled(tmp_path):
 
 
 @requires_numpy
-def test_an_object_bearing_structured_dtype_is_refused(tmp_path):
-    """`kind == 'O'` alone would miss this; NumPy's refusal covers
-    `dtype.hasobject`."""
+def test_an_object_bearing_structured_dtype_is_refused(confined):
+    """`kind == 'O'` alone would miss this. Admission refuses a structured
+    descriptor outright, without needing to reason about which fields carry
+    objects."""
     archive = _write_snapshot_ls(
-        tmp_path / "struct.npz", generation=_structured_payload_ls(tmp_path)
+        confined / "v070_struct.npz", generation=_structured_payload_ls(confined)
     )
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(lucid_server.SnapshotArchiveRejected) as excinfo:
         lucid_server.extract_render_data(archive)
-    assert "allow_pickle=False" in str(excinfo.value)
-    assert not _marker_ls(tmp_path).exists()
+    assert excinfo.value.reason == "member_dtype_structured"
+    assert not _marker_ls(confined).exists()
 
 
 @requires_numpy
-def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
+def test_the_archive_is_closed_before_any_cell_iteration(confined, monkeypatch):
     """`extract_render_data` had no context manager: the handle was held open
     across up to MAX_CELLS iterations of per-cell work. `np.argwhere` is the
     first downstream call, so it is the ordering witness."""
-    archive = _write_snapshot_ls(tmp_path / "clean.npz")
+    archive = _write_snapshot_ls(confined / "v070_clean.npz")
     real_load = np.load
     opened = []
 
@@ -507,38 +553,36 @@ def test_the_archive_is_closed_before_any_cell_iteration(tmp_path, monkeypatch):
 
 
 @requires_numpy
-def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
-    """Closure on the exceptional path, witnessed on the real `NpzFile`.
-
-    The docstring claims closure "holds on refusal too because the members are
-    read inside the block". This file's ownership is conditional now, so that
-    claim is newest here and is witnessed rather than asserted.
-    """
+def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
+    """Closure on the exceptional path, witnessed on the real file object the
+    guard opened -- a NumPy handle is never created for a refused archive."""
     archive = _write_snapshot_ls(
-        tmp_path / "refused.npz", lattice=_payload_array_ls(tmp_path)
+        confined / "v070_refused.npz", lattice=_payload_array_ls(confined)
     )
+    import builtins
     opened = []
-    real_load = np.load
+    real_open = builtins.open
 
-    def tracking_load(*args, **kwargs):
-        handle = real_load(*args, **kwargs)
-        opened.append(handle)
+    def _tracking_open(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        if str(args[0]).endswith(".npz"):
+            opened.append(handle)
         return handle
 
-    monkeypatch.setattr(lucid_server.np, "load", tracking_load)
-    with pytest.raises(ValueError):
+    monkeypatch.setattr(builtins, "open", _tracking_open)
+    with pytest.raises(lucid_server.SnapshotArchiveRejected):
         lucid_server.extract_render_data(str(archive))
 
-    assert len(opened) == 1, "the archive was never opened"
-    # `close()` drops `zip` unconditionally; `fid` is a class attribute
-    # defaulting to None and cannot carry this claim alone.
-    assert opened[0].zip is None, "the archive survived the refusal"
+    assert len(opened) == 1, "the archive was opened more than once, or not at all"
+    assert opened[0].closed, "the descriptor survived the refusal"
 
 
 @requires_numpy
-def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+def test_a_refused_archive_never_reaches_np_load_at_all(confined, monkeypatch):
+    """Stronger than "it was not retried with pickle enabled": NumPy is not
+    asked to open the archive even once."""
     archive = _write_snapshot_ls(
-        tmp_path / "retry.npz", lattice=_payload_array_ls(tmp_path)
+        confined / "v070_retry.npz", lattice=_payload_array_ls(confined)
     )
     real_load = np.load
     calls = []
@@ -548,8 +592,27 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
         return real_load(*args, **kwargs)
 
     monkeypatch.setattr(lucid_server.np, "load", _recording_load)
-    with pytest.raises(ValueError):
+    with pytest.raises(lucid_server.SnapshotArchiveRejected):
         lucid_server.extract_render_data(archive)
+    assert calls == []
+
+
+@requires_numpy
+def test_a_valid_archive_is_loaded_with_pickle_explicitly_disabled(confined,
+                                                                   monkeypatch):
+    """The counterpart control: on the admitted path the explicit literal is
+    still what NumPy receives, so the assertion above is about ordering rather
+    than about the flag having quietly disappeared."""
+    archive = _write_snapshot_ls(confined / "v070_ok.npz", compressed=True)
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(lucid_server.np, "load", _recording_load)
+    lucid_server.extract_render_data(archive)
     assert calls == [False]
 
 
@@ -593,37 +656,76 @@ def test_the_named_legacy_npy_class_is_what_numpy_actually_raises():
 
 
 @requires_numpy
-def test_a_numeric_npy_still_fails_exactly_as_it_did_before(tmp_path, monkeypatch):
-    """`extract_render_data` gained its first `with` on this branch.
+def test_a_renamed_numeric_npy_now_receives_a_typed_refusal(confined,
+                                                            monkeypatch):
+    """An explicitly authorized behaviour change, recorded rather than glossed.
 
-    An `NpzFile` needs deterministic ownership; an ndarray does not. Conditional
-    ownership keeps the archive closing while leaving a `.npy` to fail at the
-    same `snap['lattice']` subscript it always did -- and nothing downstream may
-    run, which `np.argwhere` witnesses because it is the first call after the
-    extraction.
+    A numeric `.npy` renamed `.npz` used to reach `np.load`, come back as a
+    plain ndarray, and fail at the `snap['lattice']` subscript with an
+    incidental `IndexError`. It is now refused by admission as not being a ZIP
+    archive, before NumPy sees it. The old class is still derived below and
+    asserted to be a DIFFERENT class from the new failure, so the change
+    cannot be mistaken for the old behaviour surviving.
     """
-    not_an_archive = tmp_path / "snapshot.npy"
-    np.save(not_an_archive, np.zeros((2, 2, 2), dtype=np.uint8))
+    npy_source = confined / "v070_renamed.npy"
+    np.save(npy_source, np.zeros((16, 16, 16), dtype=np.uint8))
+    not_an_archive = confined / "v070_renamed.npz"
+    not_an_archive.write_bytes(npy_source.read_bytes())
 
     reached = []
     monkeypatch.setattr(
         lucid_server.np, "argwhere", lambda *a, **k: reached.append("argwhere")
     )
 
-    with pytest.raises(_legacy_npy_error_class_ls()):
+    with pytest.raises(lucid_server.SnapshotArchiveRejected) as excinfo:
         lucid_server.extract_render_data(str(not_an_archive))
 
+    assert excinfo.value.reason == "not_zip_archive"
     assert reached == [], "downstream processing ran on a non-archive input"
+    assert not isinstance(excinfo.value, _legacy_npy_error_class_ls()), (
+        "the new refusal is the old incidental IndexError after all")
 
 
 @requires_numpy
-def test_a_numeric_snapshot_still_produces_cells_and_metrics(tmp_path):
-    archive = _write_snapshot_ls(tmp_path / "clean.npz", generation=np.int64(5))
+def test_a_numeric_snapshot_still_produces_cells_and_metrics(confined):
+    archive = _write_snapshot_ls(confined / "v070_clean.npz",
+                                 generation=np.int64(5))
     data = lucid_server.extract_render_data(archive)
     assert set(data) == {"cells", "metrics"}
     assert data["metrics"]["generation"] == 5
     assert type(data["metrics"]["generation"]) is int
     assert data["cells"], "a fully non-void lattice must yield cells"
+    assert data["metrics"]["grid_size"] == 16
+
+
+@requires_numpy
+def test_the_watcher_survives_a_rejected_snapshot_and_recovers(confined,
+                                                               monkeypatch):
+    """One poll over a poisoned directory, then one over a repaired one.
+
+    The watcher must log one bounded reason and broadcast nothing, then pick
+    up the next valid snapshot without a restart.
+    """
+    poison = confined / "v070_gen000001.npz"
+    _zip_ls(poison, _schema_ls(edge=24))  # admissible-looking, wrong edge
+
+    broadcasts = []
+
+    async def _record(message):
+        broadcasts.append(message)
+
+    monkeypatch.setattr(lucid_server, "broadcast", _record)
+    monkeypatch.setattr(lucid_server, "last_snapshot_path", None)
+    monkeypatch.setattr(lucid_server, "last_snapshot_mtime", 0)
+
+    with pytest.raises(lucid_server.SnapshotArchiveRejected):
+        lucid_server.extract_render_data(str(poison))
+    assert broadcasts == []
+
+    valid = _write_snapshot_ls(confined / "v070_gen000002.npz", compressed=True)
+    data = lucid_server.extract_render_data(valid)
+    assert data["metrics"]["generation"] == 7, (
+        "a later valid snapshot must still be accepted")
 
 
 # ===========================================================================

--- a/tests/test_lucid_server.py
+++ b/tests/test_lucid_server.py
@@ -840,7 +840,6 @@ def test_the_watcher_survives_the_chosen_snapshot_vanishing_after_selection(
     assert polls == 2, "the watcher stopped polling"
     assert "v070_gen000003" not in output
     assert "No such file" not in output
-    assert real_fingerprint is not None
 
 
 @requires_numpy

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -832,6 +832,48 @@ def test_the_descriptor_is_closed_after_a_payload_refusal(confined, monkeypatch)
     assert opened[0].closed
 
 
+def test_status_does_not_500_when_the_selected_snapshot_cannot_be_described(
+    confined, monkeypatch
+):
+    """The non-following property has to reach `/api/status`, not stop at
+    selection.
+
+    Selection deliberately KEEPS a dangling link or a symlink loop as a
+    candidate so it reaches the guard and is refused with a reason — and when
+    nothing in the window is admissible it still returns the newest. A
+    following, unguarded `.stat()` here then raised `FileNotFoundError`, which
+    Flask turns into a 500 and logs with the attacker-chosen path in the
+    traceback.
+
+    The status code is the load-bearing assertion. Flask's non-debug 500 body
+    is a generic page, so asserting the path is absent from the RESPONSE would
+    hold either way — the disclosure was to the server log, not to the caller.
+    """
+    ghost = confined / "v070_gen_LEAKNAME_0050.npz"
+    monkeypatch.setattr(medusa_api, "_find_latest_snapshot", lambda: ghost)
+    client = medusa_api.app.test_client()
+    response = client.get("/api/status")
+    assert response.status_code == 404, (
+        "a snapshot that cannot be described reached an unguarded stat()")
+    assert response.get_json() == {"error": "No snapshots found"}
+
+
+def test_status_still_reports_a_real_snapshot(confined):
+    """Counterpart control, so the test above is about the missing entry and
+    not about `/api/status` having been broken outright."""
+    archive = Path(_write_snapshot_ma(confined / "v070_gen000051.npz",
+                                      compressed=True))
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot",
+                           lambda: archive):
+        response = client.get("/api/status")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["latest_snapshot"] == "v070_gen000051.npz"
+    assert payload["snapshot_size_mb"] >= 0
+    assert payload["snapshot_age_seconds"] >= 0
+
+
 def test_selection_survives_a_snapshot_that_disappears_mid_scan(confined,
                                                                 monkeypatch):
     """The glob and the metadata read are separate syscalls, and the producer
@@ -898,6 +940,16 @@ def trimesh_sentinel(monkeypatch):
     return sentinel
 
 
+#: A lattice with SOMETHING in it. `geometry_stl` returns 404 for an all-void
+#: lattice at `if len(non_void_coords) == 0`, which is BEFORE it touches
+#: `trimesh.primitives` — so the default all-zero fixture would make the
+#: counterpart control below assert on a module that was never reached, and
+#: would let the refusal test's `touched == []` pass through the 404 path
+#: instead of through the refusal.
+def _non_void_lattice():
+    return np.ones((16, 16, 16), dtype=np.uint8)
+
+
 def test_geometry_route_answers_503_before_touching_trimesh(confined,
                                                             trimesh_sentinel):
     """Runs in CI rather than skipping: the sentinel replaces the dependency.
@@ -923,8 +975,16 @@ def test_geometry_route_reaches_trimesh_only_once_a_snapshot_is_admitted(
     confined, trimesh_sentinel
 ):
     """The counterpart control, so the assertion above is about the REFUSAL
-    and not about the route being unreachable for some other reason."""
-    archive = _write_snapshot_ma(confined / "v070_gen000012.npz", compressed=True)
+    and not about the route being unreachable for some other reason.
+
+    The lattice must be NON-VOID. With the default all-zero fixture the route
+    returns 404 at `len(non_void_coords) == 0` before any mesh work, so this
+    control would assert on a module the route never reached — and the refusal
+    test above would have been satisfied by that same 404 rather than by the
+    refusal it names.
+    """
+    archive = _write_snapshot_ma(confined / "v070_gen000012.npz",
+                                 compressed=True, lattice=_non_void_lattice())
     client = medusa_api.app.test_client()
     with mock.patch.object(medusa_api, "_find_latest_snapshot",
                            lambda: Path(archive)):
@@ -934,6 +994,7 @@ def test_geometry_route_reaches_trimesh_only_once_a_snapshot_is_admitted(
     # through, and that it was reached only after the snapshot was accepted.
     assert trimesh_sentinel.touched, (
         "an admitted snapshot never reached the mesh stage")
+    assert trimesh_sentinel.touched[0] == "primitives"
     assert response.status_code != 503
 
 

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import ast
 import os
+import sys
+import types
 from pathlib import Path
 from unittest import mock
 
@@ -773,6 +775,93 @@ def test_selection_is_bounded_and_does_not_scan_the_whole_directory(confined,
         "when nothing in the window is admissible the newest is still returned")
 
 
+def _corrupt_crc_ma(path):
+    """Break one member's CRC: a valid header over a corrupt body.
+
+    Preflight cannot see this — a payload can only be checked by decompressing
+    it, which is the work admission exists to avoid before it decides.
+    """
+    data = bytearray(Path(path).read_bytes())
+    index = data.find(b"PK\x01\x02")
+    struct.pack_into("<I", data, index + 16, 0xDEADBEEF)
+    Path(path).write_bytes(bytes(data))
+    return Path(path)
+
+
+def test_a_corrupt_payload_becomes_the_same_sanitized_503(confined):
+    """Post-admission archive corruption used to escape as `zipfile.BadZipFile`
+    — which is not a `ValueError`, so it sailed past every typed handler into a
+    500 with a traceback naming the member."""
+    archive = _corrupt_crc_ma(
+        _write_snapshot_ma(confined / "v070_gen000020.npz", compressed=True))
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot",
+                           lambda: archive):
+        response = client.get("/api/census")
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "snapshot_rejected"}
+    body = response.get_data(as_text=True)
+    assert "lattice" not in body and "CRC" not in body
+    assert "v070_gen000020" not in body and "Traceback" not in body
+
+
+def test_a_corrupt_payload_refusal_carries_only_a_reason_code(confined):
+    archive = _corrupt_crc_ma(
+        _write_snapshot_ma(confined / "v070_gen000021.npz", compressed=True))
+    with pytest.raises(medusa_api.SnapshotArchiveRejected) as excinfo:
+        medusa_api._load_snapshot(archive)
+    assert excinfo.value.reason == "member_payload_unreadable"
+    assert str(excinfo.value) == "member_payload_unreadable"
+
+
+def test_the_descriptor_is_closed_after_a_payload_refusal(confined, monkeypatch):
+    archive = _corrupt_crc_ma(
+        _write_snapshot_ma(confined / "v070_gen000022.npz", compressed=True))
+    opened = []
+    real_fdopen = os.fdopen
+
+    def _tracking_fdopen(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(os, "fdopen", _tracking_fdopen)
+    with pytest.raises(medusa_api.SnapshotArchiveRejected):
+        medusa_api._load_snapshot(archive)
+    assert len(opened) == 1
+    assert opened[0].closed
+
+
+def test_selection_survives_a_snapshot_that_disappears_mid_scan(confined,
+                                                                monkeypatch):
+    """The glob and the metadata read are separate syscalls, and the producer
+    rotates snapshots. A vanished entry must be skipped silently, not raise an
+    OSError whose message carries the attacker-chosen path."""
+    good = Path(_write_snapshot_ma(confined / "v070_gen000030.npz",
+                                   compressed=True))
+    ghost = confined / "v070_gen000031.npz"
+    real_glob = Path.glob
+
+    def _glob_with_a_ghost(self, pattern):
+        return list(real_glob(self, pattern)) + [ghost]
+
+    monkeypatch.setattr(Path, "glob", _glob_with_a_ghost)
+    assert medusa_api._find_latest_snapshot() == good
+
+    client = medusa_api.app.test_client()
+    response = client.get("/api/census")
+    assert response.status_code == 200, "a vanished candidate broke the route"
+
+
+def test_selection_survives_a_directory_of_only_vanished_candidates(confined,
+                                                                    monkeypatch):
+    ghosts = [confined / ("v070_gen0000%d.npz" % i) for i in range(40, 45)]
+    monkeypatch.setattr(Path, "glob", lambda self, pattern: list(ghosts))
+    assert medusa_api._find_latest_snapshot() is None
+    client = medusa_api.app.test_client()
+    assert client.get("/api/census").status_code == 404
+
+
 def test_selection_still_prefers_the_most_recent(confined):
     older = Path(_write_snapshot_ma(confined / "v070_gen000001.npz"))
     newer = Path(_write_snapshot_ma(confined / "v070_gen000002.npz"))
@@ -781,11 +870,42 @@ def test_selection_still_prefers_the_most_recent(confined):
     assert medusa_api._find_latest_snapshot() == newer
 
 
-def test_geometry_route_also_answers_503_for_a_rejected_archive(confined,
-                                                                monkeypatch):
-    """The fourth `_load_snapshot` route. Kept separate because it needs
-    trimesh, which is not a CI dependency."""
-    pytest.importorskip("trimesh")
+class _TrimeshSentinel(types.ModuleType):
+    """A stand-in for `trimesh` that records any attribute reached for.
+
+    `/api/geometry/stl` is the fourth `_load_snapshot` route and the only one
+    whose test used to be `importorskip`-gated — so in authoritative CI, which
+    does not install trimesh, it never ran at all. It does not need the real
+    package: the refusal must happen BEFORE any mesh work, and a sentinel
+    proves that far more directly than the real library could, because every
+    attribute access is recorded and the assertion is that none occurred.
+    """
+
+    def __init__(self):
+        super().__init__("trimesh")
+        self.touched = []
+
+    def __getattr__(self, name):
+        self.touched.append(name)
+        raise AssertionError(
+            "trimesh.%s was reached on a rejected snapshot" % name)
+
+
+@pytest.fixture
+def trimesh_sentinel(monkeypatch):
+    sentinel = _TrimeshSentinel()
+    monkeypatch.setitem(sys.modules, "trimesh", sentinel)
+    return sentinel
+
+
+def test_geometry_route_answers_503_before_touching_trimesh(confined,
+                                                            trimesh_sentinel):
+    """Runs in CI rather than skipping: the sentinel replaces the dependency.
+
+    `geometry_stl` imports trimesh first and only then loads the snapshot, so
+    the import must succeed for the refusal to be reachable at all — and
+    nothing on the module may be used once the snapshot is refused.
+    """
     archive = _hostile_ma("missing_member", confined / "v070_gen000009.npz")
     client = medusa_api.app.test_client()
     with mock.patch.object(medusa_api, "_find_latest_snapshot",
@@ -793,6 +913,28 @@ def test_geometry_route_also_answers_503_for_a_rejected_archive(confined,
         response = client.get("/api/geometry/stl")
     assert response.status_code == 503
     assert response.get_json() == {"error": "snapshot_rejected"}
+    assert trimesh_sentinel.touched == [], (
+        "mesh work began before the snapshot was refused")
+    body = response.get_data(as_text=True)
+    assert "v070_gen000009" not in body and "Traceback" not in body
+
+
+def test_geometry_route_reaches_trimesh_only_once_a_snapshot_is_admitted(
+    confined, trimesh_sentinel
+):
+    """The counterpart control, so the assertion above is about the REFUSAL
+    and not about the route being unreachable for some other reason."""
+    archive = _write_snapshot_ma(confined / "v070_gen000012.npz", compressed=True)
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot",
+                           lambda: Path(archive)):
+        response = client.get("/api/geometry/stl")
+    # The sentinel raises on first attribute use, which Flask turns into a 500.
+    # What matters is that trimesh WAS reached, i.e. admission let the route
+    # through, and that it was reached only after the snapshot was accepted.
+    assert trimesh_sentinel.touched, (
+        "an admitted snapshot never reached the mesh stage")
+    assert response.status_code != 503
 
 
 @pytest.mark.parametrize("route,expected", [

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -669,17 +669,18 @@ def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
     archive = _write_snapshot_ma(
         confined / "v070_closed.npz", lattice=_payload_array_ma(confined)
     )
-    import builtins
+    # Hooked on `os.fdopen`, not `builtins.open`: the guard opens through
+    # `os.open` so it can pass O_NONBLOCK and O_NOFOLLOW, and `os.fdopen` is
+    # what turns that descriptor into the file object it yields.
     opened = []
-    real_open = builtins.open
+    real_fdopen = os.fdopen
 
-    def _tracking_open(*args, **kwargs):
-        handle = real_open(*args, **kwargs)
-        if str(args[0]).endswith(".npz"):
-            opened.append(handle)
+    def _tracking_fdopen(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        opened.append(handle)
         return handle
 
-    monkeypatch.setattr(builtins, "open", _tracking_open)
+    monkeypatch.setattr(os, "fdopen", _tracking_fdopen)
     with pytest.raises(medusa_api.SnapshotArchiveRejected):
         medusa_api._load_snapshot(archive)
     assert len(opened) == 1, "the archive was opened more than once, or not at all"
@@ -713,6 +714,63 @@ def test_selection_no_longer_skips_a_small_snapshot(confined):
                                     compressed=True))
     assert small.stat().st_size < 1_000_000, "the fixture is not small any more"
     assert medusa_api._find_latest_snapshot() == small
+
+
+def test_selection_falls_back_past_an_unusable_newest_snapshot(confined):
+    """The 1 MB rule was not only a filter, it was a SEARCH.
+
+    It walked newest-first and skipped a file that looked unusable, so the API
+    kept answering from the previous good snapshot. Replacing it with a bare
+    `snapshots[0]` would have let one truncated or hostile archive wedge all
+    four snapshot routes at 503 until a fresh snapshot landed — and the
+    producer writes straight to its final path with no temporary-and-rename,
+    so a partially written archive IS the newest file for as long as the write
+    takes. The search is kept; the predicate is now admission.
+    """
+    good = Path(_write_snapshot_ma(confined / "v070_gen000001.npz",
+                                   compressed=True))
+    poison = Path(_hostile_ma("missing_member", confined / "v070_gen000002.npz"))
+    os.utime(good, (1_000_000, 1_000_000))
+    os.utime(poison, (2_000_000, 2_000_000))
+
+    assert medusa_api._find_latest_snapshot() == good
+
+    client = medusa_api.app.test_client()
+    response = client.get("/api/census")
+    assert response.status_code == 200, (
+        "one unusable newest archive must not wedge the route")
+    assert response.get_json()["generation"] == 7
+
+
+def test_selection_is_bounded_and_does_not_scan_the_whole_directory(confined,
+                                                                    monkeypatch):
+    """The old search walked every snapshot in the directory. Preflighting all
+    of a five-figure directory on every request would itself be the denial of
+    service, so the window is bounded — and anything older than it is simply
+    not considered."""
+    depth = medusa_api.SNAPSHOT_SELECTION_DEPTH
+    good = Path(_write_snapshot_ma(confined / "v070_gen000000.npz",
+                                   compressed=True))
+    os.utime(good, (1_000_000, 1_000_000))
+    for index in range(depth + 2):
+        poison = Path(_hostile_ma("missing_member",
+                                  confined / ("v070_gen%06d.npz" % (index + 1))))
+        os.utime(poison, (2_000_000 + index, 2_000_000 + index))
+
+    admitted = []
+    real_admit = medusa_api.admit_snapshot
+
+    def _counting_admit(path, **kwargs):
+        admitted.append(path)
+        return real_admit(path, **kwargs)
+
+    monkeypatch.setattr(medusa_api, "admit_snapshot", _counting_admit)
+    selected = medusa_api._find_latest_snapshot()
+
+    assert len(admitted) == depth, "the search was not bounded to the window"
+    assert selected != good, "a snapshot outside the window must not be found"
+    assert selected.name == "v070_gen%06d.npz" % (depth + 2), (
+        "when nothing in the window is admissible the newest is still returned")
 
 
 def test_selection_still_prefers_the_most_recent(confined):

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -795,15 +795,29 @@ def test_geometry_route_also_answers_503_for_a_rejected_archive(confined,
     assert response.get_json() == {"error": "snapshot_rejected"}
 
 
-@pytest.mark.parametrize("route", ["/api/health", "/api/status"])
-def test_routes_that_do_not_load_a_snapshot_are_unchanged(route, confined):
+@pytest.mark.parametrize("route,expected", [
+    ("/api/health", 200),
+    ("/api/status", 200),
+    ("/api/telemetry", 404),
+])
+def test_routes_that_do_not_load_a_snapshot_keep_their_own_behaviour(
+    route, expected, confined
+):
     """Health, status, telemetry and the raw download do not go through
-    `_load_snapshot`, so a poisoned directory must not change them."""
+    `_load_snapshot`, so a poisoned directory must not turn any of them into a
+    snapshot refusal.
+
+    Stated exactly, because the obvious phrasing would be wrong: these are not
+    all "unchanged and 200". `/api/telemetry` answers 404 in a directory with
+    no telemetry file, which is its own established behaviour and is what is
+    pinned here. `/api/health` reads no directory at all, so the poisoned file
+    is inert for it -- included anyway as the floor of the comparison.
+    """
     _hostile_ma("missing_member", confined / "v070_gen000010.npz")
     client = medusa_api.app.test_client()
     response = client.get(route)
-    assert response.status_code == 200
-    assert response.get_json().get("error") is None
+    assert response.status_code == expected
+    assert response.get_json().get("error") != "snapshot_rejected"
 
 
 def test_the_raw_snapshot_download_is_unchanged(confined):
@@ -831,7 +845,7 @@ def test_the_raw_snapshot_download_is_unchanged(confined):
 #
 # The fixtures are built with the standard library, because NumPy cannot write
 # a duplicate member, a corrupt NPY magic or a lying shape. None is hostile in
-# SIZE: each is a few kilobytes, and the oversized cases lie in their headers
+# SIZE: each is a few hundred kilobytes at most, and the oversized cases lie in their headers
 # rather than on disk.
 # ===========================================================================
 
@@ -894,6 +908,26 @@ def _zip_ma(path, members, *, compressed=True, duplicate=None):
     return str(path)
 
 
+def _declared_ma(edge, channels=8):
+    """The same five members, DECLARING an `edge` it does not carry.
+
+    The guard checks geometry before size arithmetic, so an archive that lies
+    about its shape is refused on the geometry rule without the bytes ever
+    needing to exist. That is what keeps a 512-edge case at a few kilobytes
+    instead of the 4.1 GiB a real 512-cube payload would require.
+    """
+    members = _schema_ma(16, channels)
+    members["lattice.npy"] = _npy_ma(
+        "|u1", (edge, edge, edge), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d), }" % (edge, edge, edge))
+    members["memory_grid.npy"] = _npy_ma(
+        "<f4", (channels, edge, edge, edge), payload=b"",
+        header="{'descr': '<f4', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d, %d), }" % (channels, edge, edge, edge))
+    return members
+
+
 def _hostile_ma(kind, path):
     """Build one hostile archive of the named kind at `path`."""
     members = _schema_ma()
@@ -922,7 +956,7 @@ def _hostile_ma(kind, path):
                    "'shape': (8, 256, 256, 256), }")
         return _zip_ma(path, members)
     if kind == "oversized_edge":
-        return _zip_ma(path, _schema_ma(edge=512))
+        return _zip_ma(path, _declared_ma(512))
     if kind == "header_payload_mismatch":
         members["lattice.npy"] = _npy_ma("|u1", (16, 16, 16)) + b"\x00" * 64
         return _zip_ma(path, members)
@@ -951,7 +985,10 @@ def _hostile_ma(kind, path):
         members["lattice.npy"] = _npy_ma("|u1", (16, 16))
         return _zip_ma(path, members)
     if kind == "spatial_mismatch":
-        members["memory_grid.npy"] = _npy_ma("<f4", (8, 32, 32, 32))
+        members["memory_grid.npy"] = _npy_ma(
+            "<f4", (8, 32, 32, 32), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 32, 32, 32), }")
         return _zip_ma(path, members)
     if kind == "fortran_order":
         members["lattice.npy"] = _npy_ma("|u1", (16, 16, 16), fortran=True)
@@ -969,6 +1006,30 @@ _HOSTILE_KINDS = [
     "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
     "spatial_mismatch", "fortran_order", "not_an_npz",
 ]
+
+#: The reason code each hostile kind must produce. Asserting only that a
+#: ValueError was raised would be weak: SnapshotArchiveRejected IS a
+#: ValueError, so an unrelated failure would satisfy it. Pinning the code ties
+#: each fixture to the defect its name claims.
+_EXPECTED_REASON = {
+    "duplicate_member": "member_duplicate",
+    "traversal_name": "member_name_unsafe",
+    "backslash_name": "member_name_unsafe",
+    "missing_member": "member_missing",
+    "extra_member": "member_unexpected",
+    "oversized_declared_payload": "member_payload_too_large",
+    "oversized_edge": "edge_out_of_range",
+    "header_payload_mismatch": "member_size_inconsistent",
+    "invalid_magic": "member_npy_magic_invalid",
+    "invalid_version": "member_npy_version_unsupported",
+    "invalid_header": "member_header_malformed",
+    "object_dtype": "member_dtype_object",
+    "structured_dtype": "member_dtype_structured",
+    "wrong_rank": "member_rank",
+    "spatial_mismatch": "spatial_disagreement",
+    "fortran_order": "member_fortran_order",
+    "not_an_npz": "not_zip_archive",
+}
 
 #: The four routes that go through `_load_snapshot`. `/api/health`,
 #: `/api/status`, `/api/telemetry` and `/api/snapshot/latest` deliberately do
@@ -996,8 +1057,10 @@ def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
 
     monkeypatch.setattr(medusa_api.np, "load", _recording_load)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(medusa_api.SnapshotArchiveRejected) as excinfo:
         medusa_api._load_snapshot(archive)
+    assert excinfo.value.reason == _EXPECTED_REASON[kind], (
+        "the fixture was refused for a different defect than its name claims")
     assert reached == [], "np.load was reached on a hostile archive"
 
 

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -568,3 +568,224 @@ def test_a_numeric_snapshot_still_loads_all_four_values(tmp_path):
     assert lattice.dtype == np.uint8 and grid.dtype == np.float32
     assert generation == 3 and type(generation) is int
     assert fitness == pytest.approx(0.25) and type(fitness) is float
+
+
+# ===========================================================================
+# Structural admission -- a hostile archive must be refused BEFORE np.load,
+# and the four snapshot routes must say so without disclosing why
+#
+# `_load_snapshot` backs four unauthenticated GET routes on a service that
+# binds 0.0.0.0. Pickle refusal and archive lifetime say nothing about an
+# archive's shape or its cost: an archive could still name members outside the
+# schema, carry traversal-bearing entries, declare a payload of hundreds of
+# gigabytes, or lie about its own sizes, and every one of those reached
+# `np.load` and the allocation behind it -- once per request, for any caller
+# who could place a file in `data/`.
+#
+# The fixtures are built with the standard library, because NumPy cannot write
+# a duplicate member, a corrupt NPY magic or a lying shape. None is hostile in
+# SIZE: each is a few kilobytes, and the oversized cases lie in their headers
+# rather than on disk.
+# ===========================================================================
+
+import struct  # noqa: E402
+import warnings  # noqa: E402
+import zipfile  # noqa: E402
+
+_NPY_MAGIC = b"\x93NUMPY"
+
+
+def _npy_ma(descr, shape, *, fortran=False, payload=None, header=None,
+            version=(1, 0)):
+    """One `.npy` member as raw bytes, with every field independently forgeable."""
+    if header is None:
+        if not shape:
+            shape_text = "()"
+        elif len(shape) == 1:
+            shape_text = "(%d,)" % shape[0]
+        else:
+            shape_text = "(" + ", ".join(str(d) for d in shape) + ")"
+        header = "{'descr': '%s', 'fortran_order': %s, 'shape': %s, }" % (
+            descr, fortran, shape_text)
+    body = header.encode("latin1")
+    prelude = 10 if version == (1, 0) else 12
+    body += b" " * ((-(prelude + len(body) + 1)) % 64) + b"\n"
+    out = bytearray(_NPY_MAGIC) + bytes(version)
+    out += (struct.pack("<H", len(body)) if version == (1, 0)
+            else struct.pack("<I", len(body)))
+    out += body
+    if payload is None:
+        digits = descr[2:] if descr[0] in "<>|=" else descr[1:]
+        itemsize = int(digits) if digits else 0
+        count = 1
+        for dim in shape:
+            count *= dim
+        payload = b"\x00" * (count * itemsize)
+    return bytes(out) + payload
+
+
+def _schema_ma(edge=16, channels=8):
+    """The five members a `v070_gen` snapshot carries, at a valid edge."""
+    return {
+        "lattice.npy": _npy_ma("|u1", (edge, edge, edge)),
+        "memory_grid.npy": _npy_ma("<f4", (channels, edge, edge, edge)),
+        "generation.npy": _npy_ma("<i8", ()),
+        "ca_step.npy": _npy_ma("<i8", ()),
+        "best_fitness.npy": _npy_ma("<f8", ()),
+    }
+
+
+def _zip_ma(path, members, *, compressed=True, duplicate=None):
+    mode = zipfile.ZIP_DEFLATED if compressed else zipfile.ZIP_STORED
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # a duplicate name is the point here
+        with zipfile.ZipFile(path, "w", compression=mode) as archive:
+            for name, blob in members.items():
+                archive.writestr(name, blob)
+            if duplicate is not None:
+                archive.writestr(duplicate, members[duplicate])
+    return str(path)
+
+
+def _hostile_ma(kind, path):
+    """Build one hostile archive of the named kind at `path`."""
+    members = _schema_ma()
+    if kind == "duplicate_member":
+        return _zip_ma(path, members, duplicate="lattice.npy")
+    if kind == "traversal_name":
+        members["../../escape.npy"] = _npy_ma("|u1", (1,))
+        return _zip_ma(path, members)
+    if kind == "backslash_name":
+        members["sub\\escape.npy"] = _npy_ma("|u1", (1,))
+        return _zip_ma(path, members)
+    if kind == "missing_member":
+        members.pop("ca_step.npy")
+        return _zip_ma(path, members)
+    if kind == "extra_member":
+        members["surprise.npy"] = _npy_ma("|u1", (1,))
+        return _zip_ma(path, members)
+    if kind == "oversized_declared_payload":
+        members["lattice.npy"] = _npy_ma(
+            "|u8", (256, 256, 256), payload=b"",
+            header="{'descr': '|u8', 'fortran_order': False, "
+                   "'shape': (256, 256, 256), }")
+        members["memory_grid.npy"] = _npy_ma(
+            "<f4", (8, 256, 256, 256), payload=b"",
+            header="{'descr': '<f4', 'fortran_order': False, "
+                   "'shape': (8, 256, 256, 256), }")
+        return _zip_ma(path, members)
+    if kind == "oversized_edge":
+        return _zip_ma(path, _schema_ma(edge=512))
+    if kind == "header_payload_mismatch":
+        members["lattice.npy"] = _npy_ma("|u1", (16, 16, 16)) + b"\x00" * 64
+        return _zip_ma(path, members)
+    if kind == "invalid_magic":
+        members["lattice.npy"] = b"XXXXXX" + members["lattice.npy"][6:]
+        return _zip_ma(path, members)
+    if kind == "invalid_version":
+        blob = bytearray(members["lattice.npy"])
+        blob[6] = 9
+        members["lattice.npy"] = bytes(blob)
+        return _zip_ma(path, members)
+    if kind == "invalid_header":
+        members["lattice.npy"] = _npy_ma(
+            "|u1", (16, 16, 16), header="{'descr': '|u1', 'shape': (1,), }")
+        return _zip_ma(path, members)
+    if kind == "object_dtype":
+        members["generation.npy"] = _npy_ma("|O", (), payload=b"")
+        return _zip_ma(path, members)
+    if kind == "structured_dtype":
+        members["generation.npy"] = _npy_ma(
+            "<i8", (), payload=b"",
+            header="{'descr': [('payload', '|O'), ('n', '<i4')], "
+                   "'fortran_order': False, 'shape': (1,), }")
+        return _zip_ma(path, members)
+    if kind == "wrong_rank":
+        members["lattice.npy"] = _npy_ma("|u1", (16, 16))
+        return _zip_ma(path, members)
+    if kind == "spatial_mismatch":
+        members["memory_grid.npy"] = _npy_ma("<f4", (8, 32, 32, 32))
+        return _zip_ma(path, members)
+    if kind == "fortran_order":
+        members["lattice.npy"] = _npy_ma("|u1", (16, 16, 16), fortran=True)
+        return _zip_ma(path, members)
+    if kind == "not_an_npz":
+        Path(path).write_bytes(_npy_ma("|u1", (16, 16, 16)))
+        return str(path)
+    raise AssertionError("unknown hostile archive kind: " + kind)
+
+
+_HOSTILE_KINDS = [
+    "duplicate_member", "traversal_name", "backslash_name", "missing_member",
+    "extra_member", "oversized_declared_payload", "oversized_edge",
+    "header_payload_mismatch", "invalid_magic", "invalid_version",
+    "invalid_header", "object_dtype", "structured_dtype", "wrong_rank",
+    "spatial_mismatch", "fortran_order", "not_an_npz",
+]
+
+#: The four routes that go through `_load_snapshot`. `/api/health`,
+#: `/api/status`, `/api/telemetry` and `/api/snapshot/latest` deliberately do
+#: not, and are asserted unchanged further down.
+_SNAPSHOT_ROUTES = ["/api/census", "/api/equanimity", "/api/acoustic"]
+
+
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_archive_is_refused_before_np_load(kind, tmp_path, monkeypatch):
+    """The load-reached recorder is the whole point.
+
+    Asserting only that something was raised would pass on code that let
+    `np.load` open, decompress and allocate first and then failed downstream --
+    which is exactly the behaviour this replaces.
+    """
+    archive = _hostile_ma(kind, tmp_path / "v070_gen000001.npz")
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+
+    reached = []
+    real_load = np.load
+
+    def _recording_load(*args, **kwargs):
+        reached.append(args[:1])
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(medusa_api.np, "load", _recording_load)
+
+    with pytest.raises(ValueError):
+        medusa_api._load_snapshot(archive)
+    assert reached == [], "np.load was reached on a hostile archive"
+
+
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_hostile_refusal_names_no_path_member_or_header(kind, tmp_path, monkeypatch):
+    """The refusal is translated for an unauthenticated caller, so it must
+    carry no archive content in the first place."""
+    archive = _hostile_ma(kind, tmp_path / "v070_gen000002.npz")
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        medusa_api._load_snapshot(archive)
+    message = str(excinfo.value)
+    assert str(tmp_path) not in message
+    assert "v070_gen000002" not in message
+    assert ".npy" not in message
+    assert "descr" not in message and "escape" not in message
+    assert message == message.strip() and "\n" not in message
+
+
+@pytest.mark.parametrize("route", _SNAPSHOT_ROUTES)
+@pytest.mark.parametrize("kind", _HOSTILE_KINDS)
+def test_snapshot_route_answers_503_snapshot_rejected(
+    kind, route, tmp_path, monkeypatch
+):
+    """One sanitized body for every refusal: no reason, no traceback, no name."""
+    archive = _hostile_ma(kind, tmp_path / "v070_gen000003.npz")
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot",
+                           lambda: Path(archive)):
+        response = client.get(route)
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "snapshot_rejected"}
+    body = response.get_data(as_text=True)
+    assert "v070_gen000003" not in body
+    assert str(tmp_path) not in body
+    assert "Traceback" not in body and ".npy" not in body

--- a/tests/test_medusa_api_snapshot_loader.py
+++ b/tests/test_medusa_api_snapshot_loader.py
@@ -132,13 +132,46 @@ def _contents(**overrides):
     return base
 
 
+_DESCRIPTOR = object()
+
+
+class _FakeAdmission:
+    """Stand-in for the shared guard.
+
+    Records how it was called, hands back a sentinel descriptor, and records
+    that its block was exited. Using a sentinel rather than a real file is what
+    lets the lifetime tests below stay free of any archive on disk, while the
+    real guard is exercised end to end by the hostile-archive tests.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.exited = 0
+
+    def __call__(self, path, *, data_dir, policy=None):
+        self.calls.append({"path": path, "data_dir": data_dir, "policy": policy})
+        return self
+
+    def __enter__(self):
+        return _DESCRIPTOR
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+        return False  # never suppress anything
+
+
 def _load(archive, path=None):
-    """Run the real `_load_snapshot` against `archive`; return (result, mock)."""
+    """Run the real `_load_snapshot` against `archive`.
+
+    Returns (result, load mock, admission recorder).
+    """
     load_mock = mock.Mock(return_value=archive)
+    admission = _FakeAdmission()
     target = path if path is not None else _FakeSnapshotPath()
-    with mock.patch.object(medusa_api.np, "load", load_mock):
+    with mock.patch.object(medusa_api, "admit_snapshot", admission), \
+         mock.patch.object(medusa_api.np, "load", load_mock):
         result = medusa_api._load_snapshot(target)
-    return result, load_mock
+    return result, load_mock, admission
 
 
 # -- import-time containment --------------------------------------------------
@@ -162,7 +195,7 @@ def test_no_event_publisher_or_watcher_was_started():
 def test_helper_returns_the_exact_objects_and_tuple_order():
     contents = _contents()
     archive = _FakeArchive(contents)
-    result, _ = _load(archive)
+    result, *_ = _load(archive)
     assert isinstance(result, tuple) and len(result) == 4
     state, memory_grid, generation, fitness = result
     assert state is contents["lattice"]            # identity, not a copy
@@ -173,14 +206,14 @@ def test_helper_returns_the_exact_objects_and_tuple_order():
 
 def test_generation_is_an_exact_builtin_int():
     archive = _FakeArchive(_contents(generation=np.int64(4242)))
-    (_, _, generation, _), _ = _load(archive)
+    (_, _, generation, _), *_ = _load(archive)
     assert type(generation) is int
     assert generation == 4242
 
 
 def test_fitness_is_an_exact_builtin_float():
     archive = _FakeArchive(_contents(best_fitness=np.float32(0.5)))
-    (_, _, _, fitness), _ = _load(archive)
+    (_, _, _, fitness), *_ = _load(archive)
     assert type(fitness) is float
     assert fitness == 0.5
 
@@ -191,21 +224,54 @@ def test_extraction_order_is_preserved():
     assert archive.lookups == ["lattice", "memory_grid", "generation", "best_fitness"]
 
 
-def test_np_load_receives_str_path_and_allow_pickle_false():
+def test_np_load_receives_the_admitted_descriptor_and_allow_pickle_false():
+    """The path is handed to the guard; NumPy is handed the descriptor the
+    guard opened. There is no second open and no `str(path)` conversion left
+    to make, because a pathname is never re-resolved for loading."""
     archive = _FakeArchive(_contents())
     path = _FakeSnapshotPath("v070_gen42.npz")
-    _, load_mock = _load(archive, path=path)
+    _, load_mock, admission = _load(archive, path=path)
     assert load_mock.call_count == 1
     args, kwargs = load_mock.call_args
-    assert args == (str(path),)
-    assert type(args[0]) is str
+    assert args == (_DESCRIPTOR,)
     assert kwargs == {"allow_pickle": False}
+    assert [call["path"] for call in admission.calls] == [path]
+
+
+def test_helper_admits_against_the_module_data_dir_and_named_policy():
+    archive = _FakeArchive(_contents())
+    _, _, admission = _load(archive)
+    assert len(admission.calls) == 1
+    assert admission.calls[0]["data_dir"] is medusa_api.DATA_DIR
+    assert admission.calls[0]["policy"] is medusa_api.SNAPSHOT_POLICY
+    assert admission.exited == 1
+
+
+def test_admission_precedes_the_load():
+    """Ordering, not merely presence: the guard must have decided before
+    NumPy was asked for anything."""
+    order = []
+    archive = _FakeArchive(_contents())
+
+    class _OrderedAdmission(_FakeAdmission):
+        def __call__(self, path, *, data_dir, policy=None):
+            order.append("admit")
+            return super().__call__(path, data_dir=data_dir, policy=policy)
+
+    def _ordered_load(*args, **kwargs):
+        order.append("load")
+        return archive
+
+    with mock.patch.object(medusa_api, "admit_snapshot", _OrderedAdmission()), \
+         mock.patch.object(medusa_api.np, "load", _ordered_load):
+        medusa_api._load_snapshot(_FakeSnapshotPath())
+    assert order == ["admit", "load"]
 
 
 def test_returned_arrays_keep_their_dtypes():
     contents = _contents()
     archive = _FakeArchive(contents)
-    (state, memory_grid, _, _), _ = _load(archive)
+    (state, memory_grid, _, _), *_ = _load(archive)
     assert state.dtype == np.uint8
     assert memory_grid.dtype == np.float32
 
@@ -230,7 +296,7 @@ def test_archive_already_closed_when_helper_returns():
     """Asserted immediately after the return, while this frame still holds a live
     reference to the archive — so closure was explicit."""
     archive = _FakeArchive(_contents())
-    result, _ = _load(archive)
+    result, *_ = _load(archive)
     assert archive.closed == 1
     assert result[2] == 1234
 
@@ -306,7 +372,8 @@ def test_unrelated_load_failure_is_not_converted_into_a_lifetime_refusal(error):
     """No blanket except was added: an `np.load` failure of any kind propagates
     unchanged rather than becoming a snapshot-lifetime error."""
     load_mock = mock.Mock(side_effect=error)
-    with mock.patch.object(medusa_api.np, "load", load_mock):
+    with mock.patch.object(medusa_api, "admit_snapshot", _FakeAdmission()), \
+         mock.patch.object(medusa_api.np, "load", load_mock):
         with pytest.raises(type(error)) as exc:
             medusa_api._load_snapshot(_FakeSnapshotPath())
     assert type(exc.value) is type(error)
@@ -332,6 +399,7 @@ def test_census_request_sees_the_archive_closed_before_first_numpy_work():
 
     client = medusa_api.app.test_client()
     with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: snapshot), \
+         mock.patch.object(medusa_api, "admit_snapshot", _FakeAdmission()), \
          mock.patch.object(medusa_api.np, "load", mock.Mock(return_value=archive)), \
          mock.patch.object(medusa_api.np, "unique", _recording_unique):
         response = client.get("/api/census")
@@ -351,6 +419,7 @@ def test_census_response_body_is_unchanged():
     snapshot = _FakeSnapshotPath("v070_gen0001000.npz")
     client = medusa_api.app.test_client()
     with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: snapshot), \
+         mock.patch.object(medusa_api, "admit_snapshot", _FakeAdmission()), \
          mock.patch.object(medusa_api.np, "load", mock.Mock(return_value=archive)):
         response = client.get("/api/census")
 
@@ -473,17 +542,36 @@ def _marker_ma(tmp_path):
 
 
 def _write_snapshot_ma(path, compressed=False, **members):
-    """A real NPZ. Object members pickle on the way in, which is harmless."""
+    """A real NPZ. Object members pickle on the way in, which is harmless.
+
+    The edge is 16 and all five schema members are present, because the
+    archive now has to be ADMISSIBLE before its member dtypes matter: a 2-cube
+    with four members would be refused for its shape and its membership, and
+    the pickle property below would never be reached.
+    """
     payload = {
-        "lattice": np.zeros((2, 2, 2), dtype=np.uint8),
-        "memory_grid": np.zeros((8, 2, 2, 2), dtype=np.float32),
+        "lattice": np.zeros((16, 16, 16), dtype=np.uint8),
+        "memory_grid": np.zeros((8, 16, 16, 16), dtype=np.float32),
         "generation": 7,
+        "ca_step": 11,
         "best_fitness": 0.5,
     }
     payload.update(members)
     writer = np.savez_compressed if compressed else np.savez
     writer(path, **payload)
     return str(path)
+
+
+@pytest.fixture
+def confined(tmp_path, monkeypatch):
+    """Point the API's data directory at pytest's own tmp_path.
+
+    Admission confines the archive to the configured data directory, so a
+    fixture written anywhere else is refused for CONTAINMENT before the
+    property under test is reached.
+    """
+    monkeypatch.setattr(medusa_api, "DATA_DIR", tmp_path)
+    return tmp_path
 
 
 def test_ma_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
@@ -504,24 +592,45 @@ def test_ma_payload_fixture_actually_fires_when_pickle_is_enabled(tmp_path):
 @pytest.mark.parametrize(
     "field", ["lattice", "memory_grid", "generation", "best_fitness"]
 )
-def test_object_payload_is_refused_by_the_helper(tmp_path, field):
-    """Four members, `best_fitness` among them.
+def test_object_payload_is_refused_by_the_helper(confined, field):
+    """The refusal moved EARLIER, and the code says so.
 
-    This was the widest loader of the six until the export CLI joined them:
-    `scripts/portable_genome.py` reads five, three of those through `.get`.
+    An object member used to be caught by NumPy at `np.load`. It is now caught
+    by admission from the member's NPY header, before NumPy is involved at
+    all -- so the assertion is the typed reason code, not NumPy's message. The
+    property that matters is unchanged and stronger: the payload never runs.
     """
     archive = _write_snapshot_ma(
-        tmp_path / f"{field}.npz", **{field: _payload_array_ma(tmp_path)}
+        confined / f"v070_{field}.npz", **{field: _payload_array_ma(confined)}
+    )
+    with pytest.raises(medusa_api.SnapshotArchiveRejected) as excinfo:
+        medusa_api._load_snapshot(archive)
+    assert excinfo.value.reason == "member_dtype_object"
+    assert not _marker_ma(confined).exists(), "the pickle payload executed"
+
+
+def test_numpys_own_pickle_refusal_is_still_in_place_behind_admission(confined):
+    """Second line of defence, kept non-vacuous.
+
+    Admission now stops an object member first, so the load-site refusal would
+    otherwise never be observed again. Calling NumPy directly on the same
+    archive shows it is still exactly as it was.
+    """
+    archive = _write_snapshot_ma(
+        confined / "v070_direct.npz", lattice=_payload_array_ma(confined)
     )
     with pytest.raises(ValueError) as excinfo:
-        medusa_api._load_snapshot(archive)
+        with np.load(archive, allow_pickle=False) as snap:
+            snap["lattice"]
     assert "allow_pickle=False" in str(excinfo.value)
-    assert not _marker_ma(tmp_path).exists(), "the pickle payload executed"
+    assert not _marker_ma(confined).exists()
 
 
-def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
+def test_a_refused_archive_never_reaches_np_load_at_all(confined, monkeypatch):
+    """Stronger than "it was not retried with pickle enabled": NumPy is not
+    asked to open the archive even once."""
     archive = _write_snapshot_ma(
-        tmp_path / "retry.npz", lattice=_payload_array_ma(tmp_path)
+        confined / "v070_retry.npz", lattice=_payload_array_ma(confined)
     )
     real_load = np.load
     calls = []
@@ -531,43 +640,123 @@ def test_a_refusal_is_never_retried_with_pickle_enabled(tmp_path, monkeypatch):
         return real_load(*args, **kwargs)
 
     monkeypatch.setattr(medusa_api.np, "load", _recording_load)
-    with pytest.raises(ValueError):
+    with pytest.raises(medusa_api.SnapshotArchiveRejected):
         medusa_api._load_snapshot(archive)
+    assert calls == []
+
+
+def test_a_valid_archive_is_loaded_with_pickle_explicitly_disabled(confined,
+                                                                   monkeypatch):
+    """The counterpart control: on the admitted path the explicit literal is
+    still what NumPy receives, so the assertion above is about ordering rather
+    than about the flag having quietly disappeared."""
+    archive = _write_snapshot_ma(confined / "v070_ok.npz", compressed=True)
+    real_load = np.load
+    calls = []
+
+    def _recording_load(*args, **kwargs):
+        calls.append(kwargs.get("allow_pickle"))
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(medusa_api.np, "load", _recording_load)
+    medusa_api._load_snapshot(archive)
     assert calls == [False]
 
 
-def test_the_real_archive_is_closed_after_a_refusal(tmp_path, monkeypatch):
+def test_the_descriptor_is_closed_after_a_refusal(confined, monkeypatch):
+    """Closure on the exceptional path, witnessed on the real file object the
+    guard opened -- a NumPy handle is never created for a refused archive."""
     archive = _write_snapshot_ma(
-        tmp_path / "closed.npz", lattice=_payload_array_ma(tmp_path)
+        confined / "v070_closed.npz", lattice=_payload_array_ma(confined)
     )
-    real_load = np.load
+    import builtins
     opened = []
+    real_open = builtins.open
 
-    def _tracking_load(*args, **kwargs):
-        handle = real_load(*args, **kwargs)
-        opened.append(handle)
+    def _tracking_open(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        if str(args[0]).endswith(".npz"):
+            opened.append(handle)
         return handle
 
-    monkeypatch.setattr(medusa_api.np, "load", _tracking_load)
-    with pytest.raises(ValueError):
+    monkeypatch.setattr(builtins, "open", _tracking_open)
+    with pytest.raises(medusa_api.SnapshotArchiveRejected):
         medusa_api._load_snapshot(archive)
-    assert len(opened) == 1
-    # `zip` is the primary witness: `close()` drops it unconditionally,
-    # whereas `fid` is a CLASS attribute defaulting to None, so asserting
-    # on it alone would pass on a handle that was never closed at all.
-    assert opened[0].zip is None and (
-        opened[0].fid is None or opened[0].fid.closed
-    )
+    assert len(opened) == 1, "the archive was opened more than once, or not at all"
+    assert opened[0].closed
 
 
-def test_a_numeric_snapshot_still_loads_all_four_values(tmp_path):
+def test_a_numeric_snapshot_still_loads_all_four_values(confined):
     archive = _write_snapshot_ma(
-        tmp_path / "clean.npz", generation=np.int64(3), best_fitness=np.float32(0.25)
+        confined / "v070_clean.npz", generation=np.int64(3),
+        best_fitness=np.float32(0.25)
     )
     lattice, grid, generation, fitness = medusa_api._load_snapshot(archive)
     assert lattice.dtype == np.uint8 and grid.dtype == np.float32
+    assert lattice.shape == (16, 16, 16) and grid.shape == (8, 16, 16, 16)
     assert generation == 3 and type(generation) is int
     assert fitness == pytest.approx(0.25) and type(fitness) is float
+
+
+# -- selection no longer guesses at "tiny/corrupt" ----------------------------
+
+
+def test_selection_no_longer_skips_a_small_snapshot(confined):
+    """The one-megabyte minimum is gone.
+
+    It was a guess and it was wrong in both directions: a sparse but
+    structurally valid snapshot compresses far below a megabyte and was never
+    selected, while a hostile archive only had to be padded past the threshold
+    to be chosen. Selection is now purely "most recent".
+    """
+    small = Path(_write_snapshot_ma(confined / "v070_gen000001.npz",
+                                    compressed=True))
+    assert small.stat().st_size < 1_000_000, "the fixture is not small any more"
+    assert medusa_api._find_latest_snapshot() == small
+
+
+def test_selection_still_prefers_the_most_recent(confined):
+    older = Path(_write_snapshot_ma(confined / "v070_gen000001.npz"))
+    newer = Path(_write_snapshot_ma(confined / "v070_gen000002.npz"))
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+    assert medusa_api._find_latest_snapshot() == newer
+
+
+def test_geometry_route_also_answers_503_for_a_rejected_archive(confined,
+                                                                monkeypatch):
+    """The fourth `_load_snapshot` route. Kept separate because it needs
+    trimesh, which is not a CI dependency."""
+    pytest.importorskip("trimesh")
+    archive = _hostile_ma("missing_member", confined / "v070_gen000009.npz")
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot",
+                           lambda: Path(archive)):
+        response = client.get("/api/geometry/stl")
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "snapshot_rejected"}
+
+
+@pytest.mark.parametrize("route", ["/api/health", "/api/status"])
+def test_routes_that_do_not_load_a_snapshot_are_unchanged(route, confined):
+    """Health, status, telemetry and the raw download do not go through
+    `_load_snapshot`, so a poisoned directory must not change them."""
+    _hostile_ma("missing_member", confined / "v070_gen000010.npz")
+    client = medusa_api.app.test_client()
+    response = client.get(route)
+    assert response.status_code == 200
+    assert response.get_json().get("error") is None
+
+
+def test_the_raw_snapshot_download_is_unchanged(confined):
+    """`/api/snapshot/latest` deliberately serves the file as bytes and does
+    not load it, so it is untouched by admission."""
+    archive = Path(_write_snapshot_ma(confined / "v070_gen000011.npz"))
+    client = medusa_api.app.test_client()
+    with mock.patch.object(medusa_api, "_find_latest_snapshot", lambda: archive):
+        response = client.get("/api/snapshot/latest")
+    assert response.status_code == 200
+    assert response.get_data() == archive.read_bytes()
 
 
 # ===========================================================================

--- a/tests/test_snapshot_archive_guard.py
+++ b/tests/test_snapshot_archive_guard.py
@@ -847,6 +847,8 @@ def test_central_directory_ceiling_boundary(root):
 
 
 @pytest.mark.parametrize("count,expected", [
+    (guard.PRODUCTION_POLICY.max_members + guard._COUNT_PARSE_SLACK - 1,
+     "member_unexpected"),
     (guard.PRODUCTION_POLICY.max_members + guard._COUNT_PARSE_SLACK,
      "member_unexpected"),
     (guard.PRODUCTION_POLICY.max_members + guard._COUNT_PARSE_SLACK + 1,

--- a/tests/test_snapshot_archive_guard.py
+++ b/tests/test_snapshot_archive_guard.py
@@ -1,0 +1,1044 @@
+"""Tests for `scripts/snapshot_archive_guard.admit_snapshot()`.
+
+The guard decides whether a file in the watched data directory is allowed to
+reach `np.load` at all. Everything it refuses, it must refuse from bounded
+reads of the ZIP central directory and the members' NPY headers -- never by
+extracting anything, never by allocating in proportion to what the archive
+claims, and never by disclosing what it saw.
+
+Fixture policy, stated once. The hostile archives here are built with the
+standard library rather than NumPy, for two reasons: NumPy cannot write a
+duplicate member, a corrupt magic, an encrypted entry or a lying shape, and
+the stdlib half of this module then runs in an environment with no NumPy at
+all. Nothing is hostile in SIZE -- the oversized cases lie in their headers
+while occupying a few kilobytes on disk, and the resource ceilings are driven
+by tiny injected policies. No test allocates, decompresses or writes a
+production-sized archive.
+
+Scope is structural and resource admission for the `v070_gen` snapshot schema.
+Not authentication, not atomic writing, not semantic state validation, not
+numeric-value validation, not arbitrary NPZ compatibility.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import dataclasses
+import struct
+import warnings
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts import snapshot_archive_guard as guard
+
+try:
+    import numpy as np
+    _HAVE_NUMPY = True
+except ImportError:  # pragma: no cover - exercised only in a bare environment
+    np = None
+    _HAVE_NUMPY = False
+
+requires_numpy = pytest.mark.skipif(not _HAVE_NUMPY, reason="numpy not installed")
+
+
+# ---------------------------------------------------------------------------
+# Standard-library NPY / NPZ construction
+# ---------------------------------------------------------------------------
+
+_NPY_MAGIC = b"\x93NUMPY"
+
+
+def npy_bytes(descr, shape, *, fortran=False, payload=None, header=None,
+              version=(1, 0)):
+    """One `.npy` member as raw bytes, every field independently forgeable."""
+    if header is None:
+        if not shape:
+            shape_text = "()"
+        elif len(shape) == 1:
+            shape_text = "(%d,)" % shape[0]
+        else:
+            shape_text = "(" + ", ".join(str(dim) for dim in shape) + ")"
+        header = "{'descr': '%s', 'fortran_order': %s, 'shape': %s, }" % (
+            descr, fortran, shape_text)
+    body = header.encode("latin1")
+    prelude = 10 if version == (1, 0) else 12
+    body += b" " * ((-(prelude + len(body) + 1)) % 64) + b"\n"
+    out = bytearray(_NPY_MAGIC) + bytes(version)
+    out += (struct.pack("<H", len(body)) if version == (1, 0)
+            else struct.pack("<I", len(body)))
+    out += body
+    if payload is None:
+        digits = descr[2:] if descr[0] in "<>|=" else descr[1:]
+        itemsize = int(digits) if digits else 0
+        count = 1
+        for dim in shape:
+            count *= dim
+        payload = b"\x00" * (count * itemsize)
+    return bytes(out) + payload
+
+
+def schema_members(edge=16, channels=8):
+    """The five members a `v070_gen` snapshot carries, at an admissible edge.
+
+    Real payloads, so keep `edge` small: at 256 the memory grid alone is
+    512 MiB, which no test may allocate. Use :func:`declared_members` for
+    anything that only needs an archive to CLAIM a large shape.
+    """
+    return {
+        "lattice.npy": npy_bytes("|u1", (edge, edge, edge)),
+        "memory_grid.npy": npy_bytes("<f4", (channels, edge, edge, edge)),
+        "generation.npy": npy_bytes("<i8", ()),
+        "ca_step.npy": npy_bytes("<i8", ()),
+        "best_fitness.npy": npy_bytes("<f8", ()),
+    }
+
+
+def declared_members(edge, channels=8):
+    """The same five members, DECLARING `edge` but carrying no payload.
+
+    The guard checks geometry (pass two) before size arithmetic (pass three),
+    so an archive that lies about its shape is refused on the geometry rule
+    without ever needing the bytes to exist. That is what lets a 512-edge case
+    cost a few kilobytes instead of four gigabytes.
+    """
+    members = schema_members(16, channels)
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (edge, edge, edge), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d), }" % (edge, edge, edge))
+    members["memory_grid.npy"] = npy_bytes(
+        "<f4", (channels, edge, edge, edge), payload=b"",
+        header="{'descr': '<f4', 'fortran_order': False, 'shape': "
+               "(%d, %d, %d, %d), }" % (channels, edge, edge, edge))
+    return members
+
+
+def write_npz(path, members, *, compression=zipfile.ZIP_DEFLATED, duplicate=None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # a duplicate name is deliberate here
+        with zipfile.ZipFile(path, "w", compression=compression) as archive:
+            for name, blob in members.items():
+                archive.writestr(name, blob)
+            if duplicate is not None:
+                archive.writestr(duplicate, members[duplicate])
+    return Path(path)
+
+
+def header_length(blob):
+    """The NPY header size a member declares, read the way the guard reads it."""
+    if blob[8:10] and blob[6:8] == b"\x01\x00":
+        return 10 + struct.unpack("<H", blob[8:10])[0]
+    return 12 + struct.unpack("<I", blob[8:12])[0]
+
+
+def set_encrypted_flag(path):
+    """Set the ZIP general-purpose encryption bit on the last directory entry.
+
+    `zipfile` will not write an encrypted entry, and `ZipInfo.flag_bits` is
+    read from the central directory, so the bit is set there directly.
+    """
+    data = bytearray(Path(path).read_bytes())
+    index = data.rfind(b"PK\x01\x02")
+    assert index > 0, "no central-directory header found in the fixture"
+    struct.pack_into("<H", data, index + 8, 0x0001)
+    Path(path).write_bytes(bytes(data))
+    return Path(path)
+
+
+@pytest.fixture
+def root(tmp_path):
+    """The confined data directory every admissible snapshot must live in."""
+    directory = tmp_path / "data"
+    directory.mkdir()
+    return directory
+
+
+def admit(path, data_dir, policy=None, *, read=True):
+    """Run the real guard; return None if admitted, else the reason code."""
+    policy = policy or guard.PRODUCTION_POLICY
+    try:
+        with guard.admit_snapshot(path, data_dir=data_dir, policy=policy) as handle:
+            if read:
+                assert handle.tell() == 0, "the descriptor was not rewound"
+                assert handle.read(4) == b"PK\x03\x04"
+        return None
+    except guard.SnapshotArchiveRejected as exc:
+        # The message IS the code: asserted on every single refusal in this
+        # module, not once in a dedicated test.
+        assert str(exc) == exc.reason
+        return exc.reason
+
+
+# ---------------------------------------------------------------------------
+# Valid archives are admitted
+# ---------------------------------------------------------------------------
+
+def test_a_producer_shaped_archive_is_admitted(root):
+    path = write_npz(root / "v070_gen000064.npz", schema_members(64))
+    assert admit(path, root) is None
+
+
+def test_an_uncompressed_archive_is_admitted(root):
+    path = write_npz(root / "v070_stored.npz", schema_members(32),
+                     compression=zipfile.ZIP_STORED)
+    assert admit(path, root) is None
+
+
+@pytest.mark.parametrize("edge", [16, 32, 48, 64])
+def test_admissible_edges_are_admitted(root, edge):
+    """Real payloads, so this stops at 64 -- the producer's own edge. The
+    policy's upper end is exercised structurally instead: a real 256-edge
+    archive is 528 MiB, and no test may allocate one."""
+    path = write_npz(root / ("v070_e%d.npz" % edge), schema_members(edge))
+    assert admit(path, root) is None
+
+
+@pytest.mark.parametrize("channels", [3, 5, 8])
+def test_documented_legacy_memory_grid_depths_are_admitted(root, channels):
+    """`continuous_evolution_ca._migrate_memory_grid` documents 3- and
+    5-channel grids alongside the current 8, so the channel count is bounded
+    by the memory-grid payload ceiling rather than pinned."""
+    path = write_npz(root / ("v070_c%d.npz" % channels),
+                     schema_members(16, channels))
+    assert admit(path, root) is None
+
+
+@pytest.mark.parametrize("descr", ["|u1", "<u2", ">u4"])
+def test_the_lattice_dtype_is_a_family_not_an_exact_width(root, descr):
+    members = schema_members(16)
+    members["lattice.npy"] = npy_bytes(descr, (16, 16, 16))
+    path = write_npz(root / "v070_family.npz", members)
+    assert admit(path, root) is None
+
+
+def test_a_version_2_npy_header_is_admitted(root):
+    members = schema_members(16)
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 16), version=(2, 0))
+    path = write_npz(root / "v070_v2.npz", members)
+    assert admit(path, root) is None
+
+
+# ---------------------------------------------------------------------------
+# Every refusal, one case per reason code
+# ---------------------------------------------------------------------------
+
+def _case_path_not_confined(root, tmp_path):
+    outside = tmp_path / "v070_outside.npz"
+    write_npz(outside, schema_members())
+    return outside, None
+
+
+def _case_path_not_regular_file(root, tmp_path):
+    directory = root / "v070_dir.npz"
+    directory.mkdir()
+    return directory, None
+
+
+def _case_path_suffix_not_npz(root, tmp_path):
+    path = root / "v070_wrong.npy"
+    write_npz(path, schema_members())
+    return path, None
+
+
+def _case_archive_too_large(root, tmp_path):
+    path = write_npz(root / "v070_big.npz", schema_members())
+    return path, dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     max_physical_bytes=64)
+
+
+def _case_archive_truncated(root, tmp_path):
+    path = root / "v070_stub.npz"
+    path.write_bytes(b"PK\x03\x04")
+    return path, None
+
+
+def _case_not_zip_archive(root, tmp_path):
+    path = root / "v070_renamed.npz"
+    path.write_bytes(npy_bytes("|u1", (16, 16, 16)))
+    return path, None
+
+
+def _case_central_directory_too_large(root, tmp_path):
+    path = write_npz(root / "v070_cd.npz", schema_members())
+    return path, dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     central_directory_max_bytes=8)
+
+
+def _case_archive_payload_total_too_large(root, tmp_path):
+    path = write_npz(root / "v070_total.npz", schema_members())
+    return path, dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     max_total_declared_bytes=1024)
+
+
+def _case_member_count(root, tmp_path):
+    path = root / "v070_many.npz"
+    with zipfile.ZipFile(path, "w") as archive:
+        for index in range(guard.PRODUCTION_POLICY.max_members
+                           + guard._COUNT_PARSE_SLACK + 1):
+            archive.writestr("m%d.npy" % index, b"x")
+    return path, None
+
+
+def _case_member_name_unsafe(root, tmp_path):
+    members = schema_members()
+    members["../../escape.npy"] = npy_bytes("|u1", (1,))
+    return write_npz(root / "v070_trav.npz", members), None
+
+
+def _case_member_is_directory(root, tmp_path):
+    members = schema_members()
+    members["subdir/"] = b""
+    return write_npz(root / "v070_subdir.npz", members), None
+
+
+def _case_member_duplicate(root, tmp_path):
+    return write_npz(root / "v070_dup.npz", schema_members(),
+                     duplicate="lattice.npy"), None
+
+
+def _case_member_unexpected(root, tmp_path):
+    members = schema_members()
+    members["surprise.npy"] = npy_bytes("|u1", (1,))
+    return write_npz(root / "v070_extra.npz", members), None
+
+
+def _case_member_missing(root, tmp_path):
+    members = schema_members()
+    members.pop("ca_step.npy")
+    return write_npz(root / "v070_missing.npz", members), None
+
+
+def _case_member_encrypted(root, tmp_path):
+    path = write_npz(root / "v070_enc.npz", schema_members())
+    return set_encrypted_flag(path), None
+
+
+def _case_member_compression_unsupported(root, tmp_path):
+    return write_npz(root / "v070_bz2.npz", schema_members(),
+                     compression=zipfile.ZIP_BZIP2), None
+
+
+def _case_member_payload_too_large(root, tmp_path):
+    members = schema_members()
+    members["memory_grid.npy"] = npy_bytes(
+        "<f4", (65536, 16, 16, 16), payload=b"",
+        header="{'descr': '<f4', 'fortran_order': False, "
+               "'shape': (65536, 16, 16, 16), }")
+    return write_npz(root / "v070_wide.npz", members), None
+
+
+def _case_member_header_unreadable(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = b"\x93NUM"
+    return write_npz(root / "v070_stubhdr.npz", members), None
+
+
+def _case_member_npy_magic_invalid(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = b"XXXXXX" + members["lattice.npy"][6:]
+    return write_npz(root / "v070_magic.npz", members), None
+
+
+def _case_member_npy_version_unsupported(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 16), version=(4, 0))
+    return write_npz(root / "v070_ver.npz", members), None
+
+
+def _case_member_header_too_large(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16),
+        header="{'descr': '|u1', 'fortran_order': False, "
+               "'shape': (16, 16, 16), }" + " " * 5000)
+    return write_npz(root / "v070_hdrbig.npz", members), None
+
+
+def _case_member_header_malformed(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16),
+        header="{'descr': '|u1', 'shape': (16, 16, 16), }")
+    return write_npz(root / "v070_hdrbad.npz", members), None
+
+
+def _case_member_dtype_object(root, tmp_path):
+    members = schema_members()
+    members["generation.npy"] = npy_bytes("|O", (), payload=b"")
+    return write_npz(root / "v070_obj.npz", members), None
+
+
+def _case_member_dtype_structured(root, tmp_path):
+    members = schema_members()
+    members["generation.npy"] = npy_bytes(
+        "<i8", (), payload=b"",
+        header="{'descr': [('payload', '|O'), ('n', '<i4')], "
+               "'fortran_order': False, 'shape': (1,), }")
+    return write_npz(root / "v070_struct.npz", members), None
+
+
+def _case_member_dtype_subarray(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16), payload=b"",
+        header="{'descr': ('|u1', (2, 2)), 'fortran_order': False, "
+               "'shape': (16, 16, 16), }")
+    return write_npz(root / "v070_sub.npz", members), None
+
+
+def _case_member_dtype_zero_itemsize(root, tmp_path):
+    members = schema_members()
+    members["best_fitness.npy"] = npy_bytes("|U0", (), payload=b"")
+    return write_npz(root / "v070_zero.npz", members), None
+
+
+def _case_member_dtype_unsupported(root, tmp_path):
+    members = schema_members()
+    members["generation.npy"] = npy_bytes(
+        "<i8", (), payload=b"",
+        header="{'descr': '<M8[ns]', 'fortran_order': False, 'shape': (), }")
+    return write_npz(root / "v070_datetime.npz", members), None
+
+
+def _case_member_dtype_family(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("<f4", (16, 16, 16))
+    return write_npz(root / "v070_family.npz", members), None
+
+
+def _case_member_fortran_order(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 16), fortran=True)
+    return write_npz(root / "v070_fortran.npz", members), None
+
+
+def _case_member_rank(root, tmp_path):
+    members = schema_members()
+    members["generation.npy"] = npy_bytes("<i8", (3,))
+    return write_npz(root / "v070_rank.npz", members), None
+
+
+def _case_member_shape_invalid(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, "
+               "'shape': (16, 16, 999999999999999999), }")
+    return write_npz(root / "v070_absurd.npz", members), None
+
+
+def _case_member_size_inconsistent(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 16)) + b"\x00" * 64
+    return write_npz(root / "v070_incon.npz", members), None
+
+
+def _case_lattice_not_cubic(root, tmp_path):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 32))
+    return write_npz(root / "v070_oblong.npz", members), None
+
+
+def _case_edge_out_of_range(root, tmp_path):
+    return write_npz(root / "v070_512.npz", declared_members(512)), None
+
+
+def _case_edge_not_multiple(root, tmp_path):
+    return write_npz(root / "v070_24.npz", declared_members(24)), None
+
+
+def _case_spatial_disagreement(root, tmp_path):
+    members = schema_members(16)
+    members["memory_grid.npy"] = npy_bytes("<f4", (8, 32, 32, 32))
+    return write_npz(root / "v070_spatial.npz", members), None
+
+
+#: One reproducible case per declared reason code. The mapping is asserted to
+#: be exactly the declared roster below, so a code can neither be added
+#: without a case nor left in place after the check that produced it is gone.
+REFUSAL_CASES = {
+    "path_not_confined": _case_path_not_confined,
+    "path_not_regular_file": _case_path_not_regular_file,
+    "path_suffix_not_npz": _case_path_suffix_not_npz,
+    "archive_too_large": _case_archive_too_large,
+    "archive_truncated": _case_archive_truncated,
+    "not_zip_archive": _case_not_zip_archive,
+    "central_directory_too_large": _case_central_directory_too_large,
+    "archive_payload_total_too_large": _case_archive_payload_total_too_large,
+    "member_count": _case_member_count,
+    "member_name_unsafe": _case_member_name_unsafe,
+    "member_is_directory": _case_member_is_directory,
+    "member_duplicate": _case_member_duplicate,
+    "member_unexpected": _case_member_unexpected,
+    "member_missing": _case_member_missing,
+    "member_encrypted": _case_member_encrypted,
+    "member_compression_unsupported": _case_member_compression_unsupported,
+    "member_payload_too_large": _case_member_payload_too_large,
+    "member_header_unreadable": _case_member_header_unreadable,
+    "member_npy_magic_invalid": _case_member_npy_magic_invalid,
+    "member_npy_version_unsupported": _case_member_npy_version_unsupported,
+    "member_header_too_large": _case_member_header_too_large,
+    "member_header_malformed": _case_member_header_malformed,
+    "member_dtype_object": _case_member_dtype_object,
+    "member_dtype_structured": _case_member_dtype_structured,
+    "member_dtype_subarray": _case_member_dtype_subarray,
+    "member_dtype_zero_itemsize": _case_member_dtype_zero_itemsize,
+    "member_dtype_unsupported": _case_member_dtype_unsupported,
+    "member_dtype_family": _case_member_dtype_family,
+    "member_fortran_order": _case_member_fortran_order,
+    "member_rank": _case_member_rank,
+    "member_shape_invalid": _case_member_shape_invalid,
+    "member_size_inconsistent": _case_member_size_inconsistent,
+    "lattice_not_cubic": _case_lattice_not_cubic,
+    "edge_out_of_range": _case_edge_out_of_range,
+    "edge_not_multiple": _case_edge_not_multiple,
+    "spatial_disagreement": _case_spatial_disagreement,
+}
+
+
+def test_every_declared_reason_code_has_a_reproducible_case():
+    """Anti-vacuity for the roster itself: no unreachable code may be declared,
+    and no case may name a code the module does not declare."""
+    assert set(REFUSAL_CASES) == set(guard.REASON_CODES)
+    assert len(guard.REASON_CODES) == len(set(guard.REASON_CODES))
+
+
+@pytest.mark.parametrize("reason", sorted(REFUSAL_CASES))
+def test_each_reason_code_is_produced_by_its_case(reason, root, tmp_path):
+    path, policy = REFUSAL_CASES[reason](root, tmp_path)
+    assert admit(path, root, policy) == reason
+
+
+@pytest.mark.parametrize("reason", sorted(REFUSAL_CASES))
+def test_no_refusal_discloses_archive_content(reason, root, tmp_path):
+    """These messages are logged unattended and translated for unauthenticated
+    HTTP callers, so they must carry nothing an attacker chose."""
+    path, policy = REFUSAL_CASES[reason](root, tmp_path)
+    with pytest.raises(guard.SnapshotArchiveRejected) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root,
+                                  policy=policy or guard.PRODUCTION_POLICY):
+            pass
+    message = str(excinfo.value)
+    assert message == reason
+    assert str(tmp_path) not in message
+    assert Path(path).name not in message
+    for leaked in (".npy", "descr", "escape", "surprise", "v070", "\n", "  "):
+        assert leaked not in message
+
+
+@pytest.mark.parametrize("name", [
+    "../escape.npy", "../../etc/passwd.npy", "/etc/passwd.npy",
+    "C:\\windows\\x.npy", "sub\\lattice.npy", "nested/lattice.npy",
+    "lattice.npy/../x.npy",
+])
+def test_every_hostile_member_name_shape_is_refused(root, name):
+    members = schema_members()
+    members[name] = npy_bytes("|u1", (1,))
+    path = write_npz(root / "v070_names.npz", members)
+    assert admit(path, root) == "member_name_unsafe"
+
+
+def test_a_symlink_out_of_the_data_directory_is_refused(root, tmp_path):
+    """Containment is decided after symlink resolution, so a link inside the
+    watched directory cannot smuggle in a file from outside it."""
+    target = tmp_path / "v070_target.npz"
+    write_npz(target, schema_members())
+    link = root / "v070_link.npz"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+    assert admit(link, root) == "path_not_confined"
+
+
+def test_a_zero_channel_memory_grid_is_refused(root):
+    members = schema_members(16)
+    members["memory_grid.npy"] = npy_bytes("<f4", (0, 16, 16, 16))
+    path = write_npz(root / "v070_nochan.npz", members)
+    assert admit(path, root) == "member_shape_invalid"
+
+
+def test_a_negative_dimension_is_refused(root):
+    members = schema_members(16)
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16), payload=b"",
+        header="{'descr': '|u1', 'fortran_order': False, "
+               "'shape': (16, 16, -1), }")
+    path = write_npz(root / "v070_neg.npz", members)
+    assert admit(path, root) == "member_shape_invalid"
+
+
+@pytest.mark.parametrize("header", [
+    "{'descr': __import__('os').system, 'fortran_order': False, 'shape': (), }",
+    "{'descr': '|u1', 'fortran_order': False, 'shape': (16, 16, 16)",
+    "[]",
+    "{'descr': '|u1', 'fortran_order': 0, 'shape': (16, 16, 16), }",
+    "{'descr': '|u1', 'fortran_order': False, 'shape': 4096, }",
+    "{'descr': '|u1', 'fortran_order': False, 'shape': (16, 16, 16), 'x': 1, }",
+], ids=["call_expression", "unterminated", "not_a_dict", "non_bool_order",
+        "non_tuple_shape", "extra_key"])
+def test_header_texts_outside_the_accepted_grammar_are_refused(root, header):
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes("|u1", (16, 16, 16), payload=b"",
+                                       header=header)
+    path = write_npz(root / "v070_grammar.npz", members)
+    assert admit(path, root) == "member_header_malformed"
+
+
+def test_a_deeply_nested_header_is_refused_without_recursion(root):
+    """The literal parser caps depth itself rather than relying on the
+    interpreter's recursion limit."""
+    members = schema_members()
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16), payload=b"",
+        header="{'descr': " + "(" * 200 + ")" * 200 + ", "
+               "'fortran_order': False, 'shape': (16, 16, 16), }")
+    path = write_npz(root / "v070_deep.npz", members)
+    assert admit(path, root) == "member_header_malformed"
+
+
+# ---------------------------------------------------------------------------
+# Boundaries: limit-1, exactly the limit, limit+1
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("edge,expected", [
+    (0, "edge_out_of_range"),
+    (8, "edge_out_of_range"),
+    (15, "edge_out_of_range"),
+    (24, "edge_not_multiple"),
+    (40, "edge_not_multiple"),
+    (257, "edge_out_of_range"),
+    (272, "edge_out_of_range"),
+    (512, "edge_out_of_range"),
+])
+def test_edge_rejections(root, edge, expected):
+    """Declared-only fixtures: the geometry rule runs before the size
+    arithmetic, so a 512-edge refusal costs kilobytes, not gigabytes."""
+    path = write_npz(root / ("v070_edge%d.npz" % edge), declared_members(edge))
+    assert admit(path, root) == expected
+
+
+@pytest.mark.parametrize("edge,expected", [
+    (2, "edge_out_of_range"),
+    (4, None),
+    (6, "edge_not_multiple"),
+    (8, None),
+    (12, "edge_out_of_range"),
+])
+def test_the_edge_rule_at_its_own_ceiling_under_a_scaled_policy(root, edge,
+                                                                expected):
+    """The production ceiling of 256 cannot be ADMITTED with a real archive
+    without allocating 528 MiB. The identical rule is therefore exercised at a
+    scaled ceiling, where minimum, maximum and multiple are all real
+    boundaries and every fixture is a few hundred bytes."""
+    policy = dataclasses.replace(guard.PRODUCTION_POLICY,
+                                 min_edge=4, max_edge=8, edge_multiple=4)
+    path = write_npz(root / ("v070_scaled%d.npz" % edge), schema_members(edge))
+    assert admit(path, root, policy) == expected
+
+
+def test_physical_ceiling_boundary(root):
+    path = write_npz(root / "v070_phys.npz", schema_members(16))
+    size = path.stat().st_size
+    for limit, expected in ((size - 1, "archive_too_large"), (size, None),
+                            (size + 1, None)):
+        policy = dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     max_physical_bytes=limit)
+        assert admit(path, root, policy) == expected, limit
+
+
+def test_declared_aggregate_boundary(root):
+    members = schema_members(16)
+    path = write_npz(root / "v070_agg.npz", members)
+    with zipfile.ZipFile(path) as archive:
+        total = sum(info.file_size for info in archive.infolist())
+    for limit, expected in ((total - 1, "archive_payload_total_too_large"),
+                            (total, None), (total + 1, None)):
+        policy = dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     max_total_declared_bytes=limit)
+        assert admit(path, root, policy) == expected, limit
+
+
+def test_member_payload_ceiling_boundary(root):
+    """The lattice payload at edge 16 is exactly 4096 bytes. The ceiling is
+    compared against the PAYLOAD, not the member's declared uncompressed size,
+    which also covers the NPY header -- an archive sitting exactly on the limit
+    must be admitted."""
+    path = write_npz(root / "v070_pay.npz", schema_members(16))
+    payload = 16 ** 3
+    for limit, expected in ((payload - 1, "member_payload_too_large"),
+                            (payload, None), (payload + 1, None)):
+        policy = dataclasses.replace(
+            guard.PRODUCTION_POLICY,
+            members=tuple(
+                dataclasses.replace(spec, max_payload_bytes=limit)
+                if spec.role == guard.ROLE_LATTICE else spec
+                for spec in guard.PRODUCTION_POLICY.members))
+        assert admit(path, root, policy) == expected, limit
+
+
+def test_header_ceiling_boundary(root):
+    members = schema_members(16)
+    path = write_npz(root / "v070_hdr.npz", members)
+    longest = max(header_length(blob) for blob in members.values())
+    for limit, expected in ((longest - 1, "member_header_too_large"),
+                            (longest, None), (longest + 1, None)):
+        policy = dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     max_header_bytes=limit)
+        assert admit(path, root, policy) == expected, limit
+
+
+def test_central_directory_ceiling_boundary(root):
+    path = write_npz(root / "v070_cd.npz", schema_members(16))
+    data = path.read_bytes()
+    index = data.rfind(b"PK\x05\x06")
+    directory_size = struct.unpack("<I", data[index + 12:index + 16])[0]
+    for limit, expected in ((directory_size - 1, "central_directory_too_large"),
+                            (directory_size, None), (directory_size + 1, None)):
+        policy = dataclasses.replace(guard.PRODUCTION_POLICY,
+                                     central_directory_max_bytes=limit)
+        assert admit(path, root, policy) == expected, limit
+
+
+@pytest.mark.parametrize("count,expected", [
+    (guard.PRODUCTION_POLICY.max_members + guard._COUNT_PARSE_SLACK,
+     "member_unexpected"),
+    (guard.PRODUCTION_POLICY.max_members + guard._COUNT_PARSE_SLACK + 1,
+     "member_count"),
+])
+def test_entry_count_parse_bound_boundary(root, count, expected):
+    """At the bound the archive still reaches the schema check and is refused
+    for what it actually is; one entry beyond it, the coarse bound fires first
+    and `ZipFile` is never asked to build the list."""
+    members = schema_members(16)
+    for index in range(count - len(members)):
+        members["filler%d.npy" % index] = npy_bytes("|u1", (1,))
+    path = write_npz(root / "v070_count.npz", members)
+    assert admit(path, root) == expected
+
+
+# ---------------------------------------------------------------------------
+# One descriptor, opened once, rewound, closed on every path
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def opened_files(monkeypatch):
+    """Record every file object the guard opens, without perturbing the rest."""
+    records = []
+    real_open = builtins.open
+
+    def _tracking_open(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        try:
+            if str(args[0]).endswith(".npz"):
+                records.append(handle)
+        except Exception:  # pragma: no cover - defensive only
+            pass
+        return handle
+
+    monkeypatch.setattr(builtins, "open", _tracking_open)
+    return records
+
+
+def test_the_archive_is_opened_exactly_once(root, opened_files):
+    path = write_npz(root / "v070_once.npz", schema_members(16))
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        assert opened_files == [handle], (
+            "a pathname must never be validated and then reopened for loading")
+
+
+def test_the_yielded_descriptor_is_rewound_and_readable(root):
+    path = write_npz(root / "v070_rewind.npz", schema_members(16))
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        assert handle.tell() == 0
+        assert handle.readable() and not handle.closed
+        assert handle.read(4) == b"PK\x03\x04"
+
+
+def test_the_descriptor_is_closed_after_a_successful_block(root):
+    path = write_npz(root / "v070_closed.npz", schema_members(16))
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        captured = handle
+    assert captured.closed
+
+
+def test_the_descriptor_is_closed_when_the_consumer_body_raises(root):
+    path = write_npz(root / "v070_boom.npz", schema_members(16))
+    captured = []
+
+    class Boom(Exception):
+        pass
+
+    with pytest.raises(Boom):
+        with guard.admit_snapshot(path, data_dir=root) as handle:
+            captured.append(handle)
+            raise Boom
+    assert captured[0].closed
+
+
+@pytest.mark.parametrize("reason", ["member_missing", "member_dtype_object",
+                                    "member_size_inconsistent"])
+def test_the_descriptor_is_closed_when_preflight_refuses(root, tmp_path,
+                                                         opened_files, reason):
+    """Refusal happens after the open, so the handle must not be left behind."""
+    path, policy = REFUSAL_CASES[reason](root, tmp_path)
+    with pytest.raises(guard.SnapshotArchiveRejected):
+        with guard.admit_snapshot(path, data_dir=root,
+                                  policy=policy or guard.PRODUCTION_POLICY):
+            pass
+    assert opened_files, "the guard never opened the archive"
+    assert all(handle.closed for handle in opened_files)
+
+
+def test_nothing_is_opened_when_the_path_is_refused_before_the_open(root,
+                                                                    tmp_path,
+                                                                    opened_files):
+    outside = tmp_path / "v070_outside.npz"
+    write_npz(outside, schema_members())
+    with pytest.raises(guard.SnapshotArchiveRejected):
+        with guard.admit_snapshot(outside, data_dir=root):
+            pass
+    assert opened_files == []
+
+
+# ---------------------------------------------------------------------------
+# Policy shape
+# ---------------------------------------------------------------------------
+
+def test_the_production_policy_is_immutable_and_named():
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        guard.PRODUCTION_POLICY.max_members = 6
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        guard.PRODUCTION_POLICY.members[0].max_payload_bytes = 1
+
+
+def test_the_production_limits_are_the_calibrated_ones():
+    policy = guard.PRODUCTION_POLICY
+    assert policy.max_members == 5
+    assert policy.max_header_bytes == 4 * 1024
+    assert policy.max_total_declared_bytes == 529 * 1024 * 1024
+    assert policy.max_physical_bytes == 544 * 1024 * 1024
+    assert (policy.min_edge, policy.max_edge, policy.edge_multiple) == (16, 256, 16)
+    caps = {spec.name: spec.max_payload_bytes for spec in policy.members}
+    assert caps["lattice"] == 16 * 1024 * 1024
+    assert caps["memory_grid"] == 512 * 1024 * 1024
+    assert set(caps) == {"lattice", "memory_grid", "generation", "ca_step",
+                         "best_fitness"}
+
+
+def test_the_limits_are_calibrated_to_the_compatibility_ceiling():
+    """256³ uint8 is exactly the lattice ceiling and 8 x 256³ float32 is
+    exactly the memory-grid ceiling, so the numbers are derived rather than
+    guessed -- and their sum is below the aggregate ceiling, which is why the
+    aggregate can only bind under a widened policy."""
+    policy = guard.PRODUCTION_POLICY
+    caps = {spec.name: spec.max_payload_bytes for spec in policy.members}
+    assert caps["lattice"] == policy.max_edge ** 3 * 1
+    assert caps["memory_grid"] == 8 * policy.max_edge ** 3 * 4
+    assert (caps["lattice"] + caps["memory_grid"]
+            < policy.max_total_declared_bytes < policy.max_physical_bytes)
+
+
+def test_no_compression_ratio_threshold_exists(root):
+    """A legitimate snapshot is mostly void and compresses enormously. A ratio
+    rule would refuse real inputs, so there must not be one -- witnessed by a
+    genuinely extreme ratio being admitted."""
+    path = write_npz(root / "v070_sparse.npz", schema_members(64))
+    with zipfile.ZipFile(path) as archive:
+        declared = sum(info.file_size for info in archive.infolist())
+        physical = sum(info.compress_size for info in archive.infolist())
+    assert declared / max(physical, 1) > 100, "the sparse control is not sparse"
+    assert admit(path, root) is None
+
+
+def test_a_high_entropy_archive_is_admitted_too(root):
+    """The mirror control: an archive that does not compress at all is equally
+    admissible, so admission is not keyed on compressibility in either
+    direction."""
+    import os as _os
+    members = schema_members(16)
+    members["lattice.npy"] = npy_bytes(
+        "|u1", (16, 16, 16), payload=_os.urandom(16 ** 3))
+    path = write_npz(root / "v070_entropy.npz", members)
+    with zipfile.ZipFile(path) as archive:
+        info = archive.getinfo("lattice.npy")
+        assert info.compress_size > info.file_size * 0.9, "not high-entropy"
+    assert admit(path, root) is None
+
+
+# ---------------------------------------------------------------------------
+# The module's own construction
+# ---------------------------------------------------------------------------
+
+def _guard_source():
+    return Path(guard.__file__).read_text(encoding="utf-8")
+
+
+def _called_attribute_names(tree):
+    return {
+        node.func.attr for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+
+def _called_plain_names(tree):
+    return {
+        node.func.id for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+
+@pytest.mark.parametrize("banned", ["extract", "extractall", "testzip"])
+def test_the_guard_never_extracts(banned):
+    """Extraction would write attacker-named paths and materialise payloads;
+    the guard reads bounded prefixes of member streams instead."""
+    assert banned not in _called_attribute_names(ast.parse(_guard_source()))
+
+
+@pytest.mark.parametrize("banned", ["eval", "exec", "compile", "literal_eval"])
+def test_the_guard_never_evaluates_header_text_by_bare_name(banned):
+    assert banned not in _called_plain_names(ast.parse(_guard_source()))
+
+
+@pytest.mark.parametrize("banned", ["eval", "exec", "literal_eval"])
+def test_the_guard_never_evaluates_header_text_through_a_module(banned):
+    """`re.compile` is legitimate and deliberately not on this list; what is
+    banned is anything that would turn header text into code."""
+    assert banned not in _called_attribute_names(ast.parse(_guard_source()))
+
+
+def test_the_construction_scanners_can_see_a_planted_call():
+    """Anti-vacuity: the two scanners above would catch what they claim to."""
+    planted = ast.parse("import ast\nz.extractall('x')\nast.literal_eval('1')\n"
+                        "eval('1')\n")
+    assert "extractall" in _called_attribute_names(planted)
+    assert "literal_eval" in _called_attribute_names(planted)
+    assert "eval" in _called_plain_names(planted)
+
+
+def test_the_guard_uses_no_numpy_and_no_private_numpy_parser():
+    """It runs before NumPy is involved at all, so it must not import NumPy or
+    reach into its private format helpers."""
+    source = _guard_source()
+    assert "import numpy" not in source and "__import__" not in source
+    assert "read_magic" not in source and "read_array_header" not in source
+    tree = ast.parse(source)
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import) for alias in node.names
+    } | {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert imported <= {"__future__", "contextlib", "dataclasses", "os", "re",
+                        "stat", "struct", "zipfile", "pathlib", "typing"}
+
+
+# ---------------------------------------------------------------------------
+# Real NumPy archives: compatibility of admitted inputs
+# ---------------------------------------------------------------------------
+
+def _numpy_snapshot(path, edge=16, channels=8, compressed=True):
+    writer = np.savez_compressed if compressed else np.savez
+    writer(
+        path,
+        lattice=np.zeros((edge, edge, edge), dtype=np.uint8),
+        memory_grid=np.zeros((channels, edge, edge, edge), dtype=np.float32),
+        generation=np.int64(1234),
+        ca_step=np.int64(99),
+        best_fitness=np.float64(0.875),
+    )
+    return Path(str(path) + ".npz") if not str(path).endswith(".npz") else Path(path)
+
+
+@requires_numpy
+@pytest.mark.parametrize("compressed", [True, False], ids=["compressed", "stored"])
+def test_a_real_numpy_snapshot_is_admitted_and_loads(root, compressed):
+    path = _numpy_snapshot(root / "v070_gen001234.npz", 64, compressed=compressed)
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        with np.load(handle, allow_pickle=False) as archive:
+            assert archive["lattice"].shape == (64, 64, 64)
+            assert archive["memory_grid"].shape == (8, 64, 64, 64)
+            assert int(archive["generation"]) == 1234
+            assert int(archive["ca_step"]) == 99
+            assert float(archive["best_fitness"]) == 0.875
+
+
+@requires_numpy
+def test_numpy_loads_from_the_very_descriptor_that_was_preflighted(root):
+    """Not an equivalent path, not a reopen: the same object.
+
+    `NpzFile` keeps the file it was handed on its `ZipFile`, so identity is
+    observable rather than inferred.
+    """
+    path = _numpy_snapshot(root / "v070_identity.npz")
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        with np.load(handle, allow_pickle=False) as archive:
+            assert archive.zip.fp is handle
+
+
+@requires_numpy
+def test_the_descriptor_survives_the_archive_close_and_is_closed_after(root):
+    """The archive's close must not take the guard's descriptor with it while
+    the block is still running, and the descriptor must be gone afterwards."""
+    path = _numpy_snapshot(root / "v070_lifetime.npz")
+    with guard.admit_snapshot(path, data_dir=root) as handle:
+        with np.load(handle, allow_pickle=False) as archive:
+            archive["lattice"]
+        assert archive.zip is None, "the archive was not closed"
+        assert not handle.closed, "the archive's close took the descriptor with it"
+    assert handle.closed
+
+
+@requires_numpy
+def test_a_missing_key_after_admission_still_fails_the_way_it_always_did(root):
+    """Admission does not take over downstream failures."""
+    path = _numpy_snapshot(root / "v070_key.npz")
+    with pytest.raises(KeyError):
+        with guard.admit_snapshot(path, data_dir=root) as handle:
+            with np.load(handle, allow_pickle=False) as archive:
+                archive["not_a_member"]
+
+
+@requires_numpy
+def test_the_descriptor_is_closed_when_a_load_inside_the_block_raises(root):
+    path = _numpy_snapshot(root / "v070_loadfail.npz")
+    captured = []
+    with pytest.raises(KeyError):
+        with guard.admit_snapshot(path, data_dir=root) as handle:
+            captured.append(handle)
+            with np.load(handle, allow_pickle=False) as archive:
+                archive["absent"]
+    assert captured[0].closed
+
+
+@requires_numpy
+def test_a_pickled_member_cannot_even_reach_numpy(root, tmp_path):
+    """The pickle refusal in each consumer stays in place, but an object member
+    no longer gets that far: admission refuses it from the header."""
+    class _Payload:
+        def __reduce__(self):
+            raise AssertionError("this must never be pickled or unpickled")
+
+    members = schema_members(16)
+    members["generation.npy"] = npy_bytes("|O", (), payload=b"")
+    path = write_npz(root / "v070_pickled.npz", members)
+    assert admit(path, root) == "member_dtype_object"
+
+
+@requires_numpy
+def test_admitted_producer_shapes_match_what_the_engine_writes(root):
+    """The schema this guard admits is the schema `_save_snapshot` emits:
+    five members, those five names, those five forms."""
+    path = _numpy_snapshot(root / "v070_producer.npz", 64)
+    with zipfile.ZipFile(path) as archive:
+        assert sorted(archive.namelist()) == [
+            "best_fitness.npy", "ca_step.npy", "generation.npy",
+            "lattice.npy", "memory_grid.npy",
+        ]
+    assert admit(path, root) is None

--- a/tests/test_snapshot_archive_guard.py
+++ b/tests/test_snapshot_archive_guard.py
@@ -29,6 +29,7 @@ import struct
 import warnings
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -262,6 +263,35 @@ def _case_not_zip_archive(root, tmp_path):
     path = root / "v070_renamed.npz"
     path.write_bytes(npy_bytes("|u1", (16, 16, 16)))
     return path, None
+
+
+def _set_extract_version(path, version):
+    """Set 'version needed to extract' on every central-directory entry."""
+    data = bytearray(Path(path).read_bytes())
+    offset = 0
+    patched = 0
+    while True:
+        index = data.find(b"PK\x01\x02", offset)
+        if index < 0:
+            break
+        struct.pack_into("<H", data, index + 6, version)
+        patched += 1
+        offset = index + 4
+    assert patched, "no central-directory header found in the fixture"
+    Path(path).write_bytes(bytes(data))
+    return Path(path)
+
+
+def _case_unsupported_extract_version(root, tmp_path):
+    """One byte per entry, and the archive is otherwise schema-perfect.
+
+    `ZipFile()`'s constructor refuses an entry whose "version needed to
+    extract" exceeds MAX_EXTRACT_VERSION (63) with `NotImplementedError` —
+    which subclasses `RuntimeError`, so the BadZipFile/OSError/ValueError
+    clause did not catch it and the exception left `admit_snapshot` untyped.
+    """
+    path = write_npz(root / "v070_extver.npz", schema_members(16))
+    return _set_extract_version(path, 255), None
 
 
 def _zip64_entry_bomb(path, entries):
@@ -723,6 +753,91 @@ def test_a_symlink_out_of_the_data_directory_is_refused(root, tmp_path):
     assert admit(link, root) == "path_not_confined"
 
 
+def test_an_unsupported_extract_version_is_refused_not_escaped(root, tmp_path):
+    """The archive is schema-perfect; one byte per central entry is changed.
+
+    `NotImplementedError` subclasses `RuntimeError`, so the constructor's
+    refusal escaped `admit_snapshot` untyped — turning every Medusa snapshot
+    route into a 500 rather than the sanitized 503, and wedging the geometry
+    daemon, which records only typed refusals in its retry memory.
+    """
+    path, policy = _case_unsupported_extract_version(root, tmp_path)
+    assert admit(path, root, policy) == "not_zip_archive"
+
+
+def test_the_same_archive_is_admitted_at_a_supported_extract_version(root):
+    """Control: the fixture differs from an admitted archive in that field
+    alone, so the refusal above is about the version and nothing else."""
+    path = write_npz(root / "v070_extver_ok.npz", schema_members(16))
+    assert admit(path, root) is None
+    _set_extract_version(path, 255)
+    assert admit(path, root) == "not_zip_archive"
+
+
+@pytest.mark.parametrize("version", [64, 100, 255])
+def test_every_extract_version_above_the_ceiling_is_typed(root, version):
+    path = write_npz(root / ("v070_ev%d.npz" % version), schema_members(16))
+    _set_extract_version(path, version)
+    assert admit(path, root) == "not_zip_archive"
+
+
+def test_a_raw_member_name_differing_from_the_sanitised_one_is_refused(root):
+    """`ZipInfo.filename` is post-`_sanitize_filename` and can additionally be
+    overridden by a 0x7075 extra field, so an entry can present a schema name
+    while `orig_filename` holds something else — which CPython quotes verbatim
+    in its "Overlapped entries" warning, putting attacker-chosen text on an
+    unattended daemon's stderr from an ADMITTED archive."""
+    path = write_npz(root / "v070_rawname.npz", schema_members(16))
+    assert admit(path, root) is None, "the fixture must be admissible first"
+
+    # Injected rather than hand-forged. `ZipInfo.__init__` truncates a NUL on
+    # CONSTRUCTION, so `writestr` cannot store a name that diverges, and a
+    # crafted central entry would additionally have to keep the local header,
+    # the directory size and the EOCD offsets all consistent -- surgery whose
+    # failure mode would be a DIFFERENT refusal, making the test say nothing
+    # about this check. Divergence is what is under test, so divergence is what
+    # is injected.
+    real_infolist = zipfile.ZipFile.infolist
+
+    def _diverging_infolist(self):
+        entries = real_infolist(self)
+        for entry in entries:
+            if entry.filename == "lattice.npy":
+                entry.orig_filename = "lattice.npy\x00../../etc/passwd"
+        return entries
+
+    with mock.patch.object(zipfile.ZipFile, "infolist", _diverging_infolist):
+        reason = admit(path, root)
+    assert reason == "member_name_unsafe"
+
+
+@pytest.mark.parametrize("descr", ["<i000004", "<f00008", "|u01"])
+def test_a_zero_padded_width_is_refused(root, descr):
+    """`<i000004` normalises to a width of 4 and would pass the allowlist, but
+    NumPy is handed the descriptor STRING, not the normalised width."""
+    members = schema_members(16)
+    members["generation.npy"] = npy_bytes(
+        "<i8", (), payload=b"\x00" * 4,
+        header="{'descr': '%s', 'fortran_order': False, 'shape': (), }" % descr)
+    path = write_npz(root / "v070_padded.npz", members)
+    assert admit(path, root) == "member_dtype_unsupported"
+
+
+def test_newest_first_breaks_ties_on_the_lower_path_first(root):
+    """Direction, not merely determinism.
+
+    The producer's `:06d` width has already been outgrown in production, so
+    lexicographic order inverts across a digit-count boundary: a descending
+    tie-break would prefer `v070_gen999999` over `v070_gen1000000` — the OLDER
+    snapshot.
+    """
+    older_name = _touch(root / "v070_gen999999_step1.npz", 7_000_000_000)
+    newer_name = _touch(root / "v070_gen1000000_step1.npz", 7_000_000_000)
+    ordered = guard.newest_first([older_name, newer_name])
+    assert [p.name for p in ordered] == ["v070_gen1000000_step1.npz",
+                                         "v070_gen999999_step1.npz"]
+
+
 def test_a_zip64_entry_bomb_is_refused_before_zipfile_builds_the_directory(root):
     """The refusal must arrive at the ZIP64 check, not later on the names.
 
@@ -845,6 +960,76 @@ def test_unsupported_general_purpose_flag_bits_are_refused(root, bits, label):
     assert admit(path, root) == "member_flags_unsupported", label
 
 
+def test_the_flag_check_refuses_before_the_member_is_ever_opened(root,
+                                                                 monkeypatch):
+    """Ordering, which the reason code alone cannot pin.
+
+    CPython raises `NotImplementedError` for bits 5/6 from `ZipFile.open`, and
+    this guard translates that to the SAME reason code — so deleting the
+    central-directory check entirely would leave every other flag-bit test
+    passing. What distinguishes the two is whether the member is opened at
+    all, so that is what is counted here.
+    """
+    path = write_npz(root / "v070_flagorder.npz", schema_members(16))
+    _set_central_flag_bits(path, 0x0020)
+
+    opens = []
+    real_open = zipfile.ZipFile.open
+
+    def _counting_open(self, name, *args, **kwargs):
+        opens.append(getattr(name, "filename", name))
+        return real_open(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _counting_open)
+    assert admit(path, root) == "member_flags_unsupported"
+    assert opens == [], (
+        "the refusal came from ZipFile.open, not from the central directory")
+
+
+def test_the_flag_check_does_not_stop_a_clean_archive_being_opened(root,
+                                                                   monkeypatch):
+    """Anti-vacuity for the counter above: an admissible archive DOES open its
+    members, so `opens == []` means something."""
+    path = write_npz(root / "v070_flagorder_ok.npz", schema_members(16))
+    opens = []
+    real_open = zipfile.ZipFile.open
+
+    def _counting_open(self, name, *args, **kwargs):
+        opens.append(getattr(name, "filename", name))
+        return real_open(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _counting_open)
+    assert admit(path, root) is None
+    assert len(opens) == 5
+
+
+def test_a_non_ascii_member_name_is_refused(root):
+    """The schema's five names are ASCII; anything else is a different name or
+    an encoding trick, and both are refusals."""
+    members = schema_members(16)
+    members["latticeİ.npy"] = npy_bytes("|u1", (1,))
+    path = write_npz(root / "v070_nonascii.npz", members)
+    assert admit(path, root) == "member_name_unsafe"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"),
+                    reason="FIFOs are a POSIX construct")
+def test_a_fifo_named_like_a_snapshot_does_not_hang_the_guard(root):
+    """`S_ISREG` cannot protect the OPEN itself.
+
+    A plain `open()` of a FIFO blocks until a writer appears, so an attacker
+    able to write to the watched directory could `mkfifo` a `v070_gen*.npz`
+    and hang Lucid's whole asyncio server, or park one Medusa request thread
+    per attempt. `O_NONBLOCK` makes the open return so `S_ISREG` can refuse.
+
+    If this ever regresses it HANGS rather than fails, which is exactly why it
+    is worth having: a hang in CI is a louder signal than a wrong reason code.
+    """
+    fifo = root / "v070_fifo.npz"
+    os.mkfifo(fifo)
+    assert admit(fifo, root) == "path_not_regular_file"
+
+
 def test_a_not_implemented_error_from_zipfile_is_translated(root, monkeypatch):
     """The defensive half of the flag-bit handling.
 
@@ -936,7 +1121,6 @@ def test_a_resolve_failure_is_typed_even_when_injected(root, monkeypatch):
     assert excinfo.value.reason == "path_not_confined"
     assert "symbolic" not in str(excinfo.value)
     assert "v070_resolve" not in str(excinfo.value)
-    assert real_resolve is not None
 
 
 @pytest.mark.parametrize("digits", ["١", "٤", "۸"], ids=["arabic_one",
@@ -947,10 +1131,12 @@ def test_a_non_ascii_digit_width_is_refused(root, digits):
     decimal-digit category — as does `int()`. So `<i١` parsed as a width of 1
     and was admitted, describing a dtype no NumPy can construct."""
     members = schema_members(16)
-    # A payload of exactly one byte, matching the width the non-ASCII digit
-    # decodes to. Without it the archive is refused for a size mismatch and the
-    # dtype rule is never reached -- which would make this test pass for the
-    # wrong reason, and would have passed before the fix too.
+    # A one-byte payload. For `١` (=1) that makes the archive size-consistent,
+    # so ONLY the dtype rule can refuse it -- and reverting the rule admits the
+    # archive outright, which is what makes this case load-bearing. For `٤`
+    # (=4) and `۸` (=8) the sizes do not line up and the refusal arrives as a
+    # size mismatch instead; those two are breadth over the digit class, not
+    # independent proofs of the rule.
     members["generation.npy"] = npy_bytes(
         "<i8", (), payload=b"\x00", version=(3, 0),
         header="{'descr': '<i%s', 'fortran_order': False, 'shape': (), }"

--- a/tests/test_snapshot_archive_guard.py
+++ b/tests/test_snapshot_archive_guard.py
@@ -63,7 +63,10 @@ def npy_bytes(descr, shape, *, fortran=False, payload=None, header=None,
             shape_text = "(" + ", ".join(str(dim) for dim in shape) + ")"
         header = "{'descr': '%s', 'fortran_order': %s, 'shape': %s, }" % (
             descr, fortran, shape_text)
-    body = header.encode("latin1")
+    # v3.0 headers are UTF-8 by specification; v1.0 and v2.0 are latin-1.
+    # Encoding v3 as latin-1 would make a non-ASCII descriptor unbuildable, and
+    # a non-ASCII descriptor is exactly what the digit-class tests need.
+    body = header.encode("utf-8" if version == (3, 0) else "latin1")
     prelude = 10 if version == (1, 0) else 12
     body += b" " * ((-(prelude + len(body) + 1)) % 64) + b"\n"
     out = bytearray(_NPY_MAGIC) + bytes(version)
@@ -348,6 +351,30 @@ def _case_member_encrypted(root, tmp_path):
     return set_encrypted_flag(path), None
 
 
+def _set_central_flag_bits(path, bits):
+    """Set general-purpose flag bits on every central-directory entry."""
+    data = bytearray(Path(path).read_bytes())
+    offset = 0
+    patched = 0
+    while True:
+        index = data.find(b"PK\x01\x02", offset)
+        if index < 0:
+            break
+        current = struct.unpack_from("<H", data, index + 8)[0]
+        struct.pack_into("<H", data, index + 8, current | bits)
+        patched += 1
+        offset = index + 4
+    assert patched, "no central-directory header found in the fixture"
+    Path(path).write_bytes(bytes(data))
+    return Path(path)
+
+
+def _case_member_flags_unsupported(root, tmp_path):
+    # Bit 5, Zip 2.7 compressed patched data. Bit 6 is covered separately.
+    path = write_npz(root / "v070_patched.npz", schema_members(16))
+    return _set_central_flag_bits(path, 0x0020), None
+
+
 def _case_member_compression_unsupported(root, tmp_path):
     return write_npz(root / "v070_bz2.npz", schema_members(),
                      compression=zipfile.ZIP_BZIP2), None
@@ -508,6 +535,7 @@ REFUSAL_CASES = {
     "member_unexpected": _case_member_unexpected,
     "member_missing": _case_member_missing,
     "member_encrypted": _case_member_encrypted,
+    "member_flags_unsupported": _case_member_flags_unsupported,
     "member_compression_unsupported": _case_member_compression_unsupported,
     "member_payload_too_large": _case_member_payload_too_large,
     "member_header_unreadable": _case_member_header_unreadable,
@@ -532,11 +560,119 @@ REFUSAL_CASES = {
 }
 
 
+def _case_member_payload_unreadable(root, tmp_path):
+    """A member whose CRC is wrong: a valid header over a corrupt body.
+
+    Preflight cannot see this. It reads each member's HEADER, and a payload can
+    only be checked by decompressing it -- which is exactly the work the guard
+    exists to avoid doing before admission. So the archive is admitted, and the
+    failure surfaces during the caller's extraction.
+    """
+    path = write_npz(root / "v070_crc.npz", schema_members(16))
+    data = bytearray(path.read_bytes())
+    index = data.find(b"PK\x01\x02")
+    assert index > 0, "no central-directory header in the fixture"
+    struct.pack_into("<I", data, index + 16, 0xDEADBEEF)  # CRC-32 field
+    path.write_bytes(bytes(data))
+    return path, None
+
+
+def _read_a_member(handle):
+    """Stand in for what a consumer's `np.load` does with the descriptor.
+
+    Reading a member decompresses it and verifies its CRC, which is the step
+    that raises `zipfile.BadZipFile` -- the exact class NumPy's own extraction
+    raises, through the same `zipfile` machinery.
+    """
+    with zipfile.ZipFile(handle) as archive:
+        archive.read("lattice.npy")
+
+
+#: Reason codes raised from INSIDE the caller's block rather than during
+#: preflight. Kept in their own table because they need a body to run, not
+#: merely an archive to open -- and because the distinction is the point: these
+#: are the failures preflight structurally cannot reach.
+BLOCK_REFUSAL_CASES = {
+    "member_payload_unreadable": (_case_member_payload_unreadable, _read_a_member),
+}
+
+
 def test_every_declared_reason_code_has_a_reproducible_case():
     """Anti-vacuity for the roster itself: no unreachable code may be declared,
     and no case may name a code the module does not declare."""
-    assert set(REFUSAL_CASES) == set(guard.REASON_CODES)
+    assert set(REFUSAL_CASES) | set(BLOCK_REFUSAL_CASES) == set(guard.REASON_CODES)
+    assert not (set(REFUSAL_CASES) & set(BLOCK_REFUSAL_CASES))
     assert len(guard.REASON_CODES) == len(set(guard.REASON_CODES))
+
+
+@pytest.mark.parametrize("reason", sorted(BLOCK_REFUSAL_CASES))
+def test_each_block_reason_code_is_produced_by_its_case(reason, root, tmp_path):
+    build, body = BLOCK_REFUSAL_CASES[reason]
+    path, policy = build(root, tmp_path)
+    with pytest.raises(guard.SnapshotArchiveRejected) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root,
+                                  policy=policy or guard.PRODUCTION_POLICY) as fh:
+            body(fh)
+    assert excinfo.value.reason == reason
+    assert str(excinfo.value) == reason
+
+
+def test_a_corrupt_payload_is_admitted_then_refused_not_refused_early(root,
+                                                                      tmp_path):
+    """The ordering claim, made explicit: this archive PASSES preflight.
+
+    Without this, the CRC case could be passing because some earlier structural
+    check happened to catch it, and the block-boundary translation would be
+    untested.
+    """
+    path, _ = _case_member_payload_unreadable(root, tmp_path)
+    with guard.admit_snapshot(path, data_dir=root) as fh:
+        assert fh.read(4) == b"PK\x03\x04"  # admitted; no refusal raised here
+
+
+@pytest.mark.parametrize("raised", [
+    MemoryError("oom"),
+    KeyboardInterrupt(),
+    ValueError("EOF: reading array data"),
+    RuntimeError("programmer error"),
+    KeyError("lattice"),
+    AttributeError("nope"),
+], ids=["memory", "keyboard_interrupt", "value_error", "runtime", "key",
+        "attribute"])
+def test_the_block_boundary_translates_nothing_else(root, raised):
+    """The narrowness of the translation IS the contract.
+
+    `MemoryError`, `KeyboardInterrupt`, an arbitrary `ValueError` -- NumPy's
+    own "EOF: reading array data" among them -- and every programmer error must
+    leave the block exactly as they were raised. Only archive transport is
+    translated.
+    """
+    path = write_npz(root / "v070_passthrough.npz", schema_members(16))
+    with pytest.raises(type(raised)) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root):
+            raise raised
+    assert type(excinfo.value) is type(raised)
+    assert str(excinfo.value) == str(raised)
+
+
+def test_a_refusal_raised_inside_the_block_keeps_its_own_reason(root):
+    """A `SnapshotArchiveRejected` from the caller's own code is re-raised
+    unchanged rather than re-coded as a payload failure."""
+    path = write_npz(root / "v070_inner.npz", schema_members(16))
+    with pytest.raises(guard.SnapshotArchiveRejected) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root):
+            raise guard.SnapshotArchiveRejected("member_missing")
+    assert excinfo.value.reason == "member_missing"
+
+
+def test_the_descriptor_is_closed_after_a_block_boundary_refusal(root, tmp_path,
+                                                                 opened_files):
+    path, _ = _case_member_payload_unreadable(root, tmp_path)
+    with pytest.raises(guard.SnapshotArchiveRejected):
+        with guard.admit_snapshot(path, data_dir=root) as fh:
+            _read_a_member(fh)
+    assert opened_files, "the guard never opened the archive"
+    assert all(handle.closed for handle in opened_files)
 
 
 @pytest.mark.parametrize("reason", sorted(REFUSAL_CASES))
@@ -695,6 +831,173 @@ def test_an_empty_header_is_a_syntax_error_not_a_depth_overflow():
     with pytest.raises(guard._HeaderSyntaxError) as excinfo:
         guard._parse_literal("{")
     assert "deep" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bits,label", [
+    (0x0020, "compressed patched data (bit 5)"),
+    (0x0040, "strong encryption (bit 6)"),
+    (0x0060, "both"),
+])
+def test_unsupported_general_purpose_flag_bits_are_refused(root, bits, label):
+    """Refused from the central directory, before the member is opened."""
+    path = write_npz(root / "v070_flags.npz", schema_members(16))
+    _set_central_flag_bits(path, bits)
+    assert admit(path, root) == "member_flags_unsupported", label
+
+
+def test_a_not_implemented_error_from_zipfile_is_translated(root, monkeypatch):
+    """The defensive half of the flag-bit handling.
+
+    CPython 3.13 reads bits 5 and 6 from the CENTRAL directory
+    (`zipfile.ZipFile.open` tests `zinfo.flag_bits`), so the check above
+    normally wins and this branch is not reached through a crafted archive.
+    It still matters: `NotImplementedError` subclasses `RuntimeError`, so
+    without an explicit clause it would be swallowed by the broad handler and
+    reported as an unreadable header, and its message names the flag. Injected
+    directly, because inventing an archive that reaches it would be inventing
+    a CPython that does not exist.
+    """
+    path = write_npz(root / "v070_notimpl.npz", schema_members(16))
+    real_open = zipfile.ZipFile.open
+
+    def _raising_open(self, name, *args, **kwargs):
+        raise NotImplementedError("strong encryption (flag bit 6)")
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _raising_open)
+    with pytest.raises(guard.SnapshotArchiveRejected) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root):
+            pass
+    assert excinfo.value.reason == "member_flags_unsupported"
+    assert "flag bit" not in str(excinfo.value)
+    assert "encryption" not in str(excinfo.value)
+    assert real_open is not None  # the real one is restored by monkeypatch
+
+
+def test_malformed_deflate_data_during_the_header_read_is_refused(root):
+    """`zlib.error` inherits from `Exception`, not `OSError`.
+
+    The header read is bounded, but for a DEFLATED member those bounded bytes
+    still go through the decompressor. Corrupt compressed data therefore raised
+    `zlib.error`, which no other clause caught, and it escaped the guard with
+    its own message.
+    """
+    members = schema_members(16)
+    path = root / "v070_deflate.npz"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, blob in members.items():
+            archive.writestr(name, blob)
+
+    # Corrupt the first member's compressed bytes in place, leaving every
+    # directory structure intact so the failure lands in the decompressor.
+    data = bytearray(path.read_bytes())
+    local = data.find(b"PK\x03\x04")
+    name_len = struct.unpack_from("<H", data, local + 26)[0]
+    extra_len = struct.unpack_from("<H", data, local + 28)[0]
+    body = local + 30 + name_len + extra_len
+    data[body:body + 24] = b"\xff" * 24
+    path.write_bytes(bytes(data))
+
+    assert admit(path, root) == "member_header_unreadable"
+
+
+def test_a_resolve_failure_is_refused_inside_the_typed_boundary(root, tmp_path):
+    """`Path.resolve()` is not total: a symlink loop raises OSError(ELOOP).
+
+    Uncaught it left the guard by a route with no reason code and with the path
+    in the message. If the real path cannot be determined then confinement
+    cannot be proved, so the fail-closed answer is the confinement refusal.
+    """
+    loop = root / "v070_loop.npz"
+    other = root / "v070_loop_b.npz"
+    try:
+        loop.symlink_to(other)
+        other.symlink_to(loop)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+
+    reason = admit(loop, root)
+    assert reason in {"path_not_confined", "path_not_regular_file"}
+    assert str(tmp_path) not in reason
+
+
+def test_a_resolve_failure_is_typed_even_when_injected(root, monkeypatch):
+    """Platform-independent proof of the same boundary, so the contract is
+    pinned on Windows runners too."""
+    path = write_npz(root / "v070_resolve.npz", schema_members(16))
+    real_resolve = Path.resolve
+
+    def _failing_resolve(self, *args, **kwargs):
+        raise OSError(40, "Too many levels of symbolic links", str(self))
+
+    monkeypatch.setattr(Path, "resolve", _failing_resolve)
+    with pytest.raises(guard.SnapshotArchiveRejected) as excinfo:
+        with guard.admit_snapshot(path, data_dir=root):
+            pass
+    assert excinfo.value.reason == "path_not_confined"
+    assert "symbolic" not in str(excinfo.value)
+    assert "v070_resolve" not in str(excinfo.value)
+    assert real_resolve is not None
+
+
+@pytest.mark.parametrize("digits", ["١", "٤", "۸"], ids=["arabic_one",
+                                                        "arabic_four",
+                                                        "extended_eight"])
+def test_a_non_ascii_digit_width_is_refused(root, digits):
+    """A v3.0 header is decoded as UTF-8, and `\\d` matches the whole Unicode
+    decimal-digit category — as does `int()`. So `<i١` parsed as a width of 1
+    and was admitted, describing a dtype no NumPy can construct."""
+    members = schema_members(16)
+    # A payload of exactly one byte, matching the width the non-ASCII digit
+    # decodes to. Without it the archive is refused for a size mismatch and the
+    # dtype rule is never reached -- which would make this test pass for the
+    # wrong reason, and would have passed before the fix too.
+    members["generation.npy"] = npy_bytes(
+        "<i8", (), payload=b"\x00", version=(3, 0),
+        header="{'descr': '<i%s', 'fortran_order': False, 'shape': (), }"
+               % digits)
+    path = write_npz(root / "v070_digit.npz", members)
+    assert admit(path, root) == "member_dtype_unsupported"
+
+
+def test_a_sixteen_byte_float_is_refused_portably(root):
+    """`float128`/`longdouble` is not portable — NumPy 2.3.5 on Windows refuses
+    `<f16` outright — and no snapshot member has ever used one. Admitting it
+    would push the failure past the guard onto whichever consumer's NumPy
+    cannot build it."""
+    members = schema_members(16)
+    members["best_fitness.npy"] = npy_bytes("<f16", (), payload=b"\x00" * 16)
+    path = write_npz(root / "v070_f16.npz", members)
+    assert admit(path, root) == "member_dtype_unsupported"
+    assert 16 not in guard._FLOAT_WIDTHS
+
+
+def test_the_zip64_central_directory_offset_sentinel_is_refused(root):
+    """The offset field says "the real value is in the ZIP64 record" just as
+    loudly as the counts do, so an archive can carry honest-looking counts and
+    still redirect `zipfile` through ZIP64."""
+    path = write_npz(root / "v070_z64off.npz", schema_members(16))
+    data = bytearray(path.read_bytes())
+    index = data.rfind(b"PK\x05\x06")
+    struct.pack_into("<I", data, index + 16, 0xFFFFFFFF)
+    path.write_bytes(bytes(data))
+    assert admit(path, root) == "zip64_unsupported"
+
+
+@pytest.mark.parametrize("field,offset", [
+    ("entries_here", 8), ("entries_total", 10), ("directory_size", 12),
+])
+def test_every_central_zip64_sentinel_is_refused_as_zip64(root, field, offset):
+    """All four report the same thing and now share one reason code; they used
+    to be split between `member_count` and `zip64_unsupported`."""
+    path = write_npz(root / ("v070_z64_%s.npz" % field), schema_members(16))
+    data = bytearray(path.read_bytes())
+    index = data.rfind(b"PK\x05\x06")
+    if offset == 12:
+        struct.pack_into("<I", data, index + offset, 0xFFFFFFFF)
+    else:
+        struct.pack_into("<H", data, index + offset, 0xFFFF)
+    path.write_bytes(bytes(data))
+    assert admit(path, root) == "zip64_unsupported"
 
 
 def test_a_zero_channel_memory_grid_is_refused(root):
@@ -952,6 +1255,100 @@ def test_nothing_is_opened_when_the_path_is_refused_before_the_open(root,
 
 
 # ---------------------------------------------------------------------------
+# Safe candidate discovery
+# ---------------------------------------------------------------------------
+
+def _touch(path, mtime_ns):
+    path.write_bytes(b"x")
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+    return path
+
+
+def test_newest_first_orders_by_modification_time(root):
+    older = _touch(root / "v070_a.npz", 1_000_000_000)
+    newer = _touch(root / "v070_b.npz", 3_000_000_000)
+    middle = _touch(root / "v070_c.npz", 2_000_000_000)
+    assert guard.newest_first([older, newer, middle]) == [newer, middle, older]
+
+
+def test_newest_first_breaks_ties_deterministically(root):
+    first = _touch(root / "v070_a.npz", 5_000_000_000)
+    second = _touch(root / "v070_b.npz", 5_000_000_000)
+    forward = guard.newest_first([first, second])
+    backward = guard.newest_first([second, first])
+    assert forward == backward, "the order depends on how the glob happened to yield"
+    assert set(forward) == {first, second}
+
+
+def test_newest_first_silently_skips_an_entry_that_disappeared(root):
+    present = _touch(root / "v070_here.npz", 1_000_000_000)
+    missing = root / "v070_gone.npz"
+    assert not missing.exists()
+    assert guard.newest_first([missing, present]) == [present]
+
+
+def test_newest_first_skips_a_whole_directory_of_vanished_entries(root):
+    """No exception, no partial result, nothing printed — there is nothing to
+    report about an entry that is simply gone."""
+    ghosts = [root / ("v070_ghost%d.npz" % i) for i in range(5)]
+    assert guard.newest_first(ghosts) == []
+
+
+def test_newest_first_keeps_a_broken_symlink_as_a_candidate(root):
+    """`lstat` succeeds on a dangling link, and that is the point: it reaches
+    the guard and is refused with a typed reason instead of vanishing from
+    selection and letting an older archive be served with no record of why."""
+    dangling = root / "v070_dangling.npz"
+    try:
+        dangling.symlink_to(root / "v070_absent_target.npz")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+    assert guard.newest_first([dangling]) == [dangling]
+    assert admit(dangling, root) == "path_not_regular_file"
+
+
+def test_newest_first_does_not_follow_a_symlink_for_its_ordering(root, tmp_path):
+    """A link must not be able to borrow its target's modification time to
+    promote itself to "newest" — that is ordering deciding admission's question
+    before admission is asked."""
+    target = tmp_path / "outside_target.npz"
+    _touch(target, 9_000_000_000)
+    link = root / "v070_link.npz"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+    os.utime(link, ns=(1_000_000_000, 1_000_000_000), follow_symlinks=False)
+
+    real = _touch(root / "v070_real.npz", 5_000_000_000)
+    ordered = guard.newest_first([link, real])
+    assert ordered[0] == real, "the link borrowed its target's mtime"
+
+
+def test_entry_fingerprint_describes_the_entry_and_raises_when_gone(root):
+    present = _touch(root / "v070_fp.npz", 4_000_000_000)
+    name, size, mtime = guard.entry_fingerprint(present)
+    assert name == os.fspath(present)
+    assert size == 1 and mtime == 4_000_000_000
+
+    with pytest.raises(OSError):
+        guard.entry_fingerprint(root / "v070_never_existed.npz")
+
+
+def test_entry_fingerprint_is_non_following(root, tmp_path):
+    target = tmp_path / "fp_target.npz"
+    target.write_bytes(b"much larger contents")
+    link = root / "v070_fplink.npz"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform gate
+        pytest.skip("symlink creation is not permitted in this environment")
+    assert guard.entry_fingerprint(link)[1] != target.stat().st_size, (
+        "the fingerprint described the target, so touching the target would "
+        "make a rejected link look changed and be retried every poll")
+
+
+# ---------------------------------------------------------------------------
 # Policy shape
 # ---------------------------------------------------------------------------
 
@@ -1082,7 +1479,8 @@ def test_the_guard_uses_no_numpy_and_no_private_numpy_parser():
         if isinstance(node, ast.ImportFrom) and node.module
     }
     assert imported <= {"__future__", "contextlib", "dataclasses", "os", "re",
-                        "stat", "struct", "zipfile", "pathlib", "typing"}
+                        "stat", "struct", "zipfile", "zlib", "pathlib",
+                        "typing"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_snapshot_archive_guard.py
+++ b/tests/test_snapshot_archive_guard.py
@@ -23,8 +23,8 @@ numeric-value validation, not arbitrary NPZ compatibility.
 from __future__ import annotations
 
 import ast
-import builtins
 import dataclasses
+import os
 import struct
 import warnings
 import zipfile
@@ -261,6 +261,38 @@ def _case_not_zip_archive(root, tmp_path):
     return path, None
 
 
+def _zip64_entry_bomb(path, entries):
+    """A file whose 32-bit EOCD lies and whose ZIP64 record tells the truth.
+
+    `zipfile._EndRecData` consults the ZIP64 locator whenever it is present and
+    takes the entry count and directory size from the ZIP64 record, WITHOUT
+    requiring the 0xFFFF sentinels. So a bounded-looking 32-bit record ("five
+    entries, a 300-byte directory") is advisory, and `ZipFile` goes on to build
+    one `ZipInfo` per real entry. Measured before the fix: 60,000 entries from
+    a 2.7 MB file cost 2.5s and 23 MB of heap, and the archive was only refused
+    afterwards, on its member names.
+    """
+    directory = bytearray()
+    for _ in range(entries):
+        directory += struct.pack("<4s4B4HL2L5H2L", b"PK\x01\x02", 20, 0, 20, 0,
+                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    cd_offset = 4
+    zip64_offset = cd_offset + len(directory)
+    zip64_eocd = struct.pack("<4sQ2H2L4Q", b"PK\x06\x06", 44, 45, 45, 0, 0,
+                             entries, entries, len(directory), cd_offset)
+    locator = struct.pack("<4sLQL", b"PK\x06\x07", 0, zip64_offset, 1)
+    eocd = struct.pack("<4s4H2LH", b"PK\x05\x06", 0, 0, 5, 5, 300, cd_offset, 0)
+    Path(path).write_bytes(b"PK\x03\x04" + bytes(directory) + zip64_eocd
+                           + locator + eocd)
+    return Path(path)
+
+
+def _case_zip64_unsupported(root, tmp_path):
+    # Small on purpose: 64 entries is enough to prove the refusal, and the
+    # point of the fix is that the count never gets to matter.
+    return _zip64_entry_bomb(root / "v070_zip64.npz", 64), None
+
+
 def _case_central_directory_too_large(root, tmp_path):
     path = write_npz(root / "v070_cd.npz", schema_members())
     return path, dataclasses.replace(guard.PRODUCTION_POLICY,
@@ -466,6 +498,7 @@ REFUSAL_CASES = {
     "archive_too_large": _case_archive_too_large,
     "archive_truncated": _case_archive_truncated,
     "not_zip_archive": _case_not_zip_archive,
+    "zip64_unsupported": _case_zip64_unsupported,
     "central_directory_too_large": _case_central_directory_too_large,
     "archive_payload_total_too_large": _case_archive_payload_total_too_large,
     "member_count": _case_member_count,
@@ -552,6 +585,116 @@ def test_a_symlink_out_of_the_data_directory_is_refused(root, tmp_path):
     except (OSError, NotImplementedError):  # pragma: no cover - platform gate
         pytest.skip("symlink creation is not permitted in this environment")
     assert admit(link, root) == "path_not_confined"
+
+
+def test_a_zip64_entry_bomb_is_refused_before_zipfile_builds_the_directory(root):
+    """The refusal must arrive at the ZIP64 check, not later on the names.
+
+    Before the fix this archive was refused as `member_name_unsafe` — a
+    verdict reached only AFTER `ZipFile` had materialised every entry, which
+    is the cost the bound exists to prevent. The reason code is therefore the
+    load-bearing assertion here, not merely that something was refused.
+    """
+    bomb = _zip64_entry_bomb(root / "v070_bomb.npz", 512)
+    assert admit(bomb, root) == "zip64_unsupported"
+
+
+@pytest.mark.parametrize("entries", [1, 5, 64])
+def test_the_zip64_refusal_does_not_depend_on_the_entry_count(root, entries):
+    bomb = _zip64_entry_bomb(root / ("v070_b%d.npz" % entries), entries)
+    assert admit(bomb, root) == "zip64_unsupported"
+
+
+@pytest.mark.parametrize("descr,member,shape", [
+    ("|u3", "lattice.npy", (16, 16, 16)),
+    ("<u5", "lattice.npy", (16, 16, 16)),
+    ("<f5", "memory_grid.npy", (8, 16, 16, 16)),
+    ("<f3", "memory_grid.npy", (8, 16, 16, 16)),
+    ("<i1000", "generation.npy", ()),
+    ("<i3", "ca_step.npy", ()),
+], ids=["u3", "u5", "f5", "f3", "i1000", "i3"])
+def test_a_width_numpy_cannot_construct_is_refused(root, descr, member, shape):
+    """`np.dtype('|u3')` raises TypeError, and its message quotes the
+    descriptor verbatim — from a call site downstream of every
+    `except SnapshotArchiveRejected`. A family rule alone admitted all of
+    these."""
+    members = schema_members(16)
+    itemsize = int(descr[2:]) if descr[0] in "<>|=" else int(descr[1:])
+    count = 1
+    for dim in shape:
+        count *= dim
+    members[member] = npy_bytes(descr, shape,
+                                payload=b"\x00" * (count * itemsize))
+    path = write_npz(root / "v070_width.npz", members)
+    assert admit(path, root) == "member_dtype_unsupported"
+
+
+@pytest.mark.parametrize("descr,member,shape", [
+    ("|u1", "lattice.npy", (16, 16, 16)),
+    ("<u2", "lattice.npy", (16, 16, 16)),
+    ("<f2", "memory_grid.npy", (8, 16, 16, 16)),
+    ("<f8", "memory_grid.npy", (8, 16, 16, 16)),
+    ("<i4", "generation.npy", ()),
+    ("<i8", "ca_step.npy", ()),
+], ids=["u1", "u2", "f2", "f8", "i4", "i8"])
+def test_every_width_numpy_can_construct_is_still_admitted(root, descr, member,
+                                                           shape):
+    """The counterpart control: the width rule must not have quietly become a
+    single pinned dtype, which would refuse legacy widths."""
+    members = schema_members(16)
+    itemsize = int(descr[2:]) if descr[0] in "<>|=" else int(descr[1:])
+    count = 1
+    for dim in shape:
+        count *= dim
+    members[member] = npy_bytes(descr, shape,
+                                payload=b"\x00" * (count * itemsize))
+    path = write_npz(root / "v070_okwidth.npz", members)
+    assert admit(path, root) is None
+
+
+@pytest.mark.parametrize("dimension", ["\xb2", "\xb3", "¹"], ids=[
+    "superscript_two", "superscript_three", "superscript_one"])
+def test_a_unicode_digit_dimension_is_refused_and_not_leaked(root, dimension):
+    """`str.isdigit()` is true for the whole Unicode digit property; `int()`
+    accepts only ASCII decimals. The parser used the former, so a header
+    declaring a shape of `(\\xb2,)` raised a bare ValueError carrying the
+    attacker's character out of the guard entirely."""
+    members = schema_members(16)
+    members["generation.npy"] = npy_bytes(
+        "<i8", (), payload=b"",
+        header="{'descr': '<i8', 'fortran_order': False, 'shape': (%s,), }"
+               % dimension)
+    path = write_npz(root / "v070_unicode.npz", members)
+    assert admit(path, root) == "member_header_malformed"
+
+
+def test_no_input_makes_the_guard_raise_an_untyped_error(root, tmp_path):
+    """The module's central promise, asserted over every case at once: nothing
+    derived from an archive's contents may leave `admit_snapshot` except as a
+    reason code."""
+    for reason, build in sorted(REFUSAL_CASES.items()):
+        path, policy = build(root, tmp_path)
+        try:
+            with guard.admit_snapshot(path, data_dir=root,
+                                      policy=policy or guard.PRODUCTION_POLICY):
+                pass
+        except guard.SnapshotArchiveRejected as exc:
+            assert exc.reason in guard.REASON_CODES
+        except Exception as exc:  # noqa: BLE001 - the escape IS the defect
+            raise AssertionError(
+                "%s escaped as %s: %s" % (reason, type(exc).__name__, exc))
+
+
+def test_an_empty_header_is_a_syntax_error_not_a_depth_overflow():
+    """`_peek()` returns "" at end of input and "" is a substring of every
+    string, so the value dispatch treated end-of-input as an opening bracket
+    and recursed to the depth cap instead of reporting the real problem."""
+    with pytest.raises(guard._HeaderSyntaxError) as excinfo:
+        guard._parse_literal("")
+    assert "deep" not in str(excinfo.value)
+    with pytest.raises(guard._HeaderSyntaxError) as excinfo:
+        guard._parse_literal("{")
+    assert "deep" not in str(excinfo.value)
 
 
 def test_a_zero_channel_memory_grid_is_refused(root):
@@ -726,20 +869,22 @@ def test_entry_count_parse_bound_boundary(root, count, expected):
 
 @pytest.fixture
 def opened_files(monkeypatch):
-    """Record every file object the guard opens, without perturbing the rest."""
-    records = []
-    real_open = builtins.open
+    """Record every file object the guard opens.
 
-    def _tracking_open(*args, **kwargs):
-        handle = real_open(*args, **kwargs)
-        try:
-            if str(args[0]).endswith(".npz"):
-                records.append(handle)
-        except Exception:  # pragma: no cover - defensive only
-            pass
+    Hooked on `os.fdopen`, not `builtins.open`: the guard opens through
+    `os.open` so it can pass O_NONBLOCK and O_NOFOLLOW, which a plain `open()`
+    cannot express. `os.fdopen` is what turns that descriptor into the file
+    object the guard yields, so it is the exact seam.
+    """
+    records = []
+    real_fdopen = os.fdopen
+
+    def _tracking_fdopen(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        records.append(handle)
         return handle
 
-    monkeypatch.setattr(builtins, "open", _tracking_open)
+    monkeypatch.setattr(os, "fdopen", _tracking_fdopen)
     return records
 
 
@@ -858,10 +1003,9 @@ def test_a_high_entropy_archive_is_admitted_too(root):
     """The mirror control: an archive that does not compress at all is equally
     admissible, so admission is not keyed on compressibility in either
     direction."""
-    import os as _os
     members = schema_members(16)
     members["lattice.npy"] = npy_bytes(
-        "|u1", (16, 16, 16), payload=_os.urandom(16 ** 3))
+        "|u1", (16, 16, 16), payload=os.urandom(16 ** 3))
     path = write_npz(root / "v070_entropy.npz", members)
     with zipfile.ZipFile(path) as archive:
         info = archive.getinfo("lattice.npy")


### PR DESCRIPTION
**OPEN, DRAFT and UNMERGED.** Auto-merge is not enabled. Readiness and merge are separately gated and neither is requested here.

## What this changes

Three services load `v070_gen*.npz` snapshots with nobody watching:

| Surface | Unattended entry points |
|---|---|
| `scripts/medusa_api.py` | `/api/census`, `/api/equanimity`, `/api/acoustic`, `/api/geometry/stl` — four unauthenticated GETs on a process that binds `0.0.0.0` |
| `scripts/lucid_server.py` | the `data/` watcher (every poll where the newest snapshot's path or mtime changed) and the initial send on **every client connect** |
| `scripts/geometry_daemon.py` | the `data/` watcher and the `--once` path |

Each already refused pickled members and already closed its archive deterministically. Neither property constrains an archive's **structure** or its **cost**. A file placed in `data/` could still name members outside the schema, carry traversal-bearing entries, declare hundreds of gigabytes of allocation from a few kilobytes on disk, or lie about its own sizes — and every one of those reached `np.load`, its decompressor and its allocator first.

This adds `scripts/snapshot_archive_guard.py`, a bounded preflight that decides admission before NumPy is involved at all.

## The schema, and the calibrated limits

`scripts/run_v070_engine.py::_save_snapshot` writes exactly five members through `np.savez_compressed`:

```
lattice.npy        (E, E, E)      uint8
memory_grid.npy    (C, E, E, E)   float32     C = 8 today; 3 and 5 are documented legacy
generation.npy     ()             signed int
ca_step.npy        ()             signed int
best_fitness.npy   ()             real float
```

The compatibility ceiling for this tranche is an edge of 256, and every limit is derived from it rather than guessed:

| Limit | Value | Derivation |
|---|---|---|
| members | exactly 5 | the schema |
| header per member | 4 KiB | |
| lattice payload | 16 MiB | 256³ × 1 byte |
| memory-grid payload | 512 MiB | 8 × 256³ × 4 bytes |
| aggregate declared uncompressed | 529 MiB | 512 + 16 + 1 MiB for the three scalars |
| physical archive | 544 MiB | 529 MiB + ZIP framing headroom |
| edge | ≥ 16, ≤ 256, divisible by 16 | 16 is `/api/acoustic`'s sector size |

A 512³ archive is outside this tranche by construction.

Stated rather than implied: **under these production numbers the aggregate ceiling cannot be the binding constraint**. The accumulator sums `ZipInfo.file_size`, which covers each member's NPY header as well as its payload, so the worst case is `528 MiB + 3 KiB + 5 × 4 KiB = 553,671,680` bytes against a ceiling of `554,696,704` — leaving `1,025,024`, exactly **1001 KiB**. It is kept so a future policy that widens one member cannot silently widen the envelope, and it is exercised through an injected policy rather than by pretending a production archive reaches it.

Also worth naming: the memory-grid ceiling has **zero margin** at the live lattice size. 8 × 256³ × float32 is *exactly* 512 MiB, so a ninth memory channel would refuse every 256³ snapshot on all three services at once. The channel count has already grown 3 → 5 → 8 across phases. The number is the one specified for this tranche and is not changed here; the absence of headroom is recorded so it is a decision rather than a surprise.

There is deliberately **no compression-ratio threshold**. A legitimate snapshot is mostly void cells and compresses enormously, so a ratio rule would refuse real inputs. Both directions are witnessed by tests: a sparse archive compressing over 100:1 and a high-entropy archive that does not compress at all are equally admitted.

The consequence is stated rather than left implied: a **539 KB** honest all-zero 256³ snapshot legitimately expands to 528 MiB, a 1027× amplification that survives admission by design. The envelope is per-call and there is no global concurrency bound, so *k* simultaneous requests cost roughly *k* × 528 MiB. That is in-policy for this tranche, not a defect, but it is the cheapest remaining remote cost multiplier and it is named here rather than discovered later.

The memory grid's channel count is bounded by its payload ceiling rather than pinned to 8. **This is not a claim that legacy grids are usable.** A 3- or 5-channel grid is admitted, and then raises `IndexError` downstream — Lucid indexes channel 6 and all three consumers index channel 3, and none of them calls the migration in `continuous_evolution_ca._migrate_memory_grid`. That was equally true before this guard existed; admission neither introduces the failure nor repairs it. Pinning the count would be a new restriction and refusing every legacy form would be a new policy, so the gap is recorded rather than papered over.

## Refused before `np.load`

Non-ZIP input; an unsupported "version needed to extract"; central-directory ZIP64; non-regular or out-of-root paths (decided **after** symlink resolution, and with `resolve()`'s own failures inside the typed boundary); missing, additional or duplicate members; a raw member name that diverges from its sanitized one; directories; absolute, nested, traversal-bearing, backslash-bearing or non-ASCII member names; encrypted entries; general-purpose flag bits 5 and 6; unsupported compression methods; excessive physical, per-member or aggregate sizes; invalid NPY magic or unsupported version; headers over 4 KiB; malformed DEFLATE data during the bounded header read; object, structured, object-bearing structured, subarray or zero-itemsize dtypes; **widths NumPy cannot construct** (`|u3`, `<f5`, `<f16`, `<i1000`, `<i000004`, or a non-ASCII digit such as `<i١`); Fortran-order arrays; wrong ranks, dtype families or scalar/vector forms; lattice/memory-grid spatial disagreement; an inadmissible edge; and any mismatch between the NPY header's own arithmetic and `ZipInfo.file_size`.

Preflight reads headers, not payloads — a valid header over a corrupt body is undetectable until NumPy extracts. So the guard also translates **archive-transport failures raised from the caller's own block** (`zipfile.BadZipFile`, `zlib.error`, `EOFError`) into `member_payload_unreadable`, at the yielded-descriptor boundary so all three consumers get identical behaviour from one place. The lane is deliberately narrow: an existing refusal is re-raised unchanged, and `MemoryError`, `KeyboardInterrupt`, an arbitrary `ValueError` — NumPy's own `"EOF: reading array data"` among them — and every programmer error propagate untouched.

## Safe candidate discovery

Discovery runs *before* admission, over a directory an attacker may be able to write to. All four selection sites read metadata with `stat`/`getmtime`, which follow symlinks and raise on a vanished entry — into loops whose only handler prints the exception, and `OSError`'s message carries the attacker-chosen path. `newest_first` and `entry_fingerprint` now back Medusa, Lucid, the geometry watcher and geometry `--once`:

- **non-following metadata**, so a link cannot borrow its target's modification time to promote itself to "newest" — ordering deciding admission's question before admission is asked;
- **vanished entries are skipped silently**, because there is nothing to report about an entry that is simply gone;
- **a dangling link or symlink loop stays a candidate**, so it reaches the typed guard rather than disappearing from selection and letting an older archive be served with no record of why;
- Lucid's **second** metadata read — selection and the watcher's fingerprint are separate syscalls — is protected the same way;
- geometry's rejection fingerprint is non-following, so a rejected link no longer looks "changed" whenever anything touches its target, which had it re-preflighted and re-logged every poll;
- ties break **newest first, then lowest path**. Direction matters: the producer's `:06d` is a minimum width production has already outgrown, so lexicographic order inverts across a digit-count boundary and a descending tie-break would prefer `v070_gen999999` over `v070_gen1000000` — the *older* snapshot.

## Same descriptor, start to finish

```python
with admit_snapshot(path, data_dir=DATA_DIR, policy=SNAPSHOT_POLICY) as fd:
    with np.load(fd, allow_pickle=False) as snap:
        ...
```

The file is opened **exactly once**, preflighted on that descriptor, rewound and yielded. A pathname is never validated and then reopened for loading, so there is no window between the check and the use — the bytes inspected are the bytes NumPy reads. `str(path)` is gone from two call sites: there is no second open left to convert a path for.

Ownership is split and both halves are explicit: the inner `with` closes the archive, the guard closes the descriptor, on success and on every exceptional exit. A test asserts identity on `NpzFile`'s own `ZipFile`, so "same descriptor" is observed rather than inferred.

`allow_pickle=False` stays at every call site even though an object-dtype member can no longer survive admission. It is the second line of defence and the property the untouched repository-wide static gate reads — and each consumer's tests now call NumPy **directly** on the same hostile archive so that refusal stays observable rather than becoming unreachable and therefore untested.

## Bounded everywhere it parses

The end-of-central-directory record is read first, in a window of at most 64 KiB + 22 bytes, and its entry count and directory size are bounded before `zipfile` is allowed to build one `ZipInfo` per entry — otherwise a 544 MiB file made entirely of directory entries would become millions of objects before any later check could refuse it. That pre-check is a **bound**, not the schema rule: a four-member archive still reaches the membership check and is refused as *missing a member*.

**Central-directory** ZIP64 is refused outright — and the distinction matters, because the **local-header** ZIP64 length form stays supported and must: NumPy's `savez` opens every member with `force_zip64=True`, which reserves ZIP64 sizes in the local header while the central directory it writes remains 32-bit. Refusing that would refuse every real snapshot. Nothing here inspects local headers.

The refusal covers all four central sentinels including the **directory offset**, which says "the real value is in the ZIP64 record" just as loudly as the counts do — so an archive can carry honest-looking counts and still redirect `zipfile` through ZIP64.

That refusal is load-bearing rather than tidiness. CPython's `zipfile._EndRecData` consults a ZIP64 locator whenever one is present and takes the entry count and directory size from the ZIP64 record — it does **not** require the `0xFFFF`/`0xFFFFFFFF` sentinels. So the 32-bit bound above was advisory until this was added: a crafted file declaring "five entries, a 300-byte directory" in its 32-bit record was measured taking **2.53 s and 23.4 MB of heap** to build 60,000 `ZipInfo` objects from a 2.7 MB file, refused only afterwards on its member names. The same input now costs **0.04 s and 0.1 MB**. A five-member snapshot under a 544 MiB ceiling never needs ZIP64 — NumPy's `force_zip64` affects only *local* headers and the central directory it writes stays 32-bit.

The archive is opened through `os.open` with `O_NONBLOCK` and `O_NOFOLLOW` where the platform has them. `S_ISREG` cannot protect the open itself, and a plain `open()` of a FIFO blocks until a writer appears — so on POSIX an attacker able to write to `data/` could `mkfifo` a `v070_gen*.npz` and hang Lucid's entire asyncio server, or park one Medusa request thread per attempt. `O_NOFOLLOW` additionally closes the window between resolving the path and opening it.

NPY headers are read from bounded member streams. Nothing is extracted: `ZipFile.extract`, `extractall` and `testzip` are never called, and a test asserts that from the module's AST. The header dict is parsed by a hand-written literal parser accepting exactly dict/tuple/list/string/int/bool/None with capped depth and token count — not `eval`, not `exec`, not `ast.literal_eval`, and no private NumPy helper. The guard imports no NumPy at all. Payload arithmetic caps each dimension before multiplying and caps the running product, so a header declaring 10³⁰⁰ cells is refused rather than computed.

## Sanitized refusals

`SnapshotArchiveRejected(ValueError)` carries a fixed code from `REASON_CODES` and nothing else — never a path, filename, member name, header fragment or underlying exception string. Diagnostic granularity is deliberately traded for non-disclosure: a refusal says *what kind* of defect was found, never *which member* carried it.

## Service failure surfaces

**Medusa.** The four `_load_snapshot` routes translate a refusal into `503 {"error": "snapshot_rejected"}` — no reason code, no member name, no traceback. 503 rather than 500 because a later valid snapshot fixes it with no code change.

Health, status, telemetry and the raw `.npz` download do not go through `_load_snapshot`, so none of them can become a snapshot refusal — asserted, including telemetry's own 404-on-empty-directory behaviour rather than a blanket "200 and unchanged". Precisely, though: three of them share the *selector*, so their input did change when the one-megabyte rule went. See the selection note below.

**Lucid.** The watcher logs one bounded reason code, sends and broadcasts nothing, and keeps polling. `last_snapshot_path`/`last_snapshot_mtime` were already advanced before extraction, so an unchanged rejected file is neither reprocessed nor re-logged, and a subsequently changed valid snapshot is accepted. The initial-client send catches the refusal before the existing broad handler: a client connecting while the directory is poisoned loses its opening frame and nothing else — the connection stays open and its messages are handled as usual.

**Geometry.** The watcher logs one bounded reason code, runs no exporter and stays alive. It remembers the rejected archive as `(path, size, mtime_ns)`, so unchanged poison causes no repeated preflight and no repeated log, while a file that *changes* at the same path gets a fresh attempt. `--once` prints one bounded reason on stderr and exits nonzero. Only the typed refusal is caught — a `MemoryError`, a `KeyboardInterrupt` or a programmer error must not become "the snapshot was bad".

## Deliberate behaviour changes

1. **A numeric `.npy` renamed `.npz` now receives a typed admission refusal** instead of Lucid's former incidental `IndexError` from a string subscript on an ndarray. This is structural hardening, not a preserved behaviour. The test asserts the new reason code *and* that it is not the old class, and the old class is still derived from a live probe so the change cannot be mistaken for NumPy shifting underneath.

2. **The one-megabyte minimum-selection guess is removed**, in Medusa's `_find_latest_snapshot` and in the geometry watcher. It was wrong in both directions: a sparse but structurally valid snapshot compresses far below a megabyte and was skipped or never selected, while a hostile archive only had to be padded past the threshold to be chosen.

   What that guess was *doing*, though, was not only filtering — it was a newest-first **search** that skipped an unusable file and fell back to the previous good one. So the search is kept and only the predicate is replaced: admission, not size, bounded to the newest `SNAPSHOT_SELECTION_DEPTH = 8` candidates because preflighting a five-figure directory on every request would itself be the denial of service. When nothing in the window is admissible the newest is still returned, so `/api/status` and `/api/snapshot/latest` keep reporting the file that is actually there while the four loading routes answer 503. The probe holds no descriptor across selection: `_load_snapshot` opens and preflights its own, so a file swapped in between is caught there rather than trusted here.

   Anything older than the window is now simply not considered, which the previous unbounded scan would have found. That is a deliberate trade against the scan itself being the attack.

3. **Geometry's `--once` body moved out of `if __name__ == "__main__"` into `run_once()`.** pytest never executes that block, so its refusal contract could only have been *restated* by a test rather than exercised by one. An AST test pins that `__main__` delegates to it and does no snapshot work of its own.

4. **Geometry's `"New snapshot: <name>"` line now prints only after admission succeeds**, so a refused archive's chosen name never reaches the log.

5. **`lucid_server.py` and `geometry_daemon.py` append the repository root to `sys.path`** before importing the guard, because both are documented as `python scripts/X.py`. Appended, not prepended, so it cannot shadow a standard-library module — and one canonical module name either way, which matters because the guard's exception type is caught by identity.

## Failing-first receipts

Commit 1 adds consumer-level negative controls only — no production change. Each wraps `np.load` in a recorder and asserts it was **never called**; asserting merely that something was raised would pass on code that allocates first and fails afterwards, which is the behaviour being replaced. Seventeen hostile archive kinds per consumer, covering duplicate and hostile names, missing/extra members, oversized declared payload and edge, header/payload inconsistency, invalid magic/version/header, object and structured dtypes, wrong rank, spatial mismatch, Fortran order and non-NPZ input.

They fail against `main` because `np.load` is reached in all three consumers, and because several of the hostile archives load successfully there.

That was verified by execution, not by argument. A stdlib harness loaded the **unmodified `a7a5dbc` version** and the branch version of `geometry_daemon._load_snapshot` and `lucid_server.extract_render_data` under a stubbed NumPy, against nine hostile archives:

```
== geometry_daemon._load_snapshot ==       main reached np.load | branch reached | branch outcome
duplicate_member                           YES  (returned)      | no  | SnapshotArchiveRejected:member_duplicate
extra_member                               YES  (returned)      | no  | SnapshotArchiveRejected:member_unexpected
header_payload_mismatch                    YES  (returned)      | no  | SnapshotArchiveRejected:member_size_inconsistent
invalid_magic                              YES  (returned)      | no  | SnapshotArchiveRejected:member_npy_magic_invalid
missing_member                             YES  (returned)      | no  | SnapshotArchiveRejected:member_missing
not_an_npz                                 YES  (returned)      | no  | SnapshotArchiveRejected:not_zip_archive
object_dtype                               YES  (returned)      | no  | SnapshotArchiveRejected:member_dtype_object
oversized_declared_shape                   YES  (returned)      | no  | SnapshotArchiveRejected:edge_out_of_range
traversal_name                             YES  (returned)      | no  | SnapshotArchiveRejected:member_name_unsafe

== lucid_server.extract_render_data ==     (same nine; main reached np.load in all nine, branch in none)
```

All 18 combinations: `main` reaches `np.load`; the branch refuses first with the expected typed code.

## Test coverage

`tests/test_snapshot_archive_guard.py` carries **one reproducible case per declared reason code**, and asserts the case table equals `REASON_CODES` exactly — so no code can be declared without a case, and none can survive the check that produced it being deleted. Boundaries are covered at limit−1, exactly the limit and limit+1 for the physical ceiling, the declared aggregate, the per-member payload, the header ceiling, the central-directory bound and the entry-count parse bound.

**No test allocates a production-sized archive.** Cases needing a large *shape* declare it in the header and carry no payload — which works because geometry is checked before size arithmetic. Cases needing a small *ceiling* inject a tiny policy through `dataclasses.replace`. The policy's own 256 ceiling cannot be *admitted* with a real archive without allocating 528 MiB, so the identical edge rule is exercised at a scaled ceiling where minimum, maximum and multiple are all real boundaries.

Also covered: a real compressed and a real uncompressed producer-shaped archive; descriptor identity through `np.load`; closure on preflight refusal, on a load failure, on a missing key and on success; hostile member-name shapes; symlink escape; header grammars outside the accepted subset; and per-consumer valid-output compatibility.

## Audit findings and corrections

Three read-only agents reviewed the first three commits: an archive/resource red team, a valid-input and failure-surface compatibility review, and a test non-vacuity and factual-claims audit. Every finding below was **reproduced by the primary agent before anything was changed**. Commits 4 and 5 are the corrections.

### Fixed — reproduced defects

| Finding | Reproduction | Fix |
|---|---|---|
| **ZIP64 voided the central-directory bound.** `_EndRecData` takes the entry count from a ZIP64 record whenever the locator is present, without needing the sentinels the guard refused, so the 32-bit bound was advisory. | Crafted file declaring "5 entries / 300 bytes": **2.53 s, 23.4 MB heap, 60,000 `ZipInfo` objects** built before refusal. | Refuse ZIP64 using `_EndRecData`'s own condition, read from the file. Same input: **0.04 s, 0.1 MB**. |
| **An untyped `ValueError` escaped the guard.** `str.isdigit()` is true for the whole Unicode digit property; `int()` accepts only ASCII decimals. | A header shape of `(\xb2,)` raised `ValueError: invalid literal for int()` **out of `admit_snapshot`** — past every typed handler, into a 500 with a traceback and into the consumers' broad `print(f"...{e}")`. | Explicit decimal digits; `ValueError`/`RecursionError` added to the header guard; a test asserts over *every* refusal case that nothing but a reason code escapes. |
| **Dtype widths NumPy cannot construct were admitted.** The rule checked family only. | `\|u3`, `<f5`, `<i1000` all **ADMITTED** — each makes `np.dtype()` raise a `TypeError` quoting the attacker's descriptor. | Per-member `itemsizes` allowlist (ints 1/2/4/8, floats 2/4/8/16), with a control that legacy widths are still admitted. |
| **A FIFO could hang the caller before `S_ISREG`.** | `S_ISREG` ran after `open()`; a POSIX `mkfifo` in `data/` blocks the open indefinitely — Lucid's whole event loop, one Medusa thread per attempt. | `os.open` with `O_NONBLOCK` and `O_NOFOLLOW` where available. |
| **Medusa's selector lost its fallback.** | `main` walked newest-first and skipped an unusable file; the branch returned `snapshots[0]`, so one truncated archive wedged four routes at 503 — and `_save_snapshot` writes with no temp-and-rename. | Search restored, bounded, with admission as the predicate. |
| **A test fixture allocated 4.12 GiB, ten times.** | `_schema_*(edge=512)` builds real payloads: 512³ + 8×512³×4 = 4,429,185,024 bytes, consumed 2+3+5 times ≈ **41 GiB per CI run** — and it falsified the "a few kilobytes" comment above every table. | Declared-only headers, which work because geometry is checked before size arithmetic. |
| **Three assertions could not fail.** | `assert broadcasts == []` on a patched `broadcast` that `extract_render_data` never calls — and **`snapshot_watcher()` was executed by no test at all**; the same dead assertion in the 17-case initial-client test, which also could not distinguish the typed handler from the broad one; and a "telemetry is asserted" claim covering only health and status. | The real `snapshot_watcher` coroutine is now driven; log lines distinguish the handlers; telemetry is covered with its own 404-on-empty behaviour. |
| Smaller: `_snapshot_fingerprint` could raise `FileNotFoundError` into the broad handler, whose message carries the attacker-chosen path; the literal parser treated end-of-input as an opening bracket; bare `except ValueError` clauses could re-code a refusal; the 17-case tables asserted only `ValueError`; the entry-count boundary had two points instead of three. | | All corrected. |

## Second audit round — Jack's pass, and three more agents

Jack's independent audit of `efaf847` produced the corrections in commit 6. Three further read-only agents then reviewed *that* commit, and their findings produced commit 7. Every finding was reproduced by the primary agent before anything changed.

### Genuine bypasses and escapes closed

| Finding | Reproduction at the prior head | Now |
|---|---|---|
| **`zlib.error` escaped the guard.** The header read is bounded, but for a DEFLATED member those bytes still go through the decompressor, and `zlib.error` inherits from `Exception`, not `OSError`. | `ESCAPED error` | `member_header_unreadable` |
| **`zipfile.BadZipFile` escaped from the caller's block.** A valid header over a corrupt body — a wrong CRC — is undetectable until NumPy extracts, and raw it is not a `ValueError`, so it sailed past every typed handler into a 500 naming the member. | `ESCAPED BadZipFile` | `member_payload_unreadable` |
| **`NotImplementedError` escaped from `ZipFile()`'s constructor**, which refuses an entry whose "version needed to extract" exceeds 63. It subclasses `RuntimeError`, so the `BadZipFile`/`OSError`/`ValueError` clause missed it. One byte per central header on a schema-perfect 136 KB archive. | `ESCAPED UNTYPED: NotImplementedError: zip file version 25.5` | `not_zip_archive` |
| **`Path.resolve()` is not total** — a symlink loop raises `OSError(ELOOP)`, and it left the guard with no reason code and the path in the message. | `ESCAPED OSError` | `path_not_confined` |
| **A v3.0 descriptor of `<i١`** (Arabic-Indic digit). A v3 header is UTF-8 and `\d` matches the whole Unicode decimal-digit category — as does `int()` — so the width parsed as 1 and described a dtype no NumPy can build. | **ADMITTED** | `member_dtype_unsupported` |
| **`<f16`.** `longdouble` is not portable; NumPy 2.3.5 on Windows refuses it outright. | **ADMITTED** | `member_dtype_unsupported` |
| **A vanished candidate during the sort.** | `ESCAPED FileNotFoundError` | skipped silently |

Two further corrections are **reason-code precision, not holes closed**, and are reported that way: flag bits 5/6 and the ZIP64 offset sentinel were already refused at the prior head, but under the misleading code `member_header_unreadable`.

### Defects in this change's own tests, found and fixed

- **A committed test could not pass.** `test_geometry_route_reaches_trimesh_only_once_a_snapshot_is_admitted` used the default all-zero lattice, and `geometry_stl` returns 404 at `len(non_void_coords) == 0` *before* touching `trimesh.primitives`. It also left its sibling unanchored: `assert trimesh_sentinel.touched == []` was satisfied by that 404 rather than by the refusal it names. Both fixed; the control now pins which attribute was reached first.
- **A test double broke discovery.** `newest_first` uses `os.lstat`, which takes only `str | bytes | os.PathLike`; the geometry `_FakeSnapshotPath` was a pure duck type. `TypeError` is not `OSError`, so it reached the daemon's broad handler: ~8 failures plus 2 vacuous passes. The double is now backed by a real file — adding `__fspath__` alone would have been *worse*, since `lstat` on a non-existent path raises `OSError`, gets skipped, and every daemon-cycle test passes exercising nothing.
- **Mutation testing showed the central flag-bit check was pinned by nothing** — deleting it killed zero tests, because CPython's `NotImplementedError` maps to the same reason code. Whether the member is opened at all is now counted, with a companion proving a clean archive *does* open its five members.
- The ASCII-name rule and the `O_NONBLOCK`/`O_NOFOLLOW` open were untested; both now have cases. The FIFO test is POSIX-gated and, if that protection regresses, **hangs rather than fails** — in CI, the louder signal.

### Claims corrected

The `NotImplementedError` comment said the flags were "declared in the LOCAL header only" — false, CPython tests `zinfo.flag_bits`, the central value, and the comment contradicted this branch's own test. `_INTEGER_WIDTHS`' comment still described floats as including 16 two lines above `_FLOAT_WIDTHS` excluding it. The `DECIMAL_DIGITS` comment claimed sole credit for an escape the `ValueError` clause also closes. The non-ASCII-dimension fixture comment overstated which of its three parameters are load-bearing. Medusa and geometry claimed `str(path)` was "preserved verbatim" when it was deliberately replaced. Three assertions that could not fail were removed.

### Reported, deliberately not fixed

Each needs a decision outside this authorization, so it is surfaced rather than quietly absorbed:

1. **The five-member schema is narrower than `nextness_observer._REQUIRED_SNAPSHOT_KEYS`** (three keys, with additional members explicitly supported). Adjudicated: the four-member `nextness_calibration` artefact lives and dies inside a `TemporaryDirectory` and `nextness_observer` is a separate consumer, so the exact-five unattended-service schema stands. Disclosed, not changed.
2. **A memory grid with fewer than 7 channels is admitted and then `IndexError`s** in all three consumers. Unchanged from `main`; closing it means pinning the channel count.
3. **`_preflight_eocd` proves its bound against a size captured by an earlier `fstat`.** A writer appending in between means the guard validates one EOCD while `zipfile` parses another. Pre-existing, and exploiting it requires winning a microsecond race.
4. **`newest_first` is unbounded in candidate count** — one `lstat` and one tuple per globbed entry before the depth window truncates. Same shape as the code it replaced, but it is now the shared chokepoint and would be the natural place to cap.
5. **Lucid and geometry have no depth-window fallback.** One future-dated entry that fails admission stalls them where Medusa recovers. At the prior head both were equally blocked but noisily; this makes the stall quiet.
6. **Lucid goes silent on a *persistent* metadata failure**, since the poll ends quietly. Correct for transient rotation, invisible for a dropped share.
7. **`run_once` now exits 0** when every candidate's metadata read fails, where an uncaught `OSError` previously exited non-zero.
8. **The block-boundary translation uses `from None`**, erasing context. Latent: no current consumer can raise `EOFError` or `zlib.error` inside the block. `from None` is what keeps the member name out of the reason.
9. **Hardlink confinement**, **non-cubic lattices**, and the **documented 512³ expansion** — as previously recorded.
10. `tests/test_medusa_api.py:75` carries a stale comment about the 1 MB threshold. **Outside the eight-file boundary**; untouched, and its test still passes.

## Verification, and exactly what it rests on

This machine has **no pytest and no NumPy**, and nothing was installed. Two standard-library harnesses were used, both narrowly labelled:

- the guard's own suite under a minimal pytest stand-in — **215 passed, 0 failed, 14 skipped** (NumPy-only, symlink-gated and the POSIX FIFO case; all of them run on the Linux CI runner)
- the red/green consumer harness above, re-run green after every change
- a counterfactual harness that loads the **previous head's** guard through `git show` into a temp file — the worktree is never reset — and proves each new regression fails there and is typed here

Medusa's 503 translation, the Flask routes and every NumPy-dependent test cannot be driven locally. The authoritative receipt is CI's, on head `cfad9dc`:

```
4615 passed, 13 skipped in 87.86s
```

against the pre-branch baseline of `4170 passed, 13 skipped` — **+445 passed, ±0 skipped**, zero failures and zero errors.

**`/api/geometry/stl` no longer contributes a dependency skip.** Its `pytest.importorskip("trimesh")` is replaced by a sentinel module in `sys.modules` that records every attribute reached for, so the real route runs in authoritative CI and the assertion is that the sanitized 503 happened before any mesh work began — a stronger claim than the real library could support. That is why the skip count returns to the baseline 13 rather than the 14 of the previous head.

Every automatically registered check passed: `verify-python` (both workflows), `Analyze Python`, `CodeQL`, `agent-safety`, `frontend-quality` (both) — seven in all. No workflow was rerun manually. `theory-tripwire` is **not** registered against this head and its absence is by design, not a failure: it triggers on `pull_request: [opened, reopened, labeled]` only, so it ran when the PR was opened and a push does not re-register it.

## Files, commits, statistics

Exactly eight files, no ninth:

```
scripts/snapshot_archive_guard.py        | 1113 ++++++++++++++++++
scripts/geometry_daemon.py               |  198 +++-
scripts/lucid_server.py                  |  149 ++-
scripts/medusa_api.py                    |  160 ++-
tests/test_snapshot_archive_guard.py     | 1774 +++++++++++++++++++++++++
tests/test_geometry_daemon.py            |  875 ++++++++++++--
tests/test_lucid_server.py               |  612 ++++++++++-
tests/test_medusa_api_snapshot_loader.py |  818 +++++++++++++-
8 files changed, 5427 insertions(+), 272 deletions(-)
```

Seven ordinary commits, no amend, no rebase, no force-push, no synchronization
with `main`:

1. `9c183d1` - failing-first consumer controls (tests only)
2. `e2e491e` - the shared guard and its focused tests
3. `b89bc18` - the three consumer integrations
4. `0c6c538` - reproduced audit corrections (guard + selection)
5. `efaf847` - reproduced test-integrity corrections
6. `5c6aaac` - transport, dtype and discovery gaps from Jack's audit
7. `cfad9dc` - an untyped escape and three vacuous tests found by review

`git diff --check` is clean; no workflow, Rust, Cargo or rustup file is touched; the working tree carries no untracked artifacts.

## Exclusions and residual limitations

- Not authentication, not authorization, not atomic writing, not semantic state validation, not numeric-value validation, not arbitrary NPZ compatibility.
- **No protection for any consumer that does not call the guard.** Other snapshot readers in this repository are untouched and out of scope.
- Admission is structural. An archive that passes is still only *well-formed*: its numeric contents are unvalidated, and its `generation`, `ca_step` and `best_fitness` values are trusted exactly as before.
- Failures *after* admission — a missing key, a failing `int()`/`float()` conversion — are deliberately unchanged and still propagate.
- The three test modules each define their own stdlib NPY/NPZ builders rather than sharing one, so that each module stays independently collectible and no module depends on another test module existing.
- `tests/test_snapshot_pickle_policy.py`, the producers, documentation, workflows and Rust files are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
